### PR TITLE
Consolidate LoadMore button in StopViewController

### DIFF
--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -365,7 +365,9 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
     }
 
     public func scrollTo(section: OBAListViewSection, at position: UICollectionView.ScrollPosition, animated: Bool) {
-        guard let lastItemOfSection = section.contents.last,
+        let sectionIdentifiers = diffableDataSource.snapshot().sectionIdentifiers
+        guard let matchingSection = sectionIdentifiers.first(where: { $0.id == section.id }),
+              let lastItemOfSection = matchingSection.contents.last,
               let indexPath = diffableDataSource.indexPath(for: lastItemOfSection) else { return }
 
         self.scrollToItem(at: indexPath, at: position, animated: animated)

--- a/OBAKit/Stops/Sections/Generic/ErrorCaptionItem.swift
+++ b/OBAKit/Stops/Sections/Generic/ErrorCaptionItem.swift
@@ -21,11 +21,18 @@ struct ErrorCaptionItem: OBAListViewItem {
         return .list(config, [])
     }
 
+    var separatorConfiguration: OBAListRowSeparatorConfiguration { .hidden() }
+
     var id: UUID
     var text: String
 
     init(id: UUID = UUID(), error: Error) {
         self.id = id
         self.text = error.localizedDescription
+    }
+
+    init(id: UUID = UUID(), text: String) {
+        self.id = id
+        self.text = text
     }
 }

--- a/OBAKit/Stops/Sections/Generic/FootnoteItem.swift
+++ b/OBAKit/Stops/Sections/Generic/FootnoteItem.swift
@@ -13,16 +13,24 @@ struct FootnoteItem: OBAListViewItem {
         config.textProperties.font = .preferredFont(forTextStyle: .footnote)
         config.textProperties.color = .secondaryLabel
         config.textProperties.alignment = .center
+
+        config.secondaryTextProperties.font = .preferredFont(forTextStyle: .footnote)
+        config.secondaryTextProperties.color = .tertiaryLabel
+        config.secondaryTextProperties.alignment = .center
+
         config.text = self.text
+        config.secondaryText = self.subtitle
 
         return .list(config, [])
     }
 
     var id: UUID
     var text: String
+    var subtitle: String?
 
-    init(id: UUID = UUID(), text: String) {
+    init(id: UUID = UUID(), text: String, subtitle: String? = nil) {
         self.id = id
         self.text = text
+        self.subtitle = subtitle
     }
 }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -549,7 +549,11 @@ public class StopViewController: UIViewController,
         sections.append(stopHeaderSection)
         sections.append(serviceAlertsSection)
         sections.append(contentsOf: stopArrivalsSection)
-        sections.append(loadMoreSection)
+
+        if self.stopPreferences.sortType == .route {
+            sections.append(listViewSection(for: .loadMoreButton, title: nil, items: loadMoreItems))
+        }
+
         sections.append(dataAttributionSection)
         return sections.compactMap({ $0 })
     }
@@ -660,6 +664,7 @@ public class StopViewController: UIViewController,
             shareAction: shareAction)
     }
 
+    /// - parameter groupRoute: If `groupRoute` is `nil`, this section will also include a "Load More" button at the end of its contents.
     func sectionForGroup(groupRoute: Route?, arrDeps: [ArrivalDeparture]) -> OBAListViewSection {
         let sectionID: String
         let sectionName: String?
@@ -678,6 +683,10 @@ public class StopViewController: UIViewController,
             .sorted(by: \.arrivalDepartureDate)
             .map { $0.typeErased }
         addWalkTimeRow(to: &items)
+
+        if groupRoute == nil {
+            items.append(contentsOf: loadMoreItems)
+        }
 
         return listViewSection(for: .arrivalDepartures(suffix: sectionID), title: sectionName, items: items)
     }
@@ -807,20 +816,20 @@ public class StopViewController: UIViewController,
 
     // MARK: - Data/Load More
     private var shouldScrollToBottomOfArrivalsDeparuresOnDataLoad = false
