### PR TITLE
moved regions from userdefaults to disk

### DIFF
--- a/OBAKitCore/Location/Regions/RegionsServiceFileManagerProtocol.swift
+++ b/OBAKitCore/Location/Regions/RegionsServiceFileManagerProtocol.swift
@@ -1,0 +1,51 @@
+//
+//  RegionsServiceFileManagerProtocol.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+public protocol RegionsServiceFileManagerProtocol: AnyObject {
+    func save<T: Encodable>(_ object: T, to destination: URL) throws
+    func load<T: Decodable>(_ type: T.Type, from source: URL) throws -> T
+    func delete(at url: URL) throws
+    func contentsOfDirectory(at url: URL) throws -> [URL]
+    func createDirectory(at url: URL) throws
+    func fileExists(atPath path: String) -> Bool
+}
+
+public class RegionsServiceFileManager: RegionsServiceFileManagerProtocol {
+    public init() {}
+
+    public func save<T: Encodable>(_ object: T, to destination: URL) throws {
+        let directoryURL = destination.deletingLastPathComponent()
+        try createDirectory(at: directoryURL)
+        let data = try JSONEncoder().encode(object)
+        try data.write(to: destination)
+    }
+
+    public func load<T: Decodable>(_ type: T.Type, from source: URL) throws -> T {
+        let data = try Data(contentsOf: source)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    public func delete(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+
+    public func contentsOfDirectory(at url: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+    }
+
+    public func createDirectory(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    public func fileExists(atPath path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}

--- a/OBAKitTests/Helpers/Mocks/FileManagerMock.swift
+++ b/OBAKitTests/Helpers/Mocks/FileManagerMock.swift
@@ -1,0 +1,55 @@
+//
+//  FileManagerMock.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+@testable import OBAKitCore
+
+class FileManagerMock: RegionsServiceFileManagerProtocol {
+    var savedObjects: [String: Data] = [:]
+
+    var existingPaths: Set<String> = []
+
+    func save<T: Encodable>(_ object: T, to destination: URL) throws {
+        let data = try JSONEncoder().encode(object)
+        savedObjects[destination.path] = data
+        existingPaths.insert(destination.path)
+
+        existingPaths.insert(destination.deletingLastPathComponent().path)
+    }
+
+    func load<T: Decodable>(_ type: T.Type, from source: URL) throws -> T {
+        guard let data = savedObjects[source.path] else {
+            throw NSError(
+                domain: "FileManagerMock", code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "File not found: \(source.path)"])
+        }
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    func delete(at url: URL) throws {
+        savedObjects.removeValue(forKey: url.path)
+        existingPaths.remove(url.path)
+    }
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        let prefix = url.path
+        return savedObjects.keys
+            .filter { $0.hasPrefix(prefix) && $0 != prefix }
+            .map { URL(fileURLWithPath: $0) }
+    }
+
+    func createDirectory(at url: URL) throws {
+        existingPaths.insert(url.path)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        existingPaths.contains(path) || savedObjects.keys.contains(path)
+    }
+}


### PR DESCRIPTION
Fixes #629 

- Store regions as JSON files instead of UserDefaults
- Add RegionsServiceFileManagerProtocol for testable file operations
- Store only regionIdentifier (Int) for current region, not full object
- all test passing

Storage Locations
- Default regions: Application Support/Regions/default-regions.json
- Custom regions: Documents/custom-regions/region-{id}.json
