### PR TITLE
fix : rendering bugs in stop icon text (fixes #882)

### DIFF
--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -32,6 +32,8 @@ class StopAnnotationView: MKAnnotationView {
         let label = StrokedLabel.autolayoutNew()
         label.textAlignment = .center
         label.numberOfLines = 2
+        label.lineBreakMode = .byTruncatingTail
+        label.adjustsFontSizeToFitWidth = false
         return label
     }()
 
@@ -57,7 +59,7 @@ class StopAnnotationView: MKAnnotationView {
 
         NSLayoutConstraint.activate([
             labelStack.topAnchor.constraint(equalTo: self.bottomAnchor),
-            labelStack.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 2.0),
+            labelStack.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 3.5),
             labelStack.widthAnchor.constraint(greaterThanOrEqualTo: self.widthAnchor),
             labelStack.centerXAnchor.constraint(equalTo: self.centerXAnchor)
         ])


### PR DESCRIPTION

Fixes #882
### **Description :**
On stops with many routes, the text under the map pin renders completely broken — letters overlap, no ellipsis, looks corrupted and the label becomes unreadable.

### Fix
- Set `lineBreakMode = .byTruncatingTail` so long route lists end cleanly with "…"
- Explicitly disable `adjustsFontSizeToFitWidth` to prevent distorted/shrunk text
- Increase maximum label width from 2.0× → 3.5× .

### **Result**

- Text stays crisp and readable 
- No visual regressions on any device or zoom level

**testing – MTA New York**

### **Before (with Rendering Bug ) :**

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/4d2f3d2f-cc44-4d1c-bb6f-5edda610a7b4" width="360">
</td>
<td><img src="https://github.com/user-attachments/assets/863ee569-52bc-421f-a5ab-679298edcbc5"  width="360"></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/68d60a3d-f0f7-4ea3-bc21-1807fdbf0e97" width="360">
</td>
</tr>
</table>

### **After (fixed) :** 

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/abef457b-4df0-4b46-ac79-fb2ced71f9f2" width="360">
</td>
<td><img src="https://github.com/user-attachments/assets/7a99dc88-98f9-4291-9c1d-2163c6d9f481" width="360"></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/a835ff8d-5bb2-4208-b0a9-7784b8c369ef" width="360"></td>
<td><img src="https://github.com/user-attachments/assets/d06ff3d1-22ea-4cf5-8cd2-0040212961be" width="360"></td>
</tr>
</table>

 






