### PR TITLE
Use xcresulttool instead of uploading artifact file when CI fails

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build OneBusAway
       run: xcodebuild clean build-for-testing
         -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 8'
+        -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 13'
         -quiet
 
     # Unit Test
@@ -42,28 +42,26 @@ jobs:
         -only-testing:OBAKitTests
         -project 'OBAKit.xcodeproj'
         -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 8'
+        -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 13'
         -resultBundlePath OBAKitTests.xcresult
         -quiet
-    - name: Upload OBAKitTests results
-      uses: actions/upload-artifact@v2
-      with:
-        name: OBAKitTests_xcresult
-        path: OBAKitTests.xcresult
 
+    # note 2021-10-22 (@ualch9): disabled for now, since there are no UI tests.
     # UI Test
-    - name: OBAKit UI Test
-      run: xcodebuild test-without-building
-        -only-testing:OBAKitUITests
-        -project 'OBAKit.xcodeproj'
-        -scheme 'App'
-        -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 8'
-        -resultBundlePath OBAKitUITests.xcresult
-        -quiet
-
+    #- name: OBAKit UI Test
+    #  run: xcodebuild test-without-building
+    #    -only-testing:OBAKitUITests
+    #    -project 'OBAKit.xcodeproj'
+    #    -scheme 'App'
+    #    -destination 'platform=iOS Simulator,OS=15.0,name=iPhone 8'
+    #    -resultBundlePath OBAKitUITests.xcresult
+    #    -quiet
+    
     # Upload results
-    - name: Upload OBAKitUITests results
-      uses: actions/upload-artifact@v2
+    - uses: kishikawakatsumi/xcresulttool@v1.0.3
+      if: ${{ success() || failure() }}
       with:
-        name: OBAKitUITests_xcresult
-        path: OBAKitUITests.xcresult
+        path: |
+          OBAKitTests.xcresult
+    #      OBAKitUITests.xcresult # note 2021-10-22 (@ualch9): disabled for now, since there are no UI tests.
+


### PR DESCRIPTION
- Use https://github.com/kishikawakatsumi/xcresulttool to generate a test report on GH actions
    - Example output: https://github.com/OneBusAway/onebusaway-ios/runs/3985637126
- Fixes #297
- Disables UI testing for CI
- Updates simulator from iPhone 8 → iPhone 13