### PR TITLE
Hides departure time badge when nil configuration applied

### DIFF
--- a/OBAKitCore/UI/DepartureTimeBadge.swift
+++ b/OBAKitCore/UI/DepartureTimeBadge.swift
@@ -90,6 +90,7 @@ public class DepartureTimeBadge: UILabel, ArrivalDepartureDrivenUI {
     }
 
     public func configure(_ config: Configuration?) {
+        isHidden = config == nil
         accessibilityLabel = config?.accessibilityLabel
         text = config?.displayText
         layer.backgroundColor = config?.backgroundColor


### PR DESCRIPTION
I'm only able to randomly reproduce #469, so I think this might be a fix for it.

Fixes #469