### PR TITLE
Fix:  stop annotation overlapping text after bookmark deletion (#915)

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -382,18 +382,13 @@ public class MapRegionManager: NSObject,
                 bookmarksHash[bookmark.stopID] == nil
             else {
                 return nil
-                }
+            }
             affectedStopIDs.insert(bookmark.stopID)
             return bookmark
         }
         let allAnnotationsToRemove = stopAnnotationsToRemove + bookmarkAnnotationsToRemove
-        for annotation in allAnnotationsToRemove {
-            if mapView.selectedAnnotations.contains(where: {
-                ($0 as? Stop)?.id == (annotation as? Stop)?.id ||
-                ($0 as? Bookmark)?.stopID == (annotation as? Bookmark)?.stopID
-            }) {
-                mapView.deselectAnnotation(annotation, animated: false)
-            }
+        for annotation in allAnnotationsToRemove where mapView.selectedAnnotations.contains(where: { $0 === annotation }) {
+            mapView.deselectAnnotation(annotation, animated: false)
         }
         mapView.removeAnnotations(allAnnotationsToRemove)
 
@@ -404,32 +399,29 @@ public class MapRegionManager: NSObject,
             !bookmarksHash.keys.contains($0.id) && !existingStopIDs.contains($0.id)
         }
         mapView.addAnnotations(stopsToAdd)
-        refreshAnnotationViews(for: Array(affectedStopIDs), bookmarksHash: bookmarksHash)
+        refreshAnnotationViews(for: Array(affectedStopIDs))
         notifyDelegatesStopsChanged()
     }
 
-    private func refreshAnnotationViews(for affectedStopIDs: [StopID], bookmarksHash: [StopID: Bookmark]) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            for stopID in affectedStopIDs {
-
-                let newAnnotation = self.mapView.annotations.first { annotation in
-                    if let bookmark = annotation as? Bookmark {
-                        return bookmark.stopID == stopID
-                    } else if let stop = annotation as? Stop {
-                        return stop.id == stopID
-                    }
-                    return false
+    private func refreshAnnotationViews(for affectedStopIDs: [StopID]) {
+        assert(Thread.isMainThread, "refreshAnnotationViews must be called on the main thread")
+        for stopID in affectedStopIDs {
+            let newAnnotation = mapView.annotations.first { annotation in
+                if let bookmark = annotation as? Bookmark {
+                    return bookmark.stopID == stopID
+                } else if let stop = annotation as? Stop {
+                    return stop.id == stopID
                 }
-                guard let annotation = newAnnotation,
-                      let view = self.mapView.view(for: annotation) as? StopAnnotationView else {
-                    continue
-                }
-                view.prepareForReuse()
-                view.annotation = annotation
-                view.delegate = self
-                self.mapViewDelegate?.mapRegionManager(self, customize: view)
+                return false
             }
+            guard let annotation = newAnnotation,
+                  let view = mapView.view(for: annotation) as? StopAnnotationView else {
+                continue
+            }
+            view.prepareForReuse()
+            view.annotation = annotation
+            view.delegate = self
+            mapViewDelegate?.mapRegionManager(self, customize: view)
         }
     }
     // MARK: - Zoom In Warning


### PR DESCRIPTION
### Description
Fixes #915
Fixes the issue where stop annotation labels appear garbled with overlapping text immediately after deleting a bookmark. The map now properly cleans up and refreshes annotation views when bookmark state changes, eliminating the visual ghosting effect.

### Root Cause
The` MapRegionManager.displayUniqueStopAnnotations()` method had two critical issues:

1. Stale Bookmark Annotations: When a bookmark was deleted, the bookmarked annotation remained on the map while a new regular stop annotation was added at the same location, causing both to render simultaneously.

2. No View Cleanup: MapKit reuses annotation views for performance, but the method didn't call `prepareForReuse()` or reset view state when swapping between bookmark and stop annotations. This caused the old visual state to persist and overlap with the new rendering.

### Problem
When users deleted a bookmark and returned to the map, the stop label for that location appeared distorted with overlapping or doubled text. This occurred because:

- The old "bookmarked" annotation view wasn't removed from the map
- The annotation view was reused without clearing its previous styling
- Both the bookmark and stop renderings were drawn on top of each other (z-fighting)

The issue persisted until the user manually refresh map.

### Solution

1. Remove Stale Bookmarks: Added logic to detect and remove bookmark annotations that no longer exist in the bookmarks list, preventing duplicate annotations at the same location.
2. Proper Deselection: Deselect annotations before removal to prevent MapKit from maintaining corrupted selection state on views that are being recycled.
3. Force View Refresh: Created a new refreshAnnotationViews() method that:
- Tracks all stops affected by bookmark state changes
- Calls `prepareForReuse()` on affected annotation views to clear old rendering state
- Reassigns the annotation property to trigger proper redraw
- Reconfigures delegate and customization callbacks

### video
Before (Bug) | After (Fixed)
-- | --
<video src="https://github.com/user-attachments/assets/52ddf8ea-9238-46db-b298-c169aec772b2" width="400"/> | <video src="https://github.com/user-attachments/assets/d8af8ef2-40fc-4fab-94db-50eb2c3df2a1" width="400"/>
Stop label appears garbled with overlapping text after deleting bookmark | Stop label renders cleanly and clearly after deleting bookmark
### screenshot :
(Bug) | (Fixed)
-- | --
<image src="https://github.com/user-attachments/assets/0f0c84b2-2293-4bea-87a9-157407785b83" width="400"/> | <image src="https://github.com/user-attachments/assets/3097846f-28c8-44ad-9cb3-3b0ec6ad52d8" width="400"/>



### Modified Files
`OBAKit/MapRegionManager.swift`
