### PR TITLE
Fix widget readability in tinted modes

### DIFF
--- a/OBAWidget/Components/RefreshButton.swift
+++ b/OBAWidget/Components/RefreshButton.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import AppIntents
 import WidgetKit
+import OBAKitCore
 
 // MARK: - RefreshWidgetIntent
 /// this intent serves as a way to refresh the widget and its timelines.
@@ -22,22 +23,42 @@ struct RefreshWidgetIntent: AppIntent {
 
 /// A button to manually trigger the widget refresh.
 struct RefreshButton: View {
+    @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
+    private var usesFullColor: Bool {
+        widgetRenderingMode == .fullColor
+    }
+
+    private var foregroundColor: Color {
+        usesFullColor ? .white : .primary
+    }
+
+    private var backgroundShape: some View {
+        Group {
+            if usesFullColor {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(uiColor: ThemeColors.shared.brand))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.primary.opacity(0.35), lineWidth: 1)
+            }
+        }
+    }
+
     var body: some View {
 
         Button(intent: RefreshWidgetIntent()) {
             HStack(spacing: 2) {
                 Image(systemName: "arrow.trianglehead.clockwise")
                     .imageScale(.small)
-                    .foregroundStyle(.white)
 
                 Text("Refresh")
                     .font(.system(size: 12))
-                    .foregroundColor(.white)
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 4)
-            .background(Color(.brand))
-            .cornerRadius(8)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundShape)
         }
         .buttonStyle(.plain)
 

--- a/OBAWidget/Views/DepartureTimeBadgeView.swift
+++ b/OBAWidget/Views/DepartureTimeBadgeView.swift
@@ -29,9 +29,16 @@ struct DepartureTimeBadgeView: View {
         )
     }
 
-    private var backgroundColor: Color {
-        Color(formatters.backgroundColorForScheduleStatus(arrivalDeparture.scheduleStatus))
+    private var scheduleColor: UIColor {
+        formatters.backgroundColorForScheduleStatus(arrivalDeparture.scheduleStatus)
+    }
 
+    private var backgroundColor: Color {
+        Color(scheduleColor)
+    }
+
+    private var foregroundColor: Color {
+        Color(scheduleColor.contrastingTextColor)
     }
 
     var body: some View {
@@ -39,6 +46,7 @@ struct DepartureTimeBadgeView: View {
             Text("\(displayText)")
                 .badgeStyle(
                     backgroundColor: backgroundColor,
+                    textColor: foregroundColor,
                     accessibilityLabel: accessibilityLabel
                 )
         }
@@ -47,25 +55,44 @@ struct DepartureTimeBadgeView: View {
 }
 
 extension View {
-    func badgeStyle(backgroundColor: Color, accessibilityLabel: String) -> some View {
-        self.modifier(BadgeStyle(backgroundColor: backgroundColor, accessibilityLabel: accessibilityLabel))
+    func badgeStyle(backgroundColor: Color, textColor: Color, accessibilityLabel: String) -> some View {
+        self.modifier(BadgeStyle(backgroundColor: backgroundColor, textColor: textColor, accessibilityLabel: accessibilityLabel))
     }
 }
 
 struct BadgeStyle: ViewModifier {
     let backgroundColor: Color
+    let textColor: Color
     let accessibilityLabel: String
+
+    @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
+    private var rendersFullColor: Bool {
+        widgetRenderingMode == .fullColor
+    }
+
     func body(content: Content) -> some View {
-        content
+        let base = content
             .font(.system(size: 13))
             .padding(.horizontal, 3)
             .padding(.vertical, 4)
             .frame(width: 40, height: 25)
-            .background(backgroundColor)
-            .foregroundColor(.white)
-            .cornerRadius(8)
             .accessibilityLabel(accessibilityLabel)
             .lineLimit(1)
             .minimumScaleFactor(0.8)
+
+        if rendersFullColor {
+            base
+                .foregroundStyle(textColor)
+                .background(backgroundColor)
+                .cornerRadius(8)
+        } else {
+            base
+                .foregroundStyle(.primary)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(.primary.opacity(0.35), lineWidth: 1)
+                )
+        }
     }
 }


### PR DESCRIPTION
### Summary

  - Fix DepartureTimeBadgeView so badge text always contrasts against its schedule color and automatically swaps to a neutral outline when WidgetKit applies a tint or glass effect (using widgetRenderingMode).
  - Update the Refresh button to share the same adaptive styling and to use ThemeColors.shared.brand in full-color mode; the control now stays readable when the widget is tinted or glass, as well.
  - No project-file or dependency changes included; this PR is scoped strictly to the widget UI.

  ### Testing

  - Regenerated the project (xcodegen generate --spec Apps/OneBusAway/project.yml).
  - Built OBAWidget in Xcode 16 / iOS 18 simulator.
  - Manually verified the medium widget in:
      - Full Color (light & dark)
      - Glass
      - Tinted (light & dark)

### Images

#### Before

![IMG_6992](https://github.com/user-attachments/assets/0e3c03cf-9e90-4116-a61b-6c80c4f55449)

#### After
<img width="314" height="168" alt="Screenshot 2025-11-10 at 9 30 46 PM" src="https://github.com/user-attachments/assets/dcb794d0-cca8-4815-a2bb-200f72b1a251" />
<img width="325" height="172" alt="Screenshot 2025-11-10 at 9 31 47 PM" src="https://github.com/user-attachments/assets/6de62d6e-c7df-450c-a7b3-35d81df909ac" />
<img width="313" height="169" alt="Screenshot 2025-11-10 at 9 31 52 PM" src="https://github.com/user-attachments/assets/a036c0ab-9b90-4744-997c-ececf2719270" />
<img width="317" height="151" alt="Screenshot 2025-11-10 at 9 31 58 PM" src="https://github.com/user-attachments/assets/622eb85f-0596-46b6-8607-3cf1e44e49ed" />
<img width="315" height="169" alt="Screenshot 2025-11-10 at 9 32 06 PM" src="https://github.com/user-attachments/assets/a50fdaf8-a2dc-4e17-b7a7-42f07b1753fd" />
