### PR TITLE
Disallow the app to “Always” get user location

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -43,7 +43,6 @@ targets:
           - fb
           - twitter
           - comgooglemaps
-        NSLocationAlwaysAndWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
         NSLocationWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
         NSLocationTemporaryUsageDescriptionDictionary:
           MapStatusView: See where you are in relation to transit, and help you navigate more easily.

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -150,7 +150,8 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Answers the question of whether the device GPS can be consulted for location data.
     public var isLocationUseAuthorized: Bool {
-        return locationManager.isLocationServicesEnabled && authorizationStatus == .authorizedWhenInUse
+        return locationManager.isLocationServicesEnabled &&
+            (authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways)
     }
 
     @available(iOS 14, *)


### PR DESCRIPTION
We don't want the user's location if they don't have the app open.

Fixes #616