### PR TITLE
Manual Regions Refresh on RegionPickerView

### DIFF
--- a/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerView.swift
@@ -61,9 +61,22 @@ public struct RegionPickerView<Provider: RegionProvider>: View, OnboardingView {
     public var body: some View {
         NavigationStack {
             List {
-                Toggle(
-                    "Automatically select region",
-                    isOn: $regionProvider.automaticallySelectRegion)
+                HStack {
+                    Toggle(
+                        "Automatically select region",
+                        isOn: $regionProvider.automaticallySelectRegion)
+
+                    Button {
+                        Task {
+                            await doRefreshRegions()
+                        }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .disabled(disableInteractions || regionProvider.automaticallySelectRegion)
+                    .buttonStyle(.plain)
+                }
+
                 Picker("", selection: $selectedRegion) {
                     ForEach(filteredRegions, id: \.self) { region in
                         cell(for: region)

--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -24,6 +24,9 @@ public class Region: NSObject, Identifiable, Codable {
         return self.regionIdentifier
     }
 
+    /// Unique instance identifier for equality and hashing purposes.
+    let instanceId = UUID()
+
     /// The unique ID for the region.
     public let regionIdentifier: RegionIdentifier
 
@@ -329,6 +332,7 @@ public class Region: NSObject, Identifiable, Codable {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Region else { return false }
         return name == rhs.name &&
+            instanceId == rhs.instanceId &&
             regionIdentifier == rhs.regionIdentifier &&
             isActive == rhs.isActive &&
             isExperimental == rhs.isExperimental &&
@@ -362,6 +366,7 @@ public class Region: NSObject, Identifiable, Codable {
         var hasher = Hasher()
         hasher.combine(name)
         hasher.combine(regionIdentifier)
+        hasher.combine(instanceId)
         hasher.combine(isActive)
         hasher.combine(isExperimental)
         hasher.combine(isCustom)


### PR DESCRIPTION
Fixes #605

- Add a Button to manually refresh regions 
- Add a instanceId to the Region Model for proper Hashable Conformance and preventing fatal errors 

https://github.com/user-attachments/assets/67899c65-56e9-4409-8a3e-32c2704f291e

