### PR TITLE
Survey Feature API Setup

### DIFF
--- a/OBAKit/Controls/ListView/Rows/EmptyData/OBAEmptyDataSetItem.swift
+++ b/OBAKit/Controls/ListView/Rows/EmptyData/OBAEmptyDataSetItem.swift
@@ -64,6 +64,10 @@ struct EmptyDataSetItem: OBAListViewItem {
                 icon = UIImage(systemName: "bolt.horizontal.circle")
             case .requestNotFound:
                 icon = UIImage(systemName: "questionmark.square.dashed")
+            case .surveyServiceNotConfigured:
+                icon = UIImage(systemName: "doc.text.magnifyingglass")
+            case .noRegionSelected:
+                icon = UIImage(systemName: "location.slash")
             }
         default:
             break

--- a/OBAKit/Controls/ListView/Rows/EmptyData/OBAListViewEmptyDataViewModel.swift
+++ b/OBAKit/Controls/ListView/Rows/EmptyData/OBAListViewEmptyDataViewModel.swift
@@ -53,6 +53,10 @@ extension OBAListView {
                     icon = UIImage(systemName: "bolt.horizontal.circle")
                 case .requestNotFound:
                     icon = UIImage(systemName: "questionmark.square.dashed")
+                case .surveyServiceNotConfigured:
+                    icon = UIImage(systemName: "doc.text.magnifyingglass")
+                case .noRegionSelected:
+                    icon = UIImage(systemName: "location.slash")
                 }
             default:
                 break

