### PR TITLE
Fix service alert duplication for stops with multiple arrivals (Fixes #828)

### DIFF
--- a/OBAKitCore/Models/REST/StopArrivals.swift
+++ b/OBAKitCore/Models/REST/StopArrivals.swift
@@ -35,7 +35,17 @@ public class StopArrivals: NSObject, Identifiable, Decodable, HasReferences {
             return _serviceAlerts
         }
         else {
-            return arrivalsAndDepartures.flatMap { $0.serviceAlerts }
+            let allAlerts = arrivalsAndDepartures.flatMap { $0.serviceAlerts }
+            var uniqueAlerts: [ServiceAlert] = []
+            var seenIDs = Set<String>()
+
+            for alert in allAlerts {
+                if !seenIDs.contains(alert.id) {
+                    uniqueAlerts.append(alert)
+                    seenIDs.insert(alert.id)
+                }
+            }
+            return uniqueAlerts
         }
     }
 


### PR DESCRIPTION
- Deduplicates service alerts by ID when aggregating from arrivals/departures
- Prevents the same alert from appearing multiple times in UI
- Fixes issue where stop shows duplicate alerts when same alert affects multiple arrivals

Solution: Deduplicate alerts by their unique ID before returning them. 
Code Change: In OBAKitCore/Models/REST/StopArrivals.swift, replaced: 
return arrivalsAndDepartures.flatMap { $0.serviceAlerts } with deduplication logic that keeps only the first occurrence of each alert ID by using a set data structure to track seen IDs.
Resolves #828

Screenshots: Before
**Before:**  
<p float="left">
  <img src="https://github.com/user-attachments/assets/c0a91232-b517-4e68-bd5a-8453df113725" width="300" />
  <img src="https://github.com/user-attachments/assets/94b895e7-8bc5-47c7-a46d-6b4e6812bbe4" width="300" />
</p>

**After:**  
<img src="https://github.com/user-attachments/assets/30a7830b-e805-4046-a222-9aa4b969fc94" width="300" />
