### PR TITLE
fix: clear searchResponse after pin drop to enable stop reloading

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -446,6 +446,11 @@ public class MapRegionManager: NSObject,
     private func displaySearchResult(mapItem: MKMapItem) {
         mapView.setCenter(mapItem.placemark.coordinate, animated: true)
         mapView.addAnnotation(mapItem.placemark)
+
+        // Clear searchResponse on next run loop to allow normal stop loading when panning
+        DispatchQueue.main.async { [weak self] in
+            self?.searchResponse = nil
+        }
     }
 
     private func displaySearchResult(stopsForRoute: StopsForRoute) {
@@ -726,6 +731,11 @@ public class MapRegionManager: NSObject,
             let mapItem = MKMapItem(placemark: MKPlacemark(placemark: placemark))
             let response = SearchResponse(request: request, results: [mapItem], boundingRegion: nil, error: nil)
             self.searchResponse = response
+
+            // Clear searchResponse on next run loop to allow normal stop loading when panning
+            DispatchQueue.main.async { [weak self] in
+                self?.searchResponse = nil
+            }
         }
     }
 


### PR DESCRIPTION
Clears searchResponse on next run loop in [`reverseGeocodeLocation()`](https://github.com/OneBusAway/onebusaway-ios/blob/2a3bbd48b7c794e61dafb61ba27a7afbc2670abd/OBAKit/Mapping/MapRegionManager.swift#L697-L730) and [`displaySearchResult(mapItem:)`](https://github.com/OneBusAway/onebusaway-ios/blob/2a3bbd48b7c794e61dafb61ba27a7afbc2670abd/OBAKit/Mapping/MapRegionManager.swift#L446-L449) to prevent blocking stop loading when user pans the map after dropping a pin or selecting a map item.

Fixes #884 