### PR TITLE
(Surveys) Fix `TextQuestionView` accessibility hint 

### DIFF
--- a/OBAKit/Surveys/View/Components/SurveyQuestionView.swift
+++ b/OBAKit/Surveys/View/Components/SurveyQuestionView.swift
@@ -158,12 +158,12 @@ struct SurveyQuestionView: View {
 /// from `SurveysVM` for use in SwiftUI-based question views hosted inside UIKit.
 extension SurveyQuestionView {
 
-    var textAnswerValue: String {
+    private var textAnswerValue: String {
         guard case let .text(value) = answer else { return "" }
         return value
     }
 
-    var selectionAnswerValues: Set<String> {
+    private var selectionAnswerValues: Set<String> {
         switch answer {
         case .checkbox(let values):
             return values

--- a/OBAKit/Surveys/View/Components/TextQuestionView.swift
+++ b/OBAKit/Surveys/View/Components/TextQuestionView.swift
@@ -31,7 +31,7 @@ struct TextQuestionView: View {
             .background(textEditorBorder)
             .padding([.horizontal, .bottom], 8)
             .accessibilityLabel(Strings.answerInputAccessibility)
-            .accessibilityHint(Strings.surveyHeroQuestionAnswerError)
+            .accessibilityHint(Strings.answerInputQuestionAccessibility)
             .accessibilityValue(text)
             .onChange(of: text) { _, newValue in
                 onUpdateAnswer(.text(newValue))


### PR DESCRIPTION
This PR resolves an issue of accessibility hint String in `TextQuestionView`.
Additionally, a minor adjustment has been made in the `SurveyQuestionView`.

> 3. Wrong accessibility hint in TextQuestionView

> 10. SurveyQuestionView helper extension should be private
