### PR TITLE
Onboarder manages bulletin manager from main thread

### DIFF
--- a/OBAKit/Onboarding/Onboarder.swift
+++ b/OBAKit/Onboarding/Onboarder.swift
@@ -49,7 +49,9 @@ class Onboarder: NSObject {
 
     private func refreshUI() {
         guard state != .complete else {
-            bulletinManager.dismissBulletin()
+            DispatchQueue.main.async {
+                self.bulletinManager.dismissBulletin()
+            }
             return
         }
 


### PR DESCRIPTION
Several App Store crashes can be traced back to using BLTNItemManager from a non-main thread. This PR fixes Onboarder's illegal usage of bulletin board by forcing it onto main thread.