### PR TITLE
Fixes #185

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -453,7 +453,11 @@ public class Application: CoreApplication, PushServiceDelegate {
     public func regionsServiceUnableToSelectRegion(_ service: RegionsService) {
         guard let app = delegate?.uiApplication else { return }
 
-        self.regionPickerBulletin = RegionPickerBulletin(regionsService: regionsService)
+        // Fixes #185
+        if regionPickerBulletin == nil || regionPickerBulletin?.regionsService != service {
+            self.regionPickerBulletin = RegionPickerBulletin(regionsService: regionsService)
+        }
+
         self.regionPickerBulletin?.show(in: app)
     }
 

--- a/OBAKit/Permissions/LocationPermissionBulletin.swift
+++ b/OBAKit/Permissions/LocationPermissionBulletin.swift
@@ -81,7 +81,7 @@ class RegionPickerBulletin: NSObject {
         return picker
     }()
 
-    private let regionsService: RegionsService
+    public let regionsService: RegionsService
 
     init(regionsService: RegionsService) {
         self.regionsService = regionsService
@@ -90,6 +90,7 @@ class RegionPickerBulletin: NSObject {
     }
 
     func show(in application: UIApplication) {
+        guard !bulletinManager.isShowingBulletin else { return }            // Fixes #185.
         bulletinManager.showBulletin(in: application)
     }
 }
@@ -115,6 +116,7 @@ class RegionPickerItem: BLTNPageItem {
             else { return }
 
             self.regionsService.currentRegion = region
+            self.regionsService.automaticallySelectRegion = false
             self.manager?.dismissBulletin()
         }
     }


### PR DESCRIPTION
Fixes #185.

In some cases, CLLocationManager will update the location multiple times a minute, causing the RegionPickerBulletin to constantly show and interrupt user interaction. 

Changes:
- Don’t show another RegionPickerBulletin if one already exists and is being presented.
- When selecting a region from the RegionPickerBulletin, ensure that automaticallySelectRegion is false.