### PR TITLE
Attempts to fix wildly incorrect arrival-departure predictions

### DIFF
--- a/OBAKitCore/Models/Helpers/ModelHelpers.swift
+++ b/OBAKitCore/Models/Helpers/ModelHelpers.swift
@@ -10,12 +10,13 @@
 import Foundation
 
 class ModelHelpers: NSObject {
-    /// Converts a date that represents the 1970 epoch date to `nil`.
-    ///
+    /// Converts a date from before the specified `earlierDate` to `nil`.
+    /// 
     /// - Parameter date: A date
-    /// - Returns: Nil if the date was represented by the value `0` and the date otherwise.
-    public static func nilifyEpochDate(_ date: Date) -> Date? {
-        if date == Date(timeIntervalSince1970: 0) {
+    /// - Parameter earlierDate: The lower bound for returning `date`.
+    /// - Returns: `date` if date >= `earlierDate`; otherwise `nil`.
+    public static func nilifyDate(_ date: Date, earlierThan earlierDate: Date) -> Date? {
+        if date < earlierDate {
             return nil
         }
         else {

--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -145,13 +145,13 @@ public class ArrivalDeparture: NSObject, Identifiable, Decodable, HasReferences 
         predicted = try container.decode(Bool.self, forKey: .predicted)
 
         if let predictedArrivalDate = try container.decodeIfPresent(Date.self, forKey: .predictedArrival) {
-            predictedArrival = ModelHelpers.nilifyEpochDate(predictedArrivalDate)
+            predictedArrival = ModelHelpers.nilifyDate(predictedArrivalDate, earlierThan: Date(timeIntervalSinceReferenceDate: 1.0))
         } else {
             predictedArrival = nil
         }
 
         if let predictedDepartureDate = try container.decodeIfPresent(Date.self, forKey: .predictedDeparture) {
-            predictedDeparture = ModelHelpers.nilifyEpochDate(predictedDepartureDate)
+            predictedDeparture = ModelHelpers.nilifyDate(predictedDepartureDate, earlierThan: Date(timeIntervalSinceReferenceDate: 1.0))
         } else {
             predictedDeparture = nil
         }


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/681

Before, we were `nil`'ing out ArrivalDeparture prediction dates whose values were `0`. Now, instead, we'll just treat anything earlier than 2001 as being invalid.

Note: 2001 is an arbitrary early cutoff. It could just as easily be `today - 1 month`.