### PR TITLE
Fix : duplicate alerts in Alerts view (#932 )

### DIFF
--- a/OBAKit/Alerts/AgencyAlertsViewController.swift
+++ b/OBAKit/Alerts/AgencyAlertsViewController.swift
@@ -148,7 +148,11 @@ class AgencyAlertsViewController: UIViewController,
     // MARK: - List data
 
     func items(for listView: OBAListView) -> [OBAListViewSection] {
-        return listSections(agencyAlerts: alertsStore.agencyAlerts)
+        var seenIDs = Set<String>()
+        let uniqueAlerts = alertsStore.agencyAlerts.filter { alert in
+            seenIDs.insert(alert.id).inserted
+        }
+        return listSections(agencyAlerts: uniqueAlerts)
     }
 
     func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {


### PR DESCRIPTION
### Description

> fixes #932

Fixes the duplicate alerts bug in the Alerts screen, where the same alert appeared multiple times in the list. Alerts are now deduplicated by their unique ID, ensuring each alert appears only once while preserving the original order.

### Problem
When viewing the Alerts screen (More tab → Alerts), users would see the same alert repeated multiple times. This occurred because:

- The alerts data source (`alertsStore.agencyAlerts`) contained duplicate entries with identical IDs
- No deduplication logic existed between the data source and UI rendering
- The list view displayed every alert in the array, including duplicates
- Users had to scroll through repeated copies of the same alert

### Root Cause
In `OBAKit/AgencyAlertsViewController.swift`, the `items(for listView:)` method passed  `alertsStore.agencyAlerts` directly to the list rendering logic without removing duplicates. When the `AgencyAlertsStore `received updates or loaded data from the Protobuf feed, it could accumulate duplicate alert entries with the same ID. Without filtering, all duplicates were rendered in the UI, creating a confusing user experience where identical alerts appeared multiple times.
### Screenshots 

| **Before (Bug)** | **After (Fixed)** |
|------------------|-------------------|
| <img src="https://github.com/user-attachments/assets/4cac39b9-1b87-4bd3-ae7e-bb694a1d7024" width="300" /> | <img src="https://github.com/user-attachments/assets/7970b6fc-74c4-46bc-bf99-b2a5658ca3cf" width="300" /> |
| <img src="https://github.com/user-attachments/assets/08c432b8-6bb8-4bb2-8b29-ae9ad224f42c" width="300" /> | <img src="https://github.com/user-attachments/assets/bf93561a-8e99-4e56-9002-39a53b5bd7b8" width="300" /> |

**Before** : The same alert appeared multiple times in the Alerts list.
**After**: Each alert now appears only once. Duplicate entries are removed , resulting in a clean, readable Alerts list with no repeated information.

### Solution
- Tracks alert IDs using a `Set<String>`
- Filters the alerts array using `Set.insert(_:).inserted` to ensure each alert appears only once
- Passes only unique alerts to the list rendering function

Modified Files

`OBAKit/Alerts/AgencyAlertsViewController.swift`
