### PR TITLE
Fix: issue 629

### DIFF
--- a/OBAKitCore/Location/Regions/RegionsServiceFileManagerProtocol.swift
+++ b/OBAKitCore/Location/Regions/RegionsServiceFileManagerProtocol.swift
@@ -1,0 +1,74 @@
+//
+//  RegionsServiceFileManagerProtocol.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// A protocol defining file management operations.
+public protocol RegionsServiceFileManagerProtocol: AnyObject {
+    
+    /// Saves the Codable object to the specified directory with the given name.
+    ///
+    /// - Parameters:
+    ///   - object: The Codable object to save.
+    ///   - destination: The destination specifying where to save the object.
+    func save<T: Codable>(_ object: T, to destination: URL) throws
+    
+    /// Loads a Codable object of the specified type from the file with the given URL.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the Codable object to load.
+    ///   - fileURL: The URL of the file to load the object from.
+    /// - Returns: The decoded Codable object.
+    func load<T: Codable>(_ type: T.Type, from fileURL: URL) throws -> T
+    
+    /// Removes the file at the specified destination.
+    ///
+    /// - Parameters:
+    ///   - destination: The destination specifying which file to remove.
+    func remove(at destination: URL) throws
+    
+    /// Returns an array of URLs for the items at the specified URL.
+    ///
+    /// - Parameters:
+    ///   - destination: The destination specifying where to load contents of.
+    /// - Returns: An array of URLs for the items in the directory.
+    func urls(at destination: URL) throws -> [URL]
+    
+}
+
+extension FileManager: RegionsServiceFileManagerProtocol {
+    
+    /// Creates a directory at the specified URL if it doesn't already exist.
+    private func createDirectoryIfNeeded(at url: URL) throws {
+        guard !fileExists(atPath: url.path) else { return }
+        try createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+    }
+    
+    public func urls(at destination: URL) throws -> [URL] {
+        return try contentsOfDirectory(at: destination, includingPropertiesForKeys: nil)
+    }
+        
+    public func load<T: Codable>(_ type: T.Type, from fileURL: URL) throws -> T {
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+    
+    public func save<T: Codable>(_ object: T, to destination: URL) throws {
+        let directoryURL = destination.deletingLastPathComponent()
+        try createDirectoryIfNeeded(at: directoryURL)
+        let encoded = try JSONEncoder().encode(object)
+        try encoded.write(to: destination)
+    }
+        
+    public func remove(at destination: URL) throws {
+        guard fileExists(atPath: destination.path) else { return }
+        try removeItem(at: destination)
+    }
+    
+}

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -28,6 +28,9 @@ open class CoreApplication: NSObject,
     /// Shared user defaults
     @objc public let userDefaults: UserDefaults
 
+    /// Default file manager.
+    private let fileManager: RegionsServiceFileManagerProtocol
+
     /// The underlying implementation of our data stores.
     private let userDefaultsStore: UserDefaultsStore
 
@@ -47,7 +50,7 @@ open class CoreApplication: NSObject,
     @objc public let locationService: LocationService
 
     /// Responsible for managing `Region`s and determining the correct `Region` for the user.
-    @objc public lazy var regionsService = RegionsService(apiService: regionsAPIService, locationService: locationService, userDefaults: userDefaults, bundledRegionsFilePath: self.config.bundledRegionsFilePath, apiPath: self.config.regionsAPIPath)
+    @objc public lazy var regionsService = RegionsService(apiService: regionsAPIService, locationService: locationService, userDefaults: userDefaults, fileManager: fileManager, bundledRegionsFilePath: self.config.bundledRegionsFilePath, apiPath: self.config.regionsAPIPath)
 
     /// Helper property that returns `regionsService.currentRegion`.
     @objc public var currentRegion: Region? {
@@ -73,6 +76,7 @@ open class CoreApplication: NSObject,
         self.config = config
 
         userDefaults = config.userDefaults
+        fileManager = FileManager.default
         userDefaultsStore = UserDefaultsStore(userDefaults: userDefaults)
 
         locationService = config.locationService

--- a/OBAKitTests/Helpers/Mocks/FileManagerMock.swift
+++ b/OBAKitTests/Helpers/Mocks/FileManagerMock.swift
@@ -1,0 +1,35 @@
+//
+//  FileManagerMock.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+class RegionsServiceFileManagerMock: RegionsServiceFileManagerProtocol {
+    
+    var savedObjects: [String: Data] = [:]
+    
+    func save<T>(_ object: T, to destination: URL) throws where T : Decodable, T : Encodable {
+        let encodedData = try JSONEncoder().encode(object)
+        savedObjects[destination.path] = encodedData
+    }
+    
+    func load<T>(_ type: T.Type, from fileURL: URL) throws -> T where T : Decodable {
+        let data = savedObjects[fileURL.path, default: Data()]
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+    
+    func remove(at destination: URL) throws {
+        savedObjects.removeValue(forKey: destination.path)
+    }
+    
+    func urls(at destination: URL) throws -> [URL] {
+        return []
+    }
+    
+}


### PR DESCRIPTION
##### This PR migrates regions storage from UserDefaults to FileManager. Same file structure followed as mentioned in issue description. 

<hr>
fixes issue: #629 
<hr>

### Code Changes

- Created `FileManagerProtocol` to abstract FileManager operations for testability.
- Updated RegionService to store and fetch defaultRegion and custom Regions in File system. 
- Created `FileManagerMock` and updated `RegionsServiceTests`.

