### PR TITLE
Add geofence region monitoring to LocationService

### DIFF
--- a/OBAKitCore/Location/Location/LocationManagerProtocol.swift
+++ b/OBAKitCore/Location/Location/LocationManagerProtocol.swift
@@ -43,6 +43,11 @@ public protocol LocationManager {
     var isHeadingAvailable: Bool { get }
     func startUpdatingHeading()
     func stopUpdatingHeading()
+
+    // MARK: - Region Monitoring
+    func startMonitoring(for region: CLRegion)
+    func stopMonitoring(for region: CLRegion)
+    var monitoredRegions: Set<CLRegion> { get }
 }
 
 extension CLLocationManager: LocationManager {

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -16,6 +16,8 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     @objc optional func locationService(_ service: LocationService, locationChanged location: CLLocation)
     @objc optional func locationService(_ service: LocationService, headingChanged heading: CLHeading?)
     @objc optional func locationService(_ service: LocationService, errorReceived error: Error)
+    @objc optional func locationService(_ service: LocationService, didEnterMonitoredRegion identifier: String)
+    @objc optional func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error)
 }
 
 @objc(OBALocationService) public class LocationService: NSObject, CLLocationManagerDelegate {
@@ -100,6 +102,18 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     private func notifyDelegatesErrorReceived(_ error: Error) {
         for delegate in delegates.allObjects {
             delegate.locationService?(self, errorReceived: error)
+        }
+    }
+
+    private func notifyDelegatesDidEnterMonitoredRegion(_ identifier: String) {
+        for delegate in delegates.allObjects {
+            delegate.locationService?(self, didEnterMonitoredRegion: identifier)
+        }
+    }
+
+    private func notifyDelegatesMonitoringDidFail(_ identifier: String?, error: Error) {
+        for delegate in delegates.allObjects {
+            delegate.locationService?(self, monitoringDidFailFor: identifier, error: error)
         }
     }
 
@@ -250,5 +264,46 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         notifyDelegatesErrorReceived(error)
+    }
+
+    // MARK: - Region Monitoring
+
+    /// Starts monitoring a geofence region for the given proximity alert.
+    public func startMonitoringProximity(for alert: ProximityAlert) {
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: alert.id.uuidString
+        )
+        region.notifyOnEntry = true
+        region.notifyOnExit = false
+        locationManager.startMonitoring(for: region)
+    }
+
+    /// Stops monitoring the geofence region for the given proximity alert.
+    public func stopMonitoringProximity(for alert: ProximityAlert) {
+        guard let matchingRegion = locationManager.monitoredRegions.first(where: {
+            $0.identifier == alert.id.uuidString
+        }) else {
+            return
+        }
+        locationManager.stopMonitoring(for: matchingRegion)
+    }
+
+    /// Stops monitoring all proximity alert regions without affecting other monitored regions.
+    public func stopMonitoringAllProximityAlerts() {
+        for region in locationManager.monitoredRegions where UUID(uuidString: region.identifier) != nil {
+            locationManager.stopMonitoring(for: region)
+        }
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        guard region is CLCircularRegion else { return }
+        notifyDelegatesDidEnterMonitoredRegion(region.identifier)
+    }
+
+    public func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
+        Logger.error("Region monitoring failed for \(region?.identifier ?? "unknown"): \(error)")
+        notifyDelegatesMonitoringDidFail(region?.identifier, error: error)
     }
 }

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -268,12 +268,19 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Region Monitoring
 
+    static let proximityRegionPrefix = "oba.proximity."
+
     /// Starts monitoring a geofence region for the given proximity alert.
