### PR TITLE
fix : bookmark name edits being lost when the user taps Done. (#655)

### DIFF
--- a/OBAKit/Bookmarks/ManageBookmarksViewController.swift
+++ b/OBAKit/Bookmarks/ManageBookmarksViewController.swift
@@ -130,7 +130,7 @@ class ManageBookmarksViewController: FormViewController {
                     $0.tag = bm.id.uuidString
                     $0.value = bm.name
                 }.onChange { [weak self] row in
-                    self?.saveBookmarkNameChange(row: row, group: group)
+                    self?.saveBookmarkNameChange(row: row)
                 }
             }
         }
@@ -148,7 +148,7 @@ class ManageBookmarksViewController: FormViewController {
                     $0.tag = bm.id.uuidString
                     $0.value = bm.name
                 }.onChange { [weak self] row in
-                    self?.saveBookmarkNameChange(row: row, group: nil)
+                    self?.saveBookmarkNameChange(row: row)
                 }
             }
         }
@@ -156,7 +156,7 @@ class ManageBookmarksViewController: FormViewController {
 
     // MARK: - Bookmark Name Updates
 
-    private func saveBookmarkNameChange(row: NameRow, group: BookmarkGroup?) {
+    private func saveBookmarkNameChange(row: NameRow) {
         guard
             let bookmarkID = UUID(optionalUUIDString: row.tag),
             let newName = row.value,
@@ -165,7 +165,13 @@ class ManageBookmarksViewController: FormViewController {
         else {
             return
         }
+
+        // Look up current group from bookmark's groupID
+        let currentGroup = bookmark.groupID.flatMap {
+            application.userDataStore.findGroup(id: $0)
+        }
+
         bookmark.name = newName
-        application.userDataStore.add(bookmark, to: group)
+        application.userDataStore.add(bookmark, to: currentGroup)
     }
 }


### PR DESCRIPTION
### Description
Fixes #655 
Fixes the issue where edited bookmark names are not saved when users tap done after editing. Bookmark name changes now persist correctly to the data store.

### Root Cause
The `NameRow` fields in `ManageBookmarksViewController` were editable but lacked `.onChange` callbacks to persist changes to the `UserDataStore`. When users edited a bookmark name, the change was visible in the UI temporarily but was never committed to persistent storage.Navigating away and returning would show the old name.

### Problem
When users edited a bookmark name in the "Edit Bookmarks" screen:
1. Navigate to the "Edit Bookmarks" screen.
2. Tap on an existing bookmark name and rename it.
3. Tap "Done" .
4. Navigate out of the screen and return.
5. **Observation**: The name reverts to the original name.

**Result**: The bookmark name reverted to its original name. Changes were lost.

### Solution

1. Added `.onChange` handlers: Attached listeners to `NameRow` instances in both the grouped and ungrouped bookmark sections to capture user input.
2. Refactored Saving Logic: Created a private helper method `saveBookmarkNameChange(row:group:)` to handle the persistence logic.
3. Added Validation: The helper method ensures bookmark names are not empty or whitespace-only before saving.

### ScreenRec : 

Before (Bug) | After (Fixed)
-- | --
<video src="https://github.com/user-attachments/assets/c7058323-05a4-4348-bd03-43f5eaacb94e" width="400"/> | <video src="https://github.com/user-attachments/assets/af80fc47-d713-4c5b-a696-7ca8bba0e8fc" width="400"/>
Edited bookmark names are lost after tapping "Done" and navigating away.  | Edited bookmark names persist correctly 


### Modified Files
`OBAKit/Bookmarks/ManageBookmarksViewController.swift`

