### PR TITLE
Split contents of MapFloatingPanelController into separate view controllers

### DIFF
--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -286,7 +286,7 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
     // MARK: - Data source
     public func applyData(animated: Bool = true) {
         var sections = self.obaDataSource?.items(for: self) ?? []
-        self.emptyDataConfiguration(isEmpty: self.lastDataSourceSnapshot.isEmpty)
+        self.emptyDataConfiguration(isEmpty: sections.isEmpty)
 
         if let collapsibleDelegate = self.collapsibleSectionsDelegate {
             // Add collapsed state to the section, if it is allowed to collapse.

--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -205,7 +205,12 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
 
     /// Accounts for whether the section has a header or not.
     func itemForIndexPath(_ indexPath: IndexPath) -> AnyOBAListViewItem? {
+        guard indexPath.section < lastDataSourceSnapshot.count else {
+            return nil
+        }
+
         var correctedItemIndex = indexPath.item
+
         if lastDataSourceSnapshot[indexPath.section].hasHeader {
             guard correctedItemIndex != 0 else { return nil }
             correctedItemIndex -= 1

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -13,6 +13,7 @@ import OBAKitCore
 
 protocol MapPanelDelegate: NSObjectProtocol {
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stopID: Stop.ID)
+    func mapPanelControllerDidChangeChildViewController(_ controller: MapFloatingPanelController)
     func mapPanelControllerDisplaySearch(_ controller: MapFloatingPanelController)
     func mapPanelController(_ controller: MapFloatingPanelController, moveTo state: FloatingPanelState, animated: Bool)
 }
@@ -24,34 +25,42 @@ class MapFloatingPanelController: VisualEffectViewController,
     AppContext,
     RegionsServiceDelegate,
     SearchDelegate,
-    OBAListViewDataSource,
     OBAListViewContextMenuDelegate,
+    NearbyStopsListDataSource,
+    NearbyStopsListDelegate,
+    SearchListViewControllerDelegate,
     UISearchBarDelegate {
 
     let mapRegionManager: MapRegionManager
 
     public weak var mapPanelDelegate: MapPanelDelegate?
+    public private(set) var currentScrollView: UIScrollView?
 
     public let application: Application
 
-    private var stops = [Stop]() {
+    // Nearby Stops
+    private var nearbyStopsListViewController: NearbyStopsListViewController!
+    var highSeverityAlerts: [AgencyAlert] {
+        application.alertsStore.recentHighSeverityAlerts
+    }
+
+    private(set) var stops = [Stop]() {
         didSet {
-            listView.applyData()
+            nearbyStopsListViewController.updateList()
         }
     }
 
-    // MARK: - Init/Deinit
+    // Search
+    private var searchListViewController: SearchListViewController!
+    var searchBarText: String = ""
 
+    // MARK: - Init/Deinit
     init(application: Application, mapRegionManager: MapRegionManager, delegate: MapPanelDelegate) {
         self.application = application
         self.mapRegionManager = mapRegionManager
         self.mapPanelDelegate = delegate
 
         super.init(nibName: nil, bundle: nil)
-
-        self.listView.obaDataSource = self
-        self.listView.contextMenuDelegate = self
-        self.listView.backgroundColor = nil
 
         self.mapRegionManager.addDelegate(self)
         self.application.regionsService.addDelegate(self)
@@ -67,8 +76,31 @@ class MapFloatingPanelController: VisualEffectViewController,
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     // MARK: - UI
-    let listView = OBAListView()
-    private lazy var stackView = UIStackView.verticalStack(arrangedSubviews: [searchBar, listView])
+    private var childContentContainerView: UIView!
+
+    func toggleSearch(showingSearch: Bool) {
+        let oldViewController: UIViewController = showingSearch ? nearbyStopsListViewController : searchListViewController
+        let newViewController: UIViewController = showingSearch ? searchListViewController : nearbyStopsListViewController
+
+        oldViewController.willMove(toParent: nil)
+        oldViewController.view.removeFromSuperview()
+        oldViewController.removeFromParent()
+
+        newViewController.willMove(toParent: self)
+        addChild(newViewController)
+        childContentContainerView.addSubview(newViewController.view)
+        newViewController.view.pinToSuperview(.edges)
+        newViewController.didMove(toParent: self)
+
+        // Update the current scroll view, so FloatingPanel can track the newly installed view.
+        if let scrollableViewController = newViewController as? Scrollable {
+            currentScrollView = scrollableViewController.scrollView
+        } else {
+            currentScrollView = nil
+        }
+
+        mapPanelDelegate?.mapPanelControllerDidChangeChildViewController(self)
+    }
 
     // MARK: - UI/Search
 
@@ -81,7 +113,8 @@ class MapFloatingPanelController: VisualEffectViewController,
             else {
                 mapPanelDelegate?.mapPanelController(self, moveTo: .tip, animated: true)
             }
-            listView.applyData()
+
+            toggleSearch(showingSearch: inSearchMode)
         }
     }
 
@@ -97,16 +130,64 @@ class MapFloatingPanelController: VisualEffectViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        updateSearchBarPlaceholderText()
+        // Add search bar
+        visualEffectView.contentView.addSubview(searchBar)
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            searchBar.topAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.topAnchor, constant: ThemeMetrics.floatingPanelTopInset),
+            searchBar.leadingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.leadingAnchor),
+            searchBar.trailingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.trailingAnchor)
+        ])
 
