### PR TITLE
[OTPKit] Integrate OTPKit: Enable trip planning in supported regions

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -103,3 +103,5 @@ packages:
     SwiftProtobuf:
         url: https://github.com/apple/swift-protobuf.git
         minorVersion: 1.28.1
+    OTPKit:
+        path: /Users/manu/Desktop/otpkit

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -104,4 +104,5 @@ packages:
         url: https://github.com/apple/swift-protobuf.git
         minorVersion: 1.28.1
     OTPKit:
-        path: /Users/manu/Desktop/otpkit
+        url: https://github.com/OneBusAway/otpkit
+        branch: main

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -8,9 +8,12 @@
 //
 
 import UIKit
+import SwiftUI
 import CoreLocation
 import OBAKitCore
 import WidgetKit
+import OTPKit
+import MapKit
 
 /// The view controller that powers the Bookmarks tab of the app.
 @objc(OBABookmarksViewController)
@@ -155,8 +158,13 @@ public class BookmarksViewController: UIViewController,
             distanceSortAction.state = .on
         }
 
+        let otpAction = UIAction(title: "Trip Planner", image: UIImage(systemName: "map.fill")) { _ in
+            self.openOTPView()
+        }
+        
         let sortMenu = UIMenu(title: Strings.sort, options: .displayInline, children: [groupSortAction, distanceSortAction])
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "arrow.up.arrow.down.circle"), menu: sortMenu)
+        let mainMenu = UIMenu(children: [otpAction, sortMenu])
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "ellipsis.circle"), menu: mainMenu)
     }
 
     // MARK: Refresh Widget
@@ -291,6 +299,58 @@ public class BookmarksViewController: UIViewController,
                     id: "distance_sorted_group",
                     title: OBALoc("bookmarks_controller.sorted_by_distance_header", value: "Sorted by Distance", comment: "The table section header on the bookmarks controller for when bookmarks are sorted by distance.")
             )].compactMap({$0})
+    }
+
+    // MARK: - OTP Actions
+    @objc private func openOTPView() {
+        // Create OTP configuration with a demo server URL and region based on current region
+        let serverURL = URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default")!
+        let region: MapCameraPosition
+
+        if let currentRegion = application.regionsService.currentRegion {
+            let center = CLLocationCoordinate2D(
+                latitude: currentRegion.centerCoordinate.latitude,
+                longitude: currentRegion.centerCoordinate.longitude
+            )
+            region = .region(MKCoordinateRegion(
+                center: center,
+                span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+            ))
+        } else {
+            // Default to Seattle region
+            region = .region(MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321),
+                span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+            ))
+        }
+
+        let config = OTPConfiguration(
+            otpServerURL: serverURL,
+            themeConfiguration: .init(
+                primaryColor: Color(uiColor: ThemeColors().brand)
+            ),
+            region: region
+        )
+
+        let apiService = RestAPIService(baseURL: serverURL)
+
+        // Get current location for origin
+        var origin: Location?
+        if let currentLocation = application.locationService.currentLocation {
+            origin = Location(
+                title: "OBA Current Location",
+                subTitle: "Your current location",
+                latitude: currentLocation.coordinate.latitude,
+                longitude: currentLocation.coordinate.longitude
+            )
+        }
+
+        let otpView = OTPView(otpConfig: config, apiService: apiService, origin: origin)
+
+        let hostingController = UIHostingController(rootView: otpView)
+        hostingController.modalPresentationStyle = .overFullScreen
+
+        present(hostingController, animated: true)
     }
 
     // MARK: - Bookmark Actions

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -8,24 +8,21 @@
 //
 
 import UIKit
-import SwiftUI
 import CoreLocation
 import OBAKitCore
 import WidgetKit
-import OTPKit
-import MapKit
 
 /// The view controller that powers the Bookmarks tab of the app.
 @objc(OBABookmarksViewController)
 public class BookmarksViewController: UIViewController,
