### PR TITLE
Clear `DepartureTimeBadge`'s `layer.backgroundColor` on `prepareForReuse`

### DIFF
--- a/OBAKitCore/UI/DepartureTimeBadge.swift
+++ b/OBAKitCore/UI/DepartureTimeBadge.swift
@@ -83,6 +83,7 @@ public class DepartureTimeBadge: UILabel, ArrivalDepartureDrivenUI {
     public func prepareForReuse() {
         accessibilityLabel = nil
         text = nil
+        layer.backgroundColor = nil
     }
 
     public func configure(with arrivalDeparture: ArrivalDeparture, formatters: Formatters) {


### PR DESCRIPTION
Fixes #469 - Little funky green dots appearing on right side of stop-level bookmarks