### PR TITLE
Fix Sound Transit 2 Line schedule trip ordering(#909)

### DIFF
--- a/OBAKit/Schedules/ScheduleForRouteViewModel.swift
+++ b/OBAKit/Schedules/ScheduleForRouteViewModel.swift
@@ -97,48 +97,76 @@ class ScheduleForRouteViewModel: ObservableObject {
     }
 
     /// Returns a sorted list of departure times for display
-    /// Each row represents a trip, sorted by the earliest non-nil departure time
+    /// Each row represents a trip, sorted by the trip's actual start time (earliest departure across all stops)
     var sortedDepartureTimes: [[Date?]] {
-        let times = departureTimes
-        return times.sorted { row1, row2 in
-            // Find the first non-nil departure time for each row
-            let date1 = row1.first { $0 != nil } ?? nil
-            let date2 = row2.first { $0 != nil } ?? nil
-
-            // If both have dates, sort by date
-            switch (date1, date2) {
-            case (let d1?, let d2?):
-                return d1 < d2
+        guard let direction = currentDirection,
+              let scheduleDate = scheduleData?.scheduleDate else {
+            return []
+        }
+        let indexedTrips: [(index: Int, times: [Date?], startTime: Date?)] = departureTimes.enumerated().map { index, times in
+            let trip = direction.tripsWithStopTimes[index]
+            let minDepartureSeconds = trip.stopTimes.map { $0.departureTime }.min()
+            let actualStartTime = minDepartureSeconds.map { seconds in
+                let calendar = Calendar.current
+                let startOfDay = calendar.startOfDay(for: scheduleDate)
+                return startOfDay.addingTimeInterval(TimeInterval(seconds))
+            }
+            return (index, times, actualStartTime)
+        }
+        let sorted = indexedTrips.sorted { trip1, trip2 in
+            switch (trip1.startTime, trip2.startTime) {
+            case (let t1?, let t2?):
+                return t1 < t2
             case (nil, _):
                 return false
             case (_, nil):
                 return true
             }
         }
+        return sorted.map { $0.times }
     }
 
     /// Returns departure times grouped by time period (AM/PM)
-    /// Each group contains trips where the earliest departure is in that period
+    /// Each group contains trips where the actual trip start time is in that period
     var departureTimesByPeriod: [TimePeriodGroup] {
-        let sorted = sortedDepartureTimes
+        guard let direction = currentDirection,
+              let scheduleDate = scheduleData?.scheduleDate else {
+            return []
+        }
         let calendar = Calendar.current
-
         var amTrips: [[Date?]] = []
         var pmTrips: [[Date?]] = []
 
-        for row in sorted {
-            // Find the earliest non-nil departure time for this row
-            guard let earliestTime = row.first(where: { $0 != nil }), let date = earliestTime else {
-                // If no departure times at all, default to PM
-                pmTrips.append(row)
+        let tripsWithStartTimes: [([Date?], Date?)] = departureTimes.enumerated().map { index, times in
+            let trip = direction.tripsWithStopTimes[index]
+            let minDepartureSeconds = trip.stopTimes.map { $0.departureTime }.min()
+            let actualStartTime = minDepartureSeconds.map { seconds in
+                let startOfDay = calendar.startOfDay(for: scheduleDate)
+                return startOfDay.addingTimeInterval(TimeInterval(seconds))
+            }
+            return (times, actualStartTime)
+        }
+        let sorted = tripsWithStartTimes.sorted { trip1, trip2 in
+            switch (trip1.1, trip2.1) {
+            case (let t1?, let t2?):
+                return t1 < t2
+            case (nil, _):
+                return false
+            case (_, nil):
+                return true
+            }
+        }
+        for (times, startTime) in sorted {
+            guard let startTime = startTime else {
+                pmTrips.append(times)
                 continue
             }
 
-            let hour = calendar.component(.hour, from: date)
+            let hour = calendar.component(.hour, from: startTime)
             if hour < 12 {
-                amTrips.append(row)
+                amTrips.append(times)
             } else {
-                pmTrips.append(row)
+                pmTrips.append(times)
             }
         }
 

--- a/OBAKitCore/Models/REST/References/References.swift
+++ b/OBAKitCore/Models/REST/References/References.swift
@@ -120,7 +120,7 @@ extension References {
     }
 
     public func stopsWithIDs(_ ids: [String]) -> [Stop] {
-        return stops.filter { ids.contains($0.id) }
+        return ids.compactMap { id in stopWithID(id) }
     }
 
     // MARK: - Trips


### PR DESCRIPTION
Fixes #909
Trips in the schedule view were being sorted incorrectly because the sorting logic only looked at the first stop's departure time. This caused trips that don't serve the first stop (like the 4:54am trip from Spring District) to appear in the middle of the schedule instead of at the beginning.
Updates (Dec 17, 2025):
Fixed additional sorting issues identified by @johnhelmuth-st
Now sorts by actual trip start time (minimum departure across all stops) instead of first visible column
Fixed stop column ordering to preserve geographic sequence from API
Changes:
Sort trips by minimum departure time across all stops (not just first visible stop)
Fix AM/PM grouping to use actual trip start time
Fix References.stopsWithIDs() to preserve stop order from API
Further details given below!!