-    AppContext,
-    BookmarkEditorDelegate,
-    BookmarkDataDelegate,
-    ManageBookmarksDelegate,
-    ModalDelegate,
-    OBAListViewDataSource,
-    OBAListViewCollapsibleSectionsDelegate,
-    OBAListViewContextMenuDelegate {
+                                      AppContext,
+                                      BookmarkEditorDelegate,
+                                      BookmarkDataDelegate,
+                                      ManageBookmarksDelegate,
+                                      ModalDelegate,
+                                      OBAListViewDataSource,
+                                      OBAListViewCollapsibleSectionsDelegate,
+                                      OBAListViewContextMenuDelegate {
 
     let application: Application
 
@@ -158,13 +155,8 @@ public class BookmarksViewController: UIViewController,
             distanceSortAction.state = .on
         }
 
-        let otpAction = UIAction(title: "Trip Planner", image: UIImage(systemName: "map.fill")) { _ in
-            self.openOTPView()
-        }
-        
         let sortMenu = UIMenu(title: Strings.sort, options: .displayInline, children: [groupSortAction, distanceSortAction])
-        let mainMenu = UIMenu(children: [otpAction, sortMenu])
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "ellipsis.circle"), menu: mainMenu)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "arrow.up.arrow.down.circle"), menu: sortMenu)
     }
 
     // MARK: Refresh Widget
@@ -238,17 +230,17 @@ public class BookmarksViewController: UIViewController,
         let body: String
 
         if application.hasDataToMigrate {
-                title = Strings.emptyBookmarkTitle
-                body = Strings.emptyBookmarkBodyWithPendingMigration
-            }
-            else if application.userDataStore.bookmarks.isEmpty {
-                title = Strings.emptyBookmarkTitle
-                body = Strings.emptyBookmarkBody
-            }
-            else {
-                // Don't show empty state if we have bookmarks
-                return nil
-            }
+            title = Strings.emptyBookmarkTitle
+            body = Strings.emptyBookmarkBodyWithPendingMigration
+        }
+        else if application.userDataStore.bookmarks.isEmpty {
+            title = Strings.emptyBookmarkTitle
+            body = Strings.emptyBookmarkBody
+        }
+        else {
+            // Don't show empty state if we have bookmarks
+            return nil
+        }
 
         return .standard(.init(title: title, body: body))
     }
@@ -295,62 +287,10 @@ public class BookmarksViewController: UIViewController,
         })
 
         return [buildListSection(
-                    bookmarks: bookmarks,
-                    id: "distance_sorted_group",
-                    title: OBALoc("bookmarks_controller.sorted_by_distance_header", value: "Sorted by Distance", comment: "The table section header on the bookmarks controller for when bookmarks are sorted by distance.")
-            )].compactMap({$0})
-    }
-
-    // MARK: - OTP Actions
-    @objc private func openOTPView() {
-        // Create OTP configuration with a demo server URL and region based on current region
-        let serverURL = URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default")!
-        let region: MapCameraPosition
-
-        if let currentRegion = application.regionsService.currentRegion {
-            let center = CLLocationCoordinate2D(
-                latitude: currentRegion.centerCoordinate.latitude,
-                longitude: currentRegion.centerCoordinate.longitude
-            )
-            region = .region(MKCoordinateRegion(
-                center: center,
-                span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-            ))
-        } else {
-            // Default to Seattle region
-            region = .region(MKCoordinateRegion(
-                center: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321),
-                span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-            ))
-        }
-
-        let config = OTPConfiguration(
-            otpServerURL: serverURL,
-            themeConfiguration: .init(
-                primaryColor: Color(uiColor: ThemeColors().brand)
-            ),
-            region: region
-        )
-
-        let apiService = RestAPIService(baseURL: serverURL)
-
-        // Get current location for origin
-        var origin: Location?
-        if let currentLocation = application.locationService.currentLocation {
-            origin = Location(
-                title: "OBA Current Location",
-                subTitle: "Your current location",
-                latitude: currentLocation.coordinate.latitude,
-                longitude: currentLocation.coordinate.longitude
-            )
-        }
-
-        let otpView = OTPView(otpConfig: config, apiService: apiService, origin: origin)
-
-        let hostingController = UIHostingController(rootView: otpView)
-        hostingController.modalPresentationStyle = .overFullScreen
-
-        present(hostingController, animated: true)
+            bookmarks: bookmarks,
+            id: "distance_sorted_group",
+            title: OBALoc("bookmarks_controller.sorted_by_distance_header", value: "Sorted by Distance", comment: "The table section header on the bookmarks controller for when bookmarks are sorted by distance.")
+        )].compactMap({$0})
     }
 
     // MARK: - Bookmark Actions
