### PR TITLE
Fix: Remove notification observers in StopAnnotationView and WalkTimeView deinit

### DIFF
--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -85,6 +85,10 @@ class StopAnnotationView: MKAnnotationView {
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     // MARK: - Annotation View Overrides
 
     public override func prepareForReuse() {

--- a/OBAKit/Stops/WalkTimeView.swift
+++ b/OBAKit/Stops/WalkTimeView.swift
@@ -83,6 +83,10 @@ class WalkTimeView: UIView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     public func set(distance: CLLocationDistance, timeToWalk: TimeInterval) {
         // bail out if the distance is 40 meters or less. Just don't show anything because
         // it suggests the user is essentially at the stop and showing '100 feet arriving in 1


### PR DESCRIPTION
### Summary

`StopAnnotationView` and `WalkTimeView` each register a notification observer in `init()` but neither class implements `deinit` to remove them. This PR adds the missing cleanup.

### Problem

**StopAnnotationView** registers a VoiceOver status observer:
- `UIAccessibility.voiceOverStatusDidChangeNotification`

**WalkTimeView** registers a device orientation observer:
- `UIDevice.orientationDidChangeNotification`

While modern NotificationCenter (iOS 9+) uses zeroing-weak references and cleans up automatically on deallocation, explicit removeObserver calls are the established convention in this codebase (see StopArrivalView, SearchListViewController, ProgressHUD) and are widely accepted defensive practice.

### Fix

Added `deinit` to both classes with `NotificationCenter.default.removeObserver(self)`.

### Why this matters

This follows the same pattern established in the recent `MapViewController` fix and the existing `subscribeToTripPlannerNotifications` / `unsubscribeFromTripPlannerNotifications` convention in the codebase. Every `addObserver` should have a corresponding `removeObserver`.
