### PR TITLE
Fix Filtering for Single-Route Stops and All-Routes-Hidden Case

### DIFF
--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -301,7 +301,6 @@ public class StopViewController: UIViewController,
 
         let showAll = UIAction(title: allRoutesTitle) { [unowned self] _ in
             if self.isListFiltered {
-                // Only change value if it's different to avoid unnecessary data loading.
                 self.isListFiltered = false
             }
         }


### PR DESCRIPTION
Fixes #790 

**Description:**
Addresses the issue where filtering could hide all data at a stop, confusing users. Two main fixes:
1. **Single-Route Stops:** Modified `filterMenu()` to only show "Filtered Routes" if `stop.routes.count > 1`, preventing filtering on stops with one route.
2. **All Routes Filtered:** Updated `stopPreferences.didSet` and `stopUpdated(_:)` to detect when all routes are hidden, disable filtering (`isListFiltered = false`), and reload the UI with all routes visible.

**Changes:**
- `stopUpdated(_:)`: Resets filtering if all routes are hidden and refreshes UI.
- `filterMenu()`: Conditionally adds "Filtered Routes" for multi-route stops only.
- `stopPreferences.didSet`: Calls `stopUpdated(_:)` when filtering is active after preferences change.

**Testing:**
- Single-route stop: Confirmed "Filtered Routes" is absent, arrivals always show.
- Multi-route stop: Filtered all routes → UI reverts to showing all routes, no continuous requests.