### PR TITLE
Improve standard visibility of StopArrivalView's minutes

### DIFF
--- a/OBAKit/Stops/StopArrivalView.swift
+++ b/OBAKit/Stops/StopArrivalView.swift
@@ -187,6 +187,7 @@ class StopArrivalView: UIView {
         addSubview(outerStackView)
         outerStackView.pinToSuperview(.edges)
 
+        minutesLabel.font = .preferredFont(forTextStyle: .headline)
         configureView(for: traitCollection)
 
         if kUseDebugColors {

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -130,10 +130,18 @@ public class ThemeColors: NSObject {
         departureEarly = .systemRed
         departureEarlyBackground = .systemRed
 
-        // Hex #129900 -- UIColor.systemGreen is too bright for small text, which StopViewController uses.
+        // Hex #129900 is better visibility for small text in light mode.
+        // UIColor.systemGreen is better visibility for small text in dark mode.
         // See #506 and #508 for user feedback.
-        departureOnTime = UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
-        departureOnTimeBackground = UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
+        let departureOnTimeColor = UIColor { traitCollection in
+            if traitCollection.userInterfaceStyle == .dark {
+                return UIColor.systemGreen
+            } else {
+                return UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
+            }
+        }
+        departureOnTime = departureOnTimeColor
+        departureOnTimeBackground = departureOnTimeColor
 
         departureUnknown = .label
         departureUnknownBackground = .systemGray

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -130,8 +130,10 @@ public class ThemeColors: NSObject {
         departureEarly = .systemRed
         departureEarlyBackground = .systemRed
 
-        departureOnTime = .systemGreen
-        departureOnTimeBackground = .systemGreen
+        // Hex #129900 -- UIColor.systemGreen is too bright for small text, which StopViewController uses.
+        // See #506 and #508 for user feedback.
+        departureOnTime = UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
+        departureOnTimeBackground = UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
 
         departureUnknown = .label
         departureUnknownBackground = .systemGray


### PR DESCRIPTION
"Standard" means regardless of iOS accessibility settings.
Fixes #508 and #506

| Before (no `.headline` font) | After (yes `.headline` font) |
| -- | -- |
| ![](https://user-images.githubusercontent.com/22162410/132104553-da4aa529-3d3e-4cfc-935f-8a446a765653.png) | ![](https://user-images.githubusercontent.com/22162410/132104554-2050533f-bf82-406d-a487-55d537a735e5.png) |