-        visualEffectView.contentView.addSubview(stackView)
-        stackView.pinToSuperview(.edges, insets: NSDirectionalEdgeInsets(top: ThemeMetrics.floatingPanelTopInset, leading: 0, bottom: 0, trailing: 0))
+        // Add child content container view
+        childContentContainerView = UIView.autolayoutNew()
+        visualEffectView.contentView.addSubview(childContentContainerView)
+        NSLayoutConstraint.activate([
+            childContentContainerView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: 0),
+            childContentContainerView.leadingAnchor.constraint(equalTo: visualEffectView.contentView.leadingAnchor),
+            childContentContainerView.trailingAnchor.constraint(equalTo: visualEffectView.contentView.trailingAnchor),
+            childContentContainerView.bottomAnchor.constraint(equalTo: visualEffectView.contentView.bottomAnchor)
+        ])
+
+        // Initialize view controllers
+        nearbyStopsListViewController = NearbyStopsListViewController()
+        nearbyStopsListViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        nearbyStopsListViewController.dataSource = self
+        nearbyStopsListViewController.delegate = self
+
+        searchListViewController = SearchListViewController()
+        searchListViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        searchListViewController.delegate = self
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        toggleSearch(showingSearch: false)
+        updateSearchBarPlaceholderText()
     }
 
     // MARK: - Agency Alerts
 
     public func agencyAlertsUpdated() {
-        listView.applyData()
+        nearbyStopsListViewController.updateList()
+    }
+
+    // MARK: - NearbyStopsListViewControllerDelegate methods
+    func didSelect(stopID: Stop.ID) {
+        mapPanelDelegate?.mapPanelController(self, didSelectStop: stopID)
+    }
+
+    func didSelect(agencyAlert: AgencyAlert) {
+        self.application.viewRouter.navigateTo(alert: agencyAlert, from: self)
+    }
+
+    func previewViewController(for stopID: Stop.ID) -> UIViewController? {
+        return StopViewController(application: application, stopID: stopID)
+    }
+
+    func commitPreviewViewController(_ viewController: UIViewController) {
+        self.application.viewRouter.navigate(to: viewController, from: self, animated: false)
     }
 
     // MARK: - Search UI and Data
@@ -139,7 +220,8 @@ class MapFloatingPanelController: VisualEffectViewController,
     }
 
     public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        listView.applyData()
+        searchBarText = searchText
+        searchListViewController.updateSearch()
     }
 
     public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
@@ -163,71 +245,7 @@ class MapFloatingPanelController: VisualEffectViewController,
         inSearchMode = false
     }
 
