### PR TITLE
Add equatable conformance for Open311Server object

### DIFF
--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -486,4 +486,11 @@ public class Open311Server: NSObject, Codable {
         try container.encode(apiKey, forKey: .apiKey)
         try container.encode(baseURL, forKey: .baseURL)
     }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? Open311Server else { return false }
+        return jurisdictionID == rhs.jurisdictionID &&
+            apiKey == rhs.apiKey &&
+            baseURL == rhs.baseURL
+    }
 }


### PR DESCRIPTION
When comparing equality of Region, `Open311Server` does not have an equatable conformance, causing the equality check to fail and causing the map to zoom out on the "new" region. As of now, it seems like only Tampa has open 311, which is why this is only reproducible in Tampa Bay.

Fixes #504.