### PR TITLE
fix: prevent stop header from expanding on first display (#880)

### DIFF
--- a/OBAKit/Stops/StopHeaderController.swift
+++ b/OBAKit/Stops/StopHeaderController.swift
@@ -184,6 +184,8 @@ class StopHeaderView: UIView {
         accessibilityTraits = [.summaryElement, .header, .staticText]
         accessibilityLabel = config.viewModel.stopName
         accessibilityValue = [stopNumberLabel.text, routesLabel.text].compactMap {$0}.joined(separator: " ")
+
+        layoutIfNeeded()
     }
 
     override func layoutSubviews() {


### PR DESCRIPTION
This PR fixes an issue where the stop header sometimes rendered with extra height on first load. The initial layout pass didn’t have accurate label sizes yet, so the header’s height calculation overshot and added unnecessary padding.

Calling `layoutIfNeeded()` at the end of `configureView()` forces the view to lay out its subviews before height computation kicks in. With this simple one line addition, the header now renders at the correct height immediately.