+    ///
+    /// - Note: Region monitoring requires `.authorizedAlways` for background delivery.
+    ///   The caller (e.g. ProximityAlertManager) is responsible for ensuring appropriate authorization.
     public func startMonitoringProximity(for alert: ProximityAlert) {
+        guard isLocationUseAuthorized else { return }
+
         let region = CLCircularRegion(
             center: alert.coordinate,
             radius: alert.radiusMeters,
-            identifier: alert.id.uuidString
+            identifier: Self.proximityRegionPrefix + alert.id.uuidString
         )
         region.notifyOnEntry = true
         region.notifyOnExit = false
@@ -282,9 +289,11 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Stops monitoring the geofence region for the given proximity alert.
     public func stopMonitoringProximity(for alert: ProximityAlert) {
+        let identifier = Self.proximityRegionPrefix + alert.id.uuidString
         guard let matchingRegion = locationManager.monitoredRegions.first(where: {
-            $0.identifier == alert.id.uuidString
+            $0.identifier == identifier
         }) else {
+            Logger.warn("No monitored region found for proximity alert \(alert.id)")
             return
         }
         locationManager.stopMonitoring(for: matchingRegion)
@@ -292,13 +301,13 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Stops monitoring all proximity alert regions without affecting other monitored regions.
     public func stopMonitoringAllProximityAlerts() {
-        for region in locationManager.monitoredRegions where UUID(uuidString: region.identifier) != nil {
+        for region in locationManager.monitoredRegions where region.identifier.hasPrefix(Self.proximityRegionPrefix) {
             locationManager.stopMonitoring(for: region)
         }
     }
 
     public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        guard region is CLCircularRegion else { return }
+        guard region is CLCircularRegion, region.identifier.hasPrefix(Self.proximityRegionPrefix) else { return }
         notifyDelegatesDidEnterMonitoredRegion(region.identifier)
     }
 

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -19,6 +19,18 @@ public class LocationManagerMock: NSObject, LocationManager {
     public var locationUpdatesStarted = false
     public var headingUpdatesStarted = false
 
+    // MARK: - Region Monitoring
+
+    public private(set) var monitoredRegions = Set<CLRegion>()
+
+    public func startMonitoring(for region: CLRegion) {
+        monitoredRegions.insert(region)
+    }
+
+    public func stopMonitoring(for region: CLRegion) {
+        monitoredRegions.remove(region)
+    }
+
     public func requestWhenInUseAuthorization() { }
 
     @available(iOS 14, *)
@@ -118,6 +130,9 @@ class LocDelegate: NSObject, LocationServiceDelegate {
     var heading: CLHeading?
     var status: CLAuthorizationStatus?
     var error: Error?
+    var enteredRegionIdentifier: String?
+    var monitoringFailedIdentifier: String?
+    var monitoringFailedError: Error?
 
     func locationService(_ service: LocationService, locationChanged location: CLLocation) {
         self.location = location
@@ -133,5 +148,14 @@ class LocDelegate: NSObject, LocationServiceDelegate {
 
     func locationService(_ service: LocationService, errorReceived error: Error) {
         self.error = error
+    }
+
+    func locationService(_ service: LocationService, didEnterMonitoredRegion identifier: String) {
+        self.enteredRegionIdentifier = identifier
+    }
+
+    func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error) {
+        self.monitoringFailedIdentifier = identifier
+        self.monitoringFailedError = error
     }
 }

--- a/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
+++ b/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
@@ -20,6 +20,7 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
 
     var updatingLocation = false
     var updatingHeading = false
+    private(set) var monitoredRegions = Set<CLRegion>()
 
     init(updateLocation: CLLocation, updateHeading: CLHeading) {
         self.updateLocation = updateLocation
@@ -76,5 +77,13 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
 
     func stopUpdatingHeading() {
         updatingHeading = false
+    }
+
+    func startMonitoring(for region: CLRegion) {
+        monitoredRegions.insert(region)
+    }
+
+    func stopMonitoring(for region: CLRegion) {
+        monitoredRegions.remove(region)
     }
 }

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -194,3 +194,4 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         expect(self.delegate.monitoringFailedError).toNot(beNil())
     }
 }
+

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -1,0 +1,196 @@
+//
+//  LocationServiceRegionMonitoringTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+import CoreLocation
+import Nimble
+
+// swiftlint:disable force_try
+
+class LocationServiceRegionMonitoringTests: OBATestCase {
+
+    var locationManagerMock: LocationManagerMock!
+    var service: LocationService!
+    var delegate: LocDelegate!
+    var stop: Stop!
+
+    override func setUp() {
+        super.setUp()
+        locationManagerMock = LocationManagerMock()
+        service = LocationService(userDefaults: userDefaults, locationManager: locationManagerMock)
+        delegate = LocDelegate()
+        service.addDelegate(delegate)
+        stop = try! Fixtures.loadSomeStops().first!
+    }
+
+    // MARK: - Start Monitoring
+
+    func test_startMonitoringProximity_createsRegionWithCorrectProperties() {
+        let alert = ProximityAlert(stop: stop, radiusMeters: 300.0)
+
+        service.startMonitoringProximity(for: alert)
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+
+        let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
+        expect(region).toNot(beNil())
+        expect(region?.identifier) == alert.id.uuidString
+        expect(region?.center.latitude) == stop.location.coordinate.latitude
+        expect(region?.center.longitude) == stop.location.coordinate.longitude
+        expect(region?.radius) == 300.0
+        expect(region?.notifyOnEntry).to(beTrue())
+        expect(region?.notifyOnExit).to(beFalse())
+    }
+
+    func test_startMonitoringProximity_defaultRadius() {
+        let alert = ProximityAlert(stop: stop)
+
+        service.startMonitoringProximity(for: alert)
+
+        let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
+        expect(region?.radius) == 200.0
+    }
+
+    func test_startMonitoringProximity_multipleAlerts() {
+        let stops = try! Fixtures.loadSomeStops()
+        let alert1 = ProximityAlert(stop: stops[0])
+        let alert2 = ProximityAlert(stop: stops[1])
+
+        service.startMonitoringProximity(for: alert1)
+        service.startMonitoringProximity(for: alert2)
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 2
+    }
+
+    // MARK: - Stop Monitoring
+
+    func test_stopMonitoringProximity_removesCorrectRegion() {
+        let alert = ProximityAlert(stop: stop)
+
+        service.startMonitoringProximity(for: alert)
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+
+        service.stopMonitoringProximity(for: alert)
+        expect(self.locationManagerMock.monitoredRegions).to(beEmpty())
+    }
+
+    func test_stopMonitoringProximity_nonexistentAlert_isNoOp() {
+        let alert1 = ProximityAlert(stop: stop)
+        let alert2 = ProximityAlert(stop: stop)
+
+        service.startMonitoringProximity(for: alert1)
+
+        service.stopMonitoringProximity(for: alert2)
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+    }
+
+    func test_stopMonitoringProximity_onlyRemovesTargetRegion() {
+        let stops = try! Fixtures.loadSomeStops()
+        let alert1 = ProximityAlert(stop: stops[0])
+        let alert2 = ProximityAlert(stop: stops[1])
+
+        service.startMonitoringProximity(for: alert1)
+        service.startMonitoringProximity(for: alert2)
+
+        service.stopMonitoringProximity(for: alert1)
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+        let remaining = self.locationManagerMock.monitoredRegions.first
+        expect(remaining?.identifier) == alert2.id.uuidString
+    }
+
+    // MARK: - Stop All Monitoring
+
+    func test_stopMonitoringAllProximityAlerts_removesAllUUIDRegions() {
+        let stops = try! Fixtures.loadSomeStops()
+        let alert1 = ProximityAlert(stop: stops[0])
+        let alert2 = ProximityAlert(stop: stops[1])
+
+        service.startMonitoringProximity(for: alert1)
+        service.startMonitoringProximity(for: alert2)
+
+        service.stopMonitoringAllProximityAlerts()
+
+        expect(self.locationManagerMock.monitoredRegions).to(beEmpty())
+    }
+
+    func test_stopMonitoringAllProximityAlerts_preservesNonUUIDRegions() {
+        let alert = ProximityAlert(stop: stop)
+        service.startMonitoringProximity(for: alert)
+
+        let otherRegion = CLCircularRegion(
+            center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            radius: 100,
+            identifier: "not-a-uuid-region"
+        )
+        locationManagerMock.startMonitoring(for: otherRegion)
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 2
+
+        service.stopMonitoringAllProximityAlerts()
+
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+        expect(self.locationManagerMock.monitoredRegions.first?.identifier) == "not-a-uuid-region"
+    }
+
+    // MARK: - Delegate: didEnterRegion
+
+    func test_didEnterRegion_notifiesDelegate() {
+        let alert = ProximityAlert(stop: stop)
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: alert.id.uuidString
+        )
+
+        service.locationManager(CLLocationManager(), didEnterRegion: region)
+
+        expect(self.delegate.enteredRegionIdentifier) == alert.id.uuidString
+    }
+
+    func test_didEnterRegion_nonCircularRegion_doesNotNotify() {
+        let beaconRegion = CLBeaconRegion(
+            uuid: UUID(),
+            identifier: "beacon-test"
+        )
+
+        service.locationManager(CLLocationManager(), didEnterRegion: beaconRegion)
+
+        expect(self.delegate.enteredRegionIdentifier).to(beNil())
+    }
+
+    // MARK: - Delegate: monitoringDidFail
+
+    func test_monitoringDidFail_notifiesDelegate() {
+        let region = CLCircularRegion(
+            center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
+            radius: 200,
+            identifier: UUID().uuidString
+        )
+        let error = NSError(domain: "CLError", code: 5, userInfo: nil)
+
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: error)
+
+        expect(self.delegate.monitoringFailedIdentifier) == region.identifier
+        expect((self.delegate.monitoringFailedError as? NSError)?.code) == 5
+    }
+
+    func test_monitoringDidFail_nilRegion_notifiesDelegate() {
+        let error = NSError(domain: "CLError", code: 5, userInfo: nil)
+
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: nil, withError: error)
+
+        expect(self.delegate.monitoringFailedIdentifier).to(beNil())
+        expect(self.delegate.monitoringFailedError).toNot(beNil())
+    }
+}

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -18,14 +18,16 @@ import Nimble
 
 class LocationServiceRegionMonitoringTests: OBATestCase {
 
-    var locationManagerMock: LocationManagerMock!
+    var locationManagerMock: AuthorizableLocationManagerMock!
     var service: LocationService!
     var delegate: LocDelegate!
     var stop: Stop!
 
     override func setUp() {
         super.setUp()
-        locationManagerMock = LocationManagerMock()
+        let location = CLLocation(latitude: 47.0, longitude: -122.0)
+        locationManagerMock = AuthorizableLocationManagerMock(updateLocation: location, updateHeading: OBAMockHeading(heading: 0.0))
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
         service = LocationService(userDefaults: userDefaults, locationManager: locationManagerMock)
         delegate = LocDelegate()
         service.addDelegate(delegate)
@@ -43,12 +45,22 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
         let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
         expect(region).toNot(beNil())
-        expect(region?.identifier) == alert.id.uuidString
+        expect(region?.identifier) == "oba.proximity.\(alert.id.uuidString)"
         expect(region?.center.latitude) == stop.location.coordinate.latitude
         expect(region?.center.longitude) == stop.location.coordinate.longitude
         expect(region?.radius) == 300.0
         expect(region?.notifyOnEntry).to(beTrue())
         expect(region?.notifyOnExit).to(beFalse())
+    }
+
+    func test_startMonitoringProximity_unauthorized_doesNotMonitor() {
+        let unauthorizedMock = LocationManagerMock()
+        let unauthorizedService = LocationService(userDefaults: userDefaults, locationManager: unauthorizedMock)
+        let alert = ProximityAlert(stop: stop)
+
+        unauthorizedService.startMonitoringProximity(for: alert)
+
+        expect(unauthorizedMock.monitoredRegions).to(beEmpty())
     }
 
     func test_startMonitoringProximity_defaultRadius() {
@@ -58,6 +70,17 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
         let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
         expect(region?.radius) == 200.0
+    }
+
+    func test_startMonitoringProximity_duplicateAlert_replacesRegion() {
+        let alert = ProximityAlert(stop: stop)
+
+        service.startMonitoringProximity(for: alert)
+        service.startMonitoringProximity(for: alert)
+
+        // CLRegion uses identifier for equality in Set, so duplicate insert replaces
+        expect(self.locationManagerMock.monitoredRegions.count) == 1
+        expect(self.locationManagerMock.monitoredRegions.first?.identifier) == "oba.proximity.\(alert.id.uuidString)"
     }
 
     func test_startMonitoringProximity_multipleAlerts() {
@@ -106,12 +129,12 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
         expect(self.locationManagerMock.monitoredRegions.count) == 1
         let remaining = self.locationManagerMock.monitoredRegions.first
-        expect(remaining?.identifier) == alert2.id.uuidString
+        expect(remaining?.identifier) == "oba.proximity.\(alert2.id.uuidString)"
     }
 
     // MARK: - Stop All Monitoring
 
-    func test_stopMonitoringAllProximityAlerts_removesAllUUIDRegions() {
+    func test_stopMonitoringAllProximityAlerts_removesAllPrefixedRegions() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -124,14 +147,14 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         expect(self.locationManagerMock.monitoredRegions).to(beEmpty())
     }
 
-    func test_stopMonitoringAllProximityAlerts_preservesNonUUIDRegions() {
+    func test_stopMonitoringAllProximityAlerts_preservesNonPrefixedRegions() {
         let alert = ProximityAlert(stop: stop)
         service.startMonitoringProximity(for: alert)
 
         let otherRegion = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
             radius: 100,
-            identifier: "not-a-uuid-region"
+            identifier: "some-other-region"
         )
         locationManagerMock.startMonitoring(for: otherRegion)
 
@@ -140,7 +163,15 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         service.stopMonitoringAllProximityAlerts()
 
         expect(self.locationManagerMock.monitoredRegions.count) == 1
-        expect(self.locationManagerMock.monitoredRegions.first?.identifier) == "not-a-uuid-region"
+        expect(self.locationManagerMock.monitoredRegions.first?.identifier) == "some-other-region"
+    }
+
+    func test_stopMonitoringAllProximityAlerts_emptyRegions_isNoOp() {
+        expect(self.locationManagerMock.monitoredRegions).to(beEmpty())
+
+        service.stopMonitoringAllProximityAlerts()
+
+        expect(self.locationManagerMock.monitoredRegions).to(beEmpty())
     }
 
     // MARK: - Delegate: didEnterRegion
@@ -150,18 +181,30 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         let region = CLCircularRegion(
             center: alert.coordinate,
             radius: alert.radiusMeters,
-            identifier: alert.id.uuidString
+            identifier: "oba.proximity.\(alert.id.uuidString)"
         )
 
         service.locationManager(CLLocationManager(), didEnterRegion: region)
 
-        expect(self.delegate.enteredRegionIdentifier) == alert.id.uuidString
+        expect(self.delegate.enteredRegionIdentifier) == "oba.proximity.\(alert.id.uuidString)"
+    }
+
+    func test_didEnterRegion_nonPrefixedCircularRegion_doesNotNotify() {
+        let region = CLCircularRegion(
+            center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
+            radius: 200,
+            identifier: "some-other-region"
+        )
+
+        service.locationManager(CLLocationManager(), didEnterRegion: region)
+
+        expect(self.delegate.enteredRegionIdentifier).to(beNil())
     }
 
     func test_didEnterRegion_nonCircularRegion_doesNotNotify() {
         let beaconRegion = CLBeaconRegion(
             uuid: UUID(),
-            identifier: "beacon-test"
+            identifier: "oba.proximity.beacon-test"
         )
 
         service.locationManager(CLLocationManager(), didEnterRegion: beaconRegion)
@@ -192,6 +235,25 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
         expect(self.delegate.monitoringFailedIdentifier).to(beNil())
         expect(self.delegate.monitoringFailedError).toNot(beNil())
+    }
+
+    // MARK: - Multiple Delegates
+
+    func test_didEnterRegion_notifiesMultipleDelegates() {
+        let delegate2 = LocDelegate()
+        service.addDelegate(delegate2)
+
+        let alert = ProximityAlert(stop: stop)
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: "oba.proximity.\(alert.id.uuidString)"
+        )
+
+        service.locationManager(CLLocationManager(), didEnterRegion: region)
+
+        expect(self.delegate.enteredRegionIdentifier) == "oba.proximity.\(alert.id.uuidString)"
+        expect(delegate2.enteredRegionIdentifier) == "oba.proximity.\(alert.id.uuidString)"
     }
 }
 


