### PR TITLE
Handle scenarios where JSON k/v for `TimeWindow.to` is missing

### DIFF
--- a/OBAKitCore/Models/REST/References/ServiceAlert.swift
+++ b/OBAKitCore/Models/REST/References/ServiceAlert.swift
@@ -134,7 +134,13 @@ public class ServiceAlert: NSObject, Identifiable, Decodable, HasReferences {
         public required init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             from = Date(timeIntervalSince1970: TimeInterval(try container.decode(Int.self, forKey: .from)))
-            to = Date(timeIntervalSince1970: TimeInterval(try container.decode(Int.self, forKey: .to)))
+
+            if let rawToValue = try container.decodeIfPresent(Int.self, forKey: .to) {
+                to = Date(timeIntervalSince1970: TimeInterval(rawToValue))
+            }
+            else {
+                to = Date.distantFuture
+            }
         }
 
         public override func isEqual(_ object: Any?) -> Bool {


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-ios/issues/706

We should gracefully handle the case where a transit agency has forgotten to set a `to` value for a service alert's time window.