### PR TITLE
Fix: Weather Button Tap Not Responding(Issue #754)

### DIFF
--- a/OBAKitCore/Models/Helpers/InternalTypes.swift
+++ b/OBAKitCore/Models/Helpers/InternalTypes.swift
@@ -37,7 +37,19 @@ extension CLLocation {
 extension JSONDecoder {
     class var obacoServiceDecoder: JSONDecoder {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withTimeZone]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+            let fixedDateString = dateString.replacingOccurrences(of: "+00:00", with: "Z")
+
+            if let date = formatter.date(from: fixedDateString) {
+                return date
+            } else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format")
+            }
+        }
 
         return decoder
     }

--- a/OBAKitCore/Models/Helpers/InternalTypes.swift
+++ b/OBAKitCore/Models/Helpers/InternalTypes.swift
@@ -36,23 +36,21 @@ extension CLLocation {
 
 extension JSONDecoder {
     class var obacoServiceDecoder: JSONDecoder {
-        let decoder = JSONDecoder()
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withTimeZone]
-        decoder.dateDecodingStrategy = .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let dateString = try container.decode(String.self)
-            let fixedDateString = dateString.replacingOccurrences(of: "+00:00", with: "Z")
-
-            if let date = formatter.date(from: fixedDateString) {
-                return date
-            } else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format")
+            let decoder = JSONDecoder()
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds, .withTimeZone]
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                let dateString = try container.decode(String.self)
+                let fixedDateString = dateString.replacingOccurrences(of: "+00:00", with: "Z")
+                if let date = formatter.date(from: fixedDateString) {
+                    return date
+                } else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format")
+                }
             }
+            return decoder
         }
-
-        return decoder
-    }
 
     class func RESTDecoder(regionIdentifier: Int? = nil) -> JSONDecoder {
         let decoder = JSONDecoder()


### PR DESCRIPTION
Refers to [Issue#754](https://github.com/OneBusAway/onebusaway-ios/issues/754)

The format of the date was not being changed correctly to match Swift's ISO8601 format, hence throwing the error "Expected date string to be ISO8601-formatted."

The weather button functions in a way that if the forecast is nil, then the button would not load on the screen(instead of being there as a hyphen and unresponsive).

Attached a video of me changing regions to see the temperature changes. In my opinion, there is still room for improvement if we can incorporate a more detailed UI of the weather function or show more than just a summary of the weather. 

Let me know if you want any additional changes.


https://github.com/user-attachments/assets/2bbd3d7b-f59d-463c-a71d-06d41abf329c

