### PR TITLE
Fix black tabbar issue

### DIFF
--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -31,8 +31,6 @@ public class ClassicApplicationRootController: UITabBarController {
 
         super.init(nibName: nil, bundle: nil)
 
-        self.tabBar.isTranslucent = false
-
         self.application.viewRouter.rootController = self
 
         let mapNav = application.viewRouter.buildNavigation(controller: self.mapController, prefersLargeTitles: false)


### PR DESCRIPTION
Fix https://github.com/OneBusAway/onebusaway-ios/issues/802

### The problem:
Tab Bar background turns black when we force `tabbar.isTranslucent = false` without any background (the background can be color, image or view) as it treated as opaque without any background

### The solution:
reset `isTranslucent` to the default value

### How to reproduce the issue
- The issue happens for `Recent` and `Bookmarks` tabs when they are **empty**, or in `more` tab when we **scroll down** (most probably because the viewcontroller doesn't extend below the tabbar when it is empty)
- It also happens for light mode only