### PR TITLE
Only update the user's location on the map if their location is valid and they're already on the map tab

### DIFF
--- a/Apps/OneBusAway/AppDelegate.m
+++ b/Apps/OneBusAway/AppDelegate.m
@@ -112,14 +112,17 @@
 
 #pragma mark - UITabBarControllerDelegate
 
-- (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {
-    NSInteger index = tabBarController.selectedIndex;
-
-    if (index == OBASelectedTabMap) {
+- (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController {
+    // If the user is already on the map tab and they tap on the map tab item again, then zoom to their location.
+    if (tabBarController.selectedViewController == viewController && tabBarController.selectedIndex == OBASelectedTabMap) {
         [self.rootController.mapController centerMapOnUserLocation];
     }
 
-    self.app.userDataStore.lastSelectedView = (OBASelectedTab)index;
+    return YES;
+}
+
+- (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {
+    self.app.userDataStore.lastSelectedView = (OBASelectedTab)tabBarController.selectedIndex;
 }
 
 #pragma mark - OBAAnalytics

--- a/OBAKit/Extensions/MapKitExtensions.swift
+++ b/OBAKit/Extensions/MapKitExtensions.swift
@@ -9,6 +9,15 @@
 import Foundation
 import MapKit
 
+extension MKUserLocation {
+
+    /// Returns `false` if `location` is `nil` or equal to `(0,0)`, and `true` otherwise.
+    public var isValid: Bool {
+        guard let location = location else { return false }
+        return location.coordinate.latitude != 0 && location.coordinate.longitude != 0
+    }
+}
+
 // MARK: - Directions
 
 extension MKDirections {

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -136,8 +136,10 @@ public class MapViewController: UIViewController,
     @objc public func centerMapOnUserLocation() {
         guard isLoadedAndOnScreen else { return }
 
-        let userLocation = mapRegionManager.mapView.userLocation.coordinate
-        mapRegionManager.mapView.setCenterCoordinate(centerCoordinate: userLocation, zoomLevel: 17, animated: true)
+        let userLocation = mapRegionManager.mapView.userLocation
+        guard userLocation.isValid else { return }
+
+        mapRegionManager.mapView.setCenterCoordinate(centerCoordinate: userLocation.coordinate, zoomLevel: 17, animated: true)
     }
 
     private let locationButton: UIButton = {


### PR DESCRIPTION
Fixes #86 - Toggling between 'Map' and 'Recent' tabs without a user location changes map center