### PR TITLE
Fix Deprecated warning for onChange(of: perform:) in iOS 17

### DIFF
--- a/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
@@ -88,11 +88,11 @@ public struct RegionPickerView<Provider: RegionProvider>: View, OnboardingView {
 
             // Lifecycle-related modifiers
             .onAppear(perform: setCurrentRegionIfPresent)
-            .onChange(of: regionProvider.currentRegion) { [regionProvider] _ in
+            .onChange(of: regionProvider.currentRegion) { _, newRegion in
                 // When the user selects to automatically select a region, update
                 // selectedRegion with the new current region.
                 if regionProvider.automaticallySelectRegion {
-                    self.selectedRegion = regionProvider.currentRegion
+                    self.selectedRegion = newRegion
                 }
             }
 


### PR DESCRIPTION
Refers to [issue#784](https://github.com/OneBusAway/onebusaway-ios/issues/784)
