### PR TITLE
Refresh the appearance of stop icons on the map

### DIFF
--- a/OBAKit/Controls/StrokedLabel.swift
+++ b/OBAKit/Controls/StrokedLabel.swift
@@ -1,0 +1,69 @@
+//
+//  StrokedLabel.swift
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 10/28/25.
+//
+
+/// A UILabel subclass that correctly renders negative stroke values.
+///
+/// Derived from here: https://gist.github.com/eeshishko/4835ee15590b626d69976b86bc644953
+/// Explained here: https://blog.devgenius.io/creating-stroked-labels-with-uikit-a-how-to-guide-7a024652e978
+/// More info on the bug this works around: https://stackoverflow.com/questions/64318125/getting-issue-on-strokewidth-nsattributedstring-in-ios-14
+class StrokedLabel: UILabel {
+    override func drawText(in rect: CGRect) {
+        guard let attributedText = attributedText?.mutableCopy() as? NSMutableAttributedString else {
+            super.drawText(in: rect)
+            return
+        }
+
+        attributedText.enumerateAttributes(in: NSRange(location: 0, length: attributedText.length), options: [], using: { attrs, range, _ in
+            guard let strokeWidth = attrs[NSAttributedString.Key.strokeWidth] as? CGFloat else {
+                return
+            }
+
+            attributedText.addAttributes([
+                NSAttributedString.Key.strokeWidth: strokeWidth * 2
+            ], range: range)
+            self.attributedText = attributedText
+            super.drawText(in: rect)
+
+            let style = NSMutableParagraphStyle()
+            style.alignment = textAlignment
+
+            let attributes = [
+                NSAttributedString.Key.strokeWidth: NSNumber(value: 0),
+                NSAttributedString.Key.foregroundColor: textColor ?? UIColor.black,
+                NSAttributedString.Key.font: font ?? UIFont.systemFont(ofSize: 17),
+                NSAttributedString.Key.paragraphStyle: style
+            ]
+
+            attributedText.addAttributes(attributes, range: range)
+            var textRect = boundingRect(
+                with: attributedText,
+                forCharacterRange: NSRange(location: 0, length: attributedText.length)
+            )
+            textRect.origin.y = (rect.size.height - textRect.size.height) / 2
+            attributedText.draw(in: rect)
+        })
+    }
+
+    private func boundingRect(
+            with attributedString: NSAttributedString?,
+            forCharacterRange range: NSRange
+    ) -> CGRect {
+        guard let attributedString = attributedString else {
+            return .zero
+        }
+        let textStorage = NSTextStorage(attributedString: attributedString)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(size: bounds.size)
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        var glyphRange = NSRange()
+        layoutManager.characterRange(forGlyphRange: range, actualGlyphRange: &glyphRange)
+        return layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+    }
+}

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -28,15 +28,12 @@ class StopAnnotationView: MKAnnotationView {
 
     // MARK: - Subviews
 
-    private let titleLabel = StopAnnotationView.buildLabel()
-
-    private class func buildLabel() -> UILabel {
-        let label = UILabel.autolayoutNew()
+    private let titleLabel: UILabel = {
+        let label = StrokedLabel.autolayoutNew()
         label.textAlignment = .center
-        label.font = UIFont.mapAnnotationFont
         label.numberOfLines = 2
         return label
-    }
+    }()
 
     private lazy var labelStack: UIStackView = {
         return UIStackView.verticalStack(arrangedSubviews: [titleLabel])
@@ -113,17 +110,41 @@ class StopAnnotationView: MKAnnotationView {
 
     // MARK: - Annotation Rendering
 
+    private func strokedText(_ text: String) -> NSAttributedString {
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: UIFont.smallSystemFontSize, weight: .bold),
+            .foregroundColor: UIColor.darkText
+        ]
+
+        attributes[.strokeColor] = UIColor.white
+        attributes[.strokeWidth] = -4.0
+
+        let shadow = NSShadow()
+        shadow.shadowColor = UIColor.white
+        shadow.shadowOffset = .zero
+        shadow.shadowBlurRadius = 1
+        attributes[.shadow] = shadow
+
+        return NSAttributedString(string: text, attributes: attributes)
+    }
+
     private func prepareForDisplay(bookmark: Bookmark, delegate: StopAnnotationDelegate) {
         labelStack.isHidden = delegate.shouldHideExtraStopAnnotationData
         image = delegate.iconFactory.buildIcon(for: bookmark.stop, isBookmarked: true, traits: traitCollection)
-        titleLabel.text = bookmark.name
+        titleLabel.attributedText = strokedText(bookmark.name)
         detailCalloutAccessoryView = buildDetailLabel(text: bookmark.stop.subtitle)
     }
 
     private func prepareForDisplay(stop: Stop, delegate: StopAnnotationDelegate) {
         labelStack.isHidden = delegate.shouldHideExtraStopAnnotationData
         image = delegate.iconFactory.buildIcon(for: stop, isBookmarked: delegate.isStopBookmarked(stop), traits: traitCollection)
-        titleLabel.text = stop.mapTitle
+        if let mapTitle = stop.mapTitle {
+            titleLabel.attributedText = strokedText(mapTitle)
+        }
+        else {
+            titleLabel.text = ""
+        }
+
         detailCalloutAccessoryView = buildDetailLabel(text: stop.subtitle)
     }
 
@@ -145,9 +166,6 @@ class StopAnnotationView: MKAnnotationView {
             frame = frame.integral
         }
     }
