### PR TITLE
Adds `#if DEBUG` around SwiftUI Preview Content

### DIFF
--- a/OBAKit/Mapping/MapStatusView.swift
+++ b/OBAKit/Mapping/MapStatusView.swift
@@ -191,6 +191,8 @@ class MapStatusView: UIView {
 
 // MARK: - Previews
 
+#if DEBUG
+
 extension MapStatusView.State: Identifiable, CaseIterable {
     var id: String { return "\(self)"}
 }
@@ -212,3 +214,5 @@ struct MapStatusView_Previews: PreviewProvider {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Bizarrely, this caused problems archiving on an M1 Mac, but didn't on an x86.