### PR TITLE
Adds a button to the Settings controller to allow for exporting user defaults

### DIFF
--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -50,6 +50,8 @@ class SettingsViewController: FormViewController {
             form +++ migrateDataSection
         }
 
+        form +++ exportDataSection
+
         form.setValues([
             mapSectionShowsScale: application.mapRegionManager.mapViewShowsScale,
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
@@ -174,6 +176,34 @@ class SettingsViewController: FormViewController {
             $0.onCellSelection { [weak self] _, _ in
                 guard let self = self else { return }
                 self.application.performDataMigration()
+            }
+        }
+
+        return section
+    }()
+
+    // MARK: - Exports Defaults Section
+
+    private lazy var exportDataSection: Section = {
+        let section = Section(header: nil, footer: nil)
+
+        section <<< ButtonRow("export_data") {
+            $0.title = Strings.exportData
+            $0.onCellSelection { [weak self] _, _ in
+                guard let self = self else { return }
+
+                let dict = self.application.userDefaults.dictionaryRepresentation()
+
+                do {
+                    let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+                    let tmpDirURL = FileManager.default.temporaryDirectory
+                    let xmlPath = tmpDirURL.appendingPathComponent("userdefaults.xml")
+                    try data.write(to: xmlPath)
+                    let activity = UIActivityViewController(activityItems: [xmlPath], applicationActivities: nil)
+                    self.present(activity, animated: true, completion: nil)
+                } catch let ex {
+                    AlertPresenter.show(error: ex, presentingController: self)
+                }
             }
         }
 

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -39,6 +39,8 @@ public class Strings: NSObject {
 
     public static let error = OBALoc("common.error", value: "Error", comment: "The noun 'error', as in 'something went wrong'.")
 
+    public static let exportData = OBALoc("common.export_data", value: "Export Data", comment: "The title of a button that exports all of the user's data into a file.")
+
     public static let filter = OBALoc("common.filter", value: "Filter", comment: "The verb 'to filter'.")
 
     public static let learnMore = OBALoc("common.learn_more", value: "Learn More", comment: "This is button text that tells the user they can tap on it to learn more about the topic at hand.")

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -67,6 +67,9 @@
 /* The noun 'error', as in 'something went wrong'. */
 "common.error" = "Error";
 
+/* The title of a button that exports all of the user's data into a file. */
+"common.export_data" = "Export Data";
+
 /* The verb 'to filter'. */
 "common.filter" = "Filter";
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/465 - Add back a way for developers to get access to users' userdefaults data