### PR TITLE
fix Stop Detail view Header Map Not Updating on Theme Change

### DIFF
--- a/OBAKit/Stops/StopHeaderController.swift
+++ b/OBAKit/Stops/StopHeaderController.swift
@@ -150,7 +150,7 @@ class StopHeaderView: UIView {
 
         addGestureRecognizer(toggleRouteDetailsGestureRecognizer)
 
-        let sizeTraits: [UITrait] = [UITraitVerticalSizeClass.self, UITraitHorizontalSizeClass.self]
+        let sizeTraits: [UITrait] = [UITraitVerticalSizeClass.self, UITraitHorizontalSizeClass.self ,  UITraitUserInterfaceStyle.self]
         registerForTraitChanges(sizeTraits) { (self: Self, _) in
             self.configureView()
         }


### PR DESCRIPTION
### **Description**
fixes #902
Fixes the issue where the Stop Detail screen's map header fails to update when the system theme is toggled between Dark and Light mode. The map now responds immediately to theme changes without requiring a manual refresh or re-navigation.

### Root Cause
The StopHeaderView was only registered to observe size class trait changes (UITraitVerticalSizeClass and UITraitHorizontalSizeClass) but was not observing UITraitUserInterfaceStyle changes. This meant that when the system theme changed, the view was not notified and configureView() was never called to regenerate the map snapshot with the updated theme.

### Problem
The Stop Detail screen's map header was not responding to system theme changes (Dark ↔ Light mode). When users toggled their system appearance settings, the map snapshot retained the previous theme's appearance until the user performed a pull-to-refresh or navigated away and back to the screen.

### Solution
Added `UITraitUserInterfaceStyle.self` to the list of traits being observed by StopHeaderView. This ensures that configureView() is called whenever the interface style changes, triggering a new map snapshot with the correct theme.


Before (Bug) | After (Fixed)
-- | --
<video src="https://github.com/user-attachments/assets/9c0e4af9-0c07-405e-9ad1-cdc7eaf338d8" width="400"/> | <video src="https://github.com/user-attachments/assets/579b4ab8-dbdb-4b8f-805e-319569501a11" width="400"/>
Map header retains old theme appearance when system theme is toggled.  | Map header updates immediately when system theme is toggled. No manual intervention needed.

### Changes Made

Modified Files
`OBAKit/StopHeaderController.swift`