@@ -412,8 +352,8 @@ public class BookmarksViewController: UIViewController,
         }
 
         return OBAListViewMenuActions(previewProvider: previewProvider,
-                               performPreviewAction: commitPreviewAction,
-                               contextMenuProvider: menu)
+                                      performPreviewAction: commitPreviewAction,
+                                      contextMenuProvider: menu)
     }
 
     // MARK: - Arrival departure highlight updates

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 import MapKit
 import FloatingPanel
 import OBAKitCore
+import OTPKit
+import SwiftUI
 
 /// Displays a map, a set of stops rendered as annotation views, and the user's location if authorized.
 ///
@@ -117,6 +119,17 @@ class MapViewController: UIViewController,
             toggleMapTypeButton.heightAnchor.constraint(equalTo: toggleMapTypeButton.widthAnchor)
         ])
 
+        // Add trip planner button as floating button
+        view.addSubview(tripPlannerButton)
+        tripPlannerButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            tripPlannerButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -ThemeMetrics.controllerMargin),
+            tripPlannerButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -ThemeMetrics.controllerMargin - 60), // 60pts above bottom to avoid tab bar
+            tripPlannerButton.widthAnchor.constraint(equalToConstant: 50),
+            tripPlannerButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+
         mapRegionManager.statusOverlay = statusOverlay
         view.addSubview(statusOverlay)
 
@@ -141,6 +154,7 @@ class MapViewController: UIViewController,
 
         updateVisibleMapRect()
         layoutMapMargins()
+        updateTripPlannerButtonVisibility()
     }
 
     public override func viewDidAppear(_ animated: Bool) {
@@ -242,6 +256,22 @@ class MapViewController: UIViewController,
         return button
     }()
 
+    private lazy var tripPlannerButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "point.topleft.down.curvedto.point.bottomright.up"), for: .normal)
+        button.backgroundColor = ThemeColors.shared.brand
+        button.tintColor = .white
+        button.layer.cornerRadius = 25
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowOffset = CGSize(width: 0, height: 2)
+        button.layer.shadowOpacity = 0.25
+        button.layer.shadowRadius = 4
+        button.addTarget(self, action: #selector(openTripPlanner), for: .touchUpInside)
+        button.accessibilityLabel = OBALoc("map_controller.open_trip_planner_button", value: "Open Trip Planner", comment: "Accessibility label for button that opens the trip planner")
+        button.isHidden = true  // Initially hidden, will be shown based on region support
+        return button
+    }()
+
     @objc private func showWeather() {
         guard let forecast = forecast else { return }
 
@@ -277,6 +307,69 @@ class MapViewController: UIViewController,
                 Logger.error(error.localizedDescription)
             }
         }
+    }
+
+    // MARK: - Trip Planner
+
+    private func updateTripPlannerButtonVisibility() {
+        guard let currentRegion = application.currentRegion else {
+            tripPlannerButton.isHidden = true
+            return
+        }
+
+        let supportsOTP = currentRegion.supportsOTP
+        let isEnabled = application.userDataStore.isTripPlanningEnabled(for: currentRegion)
+
+        tripPlannerButton.isHidden = !(supportsOTP && isEnabled)
+    }
+
+    @objc private func openTripPlanner() {
+        guard let currentRegion = application.regionsService.currentRegion,
+              let otpURL = currentRegion.openTripPlannerURL else {
+            return
+        }
+
+        let config = OTPConfiguration(
+            otpServerURL: otpURL,
+            themeConfiguration: .init(
+                primaryColor: Color(uiColor: ThemeColors().brand)
+            ),
+            region: .automatic
+        )
+
+        let apiService = RestAPIService(baseURL: otpURL)
+
+        // Get current location for origin
+        var origin: Location?
+        if let currentLocation = application.locationService.currentLocation {
+            origin = Location(
+                title: "Current Location",
+                subTitle: "Your current location",
+                latitude: currentLocation.coordinate.latitude,
+                longitude: currentLocation.coordinate.longitude
+            )
+        }
+
+        let otpView = OTPView(otpConfig: config, apiService: apiService, origin: origin)
+
+        let hostingController = UIHostingController(rootView: otpView)
+        hostingController.modalPresentationStyle = .overFullScreen
+
+        // Add navigation bar with dismiss button
+        let navController = UINavigationController(rootViewController: hostingController)
+        hostingController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .close,
+            target: self,
+            action: #selector(dismissOTPView)
+        )
+        hostingController.navigationItem.title = "Trip Planner"
+        navController.modalPresentationStyle = .overFullScreen
+
+        present(navController, animated: true)
+    }
+
+    @objc private func dismissOTPView() {
+        dismiss(animated: true)
     }
 
     // MARK: - Map Type

