### PR TITLE
ISSUES-557: Editing a bookmark prompts "Duplicate bookmark" on Save

### DIFF
--- a/OBAKit/Bookmarks/EditBookmarkViewController.swift
+++ b/OBAKit/Bookmarks/EditBookmarkViewController.swift
@@ -216,20 +216,7 @@ class EditBookmarkViewController: FormViewController, AddGroupAlertDelegate {
         let faveVal = form.values()[showInTodayViewTag]
         bookmark.isFavorite = faveVal as! Bool // swiftlint:disable:this force_cast
 
-        if application.userDataStore.checkForDuplicates(bookmark: bookmark) {
-            let alert = UIAlertController(
-                title: OBALoc("edit_bookmark_controller.duplicate_alert.title", value: "Duplicate Bookmark", comment: "The title of an alert telling the user that they have already bookmarked this thing. Noun form of 'duplicate', not the verb."),
-                message: OBALoc("edit_bookmark_controller.duplicate_alert.body", value: "You already have this bookmarked. Did you mean to create a duplicate?", comment: "Body of an alert telling the user they have already bookmarked this thing."), preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel, handler: nil))
-            alert.addAction(UIAlertAction(title: OBALoc("edit_book_controller.duplicate_alert.affirmative_button", value: "Create Duplicate", comment: "Indicates that the user wants to create a duplicate bookmark."), style: .default, handler: { _ in
-                self.addBookmarkToStore(bookmark, isNewBookmark: addMode)
-            }))
-            present(alert, animated: true, completion: nil)
-        }
-        else {
-            self.addBookmarkToStore(bookmark, isNewBookmark: addMode)
-        }
+        self.addBookmarkToStore(bookmark, isNewBookmark: addMode)
     }
 
     private func addBookmarkToStore(_ bookmark: Bookmark, isNewBookmark: Bool) {


### PR DESCRIPTION
Issues: https://github.com/OneBusAway/onebusaway-ios/issues/557

Description:
Remove the duplicated bookmark check so it does not prompt the alert asking if the intention is to duplicate bookmark. If the user did not change anything in the bookmark, on Save, it should just save the unedited bookmark.

