### PR TITLE
Accessibility Changes to OBAListView + EmptyDataSetView

### DIFF
--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -115,6 +115,10 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
 
         let reuseIdentifier = formattedConfig.obaContentView.ReuseIdentifier
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
+        if (obaDataSource?.items(for: self) ?? [])[indexPath.section].hasHeader,
+           indexPath.row == 0 {
+            cell.accessibilityTraits = .header
+        }
 
         guard let obaView = cell as? OBAListViewCell else {
             fatalError("You are trying to use a cell in OBAListView that isn't OBAListViewCell.")
@@ -144,7 +148,12 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
     }
 
     func listCell(_ collectionView: UICollectionView, indexPath: IndexPath, item: AnyOBAListViewItem, config: UIListContentConfiguration, accessories: [UICellAccessory?]) -> UICollectionViewListCell? {
-        return collectionView.dequeueConfiguredReusableCell(using: listCellRegistration, for: indexPath, item: item)
+        let cell = collectionView.dequeueConfiguredReusableCell(using: listCellRegistration, for: indexPath, item: item)
+        if (obaDataSource?.items(for: self) ?? [])[indexPath.section].hasHeader,
+           indexPath.row == 0 {
+            cell.accessibilityTraits = .header
+        }
+        return cell
     }
 
     // MARK: - Item selection actions

--- a/OBAKitCore/Collections/EmptyDataSetView.swift
+++ b/OBAKitCore/Collections/EmptyDataSetView.swift
@@ -116,7 +116,9 @@ public class EmptyDataSetView: UIView {
 
         NSLayoutConstraint.activate([
             imageViewHeightConstraint,
-            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor)
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
+            titleLabel.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 0.9),
+            bodyLabel.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 0.9)
         ])
 
         // TOOD: Use readableContentGuides instead of layoutMarginsGuide.


### PR DESCRIPTION
# Code Changes for Accessibility
- OBAListView changes. Gave the first element of every section that has a header accessibility trait of header. This will help in VoiceOver going over each header one by one
- Layout constraints fix for text label in EmptyDataSetView.