-
-    /// Foreground color for text written directly onto the map as part of this annotation view.
-    public var mapTextColor: UIColor = ThemeColors.shared.mapText
 
     // MARK: - Accessibility
 

--- a/OBAKit/Mapping/StopIconFactory.swift
+++ b/OBAKit/Mapping/StopIconFactory.swift
@@ -85,17 +85,11 @@ class StopIconFactory: NSObject {
     /// The line width of the arrow's border.
     private let arrowStroke: CGFloat = 1.0
 
-    /// The corner radius of the icon.
-    private let cornerRadius: CGFloat = 4.0
-
     /// The stroke width.
     private let borderWidth: CGFloat = 2.0
 
     /// The opacity of the icon's background.
     private let backgroundAlpha: CGFloat = 0.9
-
-    /// The drawing inset of the transport glyph.
-    private let transportGlyphInset: CGFloat = 6.0
 
     // MARK: - Rendering Steps
 
@@ -145,9 +139,27 @@ class StopIconFactory: NSObject {
         context.pushPop {
             // we inset the rect the 1/2 px in order ensure that it doesn't 'bleed' past
             // the edge of the rounded rect border that we'll draw in drawBorder()
-            let bezierPath = UIBezierPath(roundedRect: rect.insetBy(dx: 0.5, dy: 0.5), cornerRadius: cornerRadius)
-            context.setFillColor(color.cgColor)
-            bezierPath.fill(with: .normal, alpha: backgroundAlpha)
+            let bezierPath = UIBezierPath(roundedRect: rect.insetBy(dx: 0.5, dy: 0.5), cornerRadius: ThemeMetrics.stopAnnotationCornerRadius)
+
+            // Clip to the rounded rect path
+            bezierPath.addClip()
+
+            // Create lightened color (25% lighter)
+            let lightenedColor = color.lighten(by: 0.25)
+
+            // Create gradient from lightened to original color
+            let colors = [lightenedColor.cgColor, color.cgColor]
+            let colorSpace = CGColorSpaceCreateDeviceRGB()
+            guard let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: [0.0, 1.0]) else {
+                return
+            }
+
+            // Draw gradient from top to bottom
+            let startPoint = CGPoint(x: rect.midX, y: rect.minY)
+            let endPoint = CGPoint(x: rect.midX, y: rect.maxY)
+
+            context.setAlpha(backgroundAlpha)
+            context.drawLinearGradient(gradient, start: startPoint, end: endPoint, options: [])
         }
     }
 
