### PR TITLE
Fix: iOS 17 MapBuilder deprecation warning

### DIFF
--- a/OBAKit/Onboarding/RegionPicker/RegionPickerMap.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerMap.swift
@@ -34,10 +34,8 @@ struct RegionPickerMap: View {
 
             if let mapRect, isMapExpanded {
                 Map(
-                    mapRect: .constant(mapRect),
-                    interactionModes: [],
-                    showsUserLocation: false,
-                    userTrackingMode: .none
+                    position: .constant(.rect(mapRect)),
+                    interactionModes: []
                 )
                 .accessibilityElement(children: .ignore)
                 .cornerRadius(24)


### PR DESCRIPTION
'init(mapRect:interactionModes:showsUserLocation:userTrackingMode:)' was deprecated in iOS 17. Changed how the map was being built, and used MapCameraPosition instead. showsUserLocation is false by default. Refers to [Issue#766](https://github.com/OneBusAway/onebusaway-ios/issues/766)