### PR TITLE
Improve map sheet UX for VoiceOver users

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -76,10 +76,6 @@ public class MapRegionManager: NSObject,
         mapView.showsUserLocation = true
         mapView.isRotateEnabled = false
 
-        // Disables voiceover interacting with map elements (such as streets and POIs).
-        // See #431.
-        mapView.accessibilityElementsHidden = true
-
         return mapView
     }()
 

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -179,6 +179,12 @@ public class MapViewController: UIViewController,
         }
 
         mapRegionManager.mapView.setCenterCoordinate(centerCoordinate: userLocation.coordinate, zoomLevel: zoomLevel, animated: true)
+
+        // It is possible to activate the center map button via Voiceover. When the user
+        // centers the map on their location, partially collapse the sheet to enable mapview interaction.
+        if floatingPanel.position == .full {
+            floatingPanel.move(to: .half, animated: true)
+        }
     }
 
     @objc func didTapMapStatus(_ sender: Any) {

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -410,6 +410,10 @@ public class MapViewController: UIViewController,
         statusOverlay.isHidden = vc.position == .full
         mapPanelController.listView.accessibilityElementsHidden = floatingPanelPositionIsCollapsed
 
+        // Disables voiceover interacting with map elements (such as streets and POIs).
+        // See #431.
+        mapRegionManager.mapView.accessibilityElementsHidden = !floatingPanelPositionIsCollapsed
+
         if mapPanelController.inSearchMode && floatingPanelPositionIsCollapsed {
             mapPanelController.exitSearchMode()
         }


### PR DESCRIPTION
Oops, didn't mean to merge #575 yet, shouldve marked it as a draft.

Beta feedback on #575, summarized:
When the sheet is fully expanded, the prompt is confusing for Voiceover users, since the map is now inaccessible for Voiceover (see screenshot). Additionally, the map should not be disabled for all voiceover users, since low-vision users are still able to interact with the map visually.

Stuff to do:
- [x] When the sheet is fully expanded, disable mapview interactions. When the sheet is partially collapsed, enable mapview.
- [x] When the user centers the map on their location, partially collapse the sheet to enable mapview interaction.
- ~[ ] Add a button to recent stops list to "expand" the search radius if no stops were loaded (via `perferredLoadDataRegionFudgeFactor` from commit ae73f03)~ removed from this PR, see #578 

![image](https://user-images.githubusercontent.com/22162410/144118055-c86353e3-7cd2-4de6-8f14-3c3e38043b2a.png)
