### PR TITLE
(Surveys) Fix hero question state inconsistency in External Survey

### DIFF
--- a/OBAKit/Surveys/ViewModel/SurveysViewModel.swift
+++ b/OBAKit/Surveys/ViewModel/SurveysViewModel.swift
@@ -288,7 +288,7 @@ extension SurveysViewModel {
     private func clearExternalSurveyState() {
         Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(2))
-            self?.heroQuestion = nil
+            self?.clearHeroQuestionState()
             self?.externalSurveyURL = nil
             self?.openExternalSurvey = false
             self?.removeSurvey()


### PR DESCRIPTION
Fixes hero question state to ensure the view is removed from the hierarchy when opening an external survey by properly resetting hero state in `SurveysViewModel`.

> 1. showHeroQuestion not reset on external survey path -- hero popup stays visible on map