-    var searchModeEmptyData: OBAListView.EmptyData {
-        let image = UIImage(systemName: "magnifyingglass")
-        let title = OBALoc("search_controller.empty_set.title", value: "Search", comment: "Title for the empty set indicator on the Search controller.")
-        let body = OBALoc("search_controller.empty_set.body", value: "Type in an address, route name, stop number, or vehicle here to search.", comment: "Body for the empty set indicator on the Search controller.")
-
-        return .standard(.init(alignment: .top, title: title, body: body, image: image))
-    }
-
-    private lazy var searchInteractor = SearchInteractor(userDataStore: application.userDataStore, delegate: self)
-
-    // MARK: - OBAListViewDataSource (Data Loading)
-    func items(for listView: OBAListView) -> [OBAListViewSection] {
-        var sections: [OBAListViewSection]
-        if inSearchMode {
-            sections = searchInteractor.searchModeObjects(text: searchBar.text)
-        } else {
-            sections = nearbyModeObjects()
-        }
-
-        for idx in sections.indices {
-            sections[idx].configuration.backgroundColor = .clear
-        }
-        return sections
-    }
-
-    // MARK: - Nearby Mode
-
-    var nearbyModeEmptyData: OBAListView.EmptyData {
-        let title = OBALoc("nearby_controller.empty_set.title", value: "No Nearby Stops", comment: "Title for the empty set indicator on the Nearby controller")
-        let body = OBALoc("nearby_controller.empty_set.body", value: "Zoom out or pan around to find some stops.", comment: "Body for the empty set indicator on the Nearby controller.")
-
-        return .standard(.init(alignment: .top, title: title, body: body))
-    }
-
-    private func nearbyModeObjects() -> [OBAListViewSection] {
-        var sections: [OBAListViewSection] = []
-
-        let highSeverityAlerts = application.alertsStore.recentHighSeverityAlerts
-        if highSeverityAlerts.count > 0 {
-            sections.append(contentsOf: listSections(agencyAlerts: highSeverityAlerts))
-        }
-
-        if stops.count > 0 {
-            let rows = stops.map { stop -> StopViewModel in
-                let onSelect: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
-                    self.mapPanelDelegate?.mapPanelController(self, didSelectStop: viewModel.stopID)
-                }
-
-                return StopViewModel(withStop: stop, onSelect: onSelect, onDelete: nil)
-            }
-
-            let section = OBAListViewSection(id: "nearby_stops", title: OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller."), contents: rows)
-            sections.append(section)
-        }
-
-        return sections
-    }
-
-    public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        if inSearchMode {
-            return searchModeEmptyData
-        } else {
-            return nearbyModeEmptyData
-        }
-    }
+    lazy var searchInteractor = SearchInteractor(userDataStore: application.userDataStore, delegate: self)
 
     fileprivate var currentPreviewingViewController: UIViewController?
     func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
