### PR TITLE
Fix : stop annotation route labels showing solid white background after appearance changes

### DIFF
--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -77,10 +77,20 @@ class StopAnnotationView: MKAnnotationView {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
             if self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle {
                 self.rebuildIcon()
+                self.refreshLabels()
             }
         }
     }
-
+    private func refreshLabels() {
+        if let bookmark = annotation as? Bookmark {
+            titleLabel.attributedText = strokedText(bookmark.name)
+        }
+        else if let stop = annotation as? Stop {
+            if let mapTitle = stop.mapTitle {
+                titleLabel.attributedText = strokedText(mapTitle)
+            }
+        }
+    }
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     // MARK: - Annotation View Overrides


### PR DESCRIPTION
fixes #894 

### **Problem:**
Stop annotation labels on the map view displayed a solid white background after toggling between Light and Dark mode. which is inconsistent with the intended UI design.

**Root Cause:**
The trait change handler only rebuilt the stop icon when appearance changed, but did not refresh the label's attributed text. This caused the labels to retain outdated appearance-specific styling attributes.

### Solution:
- Added `refreshLabels()` method to regenerate attributed text for labels
- Call `refreshLabels()` in the trait change handler alongside rebuildIcon()
- Ensures labels maintain proper styling across appearance changes

### **Testing video:**

### Before & After

| Before (Bug)                                       | After (Fixed)                                         |
|------------------------------------------------------------|----------------------------------------------------------------|
| <video src="https://github.com/user-attachments/assets/e9cb1430-2709-43ad-b5d1-7224bcfdf63f" width="400"/> | <video src="https://github.com/user-attachments/assets/59d1472c-2c8c-4711-ba68-f105dc0a5b1b" width="400"/> |
| Solid white background appears after toggling appearance | Labels stay clean in both Light and Dark mode |

**Result:** No more ugly white boxes — stop route labels now stay clean and readable no matter how many times the user toggles appearance.