--- a/OBAKit/Onboarding/RegionPicker/Region+Previews.swift
+++ b/OBAKit/Onboarding/RegionPicker/Region+Previews.swift
@@ -17,22 +17,23 @@ extension Region {
         latitude: CLLocationDegrees,
         longitude: CLLocationDegrees,
         latitudeSpan: CLLocationDegrees,
-        longitudeSpan: CLLocationDegrees
+        longitudeSpan: CLLocationDegrees,
+        openTripPlannerURL: URL? = nil
     ) -> Region {
 
         let origin = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
         let span = MKCoordinateSpan(latitudeDelta: latitudeSpan, longitudeDelta: longitudeSpan)
         let region = MKCoordinateRegion(center: origin, span: span)
 
-        return self.init(name: name, OBABaseURL: URL(string: "www.example.com")!, coordinateRegion: region, contactEmail: "example@example.com", regionIdentifier: id)
+        return self.init(name: name, OBABaseURL: URL(string: "www.example.com")!, coordinateRegion: region, contactEmail: "example@example.com", regionIdentifier: id, openTripPlannerURL: openTripPlannerURL)
     }
 }
 
 /// A region provider for Xcode Previews.
 final class Previews_SampleRegionProvider: RegionProvider {
     @Published var allRegions: [Region] = [
-        .regionForPreview(id: 0, name: "Tampa Bay", latitude: 27.9769105, longitude: -82.445851, latitudeSpan: 0.5424609, longitudeSpan: 0.5763579),
-        .regionForPreview(id: 1, name: "Puget Sound", latitude: 47.59820, longitude: -122.32165, latitudeSpan: 0.33704, longitudeSpan: 0.440483),
+        .regionForPreview(id: 0, name: "Tampa Bay", latitude: 27.9769105, longitude: -82.445851, latitudeSpan: 0.5424609, longitudeSpan: 0.5763579, openTripPlannerURL: URL(string: "https://otp.prod.obahart.org/otp/")),
+        .regionForPreview(id: 1, name: "Puget Sound", latitude: 47.59820, longitude: -122.32165, latitudeSpan: 0.33704, longitudeSpan: 0.440483, openTripPlannerURL: URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default/")),
         .regionForPreview(id: 2, name: "MTA New York", latitude: 40.707678, longitude: -74.017681, latitudeSpan: 0.40939, longitudeSpan: 0.468666),
         .regionForPreview(id: 3, name: "Atlanta", latitude: 33.74819, longitude: -84.39086, latitudeSpan: 0.066268, longitudeSpan: 0.051677),
         .regionForPreview(id: 15, name: "Adelaide Metro", latitude: -34.833098, longitude: 138.621111, latitudeSpan: 0.52411, longitudeSpan: 0.285071)
@@ -83,6 +84,15 @@ final class Previews_SampleRegionProvider: RegionProvider {
         }
 
         allRegions.remove(at: index)
+    }
+
+    func isTripPlanningEnabled(for region: Region) -> Bool {
+        // For previews, return true for regions that support OTP
+        return region.supportsOTP
+    }
+
+    func setTripPlanningEnabled(_ enabled: Bool, for region: Region) {
+        // No-op for previews
     }
 }
 

--- a/OBAKit/Onboarding/RegionPicker/RegionPickerCoordinator.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerCoordinator.swift
@@ -11,15 +11,25 @@ import OBAKitCore
 /// Under-the-hood, this class implements RegionsServiceDelegate, which subsequently publishes new values.
 public class RegionPickerCoordinator: ObservableObject, RegionProvider, RegionsServiceDelegate {
     var regionsService: RegionsService
+    var userDataStore: UserDataStore
 
-    public init(regionsService: RegionsService) {
+    public init(regionsService: RegionsService, userDataStore: UserDataStore) {
         self.regionsService = regionsService
+        self.userDataStore = userDataStore
 
         self.allRegions = regionsService.allRegions
         self.currentRegion = regionsService.currentRegion
         self.automaticallySelectRegion = regionsService.automaticallySelectRegion
 
         regionsService.addDelegate(self)
+    }
+
+    /// Convenience initializer for backward compatibility
+    public convenience init(regionsService: RegionsService) {
+        // Get userDataStore from the regionsService's parent application
+        // This is a temporary solution - in practice, pass userDataStore explicitly
+        let userDataStore = UserDefaultsStore(userDefaults: UserDefaults.standard)
+        self.init(regionsService: regionsService, userDataStore: userDataStore)
     }
 
     deinit {
@@ -91,5 +101,15 @@ public class RegionPickerCoordinator: ObservableObject, RegionProvider, RegionsS
             // Unable to automatically select a region.
             self.automaticallySelectRegion = false
         }
+    }
+
+    // MARK: - Trip Planning
+
+    public func isTripPlanningEnabled(for region: Region) -> Bool {
+        return userDataStore.isTripPlanningEnabled(for: region)
+    }
+
+    public func setTripPlanningEnabled(_ enabled: Bool, for region: Region) {
+        userDataStore.setTripPlanningEnabled(enabled, for: region)
     }
 }

--- a/OBAKit/Onboarding/RegionPicker/RegionProvider.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionProvider.swift
@@ -24,4 +24,10 @@ public protocol RegionProvider: ObservableObject {
 
     /// Deletes the provided custom region.
     func delete(customRegion region: Region) async throws
+
+    /// Returns whether trip planning is enabled for the specified region.
+    func isTripPlanningEnabled(for region: Region) -> Bool
+
+    /// Sets trip planning enabled/disabled for the specified region.
+    func setTripPlanningEnabled(_ enabled: Bool, for region: Region)
 }

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -465,7 +465,7 @@ public class Application: CoreApplication, PushServiceDelegate {
                     adjustedRegionCoordinate.span.longitudeDelta = 2
 
                     // Create region provider
-                    let regionProvider = RegionPickerCoordinator(regionsService: self.regionsService)
+                    let regionProvider = RegionPickerCoordinator(regionsService: self.regionsService, userDataStore: self.userDataStore)
 
                     // Construct Region from URL data
                     let currentRegion = Region(name: regionData.name, OBABaseURL: regionData.obaURL, coordinateRegion: adjustedRegionCoordinate, contactEmail: "example@example.com", openTripPlannerURL: regionData.otpURL)

--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -156,7 +156,7 @@ public class MoreViewController: UIViewController,
 
             let regionPicker = UIHostingController(
                 rootView: NavigationView {
-                    RegionPickerView(regionProvider: RegionPickerCoordinator(regionsService: self.application.regionsService))
+                    RegionPickerView(regionProvider: RegionPickerCoordinator(regionsService: self.application.regionsService, userDataStore: self.application.userDataStore))
                         .interactiveDismissDisabled()
                 }.navigationViewStyle(.stack)
             )

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -263,6 +263,9 @@
 /* Accessibility label for a button that provides the current forecast */
 "map_controller.show_weather_button" = "Show Weather Forecast";
 
+/* Accessibility label for button that opens the trip planner */
+"map_controller.open_trip_planner_button" = "Open Trip Planner";
+
 /* This message appears when a searched-for vehicle doesn't have an assigned trip. */
 "map_controller.vehicle_not_on_trip_error" = "The vehicle you chose doesn't appear to be on a trip right now, which means we don't know how to show it to you.";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -464,6 +464,9 @@
 /* Title of the Region Picker Item, which lets the user choose a new region from the map. */
 "region_picker.title" = "Choose Region";
 
+/* Title of the trip planning toggle in the region picker. */
+"region_picker.trip_planning_toggle" = "Enable trip planning";
+
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Report a Problem";
 

--- a/OBAKit/project.yml
+++ b/OBAKit/project.yml
@@ -10,6 +10,7 @@ targets:
       - package: Eureka
       - package: FloatingPanel
       - package: MarqueeLabel
+      - package: OTPKit
     postBuildScripts:
       - path: "../scripts/swiftlint.sh"
         name: Swiftlint

--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -391,6 +391,11 @@ public class Region: NSObject, Identifiable, Codable {
         return hasher.finalize()
     }
 
+    /// Returns true if this region supports OpenTripPlanner (OTP) trip planning.
+    public var supportsOTP: Bool {
+        return openTripPlannerURL != nil
+    }
+
     // MARK: - Location Helpers
 
     /// Internal type for constructing regional boundaries from the server's JSON output.

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -163,6 +163,18 @@ public protocol UserDataStore: NSObjectProtocol {
     /// Lets you mark a service alert as having been read.
     /// - Parameter serviceAlert: The service alert to mark read.
     func markRead(serviceAlert: ServiceAlert)
+
+    // MARK: - Trip Planning
+
+    /// Returns whether trip planning is enabled for the specified region.
+    /// - Parameter region: The region to check trip planning status for.
+    func isTripPlanningEnabled(for region: Region) -> Bool
+
+    /// Sets trip planning enabled/disabled for the specified region.
+    /// - Parameters:
+    ///   - enabled: Whether trip planning should be enabled.
+    ///   - region: The region to set trip planning status for.
+    func setTripPlanningEnabled(_ enabled: Bool, for region: Region)
 }
 
 // MARK: - Stop Preferences
@@ -196,6 +208,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let readServiceAlerts = "UserDataStore.readServiceAlerts"
         static let recentStops = "UserDataStore.recentStops"
         static let stopPreferences = "UserDataStore.stopPreferences"
+        static let tripPlanningEnabled = "UserDataStore.tripPlanningEnabled"
     }
 
     public init(userDefaults: UserDefaults) {
@@ -557,6 +570,31 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             try! encodeUserDefaultsObjects(newValue, key: UserDefaultsKeys.readServiceAlerts) // swiftlint:disable:this force_try
+        }
+    }
+
+    // MARK: - Trip Planning
+
+    public func isTripPlanningEnabled(for region: Region) -> Bool {
+        let key = tripPlanningKey(for: region)
+        return tripPlanningSettings[key] ?? true  // Default to enabled for OTP-supported regions
+    }
+
+    public func setTripPlanningEnabled(_ enabled: Bool, for region: Region) {
+        let key = tripPlanningKey(for: region)
+        tripPlanningSettings[key] = enabled
+    }
+
+    private func tripPlanningKey(for region: Region) -> String {
+        return "\(region.regionIdentifier)_trip_planning"
+    }
+
+    private var tripPlanningSettings: [String: Bool] {
+        get {
+            return decodeUserDefaultsObjects(type: [String: Bool].self, key: UserDefaultsKeys.tripPlanningEnabled) ?? [:]
+        }
+        set {
+            try! encodeUserDefaultsObjects(newValue, key: UserDefaultsKeys.tripPlanningEnabled) // swiftlint:disable:this force_try
         }
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/SCENEE/FloatingPanel.git", .exact("1.7.6")),
         .package(url: "https://github.com/rwbutler/Hyperconnectivity.git", .exact("1.1.0")),
         .package(url: "https://github.com/cbpowell/MarqueeLabel.git", .exact("4.0.5")),
-        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.17.0")
+        .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.17.0"),
+        .package(url: "https://github.com/OneBusAway/otpkit", branch: "main")
     ],
     targets: [
         .target(
@@ -31,7 +32,8 @@ let package = Package(
                 "FloatingPanel",
                 "Hyperconnectivity",
                 "MarqueeLabel",
-                "OBAKitCore"
+                "OBAKitCore",
+                .product(name: "OTPKit", package: "otpkit")
             ],
             path: "OBAKit",
             exclude: ["Info.plist", "project.yml"],


### PR DESCRIPTION
Replaces #832, rebasing on top of `main` to get CI to pass.

## Description:
This PR integrates [OTPKit](https://github.com/OneBusAway/otpkit) into the OneBusAway iOS app to provide trip planning where a region supports OpenTripPlanner (OTP).
It adds a small floating Trip Planner button on the Map screen and a per-region toggle in the Region Picker to enable/disable trip planning.

Fixes #744 

### Changes
- Added OTPKit as a **Swift Package Manager dependency**  
- Added **Trip Planner** button to Map View (bottom-right)  
- Button is shown only if the selected region supports OTP and trip planning is enabled  
- New toggle in **Region Picker** to enable/disable trip planning per region  

## Media:

https://github.com/user-attachments/assets/ebd7e104-8d30-42a7-a9d5-41a4883a45d4

### Steps to Test

1. **Choose a region**  
   - Go to **More → Choose Region**  
   - Pick a region that supports OTP (e.g., **Puget Sound**)

2. **Go to the Map View**  
   - Open the **Map tab**

3. **Tap the trip icon**  
   - Bottom-right corner of the screen  
   - Looks like a small trip button

4. **Open the Trip Planner**  
   - Planner screen should appear  
   - Origin auto-fills with your current location (if location is allowed)

5. **Make a trip**  
   - Enter a destination  
   - Confirm a trip plan is generated