### PR TITLE
Make the donations UI work on first app launch

### DIFF
--- a/OBAKit/Donations/DonationsManager.swift
+++ b/OBAKit/Donations/DonationsManager.swift
@@ -17,7 +17,6 @@ public class DonationsManager {
     /// - Parameters:
     ///   - bundle: The application bundle. Usually, `Bundle.main`
     ///   - userDefaults: The user defaults object.
-    ///   - obacoService: The Obaco API service.
     ///   - analytics: The Analytics object.
     public init(
         bundle: Bundle,
@@ -27,7 +26,6 @@ public class DonationsManager {
     ) {
         self.bundle = bundle
         self.userDefaults = userDefaults
-        self.obacoService = obacoService
         self.analytics = analytics
 
         self.userDefaults.register(
@@ -38,7 +36,7 @@ public class DonationsManager {
     // MARK: - Data
 
     private let bundle: Bundle
-    private let obacoService: ObacoAPIService?
+    var obacoService: ObacoAPIService?
     private let analytics: Analytics?
 
     // MARK: - User Defaults

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -338,8 +338,6 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     @objc public func application(_ application: UIApplication, didFinishLaunching options: [AnyHashable: Any]) {
-        donationsManager.refreshStripePublishableKey()
-
         application.shortcutItems = nil
 
         configurePushNotifications(launchOptions: options)
@@ -436,6 +434,13 @@ public class Application: CoreApplication, PushServiceDelegate {
         return true
     }
 
+    override public func apiServicesRefreshed() {
+        super.apiServicesRefreshed()
+
+        donationsManager.obacoService = obacoService
+        donationsManager.refreshStripePublishableKey()
+    }
+
     // MARK: - Appearance and Themes
 
     /// Sets default styles for several UIAppearance proxies in order to customize the app's look and feel
@@ -458,6 +463,7 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     // MARK: - Regions Management
+
     public func regionsService(_ service: RegionsService, changedAutomaticRegionSelection value: Bool) {
         let label = value ? AnalyticsLabels.setRegionAutomatically : AnalyticsLabels.setRegionManually
         analytics?.reportEvent?(.userAction, label: label, value: nil)

--- a/OBAKitCore/Extensions/UIKitExtensions.swift
+++ b/OBAKitCore/Extensions/UIKitExtensions.swift
@@ -140,7 +140,7 @@ public extension UIColor {
     }
 
     // MARK: - From UIColor to String
-    
+
     /// Generates a hex value from the receiver
     ///
     /// The hex values _do not_ have leading `#` values.

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -87,8 +87,20 @@ open class CoreApplication: NSObject,
         Task {
             await regionsService.updateRegionsList()
         }
+        refreshServices()
+    }
+
+    /// This function reloads the REST API and Obaco Services.
+    private func refreshServices() {
         refreshRESTAPIService()
         refreshObacoService()
+        apiServicesRefreshed()
+    }
+
+    /// Called after the REST API and Obaco Services have been reloaded.
+    /// The default implementation is a no-op.
+    open func apiServicesRefreshed() {
+        // nop
     }
 
     // MARK: - Agency Alerts
@@ -178,8 +190,7 @@ open class CoreApplication: NSObject,
     }()
 
     open func regionsService(_ service: RegionsService, willUpdateToRegion region: Region) {
-        refreshRESTAPIService()
-        refreshObacoService()
+        refreshServices()
     }
 
     open func regionsService(_ service: RegionsService, updatedRegion region: Region) {


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/703

The donations UI wasn't loading because the Obaco API Service was nil on first run (due to a region not being available yet). This fix addresses that issue by refreshing the Obaco API Service object that is passed to the `DonationsManager` any time it changes. It also DRYs up reloading API services in CoreApplication and provides a hook to perform actions after they're reloaded.