### PR TITLE
Fix deprecation: 'onChange(of:perform:)' was deprecated in iOS 17.0 

### DIFF
--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -110,7 +110,9 @@ public class SearchManager: NSObject {
 
         do {
             let response = try await apiService.getRoute(query: request.query, region: CLCircularRegion(mapRect: mapRect))
-            self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
+            await MainActor.run {
+                self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
+            }
         } catch {
             await self.application.displayError(error)
         }


### PR DESCRIPTION
Marked searchRoute with @MainActor to ensure UI updates happen on the main thread. Fixes a crash in Swift 6 when updating searchResponse from a non-isolated context.

Fixes  #784
