### PR TITLE
Map tiling for loading stops

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -93,6 +93,9 @@ packages:
     FloatingPanel:
         url: https://github.com/SCENEE/FloatingPanel.git
         exactVersion: 2.6.0
+    GeohashKit:
+        url: https://github.com/ualch9/GeohashKit.git
+        exactVersion: 3.0.0
     Hyperconnectivity:
         url: https://github.com/rwbutler/Hyperconnectivity.git
         exactVersion: 1.1.0

--- a/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "geohashkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ualch9/GeohashKit.git",
+      "state" : {
+        "revision" : "d514b5af0b43bdb0a0912eaa036442f4d02f5661",
+        "version" : "3.0.0"
+      }
+    },
+    {
       "identity" : "googleappmeasurement",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -11,6 +11,7 @@ import UIKit
 import CoreLocation
 import MapKit
 import OBAKitCore
+import GeohashKit
 
 // MARK: - MapRegionDelegate
 
@@ -40,7 +41,9 @@ protocol MapRegionMapViewDelegate: NSObjectProtocol {
 public class MapRegionManager: NSObject,
     MKMapViewDelegate,
     RegionsServiceDelegate,
-    StopAnnotationDelegate {
+    StopAnnotationDelegate,
+    RESTAPIServiceProviding,
+    StopCacheDelegate {
 
     public static let DefaultLoadDataRegionFudgeFactor: Double = 1.1
 
@@ -61,6 +64,9 @@ public class MapRegionManager: NSObject,
     public var preferredLoadDataRegionFudgeFactor: Double = MapRegionManager.DefaultLoadDataRegionFudgeFactor
 
     private let application: Application
+    public var apiService: RESTAPIService? {
+        application.apiService
+    }
 
     private var regionChangeRequestTimer: Timer?
 
@@ -190,6 +196,7 @@ public class MapRegionManager: NSObject,
         ])
 
         super.init()
+        self.stopsCache = StopCache(apiServiceProvider: self, delegate: self)
 
         application.locationService.addDelegate(self)
         application.regionsService.addDelegate(self)
@@ -228,9 +235,59 @@ public class MapRegionManager: NSObject,
     }
 
     // MARK: - Data Loading
+    @MainActor
+    public func cacheDidUpdate(_ cache: StopCache, difference: GeohashCacheDifference<Geohash, StopCache.Entry>) async {
+        for keyDiff in difference.keyChanges {
+            await tileDidUpdate(keyDiff)
+        }
 
+        for entryDiff in difference.elementChanges {
+            await stopDidUpdate(entryDiff)
+        }
+    }
+
+    @MainActor
+    private func tileDidUpdate(_ diff: GeohashCacheDifference<Geohash, StopCache.Entry>.Change<Geohash>) async {
+        switch diff {
+        case .insertion(let geohash):
+            if geohashPolygon[geohash] == nil {
+                let polygon = MKPolygon(coordinateRegion: geohash.region)
+                geohashPolygon[geohash] = polygon
+                mapView.addOverlay(polygon)
+            }
+        case .removal(let geohash):
+            if let polygon = geohashPolygon[geohash] {
+                mapView.removeOverlay(polygon)
+            }
+        }
+    }
+
+    @MainActor
+    private func stopDidUpdate(_ diff: GeohashCacheDifference<Geohash, StopCache.Entry>.Change<StopCache.Entry>) async {
+        switch diff {
+        case .insertion(let entry):
+            let annotationsToAdd = entry.stops.filter { stop in
+                !isBookmark(stop)
+            }
+
+            mapView.addAnnotations(annotationsToAdd)
+        case .removal(let entry):
+            let annotationsToRemove = entry.stops.filter { stop in
+                !isBookmark(stop)
+            }
+
+            mapView.removeAnnotations(entry.stops)
+        }
+    }
+
+    var geohashPolygon: [Geohash: MKPolygon] = [:]
+
+    // Recursively look for geohashes to load
     func requestDataForMapRegion() async {
-        guard let apiService = application.apiService else {
+        let geohashes = await mapView.region.geohashes(precision: StopCache.DefaultGeohashPrecision)
+
+        guard geohashes.count < 24 else {
+            print("Too many geohashes, please zoom in.")    // TODO: Get rid of this
             return
         }
 
@@ -244,24 +301,31 @@ public class MapRegionManager: NSObject,
             }
         }
 
-        var mapRegion = await mapView.region
-        mapRegion.span.latitudeDelta *= preferredLoadDataRegionFudgeFactor
-        mapRegion.span.longitudeDelta *= preferredLoadDataRegionFudgeFactor
+        let tasks = await withTaskGroup(of: (Geohash, Result<Void, Error>).self) { taskGroup in
+            var results: [Geohash: Result<Void, Error>] = [:]
 
-        do {
-            let stops = try await apiService.getStops(region: mapRegion).list
-
-            await MainActor.run {
-                // Some UI code is dependent on this being changed on Main.
-                self.stops = stops
+            for geohash in geohashes {
+                taskGroup.addTask {
+                    do {
+                        try await self.stopsCache.loadStops(for: geohash)
+                        return (geohash, .success(Void()))
+                    } catch {
+                        return (geohash, .failure(error))
+                    }
+                }
             }
-        } catch {
-            await self.application.displayError(error)
+
+            for await result in taskGroup {
+                results[result.0] = result.1
+            }
+
+            return results
         }
     }
 
     @objc func requestDataForMapRegion(_ timer: Timer) {
-        Task(priority: .utility) {
+        loadingStopsTask?.cancel()
+        loadingStopsTask = Task(priority: .utility) {
             await requestDataForMapRegion()
         }
     }
@@ -303,9 +367,10 @@ public class MapRegionManager: NSObject,
     }
 
     private func notifyDelegatesStopsChanged() {
-        for delegate in delegates.allObjects {
-            delegate.mapRegionManager?(self, stopsUpdated: stops)
-        }
+        // TODO: (ualch9/map_tiles) Figure out what to with mapRegionManager(_:stopsUpdated:).
+//        for delegate in delegates.allObjects {
+//            delegate.mapRegionManager?(self, stopsUpdated: stops)
+//        }
     }
 
     /// Notifies delegates that data loading has started.
@@ -335,34 +400,66 @@ public class MapRegionManager: NSObject,
 
     public var bookmarks = [Bookmark]() {
         didSet {
-            displayUniqueStopAnnotations()
+            updateVisibleBookmarks()
         }
     }
 
-    public private(set) var stops = [Stop]() {
-        didSet {
-            displayUniqueStopAnnotations()
-        }
+    private var stopsCache: StopCache!
+    private var bookmarkStops: Set<Stop.ID> = []
+
+    // MARK: - Bookmark Annotation handling
+    // Bookmarks are always visible on the map, regardless of data freshness.
+    // Bookmark annotations are added first, and proactively added/removed
+    //   as bookmarks update.
+    // When loading tiles, we check if a Stop is a bookmark to avoid adding the same stop twice.
+    private func isBookmark(_ stop: Stop) -> Bool {
+        return bookmarkStops.contains(stop.id)
     }
 
-    private func displayUniqueStopAnnotations() {
-        mapView.removeAnnotations(type: Bookmark.self)
-        var bookmarksHash = [StopID: Bookmark]()
+    private func updateVisibleBookmarks() {
+        var annotationsToAdd: [Bookmark] = []
+        for bookmark in bookmarks {
+            guard !bookmarkStops.contains(bookmark.stopID) else {
+                continue
+            }
 
-        for bm in bookmarks {
-            bookmarksHash[bm.stopID] = bm
+            annotationsToAdd.append(bookmark)
         }
 
-        mapView.addAnnotations(Array(bookmarksHash.values))
+        // Remove standard Stop annotation, before adding the Bookmark annotation.
+        let stopIDToAnnotationMap = Dictionary(grouping: mapView.annotations.filter(type: Stop.self), by: \.id)
+        for annotation in annotationsToAdd {
+            if let standardStopAnnotation = stopIDToAnnotationMap[annotation.stopID] {
+                self.mapView.removeAnnotations(standardStopAnnotation)
+            }
+        }
 
-        let bookmarkStopIDs = Set(bookmarksHash.keys)
-        let rejectedStops = stops.filter { bookmarkStopIDs.contains($0.id) }
-        let acceptedStops = stops.filter { !rejectedStops.contains($0) }
+        // Finally, add the Bookmark annotations.
+        mapView.addAnnotations(annotationsToAdd)
+    }
 
-        mapView.removeAnnotations(rejectedStops)
-        mapView.addAnnotations(acceptedStops)
+    /// - returns: If this bookmark was handled.
+    private func handlePotentialBookmark(_ stop: Stop) -> Bool {
+        guard !bookmarkStops.contains(stop.id) else {
+            // If the Stop ID is in the addedBookmarks set, then it is a bookmark.
+            // We break out of it early since it is already added to the map.
+            return true
+        }
 
-        notifyDelegatesStopsChanged()
+        // Try to find the bookmark
+        let bookmark = bookmarks.first { bookmark in
+            bookmark.stopID == stop.id
+        }
+
+        // If the stop is not a bookmark, exit.
+        guard let bookmark else {
+            return false
+        }
+
+        mapView.addAnnotation(bookmark)
+        bookmarkStops.insert(bookmark.stopID)
+
+        return true
     }
 
     // MARK: - Map Status Overlay
@@ -391,7 +488,6 @@ public class MapRegionManager: NSObject,
         searchResponse = nil
         mapView.removeAllAnnotations()
         mapView.removeOverlays(mapView.overlays)
-        reloadStopAnnotations()
     }
 
     private func searchResponseOverridesStopLoading() -> Bool {
@@ -517,6 +613,7 @@ public class MapRegionManager: NSObject,
     }
 
     // MARK: - Map View Delegate
+    private var loadingStopsTask: Task<Void, any Error>?
 
     private func reloadStopAnnotations() {
         if searchResponseOverridesStopLoading() {
@@ -536,10 +633,6 @@ public class MapRegionManager: NSObject,
                 stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
             }
         }
-
-        regionChangeRequestTimer?.invalidate()
-
-        regionChangeRequestTimer = Timer.scheduledTimer(timeInterval: 0.25, target: self, selector: #selector(requestDataForMapRegion(_:)), userInfo: nil, repeats: false)
     }
 
     private var isHidingRegions: Bool? {
@@ -561,7 +654,10 @@ public class MapRegionManager: NSObject,
         lastVisibleMapRect = mapView.visibleMapRect
 
         reloadRegionAnnotations()
-        reloadStopAnnotations()
+        loadingStopsTask?.cancel()
+        loadingStopsTask = Task {
+            await requestDataForMapRegion()
+        }
     }
 
     public func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
@@ -624,6 +720,16 @@ public class MapRegionManager: NSObject,
             renderer.strokeColor = ThemeColors.shared.brand.withAlphaComponent(0.75)
             renderer.lineWidth = 3.0
             renderer.lineCap = .round
+
+            return renderer
+        }
+
+        // TODO: (ualch9/map_tiles) Only render this polygon if debug setting is enabled for "Show Geohash Tiles".
+        if let polygon = overlay as? MKPolygon {
+            let renderer = MKPolygonRenderer(polygon: polygon)
+            renderer.strokeColor = .black
+            renderer.lineWidth = 3.0
+            renderer.fillColor = UIColor.green.withAlphaComponent(0.5)
 
             return renderer
         }

--- a/OBAKitCore/Map/GeohashCache.swift
+++ b/OBAKitCore/Map/GeohashCache.swift
@@ -1,0 +1,116 @@
+//
+//  GeohashCache.swift
+//  OBAKitCore
+//
+//  Created by Alan Chu on 4/10/23.
+//
+
+import Foundation
+import GeohashKit
+
+/// A collection of insertions and removals that describe the difference between two ``GeohashCache`` states.
+public struct GeohashCacheDifference<KeyType, ElementType> {
+    public enum Change<ChangeType> {
+        case removal(ChangeType)
+        case insertion(ChangeType)
+    }
+
+    public let keyChanges: [Change<KeyType>]
+    public let elementChanges: [Change<ElementType>]
+
+    fileprivate init(keyChanges: [Change<KeyType>], elementChanges: [Change<ElementType>]) {
+        self.keyChanges = keyChanges
+        self.elementChanges = elementChanges
+    }
+}
+
+/// A data structure that organizes elements in a key-value style based on their Geohash.
+public struct GeohashCache<Element> {
+    public var geohashes: [Geohash] {
+        Array(cache.keys)
+    }
+
+    /// A flattened collection of all elements.
+    public var elements: [Element] {
+        Array(cache.values)
+    }
+
+    public var activeGeohashes: Set<Geohash> = []
+
+    private var cache: [Geohash: Element] = [:]
+
+    public subscript(_ geohash: Geohash) -> Element? {
+        get {
+            return cache[geohash]
+        }
+        set {
+            cache[geohash] = newValue
+        }
+    }
+
+    public init() {
+        self.activeGeohashes = []
+        self.cache = [:]
+    }
+
+    public func contains(geohash: Geohash) -> Bool {
+        return cache.keys.contains(geohash)
+    }
+
+    /// Updates/Inserts element for the given geohash key, and returns the difference result.
+    /// - If the geohash key did not previously exist, the difference result will include the new Geohash in its `keyChanges`, and the new element in its `elementChanges`.
+    /// - If the geohash key did previously exist, the difference result will only include the new element in its `elementChanges`.
+    @discardableResult
+    public mutating func upsert(geohash: Geohash, element: Element) -> GeohashCacheDifference<Geohash, Element> {
+        let geohashDiff: [GeohashCacheDifference<Geohash, Element>.Change<Geohash>]
+        var elementDiff: [GeohashCacheDifference<Geohash, Element>.Change<Element>] = []
+
+        if self.contains(geohash: geohash), let existingElement = cache[geohash] {
+            geohashDiff = []
+            elementDiff.append(.removal(existingElement))
+        } else {
+            geohashDiff = [.insertion(geohash)]
+        }
+
+        self.cache[geohash] = element
+        elementDiff.append(.insertion(element))
+
+        return GeohashCacheDifference(keyChanges: geohashDiff, elementChanges: elementDiff)
+    }
+
+    /// Removes non-active geohashes from memory.
+    @discardableResult
+    public mutating func discardContentIfPossible() -> GeohashCacheDifference<Geohash, Element> {
+        var geohashDiff: [GeohashCacheDifference<Geohash, Element>.Change<Geohash>] = []
+        var elementDiff: [GeohashCacheDifference<Geohash, Element>.Change<Element>] = []
+
+        // TODO: Don't remove elements of neighboring active-geohashes.
+
+        for (geohash, _) in cache where !activeGeohashes.contains(geohash) {
+            if let elements = self.cache[geohash] {
+                elementDiff.append(.removal(elements))
+            }
+            geohashDiff.append(.removal(geohash))
+            self.cache[geohash] = nil
+        }
+
+        return GeohashCacheDifference(keyChanges: geohashDiff, elementChanges: elementDiff)
+    }
+}
+
+// MARK: - GeohashCache.Difference.Change Equatable methods
+extension GeohashCacheDifference.Change: Equatable where KeyType: Equatable, ElementType: Equatable, ChangeType: Equatable {
+    public static func == (
+        lhs: GeohashCacheDifference<KeyType, ElementType>.Change<ChangeType>,
+        rhs: GeohashCacheDifference<KeyType, ElementType>.Change<ChangeType>
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (.insertion(let lhsElement), .insertion(let rhsElement)):
+            return lhsElement == rhsElement
+        case (.removal(let lhsElement), .removal(let rhsElement)):
+            return lhsElement == rhsElement
+        default:
+            return false
+        }
+    }
+}

--- a/OBAKitCore/Map/StopCache/StopCache.swift
+++ b/OBAKitCore/Map/StopCache/StopCache.swift
@@ -1,0 +1,138 @@
+//
+//  StopCache.swift
+//  OBAKitCore
+//
+//  Created by Alan Chu on 4/3/23.
+//
+
+import os.log
+import MapKit
+import Foundation
+import GeohashKit
+
+public protocol RESTAPIServiceProviding: AnyObject {
+    var apiService: RESTAPIService? { get }
+}
+
+public protocol StopCacheDelegate: AnyObject {
+    func cacheDidUpdate(_ cache: StopCache, difference: GeohashCacheDifference<Geohash, StopCache.Entry>) async
+}
+
+public actor StopCache {
+    // MARK: - Structs and such
+    public static let DefaultGeohashPrecision = 6  // Geohash precision of 6 yields cells of approximately 1.22x0.61km
+    static let DefaultExpirationInMinutes = 60
+
+    static private var ExpirationTimeIntervalFromNow: TimeInterval {
+        return TimeInterval(DefaultExpirationInMinutes) * 60
+    }
+
+    public struct Entry: Identifiable {
+        public let id: String      // AKA the geohash
+        public let stops: [Stop]
+        public let createdAt: Date
+
+        init(geohash: Geohash.Hash, apiResponse: RESTAPIResponse<[Stop]>) {
+            self.id = geohash
+            self.stops = apiResponse.list
+            self.createdAt = Date()
+        }
+    }
+
+    // MARK: - Properties
+    public weak var apiServiceProvider: RESTAPIServiceProviding?
+    public weak var delegate: StopCacheDelegate?
+
+    private let logger: os.Logger
+
+    /// Computed stops.
+    public var stops: [Stop] {
+        return cache.elements.flatMap(\.stops)
+    }
+    private var cache: GeohashCache<Entry>
+
+    public init(apiServiceProvider: RESTAPIServiceProviding, delegate: StopCacheDelegate? = nil) {
+        self.apiServiceProvider = apiServiceProvider
+        self.cache = GeohashCache()
+        self.delegate = delegate
+
+        self.logger = os.Logger(subsystem: "org.onebusaway.iphone", category: "StopCache")
+    }
+
+    nonisolated public func loadStops(for geohash: Geohash) async throws {
+        let loggingID = UUID()
+        func logTrace(_ message: String) {
+            logger.trace("[\(loggingID)] - [\(geohash.geohash)]: \(message)")
+        }
+
+        logTrace("Load stops begin")
+
+        defer {
+            logTrace("Load stops finished")
+        }
+
+        // Check if an existing entry exists, and is not expired.
+        if let existingEntry = await cache[geohash] {
+            logTrace("Cache hit")
+
+            guard existingEntry.createdAt.distance(to: .now) >= Self.ExpirationTimeIntervalFromNow else {
+                logTrace("Cache still fresh")
+                return
+            }
+
+            logTrace("Cache stale")
+        } else {
+            logTrace("Cache miss")
+        }
+
+        guard let apiService = await apiServiceProvider?.apiService else {
+            throw UnstructuredError("No API service available")
+        }
+
+        let apiResponse = try await apiService.getStops(region: geohash.region)
+        let entry = Entry(geohash: geohash.geohash, apiResponse: apiResponse)
+
+        if let limitExceeded = apiResponse.limitExceeded, limitExceeded {
+            fatalError("limit exceeded")    // TODO: Gracefully handle this by increasing Geohash precision (smaller tiles)
+        }
+
+        await updateCache(key: geohash, value: entry)
+    }
+
+    // MARK: - Mutations
+    /// Actor-enforced access.
+    private func updateCache(key: Geohash, value: Entry) async {
+        let diff = self.cache.upsert(geohash: key, element: value)
+
+        if let delegate {
+            await delegate.cacheDidUpdate(self, difference: diff)
+        }
+    }
+
+    public func discardContentsIfPossible() {
+        logger.trace("Discarding content... (current size: \(self.cache.elements.count))")
+        let diff = self.cache.discardContentIfPossible()
+        if let delegate {
+            Task { @MainActor in
+                await delegate.cacheDidUpdate(self, difference: diff)
+            }
+        }
+        logger.trace("Finished discarding content. (new size: \(self.cache.elements.count))")
+    }
+
+    /// - precondition: All elements of `geohashes` must have the same precision as ``DefaultGeohashPrecision``.
+    public func setActiveGeohashes(_ geohashes: Set<Geohash>) {
+        #if DEBUG
+        let illegalGeohashes = geohashes.filter { geohash in
+            geohash.precision != Self.DefaultGeohashPrecision
+        }
+
+        guard illegalGeohashes.isEmpty else {
+            preconditionFailure("Geohash precision mismatch: \(illegalGeohashes).")
+        }
+        #endif
+
+        logger.trace("New active geohash(es): \(geohashes)")
+        self.cache.activeGeohashes = geohashes
+    }
+}

--- a/OBAKitCore/project.yml
+++ b/OBAKitCore/project.yml
@@ -6,6 +6,7 @@ targets:
     dependencies:
       - package: CocoaLumberjack
       - package: CocoaLumberjackSwift
+      - package: GeohashKit
       - package: SwiftProtobuf
     scheme:
       gatherCoverageData: true

--- a/OBAKitTests/Modeling/Map/GeohashCacheTests.swift
+++ b/OBAKitTests/Modeling/Map/GeohashCacheTests.swift
@@ -1,0 +1,125 @@
+//
+//  GeohashCacheTests.swift
+//  OBAKitTests
+//
+//  Created by Alan Chu on 4/10/23.
+//
+
+import XCTest
+import GeohashKit
+@testable import OBAKitCore
+
+final class GeohashCacheTests: XCTestCase {
+    var seattle: Geohash!
+    var bellevue: Geohash!
+
+    let expectedSeattleElements: [String] = ["Hello", "Seattle!"]
+    let expectedBellevueElements: [String] = ["Hey", "Bellevue!"]
+
+    override func setUp() async throws {
+        seattle = try XCTUnwrap(Geohash(geohash: "c23nb"))
+        bellevue = try XCTUnwrap(Geohash(geohash: "c23ng"))
+    }
+
+    func testExample() throws {
+        var cache = GeohashCache<[String]>()
+
+        XCTAssertTrue(cache.activeGeohashes.isEmpty)
+
+        // Add elements for Seattle, and add to the active Geohashes set.
+        XCTContext.runActivity(named: "Test insertion into activeGeohashes") { _ in
+            cache[seattle] = expectedSeattleElements
+            cache.activeGeohashes.insert(seattle)
+            XCTAssertEqual(cache[seattle], expectedSeattleElements)
+        }
+
+        // Add elements for Bellevue, but don't add it to the active Geohashes set.
+        XCTContext.runActivity(named: "Test insertion, but don't add into activeGeohashes") { _ in
+            XCTAssertNil(cache[bellevue])
+            cache[bellevue] = expectedBellevueElements
+            XCTAssertEqual(cache[bellevue], expectedBellevueElements)
+        }
+    }
+
+    func testDifference() throws {
+        // MARK: Setup
+        var cache = GeohashCache<[String]>()
+
+        cache[seattle] = expectedSeattleElements
+        cache[bellevue] = expectedBellevueElements
+
+        cache.activeGeohashes = [seattle]
+
+        // MARK: Test
+        // After discarding, it is expected that Seattle still exists, but Bellevue is removed.
+        let difference = cache.discardContentIfPossible()
+
+        XCTContext.runActivity(named: "Test element difference") { _ in
+            var removedElements: [[String]] = []
+            for diff in difference.elementChanges {
+                switch diff {
+                case .insertion(_):
+                    XCTFail("There should be no insertion changes")
+                case .removal(let element):
+                    removedElements.append(element)
+                }
+            }
+
+            XCTAssertEqual(removedElements.count, 1)
+            XCTAssertEqual(removedElements.first, expectedBellevueElements)
+        }
+
+        XCTContext.runActivity(named: "Test key difference") { _ in
+            var removedKeys: Set<Geohash> = []
+            for diff in difference.keyChanges {
+                switch diff {
+                case .insertion(_):
+                    XCTFail("There should be no insertion changes")
+                case .removal(let key):
+                    removedKeys.insert(key)
+                }
+            }
+
+            XCTAssertEqual(removedKeys.count, 1)
+            XCTAssertEqual(removedKeys.first, bellevue)
+        }
+    }
+
+    func testUpsert() throws {
+        var cache = GeohashCache<[String]>()
+
+        // Testing initial insertion.
+        // - Expected key changes: one insertion.
+        // - Expected element changes: one insertion.
+        let initialSeattleElement = ["initial", "element"]
+        let initialDifference = cache.upsert(geohash: seattle, element: initialSeattleElement)
+
+        XCTAssertEqual(initialDifference.keyChanges.count, 1)
+        XCTAssertEqual(initialDifference.keyChanges.first, .insertion(seattle))
+
+        XCTAssertEqual(initialDifference.elementChanges.count, 1)
+        XCTAssertEqual(initialDifference.elementChanges.first, .insertion(initialSeattleElement))
+
+        // Testing updating of existing geohash.
+        // - Expected key changes: zero.
+        // - Expected element changes: one removal and one insertion.
+        let secondSeattleElement = ["final", "seattle"]
+        let secondDifference = cache.upsert(geohash: seattle, element: secondSeattleElement)
+
+        XCTAssertTrue(secondDifference.keyChanges.isEmpty)
+
+        XCTAssertEqual(secondDifference.elementChanges.count, 2)
+        XCTAssertEqual(secondDifference.elementChanges[0], .removal(initialSeattleElement), "Removal should occur first in the diff collection")
+        XCTAssertEqual(secondDifference.elementChanges[1], .insertion(secondSeattleElement), "Insertion should occur after the removal")
+
+        // Test upserting a new geohash, with at least 1 other existing geohash
+        let initialBellevueElement = ["bellevue"]
+
+        let initialBellevueDifference = cache.upsert(geohash: bellevue, element: initialBellevueElement)
+        XCTAssertEqual(initialBellevueDifference.keyChanges.count, 1)
+        XCTAssertEqual(initialBellevueDifference.keyChanges.first, .insertion(bellevue))
+
+        XCTAssertEqual(initialBellevueDifference.elementChanges.count, 1)
+        XCTAssertEqual(initialBellevueDifference.elementChanges.first, .insertion(initialBellevueElement))
+    }
+}


### PR DESCRIPTION
Reopen of #669, targeting feature branch `ualch9/map_tiles`.

`ualch9/map_tiles` feature needs:
- [ ] On-device caching. This PR will dramatically increase API calls if this is implemented as-is, so the device should keep a cache of stops that expire every couple of days.
- [ ] Annotation clustering. Since we are no longer getting data whenever the map moves, It is now cheaper for the device to show more annotations. It is a nicer user-experience to just show clusterings rather than a "Zoom In To See Stops" message.
- [ ] Reconfigure "Nearby Stops" in the map panel. This used to show a list of all stops on the map, but this should be reconfigured to show stops relative to the user's location. Updating the list depending on the user's map view might be too distracting...

--- 

Uses [Geohash](https://en.wikipedia.org/wiki/Geohash) to create geographical tiles. Geohash code is tested and maintained by me (https://github.com/ualch9/GeohashKit).

Fixes #563 

---

https://user-images.githubusercontent.com/22162410/236625342-9288e489-e385-4aeb-b7de-5c123f3084c9.mov