@@ -158,7 +170,7 @@ class StopIconFactory: NSObject {
     private func drawBorder(color: UIColor, rect: CGRect, context: CGContext) {
         context.pushPop {
             let inset = borderWidth / 2.0
-            let bezierPath = UIBezierPath(roundedRect: rect.insetBy(dx: inset, dy: inset), cornerRadius: cornerRadius)
+            let bezierPath = UIBezierPath(roundedRect: rect.insetBy(dx: inset, dy: inset), cornerRadius: ThemeMetrics.stopAnnotationCornerRadius)
             bezierPath.lineWidth = borderWidth
             context.setStrokeColor(color.cgColor)
             bezierPath.stroke()
@@ -166,7 +178,7 @@ class StopIconFactory: NSObject {
     }
 
     /// Draws the transport glyph onto the icon.
-    /// - Note: Drawing is inset from `rect` by `transportGlyphInset` points.
+    /// - Note: Drawing is inset from `rect` by `ThemeMetrics.stopAnnotationIconInset` points.
     ///
     /// - Parameter routeType: The transport glyph type that will be drawn.
     /// - Parameter rect: The rectangle in which to draw.
@@ -175,7 +187,7 @@ class StopIconFactory: NSObject {
     private func drawIcon(routeType: Route.RouteType, rect: CGRect, context: CGContext, color: UIColor? = nil) {
         context.pushPop {
             let image = Icons.transportIcon(from: routeType).tinted(color: color ?? transportIconColor)
-            image.draw(in: rect.insetBy(dx: transportGlyphInset, dy: transportGlyphInset))
+            image.draw(in: rect.insetBy(dx: ThemeMetrics.stopAnnotationIconInset, dy: ThemeMetrics.stopAnnotationIconInset))
         }
     }
 

--- a/OBAKitCore/Extensions/UIKitExtensions.swift
+++ b/OBAKitCore/Extensions/UIKitExtensions.swift
@@ -212,6 +212,26 @@ public extension UIColor {
         return luminance > 0.5
     }
 
+    /// Lightens the receiver by the specified percent.'
+    /// - Parameter percentage: The percent by which to lighten the receiver. Defaults to 25%.
+    /// - Returns: The lightened color.
+    func lighten(by percentage: CGFloat = 0.25) -> UIColor {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return self
+        }
+
+        return UIColor(
+            red: min(red + percentage, 1.0),
+            green: min(green + percentage, 1.0),
+            blue: min(blue + percentage, 1.0),
+            alpha: alpha
+        )
+    }
 }
 
 // MARK: - UICollectionView
@@ -277,11 +297,6 @@ public extension UIFont {
     /// Returns an italic version of `self`.
     var italic: UIFont {
         return withTraits(traits: .traitItalic)
-    }
-
-    class var mapAnnotationFont: UIFont {
-        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: UIFont.TextStyle.footnote)
-        return UIFont.systemFont(ofSize: descriptor.pointSize - 2.0, weight: .black)
     }
 }
 

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -32,6 +32,10 @@ public class ThemeMetrics: NSObject {
     public static let floatingPanelTopInset: CGFloat = 7.0
 
     public static let collectionViewLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: padding, bottom: 0, trailing: padding)
+
+    public static let stopAnnotationIconInset: CGFloat = 6.0
+
+    public static let stopAnnotationCornerRadius: CGFloat = 4.0
 }
 
 public class ThemeColors: NSObject {
@@ -44,9 +48,6 @@ public class ThemeColors: NSObject {
 
     /// A gray text color, used on light backgrounds for de-emphasized text.
     public let secondaryLabel: UIColor
-
-    /// A dark gray text color, used on maps.
-    public let mapText: UIColor
 
     /// The overlay color drawn on top of a `MapSnapshotter` image.
     public let mapSnapshotOverlayColor: UIColor
@@ -155,7 +156,6 @@ public class ThemeColors: NSObject {
         groupedTableBackground = .systemGroupedBackground
         groupedTableRowBackground = .white
         systemBackground = .systemBackground
-        mapText = .label
         label = .label
         secondaryLabel = .secondaryLabel
         separator = .separator
@@ -163,8 +163,8 @@ public class ThemeColors: NSObject {
         secondaryBackgroundColor = .secondarySystemBackground
         propertyChanged = .systemYellow
 
-        stopAnnotationFillColor = .systemBackground
-        stopAnnotationStrokeColor = .label
+        stopAnnotationFillColor = .systemGray6
+        stopAnnotationStrokeColor = .darkGray
         stopArrowFillColor = .systemRed
         systemFill = .systemFill
         lightText = .white


### PR DESCRIPTION
* Use a dark gray border color and gradient background
* Match the rendering of Apple's map annotations with an attributed string
* Make sure dark mode looks great, too