### PR TITLE
Fix :hidden arrival times when stop names are too long (#920)

### DIFF
--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -134,8 +134,10 @@ final class TripStopCell: OBAListViewCell {
 
     let titleLabel: UILabel = {
         let label = UILabel.obaLabel(textColor: ThemeColors.shared.label)
+        label.numberOfLines = 0
+        label.lineBreakMode = .byTruncatingTail
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }()
 


### PR DESCRIPTION
### Description
Fixes #920
Fixes the UI layout bug in the Trip Details view where arrival times are truncated or pushed off-screen when stop names are very long. The time label now always remains fully visible while stop names truncate gracefully with ellipsis.

### Root Cause
In `OBAKit/Trip/TripStopListItem.swift` the  `TripStopCell` class had incorrect Auto Layout priority configuration:
Both labels had .required compression resistance:
`titleLabel` (stop name): .`setContentCompressionResistancePriority(.required, for: .horizontal)`
`timeLabel` (arrival time): `.setContentCompressionResistancePriority(.required, for: .horizontal)`

When both labels refuse to compress, UIStackView cannot resolve the layout conflict. Since the stop name appears first in the stack and expands to accommodate long text, it pushes the time label beyond the visible bounds of the cell.

### Problem
When viewing the Trip Details screen (list of stops for a specific trip), stops with long names caused the arrival time to be truncated or completely invisible. This occurred because:
The stop name label was configured to never compress (`.required `priority)
The time label was also configured to never compress (`.required` priority)
The horizontal stack view had no way to resolve this conflict
The stop name, appearing first, would expand and push the time off-screen
Critical information (arrival time) was hidden while less critical information (full stop name) was prioritized.

### Solution
Fixed the Auto Layout priority hierarchy to ensure arrival times are always visible:
1. Title Label (Stop Name) - Allow Compression:
Changed compression resistance from `.required` to `.defaultLow`
Added `lineBreakMode = .byTruncatingTail` to show ellipsis (...) when text is too long
Added `numberOfLines = 0 `to allow wrapping to 2 lines when space is available

2. Time Label - Maintain Priority:
Kept compression resistance at `.required` to ensure it never truncates
Kept content hugging at `.required `to prevent unnecessary expansion
This ensures UIStackView always prioritizes the time label, allowing the stop name to truncate gracefully.

### Screenshots


| **Before (Bug)** | **After (Fixed)** |
|------------------|-------------------|
| <img src="https://github.com/user-attachments/assets/232a1a8d-8081-4b29-9fad-5eaccd386e80" width="300" /> | <img src="https://github.com/user-attachments/assets/fa3b944c-218e-4bff-86cd-f4be172d4d85" width="300" /> |
| <img src="https://github.com/user-attachments/assets/0e7cdefc-bf12-4d03-bd5d-b439f014af1b" width="300" /> | <img src="https://github.com/user-attachments/assets/aa99fd08-bc75-4cbb-bd12-96779f0d15fa" width="300" /> |

**Before:** Arrival times are cut off or completely hidden when stop names are long  
**After:** Arrival times are always fully visible; stop names truncate with an ellipsis

Modified Files : 
`OBAKit/Trip/TripStopListItem.swift`


