### PR TITLE
Fix deprecation warnings for onChange(of:perform:) in iOS 17.0 

### DIFF
--- a/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios-spm",
       "state" : {
-        "revision" : "999143c82704e6395b62a9b8259ecfbee131eff9",
-        "version" : "24.1.0"
+        "revision" : "90129926d024ea0259cb854c6b23f4061ae76323",
+        "version" : "23.30.0"
       }
     },
     {

--- a/OBAKit/Controls/Navigation/RenamableNavigationTitle.swift
+++ b/OBAKit/Controls/Navigation/RenamableNavigationTitle.swift
@@ -34,10 +34,10 @@ fileprivate struct RenamableNavigationTitle<MenuItems: View>: ViewModifier {
                 // way to have an `onChange` to fire on initial value.
                 textFieldValue = title
             }
-            .onChange(of: title) { _ , newValue in
+            .onChange(of: title) { _, newValue in
                 textFieldValue = newValue
             }
-            .onChange(of: isEditing) { _ , newIsEditing in
+            .onChange(of: isEditing) { _, newIsEditing in
                 isFocusedOnTextField = newIsEditing
             }
     }

--- a/OBAKit/Controls/Navigation/RenamableNavigationTitle.swift
+++ b/OBAKit/Controls/Navigation/RenamableNavigationTitle.swift
@@ -34,10 +34,10 @@ fileprivate struct RenamableNavigationTitle<MenuItems: View>: ViewModifier {
                 // way to have an `onChange` to fire on initial value.
                 textFieldValue = title
             }
-            .onChange(of: title) { newValue in
+            .onChange(of: title) { _ , newValue in
                 textFieldValue = newValue
             }
-            .onChange(of: isEditing) { newIsEditing in
+            .onChange(of: isEditing) { _ , newIsEditing in
                 isFocusedOnTextField = newIsEditing
             }
     }

--- a/OBAKit/Donations/DonationLearnMoreView.swift
+++ b/OBAKit/Donations/DonationLearnMoreView.swift
@@ -76,7 +76,7 @@ struct DonationLearnMoreView: View {
         .alert("Enter an amount in U.S. dollars", isPresented: otherAmountSelected) {
             buildOtherAmountAlert()
         }
-        .onChange(of: donationModel.donationComplete) { newValue in
+        .onChange(of: donationModel.donationComplete) { _, newValue in
             guard newValue else { return }
 
             let shouldDismiss: Bool

--- a/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
@@ -79,11 +79,9 @@ public struct RegionPickerView<Provider: RegionProvider>: View, OnboardingView {
 
         // Lifecycle-related modifiers
         .onAppear(perform: setCurrentRegionIfPresent)
-        .onChange(of: regionProvider.currentRegion) { [regionProvider] _ in
-            // When the user selects to automatically select a region, update
-            // selectedRegion with the new current region.
+        .onChange(of: regionProvider.currentRegion, initial: false) { newRegion, _ in
             if regionProvider.automaticallySelectRegion {
-                self.selectedRegion = regionProvider.currentRegion
+                self.selectedRegion = newRegion
             }
         }
 

--- a/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
@@ -79,7 +79,9 @@ public struct RegionPickerView<Provider: RegionProvider>: View, OnboardingView {
 
         // Lifecycle-related modifiers
         .onAppear(perform: setCurrentRegionIfPresent)
-        .onChange(of: regionProvider.currentRegion, initial: false) { newRegion, _ in
+        .onChange(of: regionProvider.currentRegion, initial: false) { _, newRegion in
+            // When the user selects to automatically select a region, update
+            // selectedRegion with the new current region.
             if regionProvider.automaticallySelectRegion {
                 self.selectedRegion = newRegion
             }


### PR DESCRIPTION
Replaced deprecated onChange(of:perform:) modifiers with the new onChange(of:initial:_:) syntax across the codebase to address deprecation warnings in iOS 17. 
#762 
@aaronbrethorst you’ve already fixed some of these deprecation issues, but I wanted to share my implementation too. 

#### Modified Files:
- `RenamableNavigationTitle.swift`
- `DonationLearnMoreView.swift`
- `RegionPickerView.swift`