### PR TITLE
Refactor schedule sorting and add tests for stop ordering

### DIFF
--- a/OBAKit/Schedules/ScheduleForRouteViewModel.swift
+++ b/OBAKit/Schedules/ScheduleForRouteViewModel.swift
@@ -103,15 +103,9 @@ class ScheduleForRouteViewModel: ObservableObject {
               let scheduleDate = scheduleData?.scheduleDate else {
             return []
         }
-        let indexedTrips: [(index: Int, times: [Date?], startTime: Date?)] = departureTimes.enumerated().map { index, times in
+        let indexedTrips: [(times: [Date?], startTime: Date?)] = departureTimes.enumerated().map { index, times in
             let trip = direction.tripsWithStopTimes[index]
-            let minDepartureSeconds = trip.stopTimes.map { $0.departureTime }.min()
-            let actualStartTime = minDepartureSeconds.map { seconds in
-                let calendar = Calendar.current
-                let startOfDay = calendar.startOfDay(for: scheduleDate)
-                return startOfDay.addingTimeInterval(TimeInterval(seconds))
-            }
-            return (index, times, actualStartTime)
+            return (times, actualStartTime(for: trip, scheduleDate: scheduleDate))
         }
         let sorted = indexedTrips.sorted { trip1, trip2 in
             switch (trip1.startTime, trip2.startTime) {
@@ -137,17 +131,12 @@ class ScheduleForRouteViewModel: ObservableObject {
         var amTrips: [[Date?]] = []
         var pmTrips: [[Date?]] = []
 
-        let tripsWithStartTimes: [([Date?], Date?)] = departureTimes.enumerated().map { index, times in
+        let tripsWithStartTimes: [(times: [Date?], startTime: Date?)] = departureTimes.enumerated().map { index, times in
             let trip = direction.tripsWithStopTimes[index]
-            let minDepartureSeconds = trip.stopTimes.map { $0.departureTime }.min()
-            let actualStartTime = minDepartureSeconds.map { seconds in
-                let startOfDay = calendar.startOfDay(for: scheduleDate)
-                return startOfDay.addingTimeInterval(TimeInterval(seconds))
-            }
-            return (times, actualStartTime)
+            return (times, actualStartTime(for: trip, scheduleDate: scheduleDate))
         }
         let sorted = tripsWithStartTimes.sorted { trip1, trip2 in
-            switch (trip1.1, trip2.1) {
+            switch (trip1.startTime, trip2.startTime) {
             case (let t1?, let t2?):
                 return t1 < t2
             case (nil, _):
@@ -194,6 +183,16 @@ class ScheduleForRouteViewModel: ObservableObject {
     // MARK: - Private Properties
 
     private var cancellables = Set<AnyCancellable>()
+
+    /// Calculates the actual start time for a trip by finding the earliest departure across all stops.
+    /// This is used for sorting trips chronologically, since some trips may not serve the first stop.
+    private func actualStartTime(for trip: ScheduleForRoute.TripWithStopTimes, scheduleDate: Date) -> Date? {
+        guard let minDepartureSeconds = trip.stopTimes.map({ $0.departureTime }).min() else {
+            return nil
+        }
+        let startOfDay = Calendar.current.startOfDay(for: scheduleDate)
+        return startOfDay.addingTimeInterval(TimeInterval(minDepartureSeconds))
+    }
 
     // MARK: - Static Formatters (for performance)
 

--- a/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
@@ -130,6 +130,37 @@ class ReferencesTests: OBATestCase {
         expect(stop.wheelchairBoarding) == .unknown
     }
 
+    func test_stopsWithIDs_preservesInputOrder() {
+        // Get some stop IDs from the references in a specific order that differs from the internal sorted order
+        let stopIDs = references.stops.map { $0.id }
+
+        // The internal stops array is sorted by ID for binary search
+        // We'll request stops in reverse order to verify the result preserves our requested order
+        let reversedIDs = Array(stopIDs.reversed())
+
+        let result = references.stopsWithIDs(reversedIDs)
+
+        // The returned stops should be in the same order as the requested IDs
+        expect(result.map { $0.id }).to(equal(reversedIDs),
+            description: "stopsWithIDs should preserve the order of the input IDs array")
+    }
+
+    func test_stopsWithIDs_returnsEmptyArrayForEmptyInput() {
+        let result = references.stopsWithIDs([])
+        expect(result).to(beEmpty())
+    }
+
+    func test_stopsWithIDs_filtersOutInvalidIDs() {
+        let validID = references.stops.first!.id
+        let invalidID = "invalid_stop_id_that_does_not_exist"
+
+        let result = references.stopsWithIDs([validID, invalidID])
+
+        // Should only return the valid stop
+        expect(result.count) == 1
+        expect(result.first!.id) == validID
+    }
+
     // MARK: - Trips
 
     func test_trips_success() {


### PR DESCRIPTION
- Extract duplicated start time calculation into actualStartTime() helper method in ScheduleForRouteViewModel for better maintainability
- Add unit tests for References.stopsWithIDs() to verify it preserves the order of input IDs (addresses John's stop column ordering feedback)