### PR TITLE
Speculative fix for “DUPLICATE_ITEM_IDENTIFIERS” and “EQUAL_IDENTIFIERS_HAVE_DIFFERENT_HASH_VALUES” crasher

### DIFF
--- a/OBAKit/Alerts/AgencyAlertsViewController.swift
+++ b/OBAKit/Alerts/AgencyAlertsViewController.swift
@@ -102,7 +102,7 @@ class AgencyAlertsViewController: UIViewController,
 
     // MARK: - Preview
 
-    var previewingVC: (identifier: String, vc: UIViewController)?
+    var previewingVC: (identifier: UUID, vc: UIViewController)?
 
     func previewAlert(_ alert: TransitAlertDataListViewModel) -> UIViewController? {
         let viewController: UIViewController

--- a/OBAKit/Alerts/TransitAlertViewModel.swift
+++ b/OBAKit/Alerts/TransitAlertViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 struct TransitAlertDataListViewModel: OBAListViewItem {
     let transitAlert: TransitAlertViewModel
 
-    let id: String
+    let id: UUID = UUID()
     let title: String
     let body: String
     let localizedURL: URL?
@@ -51,7 +51,6 @@ struct TransitAlertDataListViewModel: OBAListViewItem {
         onSelectAction: OBAListViewAction<TransitAlertDataListViewModel>? = nil)
     where TA: Hashable {
         self.transitAlert = transitAlert
-        self.id = "\(transitAlert.hashValue)"
         self.title = transitAlert.title(forLocale: locale) ?? ""
         self.body = transitAlert.body(forLocale: locale) ?? ""
         self.localizedURL = transitAlert.url(forLocale: locale)

--- a/OBAKit/Controls/ListView/Helpers/OBA/AgencyAlertListViewConverters.swift
+++ b/OBAKit/Controls/ListView/Helpers/OBA/AgencyAlertListViewConverters.swift
@@ -33,7 +33,7 @@ extension AgencyAlertListViewConverters where Self: UIViewController {
                 return TransitAlertDataListViewModel(alert, isUnread: isUnread, forLocale: Locale.current, onSelectAction: presentAlertAction)
             }
 
-            let alerts = viewModels.uniqued.sorted(by: \.title) // remove duplicates
+            let alerts = viewModels.sorted(by: \.title) // remove duplicates
             return OBAListViewSection(id: "agency_alerts_\(group.key)", title: group.key, contents: alerts)
         }.sorted(by: \.id)
     }
@@ -47,7 +47,7 @@ extension AgencyAlertListViewConverters where Self: UIViewController {
     /// - Returns: An `OBAListViewSection` representing the array of `ServiceAlert`s for use with OBAListView.
     func listSection(serviceAlerts: [ServiceAlert], showSectionTitle: Bool, sectionID: String = "service_alerts") -> OBAListViewSection {
         let onSelectAction: OBAListViewAction<TransitAlertDataListViewModel> = { [weak self] item in self?.presentAlert(item) }
-        let items = serviceAlerts.map { TransitAlertDataListViewModel($0, isUnread: false, forLocale: .current, onSelectAction: onSelectAction) }.uniqued
+        let items = serviceAlerts.map { TransitAlertDataListViewModel($0, isUnread: false, forLocale: .current, onSelectAction: onSelectAction) }
         let title: String?
         if showSectionTitle {
             if items.count > 1 {

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -205,7 +205,7 @@ class MapFloatingPanelController: VisualEffectViewController,
         if stops.count > 0 {
             let rows = stops.map { stop -> StopViewModel in
                 let onSelect: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
-                    self.mapPanelDelegate?.mapPanelController(self, didSelectStop: viewModel.id)
+                    self.mapPanelDelegate?.mapPanelController(self, didSelectStop: viewModel.stopID)
                 }
 
                 return StopViewModel(withStop: stop, onSelect: onSelect, onDelete: nil)
@@ -231,7 +231,7 @@ class MapFloatingPanelController: VisualEffectViewController,
         guard let stopViewModel = item.as(StopViewModel.self) else { return nil }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.id)
+            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.stopID)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -15,7 +15,8 @@ struct StopViewModel: OBAListViewItem {
     let name: String
     let subtitle: String?
 
-    let id: Stop.ID
+    let id: UUID = UUID()
+    let stopID: Stop.ID
     let routeType: Route.RouteType
 
     // Hide icon if there is only one type of route in the list
@@ -45,17 +46,23 @@ struct StopViewModel: OBAListViewItem {
         self.subtitle = stop.subtitle
         self.routeType = stop.prioritizedRouteTypeForDisplay
 
-        self.id = stop.id
+        self.stopID = stop.id
         self.onSelectAction = selectAction
         self.onDeleteAction = deleteAction
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(stopID)
+        hasher.combine(name)
+        hasher.combine(routeType)
     }
 
     static func == (lhs: StopViewModel, rhs: StopViewModel) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.id == rhs.id &&
+            lhs.stopID == rhs.stopID &&
+            lhs.name == rhs.name &&
+            lhs.routeType == rhs.routeType
     }
 }
 

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -131,7 +131,7 @@ public class RecentStopsViewController: UIViewController,
 
         let rows = stops.map { stop -> StopViewModel in
             let onSelect: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
-                self.application.viewRouter.navigateTo(stopID: viewModel.id, from: self)
+                self.application.viewRouter.navigateTo(stopID: viewModel.stopID, from: self)
             }
 
             let onDelete: OBAListViewAction<StopViewModel> = { [unowned self] _ in
@@ -140,7 +140,7 @@ public class RecentStopsViewController: UIViewController,
             }
 
             return StopViewModel(withStop: stop, onSelect: onSelect, onDelete: onDelete)
-        }.uniqued
+        }
 
         let title = application.userDataStore.alarms.count > 0 ? Strings.recentStops : nil
         return OBAListViewSection(id: "recent_stops", title: title, contents: rows)
@@ -171,7 +171,7 @@ public class RecentStopsViewController: UIViewController,
         guard let stopViewModel = item.as(StopViewModel.self) else { return nil }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.id)
