### PR TITLE
Fix surveys view hosting protocol observation

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1106,6 +1106,7 @@ class MapViewController: UIViewController,
 
     func stopObserveSurveysState() {
         observationActive = false
+        ProgressHUD.dismiss()
     }
 
     func observeSurveyHeroQuestion() {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1370,6 +1370,7 @@ public class StopViewController: UIViewController,
 
     func stopObserveSurveysState() {
         observationActive = false
+        ProgressHUD.dismiss()
     }
 
 }

--- a/OBAKit/Surveys/Protocol/SurveyViewHostingProtocol.swift
+++ b/OBAKit/Surveys/Protocol/SurveyViewHostingProtocol.swift
@@ -44,8 +44,9 @@ protocol SurveyViewHostingProtocol {
 extension SurveyViewHostingProtocol where Self: UIViewController {
 
     func observeSurveyLoadingState() {
-        withObservationTracking {
-            if surveysVM.isLoading {
+        withObservationTracking { [weak self] in
+            guard let self else { return }
+            if self.surveysVM.isLoading {
                 ProgressHUD.show()
             } else {
                 ProgressHUD.dismiss()

--- a/OBAKit/Surveys/Protocol/SurveyViewHostingProtocol.swift
+++ b/OBAKit/Surveys/Protocol/SurveyViewHostingProtocol.swift
@@ -77,16 +77,17 @@ extension SurveyViewHostingProtocol where Self: UIViewController {
 
     func observeSurveyToastMessage() {
         withObservationTracking { [weak self] in
+            guard let self,
+                  let toast = self.surveysVM.toast,
+                  self.surveysVM.showToastMessage
+            else { return }
 
-            guard let self, let type = self.surveysVM.toast?.type, self.surveysVM.showToastMessage else { return }
-
-            switch type {
+            switch toast.type {
             case .error:
-                showErrorToast(surveysVM.toast?.message)
+                showErrorToast(toast.message)
             case .success:
-                showSuccessToast(surveysVM.toast?.message)
+                showSuccessToast(toast.message)
             }
-
         } onChange: {
             Task { @MainActor [weak self] in
                 guard let self, self.observationActive else { return }
@@ -97,7 +98,11 @@ extension SurveyViewHostingProtocol where Self: UIViewController {
 
     func observeOpenExternalSurvey(_ router: ViewRouter) {
         withObservationTracking { [weak self] in
-            guard let self, self.surveysVM.openExternalSurvey, let url = self.surveysVM.externalSurveyURL else { return }
+            guard let self,
+                  self.surveysVM.openExternalSurvey,
+                  let url = self.surveysVM.externalSurveyURL
+            else { return }
+            
             self.openSafari(with: url, router: router)
         } onChange: {
             Task { @MainActor [weak self] in


### PR DESCRIPTION
This PR resolves two observation issues related to `SurveyViewHostingProtocol` 

> observeSurveyLoadingState() missing [weak self] -- ProgressHUD can get stuck indefinitely.

> observeSurveyToastMessage reads toast twice.