### PR TITLE
Update CI to use macOS 11/Xcode 12.5

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
           ${{ runner.os }}-spm-
 
     - name: Switch Xcode 12
-      run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
     - name: Install xcodegen
       run: brew install xcodegen
@@ -33,7 +33,7 @@ jobs:
     - name: Build OneBusAway
       run: xcodebuild clean build-for-testing
         -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=14.4,name=iPhone 8'
+        -destination 'platform=iOS Simulator,OS=14.5,name=iPhone 8'
         -quiet
 
     # Unit Test
@@ -42,7 +42,7 @@ jobs:
         -only-testing:OBAKitTests
         -project 'OBAKit.xcodeproj'
         -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=14.4,name=iPhone 8'
+        -destination 'platform=iOS Simulator,OS=14.5,name=iPhone 8'
         -resultBundlePath OBAKitTests.xcresult
         -quiet
     - name: Upload OBAKitTests results
@@ -57,7 +57,7 @@ jobs:
         -only-testing:OBAKitUITests
         -project 'OBAKit.xcodeproj'
         -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=14.4,name=iPhone 8'
+        -destination 'platform=iOS Simulator,OS=14.5,name=iPhone 8'
         -resultBundlePath OBAKitUITests.xcresult
         -quiet
 

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -14,7 +14,7 @@ options:
   generateEmptyDirectories: true
   groupSortPosition: top
   deploymentTarget:
-    iOS: "14.4"
+    iOS: "14.5"
 
 ############
 # App

--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -209,25 +209,14 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
             var configuration = sectionModel.configuration.listConfiguration()
             configuration.headerMode = sectionModel.hasHeader ? .firstItemInSection : .none
 
-            // #398 - list view separators always appears on iOS 14.4
-            // Necessary for CI compatibility. Remove check when CI is fixed.
-            // Also, remove availability checks in OBAListRowSeparatorConfiguration.swift.
-            //
-            // CI uses Xcode 12.4 (swift 5.3), which doesn't contain iOS 14.5 API,
-            // causing the code below to fail to compile.
-            // The block below builds on Xcode 12.5+ (swift 5.4).
-            #if swift(>=5.4)
-            if #available(iOS 14.5, *) {
-                configuration.separatorConfiguration = .init(listAppearance: .insetGrouped)
-                configuration.itemSeparatorHandler = { [unowned self] (indexPath, listConfiguration) -> UIListSeparatorConfiguration in
-                    guard let item = self.itemForIndexPath(indexPath) else { return listConfiguration }
+            configuration.separatorConfiguration = .init(listAppearance: .insetGrouped)
+            configuration.itemSeparatorHandler = { [unowned self] (indexPath, listConfiguration) -> UIListSeparatorConfiguration in
+                guard let item = self.itemForIndexPath(indexPath) else { return listConfiguration }
 
-                    var configuration = listConfiguration
-                    configuration.applying(item.separatorConfiguration)
-                    return configuration
-                }
+                var configuration = listConfiguration
+                configuration.applying(item.separatorConfiguration)
+                return configuration
             }
-            #endif
 
             configuration.leadingSwipeActionsConfigurationProvider = self.leadingSwipeActions
             configuration.trailingSwipeActionsConfigurationProvider = self.trailingSwipeActions

--- a/OBAKit/Controls/ListView/Rows/OBAListRowSeparatorConfiguration.swift
+++ b/OBAKit/Controls/ListView/Rows/OBAListRowSeparatorConfiguration.swift
@@ -25,9 +25,6 @@ public struct OBAListRowSeparatorConfiguration: Equatable {
     }
 }
 
-// #398 - list view separators always appears on iOS 14.4
-#if swift(>=5.4)
-@available(iOS 14.5, *)
 extension UIListSeparatorConfiguration {
     mutating func applying(_ obaConfiguration: OBAListRowSeparatorConfiguration) {
         let visibility: UIListSeparatorConfiguration.Visibility = obaConfiguration.showsSeparator ? .automatic : .hidden
@@ -39,4 +36,3 @@ extension UIListSeparatorConfiguration {
         self.bottomSeparatorInsets = obaConfiguration.insets
     }
 }
-#endif


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/398 - List view separators always appears on iOS 14.4

This is awaiting us being granted access to GitHub's macOS 11 image on their CI system. I submitted a request on Aug 14, and it looks like they're processing requests every couple of business days.