### PR TITLE
Service alert features

### DIFF
--- a/OBAKit/Alerts/TransitAlertDetailViewController.swift
+++ b/OBAKit/Alerts/TransitAlertDetailViewController.swift
@@ -7,13 +7,18 @@
 
 import OBAKitCore
 import UIKit
+import WebKit
+import SafariServices
 
-class TransitAlertDetailViewController: UIViewController {
-    private let transitAlert: TransitAlertViewModel
-    private let webView = DocumentWebView()
+/// Renders a full page version of a `TransitAlertViewModel`
+///
+/// This includes an optional "Learn More" button at the bottom of the page if the transit alert has a value for `url(forLocale:)`.
+class TransitAlertDetailViewController: UIViewController, WKScriptMessageHandler {
+    private let locale: Locale
 
-    init(_ transitAlert: TransitAlertViewModel) {
+    init(_ transitAlert: TransitAlertViewModel, locale: Locale = .current) {
         self.transitAlert = transitAlert
+        self.locale = locale
         super.init(nibName: nil, bundle: nil)
 
         self.title = Strings.serviceAlert
@@ -22,19 +27,20 @@ class TransitAlertDetailViewController: UIViewController {
     }
 
     override func viewDidLoad() {
-        webView.frame = view.bounds
-        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
+
         view.addSubview(webView)
 
-        let title = transitAlert.title(forLocale: .current) ?? Strings.serviceAlert
-        let body = transitAlert.body(forLocale: .current) ?? OBALoc("transit_alert.no_additional_details.body", value: "No additional details available.", comment: "A notice when a transit alert doesn't have body text.")
+        let title = transitAlert.title(forLocale: locale) ?? Strings.serviceAlert
+        var body = transitAlert.body(forLocale: locale) ?? OBALoc("transit_alert.no_additional_details.body", value: "No additional details available.", comment: "A notice when a transit alert doesn't have body text.")
+        body = body.replacingOccurrences(of: "\n", with: "<br>")
 
         let html = """
-        <h1>\(title)</h1>
-        <p>\(body)</p>
+        <h1 class='title'>\(title)</h1>
+        <p class='body'>\(body)</p>
         """
 
-        webView.setPageContent(html)
+        webView.setPageContent(html, actionButtonTitle: destinationURL != nil ? Strings.learnMore : nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -42,6 +48,53 @@ class TransitAlertDetailViewController: UIViewController {
         guard isModalInPresentation else { return }
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.close, style: .done, target: self, action: #selector(close))
     }
+
+    // MARK: - Transit Alert
+
+    private let transitAlert: TransitAlertViewModel
+
+    private var destinationURL: URL? {
+        transitAlert.url(forLocale: locale)
+    }
+
+    // MARK: - Web View
+
+    private lazy var webView: DocumentWebView = {
+        let configuration = WKWebViewConfiguration()
+        let userContentController = WKUserContentController()
+        userContentController.add(self, name: DocumentWebView.actionButtonHandlerName)
+        configuration.userContentController = userContentController
+
+        let view = DocumentWebView(frame: view.bounds, configuration: configuration)
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        if #available(iOS 16.4, *) {
+            view.isInspectable = true
+        }
+
+        return view
+    }()
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard
+            message.name == DocumentWebView.actionButtonHandlerName,
+            let destinationURL
+        else {
+            return
+        }
+
+        let safari = SFSafariViewController(url: destinationURL)
+        present(safari, animated: true)
+    }
+
+    // MARK: - Close
+
+    private lazy var closeButton: UIButton = {
+        let btn = UIButton.buildCloseButton()
+        btn.addTarget(self, action: #selector(close), for: .touchUpInside)
+
+        return btn
+    }()
 
     @objc func close() {
         if let navController = self.navigationController, navController.topViewController != self {

--- a/OBAKit/Donations/DonationsManager.swift
+++ b/OBAKit/Donations/DonationsManager.swift
@@ -41,7 +41,6 @@ public class DonationsManager {
     private let obacoService: ObacoAPIService?
     private let analytics: Analytics?
 
-
     // MARK: - User Defaults
 
     private let userDefaults: UserDefaults

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -276,7 +276,7 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     private var presentDonationUIOnActive = false
-    private var donationPromptID: String? = nil
+    private var donationPromptID: String?
 
     public func pushService(_ pushService: PushService, receivedDonationPrompt id: String?) {
         guard let topViewController else {

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -107,13 +107,9 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     public func navigateTo(alert: TransitAlertViewModel, locale: Locale = .current, from fromController: UIViewController) {
         guard shouldNavigate(from: fromController, to: .transitAlert(alert)) else { return }
 
-        if let url = alert.url(forLocale: locale) {
-            let safari = SFSafariViewController(url: url)
-            present(safari, from: fromController, isModal: true)
-        } else {
-            let view = TransitAlertDetailViewController(alert)
-            present(view, from: fromController)
-        }
+        let view = TransitAlertDetailViewController(alert, locale: locale)
+        let navigationController = UINavigationController(rootViewController: view)
+        present(navigationController, from: fromController)
     }
 
     // MARK: - Helpers

--- a/OBAKit/WebView/document_web_view_content.html
+++ b/OBAKit/WebView/document_web_view_content.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <meta content='initial-scale=1.0, user-scalable=no' name='viewport'>
+    <style type='text/css'>
+        :root {
+            color-scheme: light dark;
+        }
+
+        html {
+            overflow-x: hidden;
+        }
+
+        body {
+            -webkit-text-size-adjust: none;
+            font-family: system, -apple-system, "Helvetica Neue", Helvetica, sans-serif;
+            padding: 8px;
+            overflow-x: hidden;
+        }
+
+        @media screen and (prefers-color-scheme:light) {
+            body {
+                background-color: #fff;
+                color: #000;
+            }
+        }
+
+        @media screen and (prefers-color-scheme:dark) {
+            body {
+                background-color: #000;
+                color: #fff;
+            }
+        }
+
+        code,
+        pre {
+            max-width: 300px;
+            overflow-x: hidden;
+        }
+
+        code h1 {
+            font-size: 0.85rem;
+        }
+
+        h1 {
+            font-size: 1.25em;
+            line-height: 1.25;
+        }
+
+        h2 {
+            font-size: 0.85rem;
+        }
+
+        .page-content {
+            line-height: 1.5;
+        }
+
+        .actions {
+            margin-top: 8px;
+        }
+
+        .actions__button-container {
+            margin: 0 auto;
+        }
+
+        .actions__button-container__button {
+            background: {{{accent_color}}};
+            color: {{{accent_foreground_color}}};
+            display: block;
+            margin-bottom: 0.5rem;
+            border-radius: 8px;
+            font-size: 1.25rem;
+            width: 100%;
+            font-weight: 500;
+            padding: 0.75rem 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class='page-content'>
+        {{{oba_page_content}}}
+    </div>
+    <div class='actions'>
+        {{{oba_page_actions}}}
+    </div>
+</body>
+
+</html>

--- a/OBAKitCore/Extensions/UIKitExtensions.swift
+++ b/OBAKitCore/Extensions/UIKitExtensions.swift
@@ -79,6 +79,11 @@ public extension UIBarButtonItem {
 // Adapted from https://cocoacasts.com/from-hex-to-uicolor-and-back-in-swift
 public extension UIColor {
 
+    /// Returns the accent color defined in the app's xcasset bundle. Make sure this is set, or calling it will crash the app!
+    static var accentColor: UIColor {
+        return UIColor(named: "AccentColor")!
+    }
+
     /// Initializes a `UIColor` using `0-255` range `Int` values.
     /// - Parameter r: Red, `0-255`.
     /// - Parameter g: Green, `0-255`.
@@ -135,28 +140,78 @@ public extension UIColor {
     }
 
     // MARK: - From UIColor to String
-
+    
+    /// Generates a hex value from the receiver
+    ///
+    /// The hex values _do not_ have leading `#` values.
+    /// In other words, `UIColor.red` -> `ff0000`.
+    ///
+    /// - Parameter alpha: Whether to include the alpha channel.
+    /// - Returns: The hex string.
     func toHex(alpha: Bool = false) -> String? {
-        guard let components = cgColor.components, components.count >= 3 else {
+        let components = cgColor.components
+        let numberOfComponents = cgColor.numberOfComponents
+
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 1
+
+        switch numberOfComponents {
+        case 2: // Grayscale
+            r = components?[0] ?? 0
+            g = components?[0] ?? 0
+            b = components?[0] ?? 0
+            a = components?[1] ?? 1
+        case 4: // RGBA
+            r = components?[0] ?? 0
+            g = components?[1] ?? 0
+            b = components?[2] ?? 0
+            a = components?[3] ?? 1
+        default:
             return nil
         }
 
-        let r = Float(components[0])
-        let g = Float(components[1])
-        let b = Float(components[2])
-        var a = Float(1.0)
-
-        if components.count >= 4 {
-            a = Float(components[3])
-        }
-
         if alpha {
-            return String(format: "%02lX%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255), lroundf(a * 255))
-        }
-        else {
-            return String(format: "%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255))
+            return String(format: "%02lX%02lX%02lX%02lX",
+                          lroundf(Float(r) * 255),
+                          lroundf(Float(g) * 255),
+                          lroundf(Float(b) * 255),
+                          lroundf(Float(a) * 255))
+        } else {
+            return String(format: "%02lX%02lX%02lX",
+                          lroundf(Float(r) * 255),
+                          lroundf(Float(g) * 255),
+                          lroundf(Float(b) * 255))
         }
     }
+
+    // MARK: - Luminance
+
+    /// Returns a dark text color if the receiver is light, and light if the receiver is dark.
+    var contrastingTextColor: UIColor {
+        if isLightColor {
+            return UIColor.darkText
+        }
+        else {
+            return UIColor.lightText
+        }
+    }
+
+    /// Determine if the receiver is a 'light' or 'dark' color.
+    var isLightColor: Bool {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        // Calculating the Perceived Luminance
+        let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
+        return luminance > 0.5
+    }
+
 }
 
 // MARK: - UICollectionView


### PR DESCRIPTION
Fixes #700 

We now show the full content of the transit alert's body in a popup view controller, and optionally include a "Learn More" button at the bottom of it if the transit alert includes a URL.

# San Diego Ux

![SD](https://github.com/OneBusAway/onebusaway-ios/assets/2254/a03298dc-5b82-433e-97bf-9d15d63582b6)

# Seattle Ux

![SEA](https://github.com/OneBusAway/onebusaway-ios/assets/2254/57dca7cf-b50a-441d-8dcd-82fefc2e180a)
