### PR TITLE
Fix: Show bookmarks when location unavailable (fixes: #680)

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -186,12 +186,10 @@ public class BookmarksViewController: UIViewController,
 
     // MARK: - List view
     public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        if sortBookmarksByGroup {
-            return listItemsSortedByGroup()
-        }
-        else {
-            return listItemsSortedByDistance()
-        }
+        if !sortBookmarksByGroup && application.locationService.currentLocation == nil {
+                return listItemsSortedByGroup()
+            }
+        return sortBookmarksByGroup ? listItemsSortedByGroup() : listItemsSortedByDistance()
     }
 
     /// Creates an `OBAListViewSection` containing the specified bookmarks.
@@ -226,17 +224,16 @@ public class BookmarksViewController: UIViewController,
         let title: String
         let body: String
 
-        switch (application.hasDataToMigrate, distanceSortRequestedButUnavailable) {
-        case (true, _):
-            title = Strings.emptyBookmarkTitle
-            body = Strings.emptyBookmarkBodyWithPendingMigration
-        case (false, false):
-            title = Strings.emptyBookmarkTitle
-            body = Strings.emptyBookmarkBody
-        case (false, true):
-            title = Strings.locationUnavailable
-            body = OBALoc("bookmarks_controller.unable_to_sort_by_distance_error", value: "We can't sort your bookmarks by distance because your location is not available.", comment: "An error message displayed on the bookmarks tab when the user has Sort By Distance enabled and their location isn't available.")
-        }
+        if application.hasDataToMigrate {
+                title = Strings.emptyBookmarkTitle
+                body = Strings.emptyBookmarkBodyWithPendingMigration
+            } else if application.userDataStore.bookmarks.isEmpty {
+                title = Strings.emptyBookmarkTitle
+                body = Strings.emptyBookmarkBody
+            } else {
+                // Don't show empty state if we have bookmarks
+                return nil
+            }
 
         return .standard(.init(title: title, body: body))
     }
@@ -275,7 +272,7 @@ public class BookmarksViewController: UIViewController,
     /// Builds a single item array that contains a list of all bookmarks in the current region sorted by distance from the current user.
     private func listItemsSortedByDistance() -> [OBAListViewSection] {
         guard let currentLocation = application.locationService.currentLocation else {
-            return []
+            return listItemsSortedByGroup()
         }
 
         let bookmarks = application.userDataStore.bookmarks.sorted(by: {


### PR DESCRIPTION
Fixes #680 

When location services are disabled and bookmarks are sorted by distance:
- Previously: No bookmarks were shown with a "Location Unavailable" message (see screenshot below)
- Now: Falls back to showing bookmarks sorted by group.

Changes made :
1. Changed listItemsSortedByDistance() to fall back to group sorting when no location
2. Modified items(for:) to automatically fall back to group sorting when location is unavailable
3. Updated emptyData(for:) to only show empty state for actual empty bookmarks

Before (Location Unavailable):
![image](https://github.com/user-attachments/assets/07a76f30-a93b-46ba-9f89-37fe698a56a0)