### PR TITLE
Make RESTAPIResponse text property optional

### DIFF
--- a/OBAKitCore/Models/REST/RESTAPIResponse.swift
+++ b/OBAKitCore/Models/REST/RESTAPIResponse.swift
@@ -16,7 +16,7 @@ import Foundation
 public class CoreRESTAPIResponse: NSObject, Decodable {
     public let code: Int
     public let currentTime: Int?
-    public let text: String
+    public let text: String?
     public let version: Int
 
     fileprivate enum CodingKeys: String, CodingKey {
@@ -27,7 +27,7 @@ public class CoreRESTAPIResponse: NSObject, Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         code = try container.decode(Int.self, forKey: .code)
         currentTime = try container.decodeIfPresent(Int.self, forKey: .currentTime)
-        text = try container.decode(String.self, forKey: .text)
+        text = try container.decodeIfPresent(String.self, forKey: .text)
         version = try container.decode(Int.self, forKey: .version)
     }
 }


### PR DESCRIPTION
This fixes an issue relating to Sound Transit's server cutover (2021-12-13) from onsite to cloud hosting. The API was missing a `text` property, which caused the iOS app to fail parsing. Although this was eventually fixed on the server by including the `text` property, this PR will ensure that this specific issue won't occur again, such as if another transit agency makes a server side change.