### PR TITLE
(Surveys) Unify Color pattern and remove `SurveyQuestionsForm` duplicated dismiss.

### DIFF
--- a/OBAKit/Extensions/UIKitExtensions.swift
+++ b/OBAKit/Extensions/UIKitExtensions.swift
@@ -76,9 +76,3 @@ extension UIApplication {
         return windows ?? []
     }
 }
-
-extension UIColor {
-    func toColor() -> Color {
-        Color(uiColor: self)
-    }
-}

--- a/OBAKit/Surveys/View/Components/ExternalSurveyView.swift
+++ b/OBAKit/Surveys/View/Components/ExternalSurveyView.swift
@@ -34,7 +34,7 @@ struct ExternalSurveyView: View {
         .padding(.horizontal, 12)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(UIColor.tertiarySystemBackground.toColor())
+                .fill(Color(uiColor: UIColor.tertiarySystemBackground))
         )
     }
 
@@ -48,7 +48,7 @@ struct ExternalSurveyView: View {
     private var subtitleView: some View {
         Text(Strings.externalSurveyPrivacyInfo)
             .font(.footnote)
-            .foregroundStyle(UIColor.darkGray.toColor())
+            .foregroundStyle(Color(uiColor: UIColor.darkGray))
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -106,7 +106,7 @@ struct ExternalSurveyView: View {
             .padding(.vertical, verticalPadding)
             .background(
                 RoundedRectangle(cornerRadius: 18)
-                    .fill(ThemeColors.shared.brand.toColor())
+                    .fill(Color(uiColor: ThemeColors.shared.brand))
             )
         }
         .buttonStyle(.plain)

--- a/OBAKit/Surveys/View/Components/SelectionQuestionView.swift
+++ b/OBAKit/Surveys/View/Components/SelectionQuestionView.swift
@@ -111,7 +111,7 @@ struct SelectionQuestionView: View {
     }
 
     private func colorFor(option: String) -> Color {
-        isOptionSelected(option) ? ThemeColors.shared.brand.toColor() : ThemeColors.shared.gray.toColor()
+        Color(uiColor: isOptionSelected(option) ? ThemeColors.shared.brand : ThemeColors.shared.gray)
     }
 
     // MARK: - Accessibility Helpers

--- a/OBAKit/Surveys/View/Components/SurveyLabelView.swift
+++ b/OBAKit/Surveys/View/Components/SurveyLabelView.swift
@@ -22,7 +22,7 @@ struct SurveyLabelView: View {
             .frame(minHeight: 70)
             .background {
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(UIColor.tertiarySystemBackground.toColor())
+                    .fill(Color(uiColor: UIColor.tertiarySystemBackground))
                     .shadow(color: .gray.opacity(0.4), radius: 3)
             }
             .accessibilityLabel(Strings.surveyLabel)

--- a/OBAKit/Surveys/View/Components/SurveyQuestionView.swift
+++ b/OBAKit/Surveys/View/Components/SurveyQuestionView.swift
@@ -62,12 +62,12 @@ struct SurveyQuestionView: View {
     private var borderView: some View {
         if showError {
             RoundedRectangle(cornerRadius: 12)
-                .fill(UIColor.tertiarySystemBackground.toColor())
+                .fill(Color(uiColor: UIColor.tertiarySystemBackground))
                 .stroke(.red)
                 .shadow(color: .red.opacity(0.4), radius: 5)
         } else {
             RoundedRectangle(cornerRadius: 12)
-                .fill(UIColor.tertiarySystemBackground.toColor())
+                .fill(Color(uiColor: UIColor.tertiarySystemBackground))
         }
     }
 
@@ -128,7 +128,7 @@ struct SurveyQuestionView: View {
                     .padding(.horizontal, 32)
                     .background(
                         RoundedRectangle(cornerRadius: 24)
-                            .fill(ThemeColors.shared.brand.toColor())
+                            .fill(Color(uiColor: ThemeColors.shared.brand))
                     )
             }
             .buttonStyle(.plain)
@@ -144,7 +144,7 @@ struct SurveyQuestionView: View {
                 .resizable()
                 .fontWeight(.bold)
                 .frame(width: 14, height: 14)
-                .foregroundStyle(UIColor.label.toColor())
+                .foregroundStyle(Color(uiColor: UIColor.label))
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)

--- a/OBAKit/Surveys/View/Components/TextQuestionView.swift
+++ b/OBAKit/Surveys/View/Components/TextQuestionView.swift
@@ -41,7 +41,7 @@ struct TextQuestionView: View {
 
     private var textEditorBorder: some View {
         RoundedRectangle(cornerRadius: 8)
-            .fill(UIColor.tertiarySystemBackground.toColor())
+            .fill(Color(uiColor: UIColor.tertiarySystemBackground))
             .stroke(.gray, lineWidth: 0.5)
     }
 

--- a/OBAKit/Surveys/View/SurveyQuestionsForm.swift
+++ b/OBAKit/Surveys/View/SurveyQuestionsForm.swift
@@ -74,7 +74,6 @@ struct SurveyQuestionsForm: View {
         ToolbarItem(placement: .topBarLeading) {
             Button {
                 viewModel.onAction(.onCloseQuestionsForm)
-                dismiss()
             } label: {
                 Image(systemName: "xmark")
                     .resizable()

--- a/OBAKit/Surveys/View/SurveyQuestionsForm.swift
+++ b/OBAKit/Surveys/View/SurveyQuestionsForm.swift
@@ -30,7 +30,7 @@ struct SurveyQuestionsForm: View {
                 loadingView
             }
             .disabled(viewModel.isLoading)
-            .background(ThemeColors.shared.groupedTableBackground.toColor())
+            .background(Color(uiColor: ThemeColors.shared.groupedTableBackground))
             .toast(toast: viewModel.toast, isPresented: $viewModel.showToastMessage)
             .toolbar {
                 closeButton
@@ -79,7 +79,7 @@ struct SurveyQuestionsForm: View {
                     .resizable()
                     .fontWeight(.bold)
                     .frame(width: 14, height: 14)
-                    .foregroundStyle(UIColor.label.toColor())
+                    .foregroundStyle(Color(uiColor: UIColor.label))
             }
             .buttonStyle(.plain)
         }
@@ -94,7 +94,7 @@ struct SurveyQuestionsForm: View {
                 Text(Strings.submit)
                     .font(.body)
                     .fontWeight(.bold)
-                    .foregroundStyle(ThemeColors.shared.brand.toColor())
+                    .foregroundStyle(Color(uiColor: ThemeColors.shared.brand))
             }
         }
     }
@@ -134,12 +134,12 @@ struct SurveyQuestionsForm: View {
                 submitButtonLabelText
                     .glassEffect(
                         .regular
-                            .tint(ThemeColors.shared.brand.toColor())
+                            .tint(Color(uiColor: ThemeColors.shared.brand))
                             .interactive()
                     )
             } else {
                 submitButtonLabelText
-                    .background(ThemeColors.shared.brand.toColor())
+                    .background(Color(uiColor: ThemeColors.shared.brand))
             }
         }
         .clipShape(.rect(cornerRadius: 8))
@@ -160,7 +160,7 @@ struct SurveyQuestionsForm: View {
     private var loadingView: some View {
         if viewModel.isLoading {
             Rectangle()
-                .fill(ThemeColors.shared.gray.toColor().opacity(0.4))
+                .fill(Color(uiColor: ThemeColors.shared.gray).opacity(0.4))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .overlay {
                     ProgressView()

--- a/OBAKit/ToastMessageBar/ToastModel.swift
+++ b/OBAKit/ToastMessageBar/ToastModel.swift
@@ -29,7 +29,7 @@ public struct Toast: Equatable {
         var color: Color {
             switch self {
             case .success:
-                return ThemeColors.shared.brand.toColor()
+                return Color(uiColor: ThemeColors.shared.brand)
             case .error:
                 return .red
             }


### PR DESCRIPTION
This PR resolves these points:

> 6. Close button double-dismisses SurveyQuestionsForm

> 7. UIColor.toColor() extension is inconsistent with existing codebase