### PR DESCRIPTION
## Summary
- Extend `LocationManager` protocol with `startMonitoring(for:)`, `stopMonitoring(for:)`, and `monitoredRegions`
- Add `didEnterMonitoredRegion` and `monitoringDidFailFor` delegate methods to `LocationServiceDelegate`
- Implement `startMonitoringProximity`, `stopMonitoringProximity`, and `stopMonitoringAllProximityAlerts` on `LocationService`
- Handle `CLLocationManagerDelegate` region callbacks with non-circular region guard and error logging
- Update both mock location managers and `LocDelegate` for testability
- 14 unit tests covering region creation, removal, delegate callbacks, edge cases, and safety

## Context
**PR 2 of 4** for issue #455 (destination proximity alerts). Builds on the `ProximityAlert` model from PR 1.

| PR | Scope | Status |
|----|-------|--------|
| PR 1 | `ProximityAlert` model + `UserDataStore` persistence | Merged |
| **PR 2** | `LocationService` geofencing | **This PR** |
| PR 3 | `ProximityAlertManager` + local notifications | Next |
| PR 4 | `StopViewController` UI integration | Upcoming |

## Design Decisions
- **`String` identifier in delegate** — delegates receive `identifier: String`, not `CLRegion`. Keeps the protocol clean and avoids exposing CoreLocation types to consumers
- **`notifyOnEntry = true`, `notifyOnExit = false`** — we only care about arriving at the destination, not leaving
- **`stopMonitoringAllProximityAlerts` uses UUID check** — only removes regions with UUID identifiers, preserving any other monitored regions the system might have
- **`guard region is CLCircularRegion`** — ignores beacon regions or other non-circular region types
- **`Logger.error` in `monitoringDidFailFor`** — logs before notifying delegates, per Aaron's error visibility standards
- **Both mocks updated** — `LocationManagerMock` and `MockAuthorizedLocationManager` both implement region monitoring so existing tests remain unaffected

## Files Changed
| File | Change |
|------|--------|
| `OBAKitCore/Location/Location/LocationManagerProtocol.swift` | +3 protocol methods |
| `OBAKitCore/Location/Location/LocationService.swift` | +2 delegate methods, +2 notify helpers, +3 public methods, +2 CLLocationManager delegates |
| `OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift` | Region monitoring in mock + 2 delegate capture properties |
| `OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift` | Region monitoring in mock |
| `OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift` | **New** — tests |


Closes part of #455