+            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.stopID)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Reporting/ReportProblemViewController.swift
+++ b/OBAKit/Reporting/ReportProblemViewController.swift
@@ -114,11 +114,11 @@ class ReportProblemViewController: OperationController<DecodableOperation<RESTAP
 
         let rows = arrivalsAndDepartures.map { ArrivalDepartureItem(arrivalDeparture: $0, isAlarmAvailable: false, isDeepLinkingAvailable: false, onSelectAction: onSelectArrivalDeparture) }
 
-        return OBAListViewSection(id: "vehicle_problem_section", title: OBALoc("report_problem_controller.vehicle_problem.header", value: "Problem with a Vehicle at the Stop", comment: "A table header in the 'Report Problem' view controller."), contents: rows.uniqued)
+        return OBAListViewSection(id: "vehicle_problem_section", title: OBALoc("report_problem_controller.vehicle_problem.header", value: "Problem with a Vehicle at the Stop", comment: "A table header in the 'Report Problem' view controller."), contents: rows)
     }
 
     func onSelectArrivalDeparture(_ arrivalDepartureItem: ArrivalDepartureItem) {
-        guard let arrDep = data?.arrivalsAndDepartures.first(where: { $0.id == arrivalDepartureItem.id }) else { return }
+        guard let arrDep = data?.arrivalsAndDepartures.first(where: { $0.id == arrivalDepartureItem.arrivalDepartureID }) else { return }
         let controller = VehicleProblemViewController(application: self.application, arrivalDeparture: arrDep)
         self.navigationController?.pushViewController(controller, animated: true)
     }

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -120,7 +120,7 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
         }
 
         let tapHandler = { [unowned self] (vm: StopViewModel) -> Void in
-            self.application.viewRouter.navigateTo(stopID: vm.id, from: self)
+            self.application.viewRouter.navigateTo(stopID: vm.stopID, from: self)
         }
 
         return directions.sorted(by: \.key).map { (direction, _) -> OBAListViewSection in

--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
@@ -22,7 +22,8 @@ struct ArrivalDepartureItem: OBAListViewItem {
     var bookmarkAction: OBAListViewAction<ArrivalDepartureItem>?
     var shareAction: OBAListViewAction<ArrivalDepartureItem>?
 
-    let id: String
+    let id: UUID = UUID()
+    let arrivalDepartureID: String
     let routeID: RouteID
     let stopID: StopID
 
@@ -102,7 +103,7 @@ struct ArrivalDepartureItem: OBAListViewItem {
          bookmarkAction: OBAListViewAction<ArrivalDepartureItem>? = nil,
          shareAction: OBAListViewAction<ArrivalDepartureItem>? = nil) {
 
-        self.id = arrivalDeparture.id
+        self.arrivalDepartureID = arrivalDeparture.id
         self.routeID = arrivalDeparture.routeID
         self.stopID = arrivalDeparture.stopID
         self.name = arrivalDeparture.routeAndHeadsign
@@ -131,6 +132,7 @@ struct ArrivalDepartureItem: OBAListViewItem {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(arrivalDepartureID)
         hasher.combine(routeID)
         hasher.combine(stopID)
         hasher.combine(name)
@@ -140,7 +142,9 @@ struct ArrivalDepartureItem: OBAListViewItem {
     }
 
     static func == (lhs: ArrivalDepartureItem, rhs: ArrivalDepartureItem) -> Bool {
-        return lhs.routeID == rhs.routeID &&
+        return lhs.id == rhs.id &&
+            lhs.arrivalDepartureID == rhs.arrivalDepartureID &&
+            lhs.routeID == rhs.routeID &&
             lhs.stopID == rhs.stopID &&
             lhs.name == rhs.name &&
             lhs.scheduledDate == rhs.scheduledDate &&

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -687,8 +687,7 @@ public class StopViewController: UIViewController,
 
         let arrDepItems = arrDeps.map { arrivalDepartureItem(for: $0) }
 
-        // Sometimes stopArrivals will respond with duplicate entries, so get rid of them.
-        var items = arrDepItems.uniqued
+        var items = arrDepItems
             .sorted(by: \.arrivalDepartureDate)
             .map { $0.typeErased }
         addWalkTimeRow(to: &items)
@@ -709,7 +708,7 @@ public class StopViewController: UIViewController,
     //           revisit this decision.
 
     func arrivalDeparture(forViewModel viewModel: ArrivalDepartureItem) -> ArrivalDeparture? {
-        return stopArrivals?.arrivalsAndDepartures.filter({ $0.id == viewModel.id }).first
+        return stopArrivals?.arrivalsAndDepartures.filter({ $0.id == viewModel.arrivalDepartureID }).first
     }
 
     // MARK: Actions
@@ -760,7 +759,7 @@ public class StopViewController: UIViewController,
     private func previewStopArrival(_ viewModel: ArrivalDepartureItem) -> UIViewController? {
         guard let arrivalDeparture = self.arrivalDeparture(forViewModel: viewModel) else { return nil }
         let vc = TripViewController(application: self.application, arrivalDeparture: arrivalDeparture)
-        self.previewingVC = (arrivalDeparture.id, vc)
+        self.previewingVC = (viewModel.id, vc)
         return vc
     }
 
@@ -917,7 +916,7 @@ public class StopViewController: UIViewController,
     /// The view controller currently being previewed (via context menu).
     /// The identifier is a string (ideally a `UUID`) used when the user commits the context menu to ensure
     /// that the `previewingVC` is actually the view controller that the user committed to.
-    var previewingVC: (identifier: String, vc: UIViewController)?
+    var previewingVC: (identifier: UUID, vc: UIViewController)?
     public func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
         if let arrDepItem = item.as(ArrivalDepartureItem.self) {
             return stopArrivalContextMenu(arrDepItem)


### PR DESCRIPTION
View models now has a guaranteed unique identifier (by UUID during initialization). This is fine for now, since we are directly consuming API results, but at the cost of potentially causing the entire table view to update when one item changes.

Ultimately, `OBAListView` implementation is flawed and requires a bit of fixing, so this is a stop gap.