### PR TITLE
Displays the current temperature in the user's preferred scale

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -153,6 +153,7 @@ public class MapViewController: UIViewController,
     private let weatherButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("—", for: .normal)
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.addTarget(self, action: #selector(showWeather), for: .touchUpInside)
         button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body).bold
         button.accessibilityLabel = NSLocalizedString("map_controller.show_weather_button", value: "Show Weather Forecast", comment: "Accessibility label for a button that provides the current forecast")
@@ -172,8 +173,8 @@ public class MapViewController: UIViewController,
     private var forecast: WeatherForecast? {
         didSet {
             if let forecast = forecast {
-                let truncated = Int(forecast.currentForecast.temperature)
-                weatherButton.setTitle("\(truncated)º", for: .normal)
+                let formattedTemp = MeasurementFormatter.unitlessConversion(temperature: forecast.currentForecast.temperature, unit: .fahrenheit, to: application.locale)
+                weatherButton.setTitle(formattedTemp, for: .normal)
             }
             else {
                 weatherButton.setTitle("—", for: .normal)

--- a/OBAKitCore/Extensions/FoundationExtensions.swift
+++ b/OBAKitCore/Extensions/FoundationExtensions.swift
@@ -100,6 +100,33 @@ public extension Dictionary where Key == String {
     }
 }
 
+// MARK: - MeasurementFormatter
+
+public extension MeasurementFormatter {
+    /// Converts `temperature` in the specified `unit` to `locale` without displaying a resulting unit.
+    ///
+    /// For example, converts 32ºF -> "0º" for Celsius locale, or 0ºC -> "32º" for Fahrenheit locale.
+    /// - Parameter temperature: The temperature
+    /// - Parameter unit: The unit for `temperature`
+    /// - Parameter locale: The target locale
+    class func unitlessConversion(temperature: Double, unit: UnitTemperature, to locale: Locale) -> String {
+        let temp = Measurement(value: temperature, unit: unit)
+        let formatter = MeasurementFormatter()
+        formatter.locale = locale
+        formatter.unitStyle = .short
+        formatter.numberFormatter.usesSignificantDigits = false
+        formatter.numberFormatter.maximumSignificantDigits = 0
+
+        var formattedTemp = formatter.string(from: temp)
+
+        if formattedTemp.hasSuffix("C") || formattedTemp.hasSuffix("F") {
+            formattedTemp.removeLast()
+        }
+
+        return formattedTemp
+    }
+}
+
 // MARK: - Sequence
 
 public extension Sequence where Element == String {


### PR DESCRIPTION
Fixes #75 - Display temperature in Fahrenheit or celsius

Note: this only works on-device. In the simulator, it appears that you will always see the locale's specified temperature unit and not the user's override.