### PR TITLE
Fix crash when routes visit the same stop multiple times

### DIFF
--- a/OBAKit/Schedules/ScheduleForRouteViewModel.swift
+++ b/OBAKit/Schedules/ScheduleForRouteViewModel.swift
@@ -87,8 +87,11 @@ class ScheduleForRouteViewModel: ObservableObject {
 
         return direction.tripsWithStopTimes.map { tripWithStopTimes in
             // Pre-compute dictionary for O(1) lookups instead of O(k) first(where:)
+            // Use uniquingKeysWith to handle routes that visit the same stop multiple times
+            // (e.g., circular routes). Keep the first occurrence.
             let stopTimesDict = Dictionary(
-                uniqueKeysWithValues: tripWithStopTimes.stopTimes.map { ($0.stopID, $0) }
+                tripWithStopTimes.stopTimes.map { ($0.stopID, $0) },
+                uniquingKeysWith: { first, _ in first }
             )
             return direction.stopIDs.map { stopID in
                 stopTimesDict[stopID]?.departureDate(for: scheduleDate)


### PR DESCRIPTION
The crash occurred when Dictionary(uniqueKeysWithValues:) was called
with duplicate stopID keys, which happens on circular routes or routes
that loop back to a previously visited stop.

Replace with Dictionary(_:uniquingKeysWith:) which handles duplicate
keys by keeping the first occurrence (earlier in the trip sequence).

Fixes crash: EXC_BREAKPOINT in _NativeDictionary.merge
Stack: ScheduleForRouteViewModel.departureTimes.getter (line 90)