### PR TITLE
Add otpkit as a bottom sheet

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -336,10 +336,10 @@ class MapViewController: UIViewController,
             apiService: apiService,
             mapProvider: mapViewProvider
         )
-        
+
         otpBottomSheet?.delegate = self
         otpBottomSheet?.present(origin: origin, destination: destinationLocation, on: self)
-        
+
     }
 
     // MARK: - Map Type


### PR DESCRIPTION
## Add OTPKit as a bottom sheet modal
Replaces the previous semi-modal trip planner implementation with a new bottom sheet approach. Includes proper panel coordination to hide/show other UI elements when the OTP bottom sheet is presented or dismissed.

## Test Instructions

1. Long tap on the map
2. Tap "Plan a trip"
3. Verify OTP view appears as `Bottom Sheet`
4. Confirm floating panels hide when trip planner opens and restore when dismissed
5. Test opening stop details while trip planner is open - verify trip planner dismisses

