### PR TITLE
Fixes some concurrency related crashes

### DIFF
--- a/OBAKit/Controls/AlertPresenter.swift
+++ b/OBAKit/Controls/AlertPresenter.swift
@@ -16,22 +16,25 @@ class AlertPresenter: NSObject {
     /// Displays an error message to the user
     /// - Parameter error: The error to show to the user.
     /// - Parameter presentingController: The view controller that will act as the host for the presented error alert UI.
-    public class func show(error: Error, presentingController: UIViewController) {
-        show(errorMessage: error.localizedDescription, presentingController: presentingController)
+    @MainActor
+    public class func show(error: Error, presentingController: UIViewController) async {
+        await show(errorMessage: error.localizedDescription, presentingController: presentingController)
     }
 
     /// Displays an error message to the user.
     /// - Parameter errorMessage: The error message that will be shown.
     /// - Parameter presentingController: The view controller that will act as the host for the presented error alert UI.
-    public class func show(errorMessage: String, presentingController: UIViewController) {
-        showDismissableAlert(title: Strings.error, message: errorMessage, presentingController: presentingController)
+    @MainActor
+    public class func show(errorMessage: String, presentingController: UIViewController) async {
+        await showDismissableAlert(title: Strings.error, message: errorMessage, presentingController: presentingController)
     }
 
     /// Displays an alert with a Dismiss button, presented from `presentingController`.
     /// - Parameter title: Optional alert title.
     /// - Parameter message: Optional alert message.
     /// - Parameter presentingController: The presenting view controller.
-    public class func showDismissableAlert(title: String?, message: String?, presentingController: UIViewController) {
+    @MainActor
+    public class func showDismissableAlert(title: String?, message: String?, presentingController: UIViewController) async {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: Strings.dismiss, style: .default, handler: nil))
         presentingController.present(alert, animated: true, completion: nil)

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -203,7 +203,9 @@ public class MapRegionManager: NSObject,
 
         mapView.delegate = self
 
-        renderRegionsOnMap()
+        Task { @MainActor [weak self] in
+            await self?.renderRegionsOnMap()
+        }
     }
 
     deinit {
@@ -632,14 +634,17 @@ public class MapRegionManager: NSObject,
     // MARK: - Regions
 
     public func regionsService(_ service: RegionsService, updatedRegionsList regions: [Region]) {
-        renderRegionsOnMap()
+        Task { @MainActor [weak self] in
+            await self?.renderRegionsOnMap()
+        }
     }
 
     public func regionsService(_ service: RegionsService, updatedRegion region: Region) {
         mapView.setVisibleMapRect(region.serviceRect, animated: true)
     }
 
-    private func renderRegionsOnMap() {
+    @MainActor
+    private func renderRegionsOnMap() async {
         mapView.updateAnnotations(with: application.regionsService.regions)
     }
 }

--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -92,8 +92,10 @@ public class PushService: NSObject {
     }
 
     private func displayMessage(_ message: String) {
-        if let presentingController = delegate?.pushServicePresentingController(self) {
-            AlertPresenter.showDismissableAlert(title: message, message: nil, presentingController: presentingController)
+        Task { @MainActor in
+            if let presentingController = delegate?.pushServicePresentingController(self) {
+                await AlertPresenter.showDismissableAlert(title: message, message: nil, presentingController: presentingController)
+            }
         }
     }
 

--- a/OBAKit/Reporting/StopProblemViewController.swift
+++ b/OBAKit/Reporting/StopProblemViewController.swift
@@ -142,8 +142,8 @@ class StopProblemViewController: FormViewController {
         } catch {
             await MainActor.run {
                 ProgressHUD.dismiss()
-                AlertPresenter.show(error: error, presentingController: self)
             }
+            await AlertPresenter.show(error: error, presentingController: self)
         }
     }
 }

--- a/OBAKit/Reporting/VehicleProblemViewController.swift
+++ b/OBAKit/Reporting/VehicleProblemViewController.swift
@@ -180,8 +180,8 @@ class VehicleProblemViewController: FormViewController {
         } catch {
             await MainActor.run {
                 ProgressHUD.dismiss()
-                AlertPresenter.show(error: error, presentingController: self)
             }
+            await AlertPresenter.show(error: error, presentingController: self)
         }
     }
 }

--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -264,7 +264,10 @@ public class MoreViewController: UIViewController,
         controller.dismiss(animated: true, completion: nil)
 
         if let error = error {
-            AlertPresenter.show(error: error, presentingController: self)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await AlertPresenter.show(error: error, presentingController: self)
+            }
         }
     }
 
@@ -305,7 +308,10 @@ public class MoreViewController: UIViewController,
     }
 
     public func farePayments(_ farePayments: FarePayments, present error: Error) {
-        AlertPresenter.show(error: error, presentingController: self)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await AlertPresenter.show(error: error, presentingController: self)
+        }
     }
 
     // MARK: - Regions Service Delegate

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -234,7 +234,10 @@ class SettingsViewController: FormViewController {
                     let activity = UIActivityViewController(activityItems: [xmlPath], applicationActivities: nil)
                     self.present(activity, animated: true, completion: nil)
                 } catch let ex {
-                    AlertPresenter.show(error: ex, presentingController: self)
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        await AlertPresenter.show(error: ex, presentingController: self)
+                    }
                 }
             }
         }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -966,7 +966,9 @@ public class StopViewController: UIViewController,
 
     func alarmBuilder(_ alarmBuilder: AlarmBuilder, error: Error) {
         ProgressHUD.dismiss()
-        AlertPresenter.show(error: error, presentingController: self)
+        Task { @MainActor in
+            await AlertPresenter.show(error: error, presentingController: self)
+        }
     }
 
     // MARK: - Bookmarks

--- a/OBAKitCore/Location/Regions/RegionsService.swift
+++ b/OBAKitCore/Location/Regions/RegionsService.swift
@@ -345,10 +345,7 @@ public class RegionsService: NSObject, LocationServiceDelegate {
             return
         }
 
-        // FIXME: Audit which delegates are doing stuff on background thread, when they should be on Main.
-        await MainActor.run {
-            self.regions = regions
-        }
+        self.regions = regions
     }
 
     /// Fetches the current list of `Region`s from the network.


### PR DESCRIPTION
- Fixes #635 — Audit RegionsService delegates to make sure they are performing UI actions on Main
- Fixes a search related crash, where the search results are processed on a non-main actor.
- Require AlertPresenter calls to be on the MainActor