### PR TITLE
needsToOnboard checks shouldPerformMigration instead of hasDataToMigrate

### DIFF
--- a/Apps/OneBusAway/Onboarding/OnboardingNavigationController.swift
+++ b/Apps/OneBusAway/Onboarding/OnboardingNavigationController.swift
@@ -45,7 +45,7 @@ public class OnboardingNavigationController: UINavigationController {
             return true
         }
 
-        return application.regionsService.currentRegion == nil || application.hasDataToMigrate
+        return application.regionsService.currentRegion == nil || application.shouldPerformMigration
     }
 
     public init(application: Application, dataMigrator: DataMigrator = .standard, completion: @escaping VoidBlock) {

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -141,6 +141,12 @@ public class Application: CoreApplication, PushServiceDelegate {
 
     // MARK: - Onboarding/Data Migration
 
+    /// Returns whether we should prompt the user to perform a data migration.
+    /// If the user has performed the migration before, this returns `false`.
+    public var shouldPerformMigration: Bool {
+        DataMigrator.standard.shouldPerformMigration
+    }
+
     /// When true, this means that the application's user defaults contain data that can be migrated into a modern format.
     public var hasDataToMigrate: Bool {
         DataMigrator.standard.hasDataToMigrate

--- a/OBAKitCore/DataMigration/DataMigrator.swift
+++ b/OBAKitCore/DataMigration/DataMigrator.swift
@@ -70,6 +70,8 @@ public class DataMigrator {
         }
     }
 
+    /// Returns whether we should prompt the user to perform a data migration.
+    /// If the user has performed the migration before, this returns `false`.
     public var shouldPerformMigration: Bool {
         return extractor.hasDataToMigrate && isMigrationPending
     }


### PR DESCRIPTION
User reports that the onboarding screen is appearing every time during launch.

I think this is caused by `needsToOnboard` checking the wrong state, instead of checking only the existence of classic-OBA data, we should be checking the existence AND the UserDefault value of whether the user has already upgraded their data.