### PR TITLE
Fix : re-render glitch in Edit Bookmarks during bottom sheet interaction (#976)

### DIFF
--- a/OBAKit/Bookmarks/ManageBookmarksViewController.swift
+++ b/OBAKit/Bookmarks/ManageBookmarksViewController.swift
@@ -13,7 +13,6 @@ import OBAKitCore
 
 class ManageBookmarksViewController: FormViewController {
     private let application: Application
-    private var isFormLoaded = false
 
     init(application: Application) {
         self.application = application
@@ -35,15 +34,6 @@ class ManageBookmarksViewController: FormViewController {
         tableView.setEditing(true, animated: false)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if !isFormLoaded {
-            loadForm()
-            tableView.setEditing(true, animated: false)
-            isFormLoaded = true
-        }
-    }
-
     // MARK: - Form Builders
 
     /// Creates, loads, and populates data in the Eureka Form object.
@@ -53,7 +43,6 @@ class ManageBookmarksViewController: FormViewController {
         for s in bookmarksSections {
             form +++ s
         }
-        isFormLoaded = true
     }
 
     // MARK: - TableView Delegate Overrides
@@ -153,11 +142,5 @@ class ManageBookmarksViewController: FormViewController {
                 }
             }
         }
-    }
-    
-    func reloadData() {
-        isFormLoaded = false
-        loadForm()
-        tableView.setEditing(true, animated: false)
     }
 }

--- a/OBAKit/Bookmarks/ManageGroupsViewController.swift
+++ b/OBAKit/Bookmarks/ManageGroupsViewController.swift
@@ -13,7 +13,6 @@ import OBAKitCore
 
 class ManageGroupsViewController: FormViewController {
     private let application: Application
-    private var isFormLoaded = false
 
     init(application: Application) {
         self.application = application
@@ -33,15 +32,6 @@ class ManageGroupsViewController: FormViewController {
         tableView.setEditing(true, animated: false)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if !isFormLoaded {
-            loadForm()
-            tableView.setEditing(true, animated: false)
-            isFormLoaded = true
-        }
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -54,7 +44,6 @@ class ManageGroupsViewController: FormViewController {
     private func loadForm() {
         form.removeAll()
         form +++ groupsSection
-        isFormLoaded = true
     }
 
     // MARK: - Groups Section
@@ -96,12 +85,6 @@ class ManageGroupsViewController: FormViewController {
         let nameRows = groupsSection.allRows.filter { $0 is NameRow } as! [NameRow] // swiftlint:disable:this force_cast
         let newGroups = nameRows.bookmarkGroups
         application.userDataStore.replaceBookmarkGroups(with: newGroups)
-    }
-    
-    func reloadData() {
-        isFormLoaded = false
-        loadForm()
-        tableView.setEditing(true, animated: false)
     }
 }
 


### PR DESCRIPTION
> fixes  #976

### Problem
When users interact with the bottom sheet in Edit Bookmarks or Edit Groups screens, the entire list reloads and re-animates, causing visual glitches and unnecessary state resets.

### Solution
Moved form initialization from `viewWillAppear` to `viewDidLoad` to ensure forms load only once during the view controller lifecycle.

### Changes
- Added `isFormLoaded` flag to track initialization state
- Moved `loadForm()` call to `viewDidLoad()`
- Added `reloadData()` method for future external refresh needs
- Applied fix to both `ManageGroupsViewController` and `ManageBookmarksViewController`

### ScreenRec
Before (Bug) | After (Fixed)
-- | --
<video src="https://github.com/user-attachments/assets/a662dd0c-aa1e-4726-b6d7-01f3137b59ed" width="400"/> | <video src="https://github.com/user-attachments/assets/4e142640-ad06-4db1-9153-0d5c6a98ed21" width="400"/>
Interacting with the bottom sheet (dragging or bouncing) triggers a full reload of the list. This causes a jumpy "slide-in" animation and visual glitch every time the sheet moves. | The list is loaded only once. Interacting with the bottom sheet no longer triggers a reload, ensuring the list remains stable and the animation only happens when entering the screen.

### Files Changed
- `ManageGroupsViewController.swift`
- `ManageBookmarksViewController.swift`


