### PR TITLE
Fixes a bunch of usability issues

### DIFF
--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -47,10 +47,6 @@ extension Stop: MKAnnotation {
     public var mapTitle: String? {
         return Formatters.formattedRoutes(routes, limit: 3)
     }
-
-    public var mapSubtitle: String? {
-        Formatters.adjectiveFormOfCardinalDirection(direction)
-    }
 }
 
 // MARK: - TripStatus/MKAnnotation

--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -38,8 +38,10 @@ extension Stop: MKAnnotation {
         Formatters.formattedTitle(stop: self)
     }
 
+    /// The subtitle for a `Stop` as an `MKAnnotation` is a formatted list of `Route`s served by this `Stop`,
+    /// plus the value of `Stop.code`, which is the transit rider-visible stop ID number.
     public var subtitle: String? {
-        Formatters.formattedRoutes(routes)
+        ["#\(code)", Formatters.formattedRoutes(routes)].compactMap {$0}.joined(separator: "\n")
     }
 
     public var mapTitle: String? {

--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -45,7 +45,7 @@ extension Stop: MKAnnotation {
     }
 
     public var mapTitle: String? {
-        routes.map { $0.shortName }.prefix(3).joined(separator: ", ")
+        return Formatters.formattedRoutes(routes, limit: 3)
     }
 
     public var mapSubtitle: String? {

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -29,7 +29,6 @@ class StopAnnotationView: MKAnnotationView {
     // MARK: - Subviews
 
     private let titleLabel = StopAnnotationView.buildLabel()
-    private let subtitleLabel = StopAnnotationView.buildLabel()
 
     private class func buildLabel() -> UILabel {
         let label = UILabel.autolayoutNew()
@@ -40,7 +39,7 @@ class StopAnnotationView: MKAnnotationView {
     }
 
     private lazy var labelStack: UIStackView = {
-        return UIStackView.verticalStack(arrangedSubviews: [titleLabel, subtitleLabel])
+        return UIStackView.verticalStack(arrangedSubviews: [titleLabel])
     }()
 
     public var isHidingExtraStopAnnotationData: Bool {
@@ -69,7 +68,6 @@ class StopAnnotationView: MKAnnotationView {
         if kUseDebugColors {
             backgroundColor = .red
             titleLabel.backgroundColor = .yellow
-            subtitleLabel.backgroundColor = .orange
         }
 
         rightCalloutAccessoryView = UIButton.chevronButton
@@ -88,7 +86,6 @@ class StopAnnotationView: MKAnnotationView {
         labelStack.isHidden = true
 
         titleLabel.text = nil
-        subtitleLabel.text = nil
     }
 
     public override func prepareForDisplay() {
@@ -106,7 +103,6 @@ class StopAnnotationView: MKAnnotationView {
         image = iconFactory.buildIcon(for: stop, isBookmarked: bookmarked, traits: self.traitCollection)
 
         titleLabel.text = stop.mapTitle
-        subtitleLabel.text = stop.mapSubtitle
 
         let detailLabel = UILabel()
         detailLabel.font = .preferredFont(forTextStyle: .caption1)

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -35,6 +35,7 @@ class StopAnnotationView: MKAnnotationView {
         let label = UILabel.autolayoutNew()
         label.textAlignment = .center
         label.font = UIFont.mapAnnotationFont
+        label.numberOfLines = 2
         return label
     }
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -247,6 +247,9 @@
 /* A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49' */
 "formatters.routes_label_fmt" = "Routes: %@";
 
+/* A format string used to denote the overflowing list of routes served by this stop. e.g. 'Routes: 10, 12, 49, + 3 more */
+"formatters.routes_label_plus_more_fmt" = "Routes: %1$@, + %2$d more";
+
 /* Placeholder text for the search bar: 'Search in {REGION NAME}' */
 "formatters.search_bar_placeholder_fmt" = "Search in %@";
 
@@ -261,6 +264,30 @@
 
 /* Formatted time text for arrivals/departures. Used for accessibility labels, so be sure to spell out the word for 'minute'. Example: 7 minutes means that this event happens 7 minutes in the future. -7 minutes means 7 minutes in the past. */
 "formatters.time_fmt" = "%d minutes";
+
+/* Bus. Used for short- and long-distance bus routes. */
+"route_type.bus" = "Bus";
+
+/* Cable car. Used for street-level cable cars where the cable runs beneath the car. */
+"route_type.cable_car" = "Cable Car";
+
+/* Ferry. Used for short- and long-distance boat service. */
+"route_type.ferry" = "Ferry";
+
+/* Funicular. Any rail system designed for steep inclines. */
+"route_type.funicular" = "Funicular";
+
+/* Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable. */
+"route_type.gondola" = "Gondola";
+
+/* Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area. */
+"route_type.light_rail" = "Light Rail";
+
+/* Rail. Used for intercity or long-distance travel. */
+"route_type.rail" = "Rail";
+
+/* Subway, Metro. Any underground rail system within a metropolitan area. */
+"route_type.subway" = "Subway";
 
 /* User-facing string that means the location of the stop on the map is wrong. */
 "stop_problem_code.user_description.location_wrong" = "Location is wrong";

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -510,11 +510,21 @@ public class Formatters: NSObject {
     /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
     /// - Returns: A human-readable list of the passed-in `Route`s.
     public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
-        let routeNames = routes
+        guard routes.count > 0 else { return nil }
+
+        var routeNames = routes
             .map { $0.shortName }
             .filter { !$0.isEmpty && $0.count > 0 } // Some agencies may not provide a shortName (i.e. Washington State Ferries in Puget Sound)
             .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
-        guard !routeNames.isEmpty else { return nil }
+
+        // If we don't have any shortNames (as is the case with WA State Ferries), then use route types instead.
+        if routeNames.count == 0 {
+            routeNames = routes.map { $0.routeType }.uniqued.compactMap { routeTypeToString($0) }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        }
+
+        guard !routeNames.isEmpty else {
+            return nil
+        }
 
         if routeNames.count > limit {
             let fmt = OBALoc("formatters.routes_label_plus_more_fmt", value: "Routes: %@, + %d more", comment: "A format string used to denote the overflowing list of routes served by this stop. e.g. 'Routes: 10, 12, 49, + 3 more")
@@ -525,6 +535,31 @@ public class Formatters: NSObject {
         else {
             let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
             return String(format: fmt, routeNames.joined(separator: ", "))
+        }
+    }
+
+    /// Returns a localized, human-readable string representation of the passed-in route type value.
+    /// - Parameter routeType: A route type, like train, light rail, or bus.
+    public class func routeTypeToString(_ routeType: Route.RouteType) -> String? {
+        switch routeType {
+        case .lightRail:
+            return OBALoc("route_type.light_rail", value: "Light Rail", comment: "Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.")
+        case .subway:
+            return OBALoc("route_type.subway", value: "Subway", comment: "Subway, Metro. Any underground rail system within a metropolitan area.")
+        case .rail:
+            return OBALoc("route_type.rail", value: "Rail", comment: "Rail. Used for intercity or long-distance travel.")
+        case .bus:
+            return OBALoc("route_type.bus", value: "Bus", comment: "Bus. Used for short- and long-distance bus routes.")
+        case .ferry:
+            return OBALoc("route_type.ferry", value: "Ferry", comment: "Ferry. Used for short- and long-distance boat service.")
+        case .cableCar:
+            return OBALoc("route_type.cable_car", value: "Cable Car", comment: "Cable car. Used for street-level cable cars where the cable runs beneath the car.")
+        case .gondola:
+            return OBALoc("route_type.gondola", value: "Gondola", comment: "Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.")
+        case .funicular:
+            return OBALoc("route_type.funicular", value: "Funicular", comment: "Funicular. Any rail system designed for steep inclines.")
+        default:
+            return nil
         }
     }
 

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -504,19 +504,28 @@ public class Formatters: NSObject {
 
     /// Generates a formatted, human readable list of routes.
     ///
-    /// For example: "Routes: 10, 12, 49".
+    /// For example: "Routes: 10, 12, 49, + 3 more".
     ///
     /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
     /// - Returns: A human-readable list of the passed-in `Route`s.
-    public class func formattedRoutes(_ routes: [Route]) -> String? {
+    public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
         let routeNames = routes
             .map { $0.shortName }
-            .filter { !$0.isEmpty }     // Some agencies may not provide a shortName (i.e. Washington State Ferries in Puget Sound)
+            .filter { !$0.isEmpty && $0.count > 0 } // Some agencies may not provide a shortName (i.e. Washington State Ferries in Puget Sound)
             .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
-        guard routeNames.isEmpty == false else { return nil }
+        guard !routeNames.isEmpty else { return nil }
 
-        let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
-        return String(format: fmt, routeNames.joined(separator: ", "))
+        if routeNames.count > limit {
+            let fmt = OBALoc("formatters.routes_label_plus_more_fmt", value: "Routes: %@, + %d more", comment: "A format string used to denote the overflowing list of routes served by this stop. e.g. 'Routes: 10, 12, 49, + 3 more")
+            let shortList = routeNames.prefix(limit).joined(separator: ", ")
+            let overflowCount = routeNames.count - limit
+            return String(format: fmt, shortList, overflowCount)
+        }
+        else {
+            let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
+            return String(format: fmt, routeNames.joined(separator: ", "))
+        }
     }
 
     /// Generates an alphabetical-ordered, formatted, human readable unique list of agencies.


### PR DESCRIPTION
* Fixes #413 - Add setting to show stop number instead of other information on map
* Fixes #472 - Route Number Order Inconsistency
* Fixes #478 - Show route type on map stop annotations when route shortName is blank
* Fixes #479 - Remove directional labels from stop annotations on map