--- a/OBAKit/Surveys/SurveyService.swift
+++ b/OBAKit/Surveys/SurveyService.swift
@@ -1,0 +1,313 @@
+//
+//  SurveyService.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Service responsible for managing survey operations including fetching, visibility logic, and submission
+@MainActor
+public class SurveyService: ObservableObject {
+
+    // MARK: - Properties
+
+    private let apiService: RESTAPIService?
+    private let userDataStore: UserDataStore
+    private let currentRegionProvider: () -> Region?
+
+    /// All surveys fetched from the API
+    @Published public private(set) var allSurveys: [Survey] = []
+
+    /// Surveys currently visible to the user based on context
+    @Published public private(set) var visibleSurveys: [Survey] = []
+
+    /// Whether surveys are currently being loaded
+    @Published public private(set) var isLoading: Bool = false
+
+    /// Last error that occurred during survey operations
+    @Published public private(set) var lastError: Error?
+
+    // MARK: - Initialization
+
+    public init(apiService: RESTAPIService?, userDataStore: UserDataStore, currentRegionProvider: @escaping () -> Region?) {
+        self.apiService = apiService
+        self.userDataStore = userDataStore
+        self.currentRegionProvider = currentRegionProvider
+    }
+
+    // MARK: - Survey Fetching
+
+    /// Fetches surveys from the API for the current user
+    public func fetchSurveys() async {
+        guard let apiService = apiService else {
+            lastError = APIError.surveyServiceNotConfigured
+            return
+        }
+
+        isLoading = true
+        lastError = nil
+
+        do {
+            let userID = userDataStore.surveyUserIdentifier
+            let response = try await apiService.getSurveys(userID: userID)
+
+            allSurveys = response.entry.surveys
+            updateVisibleSurveys()
+
+        } catch {
+            lastError = error
+            allSurveys = []
+            visibleSurveys = []
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Survey Visibility Logic
+
+    /// Updates surveys that are currently active based on date/time constraints
+    private func updateVisibleSurveys() {
+        visibleSurveys = allSurveys.filter { survey in
+              survey.isActive
+          }
+    }
+
+    /// Finds the appropriate survey to show for a specific stop
+    /// Applies visibility rules, completion status, and priority logic
+    /// - Parameter stopID: The ID of the stop
+    /// - Parameter routeIDs: Route IDs that serve this stop
+    /// - Returns: Survey to display, or nil if no survey should be shown
+    public func findSurveyForStop(stopID: String, routeIDs: [String]) -> Survey? {
+        return findSurvey(isVisibleOnStop: true, stopID: stopID, routeIDs: routeIDs)
+    }
+
+    /// Finds the appropriate survey to show on the map
+    /// - Returns: Survey to display on map, or nil if no survey should be shown
+    public func findSurveyForMap() -> Survey? {
+        return findSurvey(isVisibleOnStop: false, stopID: nil, routeIDs: [])
+    }
+
+    /// Finds the highest priority survey that should be displayed to the user
+    /// Returns the first survey that matches visibility rules and completion status
+    private func findSurvey(isVisibleOnStop: Bool, stopID: String?, routeIDs: [String]) -> Survey? {
+        let surveys = allSurveys
+
+        guard !surveys.isEmpty else { return nil }
+
+        let userID = userDataStore.surveyUserIdentifier
+        var alwaysVisibleIndex: Int = -1
+        var oneTimeSurveyIndex: Int = -1
+
+        for (index, survey) in surveys.enumerated() {
+            guard isValidSurvey(survey) else { continue }
+            guard checkSurveyVisibility(survey: survey, isVisibleOnStop: isVisibleOnStop, stopID: stopID, routeIDs: routeIDs) else { continue }
+
+            let priorityResult = applySurveyPriorityLogic(survey: survey, userID: userID, index: index)
+
+            switch priorityResult {
+            case .returnImmediately(let survey):
+                return survey
+            case .setAlwaysVisible(let index):
+                alwaysVisibleIndex = index
+            case .setOneTime(let index):
+                oneTimeSurveyIndex = index
+            case .continue:
+                continue
+            }
+        }
+
+        // Priority order: one-time surveys override always-visible surveys
+        if oneTimeSurveyIndex != -1 {
+            return surveys[oneTimeSurveyIndex]
+        } else if alwaysVisibleIndex != -1 {
+            return surveys[alwaysVisibleIndex]
+        }
+
+        return nil
+    }
+
+    // MARK: - Survey Finding Helper Methods
+
+    private enum SurveyPriorityResult {
+      case returnImmediately(Survey)
+      case setAlwaysVisible(Int)
+      case setOneTime(Int)
+      case `continue`
+    }
+
+    /// Checks if survey has required questions to be displayable
+    private func isValidSurvey(_ survey: Survey) -> Bool {
+        return !survey.questions.isEmpty
+    }
+
+    /// Determines if survey meets location-based visibility requirements
+    private func checkSurveyVisibility(survey: Survey, isVisibleOnStop: Bool, stopID: String?, routeIDs: [String]) -> Bool {
+        if isVisibleOnStop {
+            return checkStopVisibility(survey: survey, stopID: stopID, routeIDs: routeIDs)
+        } else {
+            return survey.shouldShowOnMap
+        }
+    }
+
+    /// Validates survey visibility rules for stop-based display
+    private func checkStopVisibility(survey: Survey, stopID: String?, routeIDs: [String]) -> Bool {
+        guard survey.showOnStops else { return false }
+        guard let stopID = stopID else { return true }
+
+        if survey.shouldShowOnStop(stopID) {
+            return true
+        }
+
+        return routeIDs.contains { routeID in
+            survey.shouldShowOnRoute(routeID)
+        }
+    }
+
+    /// Determines survey priority based on completion status and response settings
+    private func applySurveyPriorityLogic(survey: Survey, userID: String, index: Int) -> SurveyPriorityResult {
+        let isSurveyCompleted = userDataStore.isSurveyCompleted(surveyId: survey.id, userIdentifier: userID)
+
+        if survey.alwaysVisible {
+            return handleAlwaysVisibleSurvey(survey: survey, isSurveyCompleted: isSurveyCompleted, index: index)
+        } else {
+            return handleRegularSurvey(survey: survey, userID: userID, isSurveyCompleted: isSurveyCompleted, index: index)
+        }
+    }
+
+    /// Processes priority logic for surveys marked as always visible
+    private func handleAlwaysVisibleSurvey(survey: Survey, isSurveyCompleted: Bool, index: Int) -> SurveyPriorityResult {
+        if survey.allowsMultipleResponses {
+            return .setAlwaysVisible(index)
+        } else {
+            if !isSurveyCompleted {
+                return .returnImmediately(survey)
+            } else {
+                return .continue
+            }
+        }
+    }
+
+    /// Processes priority logic for standard one-time surveys
+    private func handleRegularSurvey(survey: Survey, userID: String, isSurveyCompleted: Bool, index: Int) -> SurveyPriorityResult {
+        if !isSurveyCompleted {
+            return .setOneTime(index)
+        } else {
+            if userDataStore.shouldShowSurveyLater(surveyId: survey.id, userIdentifier: userID) {
+                return .setOneTime(index)
+            } else {
+                return .continue
+            }
+        }
+    }
+
+    // MARK: - Survey Submission
+
+    /// Submits a hero question response
+    /// - Parameters:
+    ///   - survey: The survey being answered
+    ///   - heroQuestionResponse: The response to the hero question
+    ///   - stopID: Optional stop ID if answered at a stop
+    ///   - stopLocation: Optional stop coordinates
+    /// - Returns: Submission response with update path for additional questions
+    public func submitHeroQuestion(
+        survey: Survey,
+        heroQuestionResponse: SurveyQuestionResponse,
+        stopID: String? = nil,
+        stopLocation: (latitude: Double, longitude: Double)? = nil
+    ) async throws -> SurveySubmissionResponse {
+        guard let apiService = apiService else {
+            throw APIError.surveyServiceNotConfigured
+        }
+
+        let userID = userDataStore.surveyUserIdentifier
+
+        let surveyResponse = SurveyResponse(
+            userIdentifier: userID,
+            surveyId: survey.id,
+            stopIdentifier: stopID,
+            stopLatitude: stopLocation?.latitude,
+            stopLongitude: stopLocation?.longitude,
+            response: [heroQuestionResponse]
+        )
+
+        let response = try await apiService.submitSurveyResponse(surveyResponse)
+        return response.entry
+    }
+
+    /// Submits additional questions for an existing survey response
+    /// - Parameters:
+    ///   - responseID: The ID from the initial submission
+    ///   - additionalResponses: Responses to the remaining questions
+    /// - Returns: Updated submission response
+    public func submitAdditionalQuestions(
+        responseID: String,
+        additionalResponses: [SurveyQuestionResponse]
+    ) async throws -> SurveySubmissionResponse {
+        guard let apiService = apiService else {
+            throw APIError.surveyServiceNotConfigured
+        }
+
+        let response = try await apiService.updateSurveyResponse(
+            responseID: responseID,
+            additionalResponses: additionalResponses
+        )
+        return response.entry
+    }
+
+    // MARK: - Survey State Management
+
+    /// Marks a survey as completed
+    /// - Parameter survey: The survey that was completed
+    public func markSurveyCompleted(_ survey: Survey) {
+        let userID = userDataStore.surveyUserIdentifier
+        userDataStore.markSurveyCompleted(surveyId: survey.id, userIdentifier: userID)
+        updateVisibleSurveys()
+    }
+
+    /// Marks a survey to be shown later
+    /// - Parameter survey: The survey to show later
+    public func markSurveyForLater(_ survey: Survey) {
+        let userID = userDataStore.surveyUserIdentifier
+        userDataStore.markSurveyForLater(surveyId: survey.id, userIdentifier: userID)
+        updateVisibleSurveys()
+    }
+
+    /// Marks a survey as dismissed (same as completed for dismissal purposes)
+    /// - Parameter survey: The survey that was dismissed
+    public func dismissSurvey(_ survey: Survey) {
+        markSurveyCompleted(survey)
+    }
+
+    // MARK: - Helper Methods
+
+    /// Creates a question response for a given question and answer
+    /// - Parameters:
+    ///   - question: The survey question
+    ///   - answer: The answer provided by the user
+    /// - Returns: Formatted survey question response
+    public func createQuestionResponse(question: SurveyQuestion, answer: String) -> SurveyQuestionResponse {
+        return SurveyQuestionResponse(
+            questionId: question.id,
+            questionType: question.content.typeString,
+            questionLabel: question.content.displayText,
+            answer: answer
+        )
+    }
+
+    /// Formats multiple checkbox selections into a JSON array string
+    /// - Parameter selections: Array of selected options
+    /// - Returns: JSON-formatted string for checkbox responses
+    public func formatCheckboxAnswer(_ selections: [String]) -> String {
+        do {
+            let jsonData = try JSONEncoder().encode(selections)
+            return String(data: jsonData, encoding: .utf8) ?? "[]"
+        } catch {
+            return "[]"
+        }
+    }
+}

--- a/OBAKitCore/Models/REST/Survey.swift
+++ b/OBAKitCore/Models/REST/Survey.swift
@@ -1,0 +1,335 @@
+//
+//  Survey.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+// MARK: - Survey Question Content Types
+
+/// Represents the different types of question content that can be displayed in a survey
+public enum SurveyQuestionContent: Codable, Hashable {
+    case label(text: String)
+    case radio(labelText: String, options: [String])
+    case checkbox(labelText: String, options: [String])
+    case text(labelText: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case labelText = "label_text"
+        case options
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "label":
+            let text = try container.decode(String.self, forKey: .labelText)
+            self = .label(text: text)
+        case "radio":
+            let labelText = try container.decode(String.self, forKey: .labelText)
+            let options = try container.decode([String].self, forKey: .options)
+            self = .radio(labelText: labelText, options: options)
+        case "checkbox":
+            let labelText = try container.decode(String.self, forKey: .labelText)
+            let options = try container.decode([String].self, forKey: .options)
+            self = .checkbox(labelText: labelText, options: options)
+        case "text":
+            let labelText = try container.decode(String.self, forKey: .labelText)
+            self = .text(labelText: labelText)
+        default:
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unknown question type: \(type)"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .label(let text):
+            try container.encode("label", forKey: .type)
+            try container.encode(text, forKey: .labelText)
+        case .radio(let labelText, let options):
+            try container.encode("radio", forKey: .type)
+            try container.encode(labelText, forKey: .labelText)
+            try container.encode(options, forKey: .options)
+        case .checkbox(let labelText, let options):
+            try container.encode("checkbox", forKey: .type)
+            try container.encode(labelText, forKey: .labelText)
+            try container.encode(options, forKey: .options)
+        case .text(let labelText):
+            try container.encode("text", forKey: .type)
+            try container.encode(labelText, forKey: .labelText)
+        }
+    }
+
+    /// Returns the display text for this question content
+    public var displayText: String {
+        switch self {
+        case .label(let text):
+            return text
+        case .radio(let labelText, _):
+            return labelText
+        case .checkbox(let labelText, _):
+            return labelText
+        case .text(let labelText):
+            return labelText
+        }
+    }
+
+    /// Returns the question type as a string for API submission
+    public var typeString: String {
+        switch self {
+        case .label: return "label"
+        case .radio: return "radio"
+        case .checkbox: return "checkbox"
+        case .text: return "text"
+        }
+    }
+}
+
+// MARK: - Survey Question
+
+/// Represents a single question in a survey
+public struct SurveyQuestion: Codable, Hashable, Identifiable {
+    public let id: Int
+    public let position: Int
+    public let required: Bool
+    public let content: SurveyQuestionContent
+
+    public init(id: Int, position: Int, required: Bool, content: SurveyQuestionContent) {
+        self.id = id
+        self.position = position
+        self.required = required
+        self.content = content
+    }
+
+    /// Returns true if this question is the first question (hero question)
+    public var isHeroQuestion: Bool {
+        return position == 1
+    }
+
+    /// Returns true if this question can be skipped (not required)
+    public var canBeSkipped: Bool {
+        return !required
+    }
+}
+
+// MARK: - Study
+
+/// Represents a study that contains surveys
+public struct Study: Codable, Hashable, Identifiable {
+    public let id: Int
+    public let name: String
+    public let description: String
+
+    public init(id: Int, name: String, description: String) {
+        self.id = id
+        self.name = name
+        self.description = description
+    }
+}
+
+// MARK: - Survey
+
+/// Represents a survey with its questions and visibility settings
+public struct Survey: Codable, Hashable, Identifiable {
+    public let id: Int
+    public let name: String
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let showOnMap: Bool
+    public let showOnStops: Bool
+    public let startDate: Date?
+    public let endDate: Date?
+    public let visibleStopList: [String]?
+    public let visibleRouteList: [String]?
+    public let allowsMultipleResponses: Bool
+    public let alwaysVisible: Bool
+    public let study: Study
+    public let questions: [SurveyQuestion]
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, study, questions
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case showOnMap = "show_on_map"
+        case showOnStops = "show_on_stops"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case visibleStopList = "visible_stop_list"
+        case visibleRouteList = "visible_route_list"
+        case allowsMultipleResponses = "allows_multiple_responses"
+        case alwaysVisible = "always_visible"
+    }
+
+    public init(id: Int, name: String, createdAt: Date, updatedAt: Date, showOnMap: Bool, showOnStops: Bool, startDate: Date?, endDate: Date?, visibleStopList: [String]?, visibleRouteList: [String]?, allowsMultipleResponses: Bool, alwaysVisible: Bool, study: Study, questions: [SurveyQuestion]) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.showOnMap = showOnMap
+        self.showOnStops = showOnStops
+        self.startDate = startDate
+        self.endDate = endDate
+        self.visibleStopList = visibleStopList
+        self.visibleRouteList = visibleRouteList
+        self.allowsMultipleResponses = allowsMultipleResponses
+        self.alwaysVisible = alwaysVisible
+        self.study = study
+        self.questions = questions
+    }
+
+    /// Returns the first question (hero question) if it exists
+    public var heroQuestion: SurveyQuestion? {
+        return questions.first { $0.isHeroQuestion }
+    }
+
+    /// Returns all questions except the hero question
+    public var remainingQuestions: [SurveyQuestion] {
+        return questions.filter { !$0.isHeroQuestion }
+    }
+
+    /// Returns true if the survey is currently active (within date range)
+    public var isActive: Bool {
+        let now = Date()
+
+        if let startDate = startDate, now < startDate {
+            return false
+        }
+
+        if let endDate = endDate, now > endDate {
+            return false
+        }
+
+        return true
+    }
+
+    /// Returns true if the survey should be shown on the specified stop
+    public func shouldShowOnStop(_ stopID: String) -> Bool {
+        guard showOnStops else { return false }
+        guard isActive else { return false }
+
+        // If no specific stops are listed, show on all stops
+        guard let visibleStops = visibleStopList else { return true }
+
+        return visibleStops.contains(stopID)
+    }
+
+    /// Returns true if the survey should be shown for the specified route
+    public func shouldShowOnRoute(_ routeID: String) -> Bool {
+        guard showOnStops else { return false }
+        guard isActive else { return false }
+
+        // If no specific routes are listed, show on all routes
+        guard let visibleRoutes = visibleRouteList else { return true }
+
+        return visibleRoutes.contains(routeID)
+    }
+
+    /// Returns true if the survey should be shown on the map
+    public var shouldShowOnMap: Bool {
+        return showOnMap && isActive
+    }
+}
+
+// MARK: - Survey Response
+
+/// Represents a response to a survey question
+public struct SurveyQuestionResponse: Codable, Hashable {
+    public let questionId: Int
+    public let questionType: String
+    public let questionLabel: String
+    public let answer: String
+
+    private enum CodingKeys: String, CodingKey {
+        case questionId = "question_id"
+        case questionType = "question_type"
+        case questionLabel = "question_label"
+        case answer
+    }
+
+    public init(questionId: Int, questionType: String, questionLabel: String, answer: String) {
+        self.questionId = questionId
+        self.questionType = questionType
+        self.questionLabel = questionLabel
+        self.answer = answer
+    }
+}
+
+/// Represents a complete survey response submission
+public struct SurveyResponse: Codable {
+    public let userIdentifier: String
+    public let surveyId: Int
+    public let stopIdentifier: String?
+    public let stopLatitude: Double?
+    public let stopLongitude: Double?
+    public let response: [SurveyQuestionResponse]
+
+    private enum CodingKeys: String, CodingKey {
+        case userIdentifier = "user_identifier"
+        case surveyId = "survey_id"
+        case stopIdentifier = "stop_identifier"
+        case stopLatitude = "stop_latitude"
+        case stopLongitude = "stop_longitude"
+        case response
+    }
+
+    public init(userIdentifier: String, surveyId: Int, stopIdentifier: String?, stopLatitude: Double?, stopLongitude: Double?, response: [SurveyQuestionResponse]) {
+        self.userIdentifier = userIdentifier
+        self.surveyId = surveyId
+        self.stopIdentifier = stopIdentifier
+        self.stopLatitude = stopLatitude
+        self.stopLongitude = stopLongitude
+        self.response = response
+    }
+}
+
+/// Represents the response from the survey submission API
+public struct SurveySubmissionResponse: Codable {
+    public let id: String
+    public let updatePath: String
+    public let userIdentifier: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case updatePath
+        case userIdentifier
+    }
+
+    public init(id: String, updatePath: String, userIdentifier: String) {
+        self.id = id
+        self.updatePath = updatePath
+        self.userIdentifier = userIdentifier
+    }
+}
+
+// MARK: - Surveys API Response
+
+/// Represents the response from the surveys API endpoint
+public struct SurveysResponse: Codable {
+    public let surveys: [Survey]
+    public let region: SurveyRegion
+
+    public init(surveys: [Survey], region: SurveyRegion) {
+        self.surveys = surveys
+        self.region = region
+    }
+}
+
+/// Represents region information in the surveys response
+public struct SurveyRegion: Codable {
+    public let id: Int
+    public let name: String
+
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/OBAKitCore/Network/APIService.swift
+++ b/OBAKitCore/Network/APIService.swift
@@ -25,15 +25,20 @@ public struct APIServiceConfiguration {
     let appVersion: String
     let regionIdentifier: Int?
 
+    /// Survey API base URL - different from regular OBA API base URL
+      let surveyBaseURL: URL?
+
     /// Generated query items from the initializer. Include this set of query items with every request you make.
     let defaultQueryItems: [URLQueryItem]
 
     /// - parameter baseURL: Any queries included in the `baseURL` will be moved to the `defaultQueryItems`.
-    init(baseURL: URL, apiKey: String, uuid: String, appVersion: String, regionIdentifier: Int?) {
+    /// - parameter surveyBaseURL: Optional survey API base URL. If nil, surveys will be disabled.
+    init(baseURL: URL, apiKey: String, uuid: String, appVersion: String, regionIdentifier: Int?, surveyBaseURL: URL? = nil) {
         self.apiKey = apiKey
         self.uuid = uuid
         self.appVersion = appVersion
         self.regionIdentifier = regionIdentifier
+        self.surveyBaseURL = surveyBaseURL
 
         // Add default query items, including the component query of the baseURL.
         var queryItems: [URLQueryItem] = [

--- a/OBAKitCore/Network/Operations/NetworkOperation.swift
+++ b/OBAKitCore/Network/Operations/NetworkOperation.swift
@@ -19,6 +19,12 @@ public enum APIError: Error, LocalizedError {
     /// A `404` error.
     case requestNotFound(HTTPURLResponse)
 
+    /// Survey service is not configured or survey base URL is missing.
+      case surveyServiceNotConfigured
+
+    /// No region has been selected.
+      case noRegionSelected
+
     public var errorDescription: String? {
         switch self {
         case .captivePortal:
@@ -51,6 +57,10 @@ public enum APIError: Error, LocalizedError {
         case .requestNotFound(let response):
             let fmt = OBALoc("api_error.request_not_found", value: "404 Not found (%@)", comment: "An error that is produced in response to HTTP status code 404")
             return String(format: fmt, response.url?.absoluteString ?? "(nil)")
+        case .surveyServiceNotConfigured:
+            return OBALoc("api_error.survey_service_not_configured", value: "Survey service is not available in this region.", comment: "An error message that tells the user that surveys are not available.")
+        case .noRegionSelected:
+            return OBALoc("api_error.no_region_selected", value: "No region has been selected. Please select a region to continue.", comment: "An error message that tells the user that no region has been selected.")
         }
     }
 }

--- a/OBAKitCore/Network/RESTAPIService/RESTAPIService+Surveys.swift
+++ b/OBAKitCore/Network/RESTAPIService/RESTAPIService+Surveys.swift
@@ -1,0 +1,88 @@
+//
+//  RESTAPIService+Surveys.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+extension RESTAPIService {
+
+    // MARK: - Survey Endpoints
+
+    /// Fetches all available surveys for a region and user
+    /// - Parameter userID: The user's unique identifier
+    /// - Returns: SurveysResponse containing surveys and region info
+    public nonisolated func getSurveys(userID: String) async throws -> RESTAPIResponse<SurveysResponse> {
+        guard let regionID = configuration.regionIdentifier else {
+            throw APIError.noRegionSelected
+        }
+
+        guard let url = urlBuilder.getSurveys(userID: userID, regionID: regionID) else {
+            throw APIError.surveyServiceNotConfigured
+        }
+
+        return try await getData(for: url, decodeRESTAPIResponseAs: SurveysResponse.self)
+    }
+
+    /// Submits a survey response to the server
+    /// - Parameter surveyResponse: The survey response to submit
+    /// - Returns: SurveySubmissionResponse with response ID and update path
+    public nonisolated func submitSurveyResponse(_ surveyResponse: SurveyResponse) async throws -> RESTAPIResponse<SurveySubmissionResponse> {
+        guard let url = urlBuilder.submitSurveyResponse() else {
+            throw APIError.surveyServiceNotConfigured
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        request.httpBody = try encoder.encode(surveyResponse)
+
+        return try await performSurveyRequest(request: request)
+    }
+
+    /// Updates an existing survey response with additional answers
+    /// - Parameters:
+    ///   - responseID: The ID of the existing survey response
+    ///   - additionalResponses: Additional question responses to add
+    /// - Returns: Updated SurveySubmissionResponse
+    public nonisolated func updateSurveyResponse(responseID: String, additionalResponses: [SurveyQuestionResponse]) async throws -> RESTAPIResponse<SurveySubmissionResponse> {
+        guard let url = urlBuilder.updateSurveyResponse(responseID: responseID) else {
+            throw APIError.surveyServiceNotConfigured
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let requestBody = ["response": additionalResponses]
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        request.httpBody = try encoder.encode(requestBody)
+
+        return try await performSurveyRequest(request: request)
+    }
+
+    // MARK: - Private Helper Methods
+
+    private nonisolated func performSurveyRequest<T: Codable>(request: URLRequest) async throws -> RESTAPIResponse<T> {
+        let (data, response) = try await dataLoader.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.networkFailure(NSError(domain: "HTTPResponseError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"]))
+        }
+
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 201 else {
+            throw APIError.requestFailure(httpResponse)
+        }
+
+        let decodedResponse = try decoder.decode(RESTAPIResponse<T>.self, from: data)
+        return decodedResponse
+    }
+}

--- a/OBAKitCore/Network/RESTAPIService/RESTAPIService.swift
+++ b/OBAKitCore/Network/RESTAPIService/RESTAPIService.swift
@@ -21,7 +21,11 @@ public actor RESTAPIService: @preconcurrency APIService {
     public init(_ configuration: APIServiceConfiguration, dataLoader: URLDataLoader = URLSession.shared) {
         self.configuration = configuration
         self.dataLoader = dataLoader
-        self.urlBuilder = RESTAPIURLBuilder(baseURL: configuration.baseURL, defaultQueryItems: configuration.defaultQueryItems)
+        self.urlBuilder = RESTAPIURLBuilder(
+            baseURL: configuration.baseURL,
+            defaultQueryItems: configuration.defaultQueryItems,
+            surveyBaseURL: configuration.surveyBaseURL
+        )
         self.decoder = JSONDecoder.RESTDecoder(regionIdentifier: configuration.regionIdentifier)
     }
 }

--- a/OBAKitCore/Network/RESTAPIURLBuilder.swift
+++ b/OBAKitCore/Network/RESTAPIURLBuilder.swift
@@ -19,11 +19,19 @@ import MapKit
 class RESTAPIURLBuilder: NSObject {
     private let baseURL: URL
     private let defaultQueryItems: [URLQueryItem]
+    private let surveyBaseURL: URL?
 
     init(baseURL: URL, defaultQueryItems: [URLQueryItem]) {
         self.baseURL = baseURL
         self.defaultQueryItems = defaultQueryItems
+        self.surveyBaseURL = nil
     }
+
+    init(baseURL: URL, defaultQueryItems: [URLQueryItem], surveyBaseURL: URL?) {
+          self.baseURL = baseURL
+          self.defaultQueryItems = defaultQueryItems
+          self.surveyBaseURL = surveyBaseURL
+      }
 
     public func generateURL(path: String, params: [String: Any]? = nil) -> URL {
         let urlString = joinBaseURLToPath(path)
@@ -383,5 +391,49 @@ extension RESTAPIURLBuilder {
         }
 
         return generateURL(path: apiPath, params: args)
+    }
+
+    // MARK: - Survey API URL Builders
+
+    /// Creates a full URL for the `getSurveys` API call, including query params.
+    ///
+    /// - API Endpoint: `/api/v1/regions/{region_id}/surveys.json`
+    ///
+    /// - Parameter userID: The user's unique identifier
+    /// - Parameter regionID: The region identifier
+    /// - Returns: An URL suitable for making a request to retrieve surveys.
+    public func getSurveys(userID: String, regionID: Int) -> URL? {
+        guard let surveyBaseURL = surveyBaseURL else { return nil }
+
+        let builder = RESTAPIURLBuilder(baseURL: surveyBaseURL, defaultQueryItems: defaultQueryItems)
+        return builder.generateURL(
+            path: "/api/v1/regions/\(regionID)/surveys.json",
+            params: ["user_id": userID]
+        )
+    }
+
+    /// Creates a full URL for the `submitSurveyResponse` API call.
+    ///
+    /// - API Endpoint: `/api/v1/survey_responses/`
+    ///
+    /// - Returns: An URL suitable for making a POST request to submit survey responses.
+    public func submitSurveyResponse() -> URL? {
+        guard let surveyBaseURL = surveyBaseURL else { return nil }
+
+        let builder = RESTAPIURLBuilder(baseURL: surveyBaseURL, defaultQueryItems: defaultQueryItems)
+        return builder.generateURL(path: "/api/v1/survey_responses/")
+    }
+
+    /// Creates a full URL for the `updateSurveyResponse` API call.
+    ///
+    /// - API Endpoint: `/api/v1/survey_responses/{response_id}`
+    ///
+    /// - Parameter responseID: The ID of the existing survey response
+    /// - Returns: An URL suitable for making a PUT request to update survey responses.
+    public func updateSurveyResponse(responseID: String) -> URL? {
+        guard let surveyBaseURL = surveyBaseURL else { return nil }
+
+        let builder = RESTAPIURLBuilder(baseURL: surveyBaseURL, defaultQueryItems: defaultQueryItems)
+        return builder.generateURL(path: "/api/v1/survey_responses/\(NetworkHelpers.escapePathVariable(responseID))")
     }
 }


### PR DESCRIPTION
**Overview**
This PR implements the foundation and network layer for the Survey feature, enabling OneBusAway to display and manage user surveys for transit research. The implementation follows the Android app's survey logic and supports both internal surveys (built from scratch) and external surveys (URL-based).

**Key Features Added**
- **Survey Data Models**: Complete models for Survey, Study, Question, and SurveyResponse
- **Survey Question Types**: Support for 4 question types (label, radio, checkbox, text)
- **Survey Visibility Logic**: Complex logic for showing surveys based on stops, routes, and user preferences
- **Survey State Management**: Tracking completed surveys and "answer later" functionality
- **Two-stage Submission**: Hero question submission followed by additional questions
- **Survey Prioritization**: Handles always_visible vs one-time surveys correctly

 **Technical Architecture**

**Survey Visibility Logic**
Implements the exact Android algorithm with these priorities:
1. **Always Visible + Multiple Responses**: Shows unless one-time survey exists
2. **Always Visible + Single Response**: Shows only if not completed
3. **Regular Surveys**: Shows only if not completed or marked for later
4. **Answer Later Logic**: Re-shows surveys after 3, 6, 9, 12+ app launches

**Network Layer**
- **Dual Base URL Support**: Regular OBA API + Survey API server
- **Same Authentication**: Uses existing API key system
- **Async/Await**: Modern Swift concurrency throughout
- **Proper Error Handling**: Comprehensive error types and messages

**Data Storage**
- **UserDefaults Integration**: Leverages existing UserDataStore pattern
- **Survey State Tracking**: Completed surveys, "answer later" surveys
- **User UUID Management**: Automatic generation and persistence
- **App Launch Counting**: For "answer later" functionality
