### PR TITLE
Make map annotation detail callout multiple lines

### DIFF
--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -104,6 +104,13 @@ class StopAnnotationView: MKAnnotationView {
 
         titleLabel.text = stop.mapTitle
         subtitleLabel.text = stop.mapSubtitle
+
+        let detailLabel = UILabel()
+        detailLabel.font = .preferredFont(forTextStyle: .caption1)
+        detailLabel.numberOfLines = 0
+        detailLabel.text = stop.subtitle
+
+        detailCalloutAccessoryView = detailLabel
     }
 
     // MARK: - Appearance


### PR DESCRIPTION
Addresses the truncation issue mentioned in #132 by allowing the text to overflow.