### PR TITLE
Only load ArrivalDeparture data for trip bookmarks

### DIFF
--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -56,7 +56,10 @@ public class BookmarkDataLoader: NSObject {
     }
 
     private func loadData(bookmark: Bookmark) {
-        guard let apiService = application.restAPIService else { return }
+        guard
+            let apiService = application.restAPIService,
+            bookmark.isTripBookmark
+        else { return }
 
         let op = apiService.getArrivalsAndDeparturesForStop(id: bookmark.stopID, minutesBefore: 0, minutesAfter: 60)
         op.complete { [weak self] result in


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/497 - Bookmarks tab should only load network data for trip bookmarks