@@ -252,15 +270,6 @@ class MapFloatingPanelController: VisualEffectViewController,
 // MARK: - MapRegionDelegate
 
 extension MapFloatingPanelController: MapRegionDelegate {
-    public var bottomScrollInset: CGFloat {
-        get {
-            return listView.contentInset.bottom
-        }
-        set {
-            listView.contentInset.bottom = newValue
-        }
-    }
-
     public func mapRegionManager(_ manager: MapRegionManager, showSearchResult response: SearchResponse) {
         exitSearchMode()
     }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -393,9 +393,6 @@ class MapViewController: UIViewController,
         // Set a content view controller.
         panel.set(contentViewController: mapPanelController)
 
-        // Track a scroll view (or the siblings) in the content view controller.
-        panel.track(scrollView: mapPanelController.listView)
-
         // Content Inset Adjustment + OBAListView don't play well together and causes undefined behavior,
         // as described in "OBAListView "sticky" row behavior while scrolling in panel" (#321)
         panel.contentInsetAdjustmentBehavior = .never
@@ -417,7 +414,7 @@ class MapViewController: UIViewController,
         // Floating Panel is fully open because it looks weird.
         let floatingPanelPositionIsCollapsed = vc.state == .tip || vc.state == .hidden
         statusOverlay.isHidden = vc.state == .full
-        mapPanelController.listView.accessibilityElementsHidden = floatingPanelPositionIsCollapsed
+        mapPanelController.currentScrollView?.accessibilityElementsHidden = floatingPanelPositionIsCollapsed
 
         // Disables voiceover interacting with map elements (such as streets and POIs).
         // See #431.
@@ -467,6 +464,16 @@ class MapViewController: UIViewController,
 
     func mapPanelControllerDisplaySearch(_ controller: MapFloatingPanelController) {
         floatingPanel.move(to: .full, animated: true)
+    }
+
+    func mapPanelControllerDidChangeChildViewController(_ controller: MapFloatingPanelController) {
+        // If there is a new scroll view, tell floating panel to track the new scroll view.
+        // Else, untrack its currently tracking scroll view.
+        if let newScrollView = controller.currentScrollView {
+            floatingPanel.track(scrollView: newScrollView)
+        } else if let currentTrackingScrollView = floatingPanel.trackingScrollView {
+            floatingPanel.untrack(scrollView: currentTrackingScrollView)
+        }
     }
 
     func mapPanelController(_ controller: MapFloatingPanelController, moveTo state: FloatingPanelState, animated: Bool) {

--- a/OBAKit/Mapping/NearbyStopsListViewController.swift
+++ b/OBAKit/Mapping/NearbyStopsListViewController.swift
@@ -1,0 +1,291 @@
+//
+//  NearbyStopsViewController.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 4/4/23.
+//
+
+import Foundation
+
+import MapKit
+import OBAKitCore
+
+protocol NearbyStopsListDelegate: AnyObject {
+    func didSelect(stopID: Stop.ID)
+    func didSelect(agencyAlert: AgencyAlert)
+
+    func previewViewController(for stopID: Stop.ID) -> UIViewController?
+    func commitPreviewViewController(_ viewController: UIViewController)
+}
+
+protocol NearbyStopsListDataSource: AnyObject {
+    var highSeverityAlerts: [AgencyAlert] { get }
+    var stops: [Stop] { get }
+}
+
+/// Displays a list of stops and high-priority alerts.
+class NearbyStopsListViewController: UIViewController, UICollectionViewDelegate, Scrollable {
+    // MARK: - Type definitions
+    private enum Section: Hashable {
+        case alert
+        case nearbyStops
+
+        public var localizedTitle: String {
+            switch self {
+            case .alert:
+                return Strings.serviceAlerts
+            case .nearbyStops:
+                return OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller.")
+            }
+        }
+    }
+
+    private struct Item: Hashable {
+        // swiftlint:disable:next nesting
+        enum ItemType: Hashable {
+            case header
+            case stop(stopID: Stop.ID)
+            case alert(AgencyAlert)
+        }
+
+        let title: String
+        let subtitle: String?
+        let image: UIImage?
+        let type: ItemType
+
+        init(headerForSection section: Section) {
+            self.title = section.localizedTitle
+            self.subtitle = nil
+            self.image = nil
+            self.type = .header
+        }
+
+        init(_ stop: Stop) {
+            self.title = stop.nameWithLocalizedDirectionAbbreviation
+            self.subtitle = stop.subtitle
+            self.image = Icons.transportIcon(from: stop.prioritizedRouteTypeForDisplay)
+            self.type = .stop(stopID: stop.id)
+        }
+
+        init(_ alert: AgencyAlert) {
+            self.title = alert.title(forLocale: .current) ?? ""
+            self.subtitle = nil
+            self.image = Icons.unreadAlert
+            self.type = .alert(alert)
+        }
+    }
+
+    private typealias SectionType = Section
+    private typealias ItemType = Item
+
+    // MARK: - Scrollable methods
+    var scrollView: UIScrollView {
+        collectionView
+    }
+
+    // MARK: - Data management
+    public weak var delegate: NearbyStopsListDelegate?
+    public weak var dataSource: NearbyStopsListDataSource?
+
+    // MARK: - UICollectionView properties
+    private var collectionView: UICollectionView!
+    private var diffableDataSource: UICollectionViewDiffableDataSource<Section, ItemType>!
+    private var cellRegistration: UICollectionView.CellRegistration<UICollectionViewListCell, ItemType>!
+    private lazy var emptyDataView: EmptyDataSetView = {
+        let view = EmptyDataSetView(alignment: .top)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - UIViewController lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemType> { cell, _, item in
+            var config = cell.defaultContentConfiguration()
+            config.text = item.title
+            config.secondaryText = item.subtitle
+            config.image = item.image
+            config.imageProperties.tintColor = .label
+            config.imageProperties.maximumSize = CGSize(width: 24, height: 24)
+
+            cell.contentConfiguration = config
+        }
+
+        self.collectionView = .init(frame: .zero, collectionViewLayout: createLayout())
+        self.collectionView.backgroundColor = .clear
+        self.diffableDataSource = .init(collectionView: collectionView, cellProvider: cellFor(_:indexPath:itemIdentifier:))
+        self.collectionView.dataSource = diffableDataSource
+        self.collectionView.delegate = self
+
+        self.view.addSubview(collectionView)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.pinToSuperview(.edges)
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { _, layoutEnvironment in
+            var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+            config.backgroundColor = .clear
+            config.headerMode = .firstItemInSection
+
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
+
+            // Change the section's content insets reference to the readable content.
+            // This changes the way that the insets in the section's contentInsets property are interpreted.
+            section.contentInsetsReference = .readableContent
+
+            // Zero out the default leading/trailing contentInsets, but preserve the default top/bottom values.
+            // This ensures each section will be inset horizontally exactly to the readable content width.
+            var contentInsets = section.contentInsets
+            contentInsets.leading = 0
+            contentInsets.trailing = 0
+            section.contentInsets = contentInsets
+
+            return section
+        }
+    }
+
+    private func cellFor(_ collectionView: UICollectionView, indexPath: IndexPath, itemIdentifier: ItemType) -> UICollectionViewCell? {
+        return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+    }
+
+    private func toggleEmptyDataView(isShowing: Bool) {
+        if isShowing {
+            let viewModel = OBAListView.StandardEmptyDataViewModel(
+                title: OBALoc("nearby_controller.empty_set.title", value: "No Nearby Stops", comment: "Title for the empty set indicator on the Nearby controller"),
+                body: OBALoc("nearby_controller.empty_set.body", value: "Zoom out or pan around to find some stops.", comment: "Body for the empty set indicator on the Nearby controller.")
+            )
+
+            emptyDataView.apply(viewModel)
+            collectionView.backgroundView = emptyDataView
+        } else {
+            collectionView.backgroundView = nil
+        }
+    }
+
+    @MainActor
+    public func updateList() {
+        guard let dataSource else {
+            #if DEBUG
+            preconditionFailure("dataSource must be set.")
+            #else
+            return
+            #endif
+        }
+
+        var sections: [SectionType] = []
+
+        // Add alerts, if any.
+        var alertSectionSnapshot: NSDiffableDataSourceSectionSnapshot<ItemType>?
+        let alerts = dataSource.highSeverityAlerts
+        if !alerts.isEmpty {
+            var sectionSnapshot = NSDiffableDataSourceSectionSnapshot<ItemType>()
+            let alertHeader = Item(headerForSection: .alert)
+            sectionSnapshot.append([alertHeader])
+
+            let items = alerts.map(Item.init)
+            sectionSnapshot.append(items)
+
+            alertSectionSnapshot = sectionSnapshot
+            sections.append(.alert)
+        }
+
+        // Add nearby stops.
+        var stopsSectionSnapshot: NSDiffableDataSourceSectionSnapshot<ItemType>?
+        let stops = dataSource.stops
+        if !stops.isEmpty {
+            var sectionSnapshot = NSDiffableDataSourceSectionSnapshot<ItemType>()
+
+            let nearbyStopsHeader = Item(headerForSection: .nearbyStops)
+            sectionSnapshot.append([nearbyStopsHeader])
+
+            let nearbyStops = dataSource.stops.map(Item.init)
+            sectionSnapshot.append(nearbyStops)
+
+            stopsSectionSnapshot = sectionSnapshot
+
+            sections.append(.nearbyStops)
+        }
+
+        var snapshot = NSDiffableDataSourceSnapshot<SectionType, ItemType>()
+        snapshot.appendSections(sections)
+        self.diffableDataSource.apply(snapshot)
+
+        if let alertSectionSnapshot {
+            self.diffableDataSource.apply(alertSectionSnapshot, to: .alert, animatingDifferences: true)
+        }
+
+        if let stopsSectionSnapshot {
+            self.diffableDataSource.apply(stopsSectionSnapshot, to: .nearbyStops, animatingDifferences: true)
+        }
+
+        toggleEmptyDataView(isShowing: sections.isEmpty)
+    }
+
+    // MARK: - UICollectionViewDelegate methods
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let delegate, let item = diffableDataSource.itemIdentifier(for: indexPath) else {
+            return
+        }
+
+        switch item.type {
+        case .stop(let id):
+            delegate.didSelect(stopID: id)
+        case .alert(let alert):
+            delegate.didSelect(agencyAlert: alert)
+        case .header:
+            // Do nothing.
+            return
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemsAt indexPaths: [IndexPath], point: CGPoint) -> UIContextMenuConfiguration? {
+        guard let delegate else {
+            return nil
+        }
+
+        // Supports only single selection.
+        guard indexPaths.count == 1, let indexPath = indexPaths.first else {
+            return nil
+        }
+
+        guard let item = diffableDataSource.itemIdentifier(for: indexPath) else {
+            return nil
+        }
+
+        guard case let .stop(stopID) = item.type else {
+            return nil
+        }
+
+        guard let viewController = delegate.previewViewController(for: stopID) else {
+            return nil
+        }
+
+        if let previewable = viewController as? Previewable {
+            previewable.enterPreviewMode()
+        }
+
+        return UIContextMenuConfiguration(previewProvider: {
+            viewController
+        }, actionProvider: nil)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionCommitAnimating) {
+        guard let viewController = animator.previewViewController else {
+            return
+        }
+
+        animator.addCompletion { [weak self] in
+            guard let self else {
+                return
+            }
+
+            if let previewable = viewController as? Previewable {
+                previewable.exitPreviewMode()
+            }
+
+            self.delegate?.commitPreviewViewController(viewController)
+        }
+    }
+}

--- a/OBAKit/Mapping/SearchListViewController.swift
+++ b/OBAKit/Mapping/SearchListViewController.swift
@@ -1,0 +1,65 @@
+//
+//  SearchListViewController.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 4/4/23.
+//
+
+import OBAKitCore
+
+protocol SearchListViewControllerDelegate: AnyObject {
+    var searchBarText: String { get }
+    var searchInteractor: SearchInteractor { get }
+}
+
+class SearchListViewController: UIViewController, Scrollable, OBAListViewDataSource {
+    var scrollView: UIScrollView {
+        listView
+    }
+
+    var listView: OBAListView!
+    var searchInteractor: SearchInteractor?
+
+    weak var delegate: SearchListViewControllerDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        listView = OBAListView()
+        listView.obaDataSource = self
+        listView.backgroundColor = .clear
+        view.addSubview(listView)
+        listView.pinToSuperview(.edges)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        listView.applyData()
+    }
+
+    func updateSearch() {
+        listView.applyData()
+    }
+
+    func items(for listView: OBAListView) -> [OBAListViewSection] {
+        guard let delegate else {
+            return []
+        }
+
+        var sections = delegate.searchInteractor.searchModeObjects(text: delegate.searchBarText)
+        for (idx, _) in sections.enumerated() {
+            sections[idx].configuration.backgroundColor = .clear
+        }
+
+        return sections
+    }
+
+    func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
+        let image = UIImage(systemName: "magnifyingglass")
+        let title = OBALoc("search_controller.empty_set.title", value: "Search", comment: "Title for the empty set indicator on the Search controller.")
+        let body = OBALoc("search_controller.empty_set.body", value: "Type in an address, route name, stop number, or vehicle here to search.", comment: "Body for the empty set indicator on the Search controller.")
+
+        return .standard(.init(alignment: .top, title: title, body: body, image: image))
+    }
+}

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -297,8 +297,8 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     func agencyAlertsStore(_ store: AgencyAlertsStore, displayError error: Error) {
-        Task { @MainActor in
-            self.displayError(error)
+        Task {
+            await self.displayError(error)
         }
     }
 
@@ -434,8 +434,8 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     public func regionsService(_ service: RegionsService, displayError error: Error) {
-        Task { @MainActor in
-            displayError(error)
+        Task {
+            await displayError(error)
         }
     }
 
@@ -457,8 +457,8 @@ public class Application: CoreApplication, PushServiceDelegate {
     ///
     /// - Parameter error: The error to display.
     @MainActor
-    public override func displayError(_ error: Error) {
-        super.displayError(error)
+    public override func displayError(_ error: Error) async {
+        await super.displayError(error)
         guard let uiApp = delegate?.uiApplication else { return }
         let bulletin = ErrorBulletin(application: self, message: error.localizedDescription)
         bulletin.show(in: uiApp)

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -100,7 +100,7 @@ public class RecentStopsViewController: UIViewController,
                 self.application.viewRouter.navigateTo(arrivalDeparture: response.entry, from: self)
             }
         } catch {
-            self.application.displayError(error)
+            await self.application.displayError(error)
         }
     }
 

--- a/OBAKit/Search/SearchResultsController.swift
+++ b/OBAKit/Search/SearchResultsController.swift
@@ -119,7 +119,7 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
                     self.delegate?.dismissModalController(self)
                 }
             } catch {
-                self.application.displayError(error)
+                await self.application.displayError(error)
             }
         }
     }

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -93,7 +93,7 @@ class NearbyStopsViewController: UIViewController,
             }
         } catch {
             // TODO: (ualch9) Show error inline instead of presenting an ugly error.
-            self.application.displayError(error)
+            await self.application.displayError(error)
         }
     }
 

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -233,7 +233,7 @@ class TripFloatingPanelController: UIViewController,
                     self.application.viewRouter.navigate(to: controller, from: self)
                 }
             } catch {
-                self.application.displayError(error)
+                await self.application.displayError(error)
             }
 
             ProgressHUD.dismiss()

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -303,8 +303,8 @@ class TripViewController: UIViewController,
         do {
             trip = try await apiService.getTrip(tripID: tripConvertible.trip.id, vehicleID: tripConvertible.vehicleID, serviceDate: tripConvertible.serviceDate).entry
         } catch {
+            await self.application.displayError(error)
             await MainActor.run {
-                self.application.displayError(error)
                 self.dataLoadFeedbackGenerator.dataLoad(.failed)
             }
             return
@@ -360,7 +360,7 @@ class TripViewController: UIViewController,
                 }
             }
         } catch {
-            self.application.displayError(error)
+            await self.application.displayError(error)
         }
     }
 

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -210,7 +210,7 @@ open class CoreApplication: NSObject,
     // MARK: - Error Handling
 
     @MainActor
-    open func displayError(_ error: Error) {
+    open func displayError(_ error: Error) async {
         Logger.error("Error: \(error.localizedDescription)")
     }
 }


### PR DESCRIPTION
I suspect the layout system in OBAListView is partially responsible for #660. As a hotfix, I am replacing the Recent Stops list view with a standard UICollectionView. The current search view controller was more complicated to replace, so that will stay as an OBAListView for now. To facilitate the UICollectionView and OBAListView, the two states are now separate view controllers, and MapFloatingPanelController will facilitate the view controller's lifecycles. 

MapFloatingPanelController is now spaghetti, but I want to collect crash data on whether the problem is really with OBAListView's layout before cleaning up the logic.

Also, some opportunistic fixes too.