-    private var loadMoreSection: OBAListViewSection {
+    private var loadMoreItems: [AnyOBAListViewItem] {
         var items: [AnyOBAListViewItem] = []
 
         if let error = operationError {
             items.append(ErrorCaptionItem(error: error).typeErased)
         }
 
-        let loadMoreButton = MessageButtonItem(asLoadMoreButtonWithID: "load_more_item", showActivityIndicatorOnSelect: true) { [weak self] _ in
+        let loadMoreButton = MessageButtonItem(asLoadMoreButtonWithID: UUID().uuidString, showActivityIndicatorOnSelect: true) { [weak self] _ in
             self?.shouldScrollToBottomOfArrivalsDeparuresOnDataLoad = true
             self?.loadMoreDepartures()
         }
         items.append(loadMoreButton.typeErased)
 
-        return listViewSection(for: .loadMoreButton, title: nil, items: items)
+        return items
     }
 
     fileprivate var dataAttributionSection: OBAListViewSection {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -808,10 +808,6 @@ public class StopViewController: UIViewController,
     // MARK: - Data/Load More
     private var shouldScrollToBottomOfArrivalsDeparuresOnDataLoad = false
     private var loadMoreSection: OBAListViewSection {
-        let beforeTime = Date().addingTimeInterval(Double(minutesBefore) * -60.0)
-        let afterTime = Date().addingTimeInterval(Double(minutesAfter) * 60.0)
-        let footerText = application.formatters.formattedDateRange(from: beforeTime, to: afterTime)
-
         var items: [AnyOBAListViewItem] = []
 
         if let error = operationError {
@@ -823,16 +819,19 @@ public class StopViewController: UIViewController,
             self?.loadMoreDepartures()
         }
         items.append(loadMoreButton.typeErased)
-        items.append(FootnoteItem(text: footerText).typeErased)
 
         return listViewSection(for: .loadMoreButton, title: nil, items: items)
     }
 
     fileprivate var dataAttributionSection: OBAListViewSection {
         let agencies = Formatters.formattedAgenciesForRoutes(self.stop!.routes)
-
         let dataAttributionStringFormat = OBALoc("stop_controller.data_attribution_format", value: "Data provided by %@", comment: "A string listing the data providers (agencies) for this stop's data. It contains one or more providers separated by commas. e.g. Data provided by King County Metro, Sound Transit")
-        let dataAttribution = FootnoteItem(text: String(format: dataAttributionStringFormat, agencies))
+
+        let dataDateRangeBeforeTime = Date().addingTimeInterval(Double(minutesBefore) * -60.0)
+        let dataDateRangeAfterTime = Date().addingTimeInterval(Double(minutesAfter) * 60.0)
+        let dataDateRangeText = application.formatters.formattedDateRange(from: dataDateRangeBeforeTime, to: dataDateRangeAfterTime)
+
+        let dataAttribution = FootnoteItem(text: String(format: dataAttributionStringFormat, agencies), subtitle: dataDateRangeText)
 
         var section = listViewSection(for: .dataAttribution, title: nil, items: [dataAttribution])
         section.configuration.backgroundColor = .clear

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -590,7 +590,7 @@ public class StopViewController: UIViewController,
         // Related 2: https://github.com/OneBusAway/OBAKit/issues/389#issuecomment-867014676
 
         if self.shouldScrollToBottomOfArrivalsDeparuresOnDataLoad {
-            listView.scrollTo(section: loadMoreSection, at: .top, animated: false)
+            listView.scrollTo(section: dataAttributionSection, at: .bottom, animated: false)
             shouldScrollToBottomOfArrivalsDeparuresOnDataLoad = false
         }
         // This method will set up a UI affordance for showing the user how

--- a/OBAKitCore/Collections/ActivityIndicatedButton.swift
+++ b/OBAKitCore/Collections/ActivityIndicatedButton.swift
@@ -67,6 +67,13 @@ public class ActivityIndicatedButton: UIView {
         return button
     }()
 
+    fileprivate let chevron: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "chevron.compact.down"))
+        view.preferredSymbolConfiguration = UIImage.SymbolConfiguration(textStyle: .headline)
+        view.tintColor = ThemeColors.shared.brand
+        return view
+    }()
+
     fileprivate let activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView(style: .medium)
         activityIndicator.hidesWhenStopped = true
@@ -80,7 +87,8 @@ public class ActivityIndicatedButton: UIView {
         let stackView = UIStackView.stack(axis: .vertical,
                                           distribution: .fill,
                                           alignment: .center,
-                                          arrangedSubviews: [button, activityIndicator])
+                                          arrangedSubviews: [button, chevron, activityIndicator])
+        stackView.setCustomSpacing(0, after: button)
         addSubview(stackView)
         stackView.pinToSuperview(.edges)
 
@@ -98,17 +106,20 @@ public class ActivityIndicatedButton: UIView {
 
     public func showActivityIndicator() {
         self.button.isHidden = true
+        self.chevron.isHidden = true
         self.activityIndicator.startAnimating()
     }
 
     public func hideActivityIndicator() {
         self.button.isHidden = false
+        self.chevron.isHidden = false
         self.activityIndicator.stopAnimating()
     }
 
     func configureView() {
         self.activityIndicator.stopAnimating()
         self.button.isHidden = false
+        self.chevron.isHidden = false
 
         // If there is no config, then hide the view to prevent Voiceover interaction.
         self.isHidden = self.config == nil


### PR DESCRIPTION
Fixes #475

Moves data load time to the data attribution footer (iOS "Increase Contrast" improves the visibility of data data range text).

| Sort by Time | Sort by Route |
| -- | -- |
| ![sort by time](https://user-images.githubusercontent.com/22162410/132105950-779b8f2d-e77e-4a02-8c43-aa6dac488e80.png) | ![sort by route](https://user-images.githubusercontent.com/22162410/132105953-3e3d1c10-4179-4a18-ad7e-923775566890.png) |

| Sort by Time with Error | Sort by Route with Error |
| -- | -- | 
| ![sort by time with error](https://user-images.githubusercontent.com/22162410/132105955-5ac94c8e-1e14-4a9f-88c7-391fcd26c443.png) | ![sort by error with error](https://user-images.githubusercontent.com/22162410/132105954-43cecf64-4dbc-4dcc-be87-5cd24a36e809.png) | 
