### PR TITLE
Enhance trip view with stop progress tracking and past/future distinction

### DIFF
--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -383,12 +383,13 @@ class TripFloatingPanelController: UIViewController,
         )
 
         // Compute ETA to user's destination stop, if available.
+        // Uses arrivalDepartureMinutes from ArrivalDeparture which already
+        // accounts for predicted/real-time arrival — same value as the "Xm" badge.
         var etaText: String?
         if let arrivalDeparture = tripConvertible?.arrivalDeparture {
             let userStopIndex = tripDetails.stopTimes.firstIndex { $0.stopID == arrivalDeparture.stopID }
             if let userStopIndex = userStopIndex {
                 if userStopIndex < currentIndex {
-                    // Vehicle has already passed the user's stop.
                     etaText = OBALoc(
                         "trip_progress.passed_your_stop",
                         value: "Passed your stop",
@@ -401,17 +402,15 @@ class TripFloatingPanelController: UIViewController,
                         comment: "Shown when the vehicle is arriving at the user's stop"
                     )
                 } else {
-                    let userStopTime = tripDetails.stopTimes[userStopIndex]
-                    let secondsUntilArrival = userStopTime.arrivalDate.timeIntervalSince(Date())
-                    let minutesUntilArrival = Int(ceil(secondsUntilArrival / 60.0))
-                    if minutesUntilArrival > 0 {
+                    let minutes = arrivalDeparture.arrivalDepartureMinutes
+                    if minutes > 0 {
                         etaText = String(
                             format: OBALoc(
                                 "trip_progress.eta_to_stop_fmt",
                                 value: "~%d min to your stop",
                                 comment: "Estimated time of arrival to the user's stop. e.g. ~8 min to your stop"
                             ),
-                            minutesUntilArrival
+                            minutes
                         )
                     } else {
                         etaText = OBALoc(

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -15,7 +15,7 @@ import FloatingPanel
 
 /// Testable value type encapsulating the "Stop X of Y" header data.
 /// Returns `nil` when progress data is unavailable and the header should be hidden.
-struct TripProgressViewModel {
+nonisolated struct TripProgressViewModel {
     let stopCountText: String
     let etaText: String?
     let progress: Float
@@ -54,12 +54,19 @@ struct TripProgressViewModel {
                     ),
                     minutes
                 )
-            } else {
+            } else if userStopIndex - closestStopIndex == 1 {
+                // The prediction is non-positive but the vehicle is at the adjacent
+                // stop, so "Arriving now" is justified by position alone.
                 etaText = OBALoc(
                     "trip_progress.arriving_now",
                     value: "Arriving now",
                     comment: "Shown when the vehicle is arriving at the user's stop"
                 )
+            } else {
+                // The prediction is stale (e.g. the vehicle is running late) and it is
+                // still several stops away — omit the ETA rather than show a
+                // misleading "Arriving now".
+                etaText = nil
             }
         } else {
             etaText = nil

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -24,6 +24,7 @@ class TripFloatingPanelController: UIViewController,
         didSet {
             if isLoadedAndOnScreen {
                 listView.applyData(animated: false)
+                updateProgressView()
             }
         }
     }
@@ -90,6 +91,7 @@ class TripFloatingPanelController: UIViewController,
         super.viewWillAppear(animated)
 
         listView.applyData(animated: false)
+        updateProgressView()
     }
 
     // MARK: - Public Methods
@@ -122,15 +124,18 @@ class TripFloatingPanelController: UIViewController,
         switch panelState {
         case .tip:
             self.separatorView.isHidden = true
+            self.tripProgressWrapper.isHidden = true
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
         case .half:
             self.separatorView.isHidden = false
+            self.tripProgressWrapper.isHidden = false
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
             self.stopArrivalView.accessibilityMinimalInfoStack.forEach { $0.isHidden = !isAccessibility }
         case .full:
             self.separatorView.isHidden = false
+            self.tripProgressWrapper.isHidden = false
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
         case .hidden: break
@@ -186,7 +191,32 @@ class TripFloatingPanelController: UIViewController,
         return view
     }()
 
-    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, separatorView, listView])
+    private lazy var tripProgressView: TripProgressView = {
+        let view = TripProgressView.autolayoutNew()
+        view.isHidden = true
+        return view
+    }()
+
+    private lazy var tripProgressWrapper: UIView = {
+        let wrapper = tripProgressView.embedInWrapperView(setConstraints: false)
+        NSLayoutConstraint.activate([
+            tripProgressView.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: ThemeMetrics.compactPadding),
+            tripProgressView.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
+            tripProgressView.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor),
+            tripProgressView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -ThemeMetrics.compactPadding)
+        ])
+        return wrapper
+    }()
+
+    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, tripProgressWrapper, separatorView, listView])
+
+    // MARK: - Helpers
+
+    /// Returns the index of the vehicle's closest stop within the trip's stop list, or nil if unavailable.
+    private func closestStopIndex(in tripDetails: TripDetails) -> Int? {
+        guard let closestStopID = tripDetails.status?.closestStopID else { return nil }
+        return tripDetails.stopTimes.firstIndex { $0.stopID == closestStopID }
+    }
 
     // MARK: - ListAdapterDataSource (Data Loading)
     func canCollapseSection(_ listView: OBAListView, section: OBAListViewSection) -> Bool {
@@ -293,9 +323,21 @@ class TripFloatingPanelController: UIViewController,
             contents.append(AdjacentTripItem(order: .previous, trip: previousTrip, onSelectAction: selectAdjacentTripAction).typeErased)
         }
 
+        let closestStopIdx = closestStopIndex(in: tripDetails)
+
         // Stop times
         let selectTripStopAction: OBAListViewAction<TripStopViewModel> = { [unowned self] item in self.onSelectTripStop(item) }
-        let stopTimes: [AnyOBAListViewItem] = tripDetails.stopTimes.map { TripStopViewModel(stopTime: $0, arrivalDeparture: arrivalDeparture, onSelectAction: selectTripStopAction).typeErased }
+        let totalStops = tripDetails.stopTimes.count
+        let stopTimes: [AnyOBAListViewItem] = tripDetails.stopTimes.enumerated().map { index, stopTime in
+            TripStopViewModel(
+                stopTime: stopTime,
+                arrivalDeparture: arrivalDeparture,
+                stopIndex: index,
+                totalStops: totalStops,
+                closestStopIndex: closestStopIdx,
+                onSelectAction: selectTripStopAction
+            ).typeErased
+        }
         contents.append(contentsOf: stopTimes)
 
         // Next trip, if any.
@@ -305,6 +347,85 @@ class TripFloatingPanelController: UIViewController,
 
         let title: String? = showHeader ? OBALoc("trip_details_controller.service_alerts_footer", value: "Trip Details", comment: "Service alerts header in the trip details controller.") : nil
         return OBAListViewSection(id: "trip_stop_times", title: title, contents: contents)
+    }
+
+    // MARK: - Trip Progress
+
+    private func updateProgressView() {
+        guard let tripDetails = tripDetails else {
+            tripProgressView.isHidden = true
+            return
+        }
+
+        let totalStops = tripDetails.stopTimes.count
+        guard totalStops > 0 else {
+            tripProgressView.isHidden = true
+            return
+        }
+
+        guard let currentIndex = closestStopIndex(in: tripDetails) else {
+            tripProgressView.isHidden = true
+            return
+        }
+
+        // 1-based stop number for display
+        let currentStopNumber = currentIndex + 1
+        let progress = Float(currentStopNumber) / Float(totalStops)
+
+        let stopCountText = String(
+            format: OBALoc(
+                "trip_progress.stop_count_fmt",
+                value: "Stop %d of %d",
+                comment: "Shows the current stop position. e.g. Stop 5 of 18"
+            ),
+            currentStopNumber,
+            totalStops
+        )
+
+        // Compute ETA to user's destination stop, if available.
+        var etaText: String?
+        if let arrivalDeparture = tripConvertible?.arrivalDeparture {
+            let userStopIndex = tripDetails.stopTimes.firstIndex { $0.stopID == arrivalDeparture.stopID }
+            if let userStopIndex = userStopIndex {
+                if userStopIndex < currentIndex {
+                    // Vehicle has already passed the user's stop.
+                    etaText = OBALoc(
+                        "trip_progress.passed_your_stop",
+                        value: "Passed your stop",
+                        comment: "Shown when the vehicle has already passed the user's destination stop"
+                    )
+                } else if userStopIndex == currentIndex {
+                    etaText = OBALoc(
+                        "trip_progress.arriving_now",
+                        value: "Arriving now",
+                        comment: "Shown when the vehicle is arriving at the user's stop"
+                    )
+                } else {
+                    let userStopTime = tripDetails.stopTimes[userStopIndex]
+                    let secondsUntilArrival = userStopTime.arrivalDate.timeIntervalSince(Date())
+                    let minutesUntilArrival = Int(ceil(secondsUntilArrival / 60.0))
+                    if minutesUntilArrival > 0 {
+                        etaText = String(
+                            format: OBALoc(
+                                "trip_progress.eta_to_stop_fmt",
+                                value: "~%d min to your stop",
+                                comment: "Estimated time of arrival to the user's stop. e.g. ~8 min to your stop"
+                            ),
+                            minutesUntilArrival
+                        )
+                    } else {
+                        etaText = OBALoc(
+                            "trip_progress.arriving_now",
+                            value: "Arriving now",
+                            comment: "Shown when the vehicle is arriving at the user's stop"
+                        )
+                    }
+                }
+            }
+        }
+
+        tripProgressView.configure(stopCountText: stopCountText, etaText: etaText, progress: progress)
+        tripProgressView.isHidden = false
     }
 
     // MARK: - TripStop actions
@@ -377,5 +498,74 @@ class TripFloatingPanelController: UIViewController,
         }
 
         return OBAListViewMenuActions(previewProvider: previewProvider, performPreviewAction: commitPreviewAction, contextMenuProvider: menu)
+    }
+}
+
+// MARK: - TripProgressView
+
+/// Displays trip progress as "Stop X of Y", an optional ETA label, and a thin progress bar.
+final class TripProgressView: UIView {
+
+    private let stopCountLabel: UILabel = {
+        let label = UILabel.obaLabel(font: .preferredFont(forTextStyle: .caption1), textColor: ThemeColors.shared.secondaryLabel)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return label
+    }()
+
+    private let etaLabel: UILabel = {
+        let label = UILabel.obaLabel(font: .preferredFont(forTextStyle: .caption1), textColor: ThemeColors.shared.brand)
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.textAlignment = .right
+        return label
+    }()
+
+    private let progressBar: UIProgressView = {
+        let bar = UIProgressView(progressViewStyle: .default)
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.progressTintColor = ThemeColors.shared.brand
+        bar.trackTintColor = ThemeColors.shared.separator
+        bar.layer.cornerRadius = 1.5
+        bar.clipsToBounds = true
+        return bar
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        let labelsStack = UIStackView(arrangedSubviews: [stopCountLabel, etaLabel])
+        labelsStack.translatesAutoresizingMaskIntoConstraints = false
+        labelsStack.axis = .horizontal
+        labelsStack.spacing = ThemeMetrics.padding
+
+        addSubview(labelsStack)
+        addSubview(progressBar)
+
+        NSLayoutConstraint.activate([
+            labelsStack.topAnchor.constraint(equalTo: topAnchor),
+            labelsStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelsStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            progressBar.topAnchor.constraint(equalTo: labelsStack.bottomAnchor, constant: ThemeMetrics.compactPadding),
+            progressBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            progressBar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            progressBar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            progressBar.heightAnchor.constraint(equalToConstant: 3.0)
+        ])
+
+        isAccessibilityElement = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(stopCountText: String, etaText: String?, progress: Float) {
+        stopCountLabel.text = stopCountText
+        etaLabel.text = etaText
+        etaLabel.isHidden = etaText == nil
+        progressBar.setProgress(progress, animated: true)
+
+        accessibilityLabel = [stopCountText, etaText].compactMap { $0 }.joined(separator: ". ")
     }
 }

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -11,6 +11,64 @@ import UIKit
 import OBAKitCore
 import FloatingPanel
 
+// MARK: - TripProgressViewModel
+
+/// Testable value type encapsulating the "Stop X of Y" header data.
+/// Returns `nil` when progress data is unavailable and the header should be hidden.
+struct TripProgressViewModel {
+    let stopCountText: String
+    let etaText: String?
+    let progress: Float
+
+    init?(closestStopIndex: Int, totalStops: Int, userStopIndex: Int?, arrivalDepartureMinutes: Int?) {
+        guard totalStops > 0 else { return nil }
+        let currentStopNumber = closestStopIndex + 1
+        progress = Float(currentStopNumber) / Float(totalStops)
+        stopCountText = String(
+            format: OBALoc(
+                "trip_progress.stop_count_fmt",
+                value: "Stop %1$d of %2$d",
+                comment: "Shows the current stop position. e.g. Stop 5 of 18"
+            ),
+            currentStopNumber, totalStops
+        )
+        if let userStopIndex {
+            if userStopIndex < closestStopIndex {
+                etaText = OBALoc(
+                    "trip_progress.passed_your_stop",
+                    value: "Passed your stop",
+                    comment: "Shown when the vehicle has already passed the user's destination stop"
+                )
+            } else if userStopIndex == closestStopIndex {
+                etaText = OBALoc(
+                    "trip_progress.arriving_now",
+                    value: "Arriving now",
+                    comment: "Shown when the vehicle is arriving at the user's stop"
+                )
+            } else if let minutes = arrivalDepartureMinutes, minutes > 0 {
+                etaText = String(
+                    format: OBALoc(
+                        "trip_progress.eta_to_stop_fmt",
+                        value: "~%d min to your stop",
+                        comment: "Estimated time of arrival to the user's stop. e.g. ~8 min to your stop"
+                    ),
+                    minutes
+                )
+            } else {
+                etaText = OBALoc(
+                    "trip_progress.arriving_now",
+                    value: "Arriving now",
+                    comment: "Shown when the vehicle is arriving at the user's stop"
+                )
+            }
+        } else {
+            etaText = nil
+        }
+    }
+}
+
+// MARK: -
+
 /// Displays a list of stops for the trip corresponding to an `ArrivalDeparture` object.
 class TripFloatingPanelController: UIViewController,
     AppContext,
@@ -41,6 +99,11 @@ class TripFloatingPanelController: UIViewController,
 
     /// Delays the post-scroll `blink` until scrolling has hopefully settled.
     private let scrollBlinkThrottler = Throttler()
+
+    /// Tracks whether the floating panel is expanded enough to show the progress header.
+    /// Combined with data availability in `updateProgressView` to give `tripProgressWrapper`
+    /// a single source of truth for its hidden state.
+    private var isPanelExpandedEnoughForProgress = false
 
     // MARK: - Init/Deinit
 
@@ -124,23 +187,25 @@ class TripFloatingPanelController: UIViewController,
         switch panelState {
         case .tip:
             self.separatorView.isHidden = true
-            self.tripProgressWrapper.isHidden = true
+            self.isPanelExpandedEnoughForProgress = false
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
         case .half:
             self.separatorView.isHidden = false
-            self.tripProgressWrapper.isHidden = false
+            self.isPanelExpandedEnoughForProgress = true
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
             self.stopArrivalView.accessibilityMinimalInfoStack.forEach { $0.isHidden = !isAccessibility }
         case .full:
             self.separatorView.isHidden = false
-            self.tripProgressWrapper.isHidden = false
+            self.isPanelExpandedEnoughForProgress = true
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
-        case .hidden: break
+        case .hidden:
+            self.isPanelExpandedEnoughForProgress = false
         default: break
         }
+        updateProgressView()
     }
 
     public func setListVisibility(isVisible: Bool) {
@@ -191,14 +256,11 @@ class TripFloatingPanelController: UIViewController,
         return view
     }()
 
-    private lazy var tripProgressView: TripProgressView = {
-        let view = TripProgressView.autolayoutNew()
-        view.isHidden = true
-        return view
-    }()
+    private lazy var tripProgressView: TripProgressView = TripProgressView.autolayoutNew()
 
     private lazy var tripProgressWrapper: UIView = {
         let wrapper = tripProgressView.embedInWrapperView(setConstraints: false)
+        wrapper.isHidden = true
         NSLayoutConstraint.activate([
             tripProgressView.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: ThemeMetrics.compactPadding),
             tripProgressView.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
@@ -327,13 +389,11 @@ class TripFloatingPanelController: UIViewController,
 
         // Stop times
         let selectTripStopAction: OBAListViewAction<TripStopViewModel> = { [unowned self] item in self.onSelectTripStop(item) }
-        let totalStops = tripDetails.stopTimes.count
         let stopTimes: [AnyOBAListViewItem] = tripDetails.stopTimes.enumerated().map { index, stopTime in
             TripStopViewModel(
                 stopTime: stopTime,
                 arrivalDeparture: arrivalDeparture,
                 stopIndex: index,
-                totalStops: totalStops,
                 closestStopIndex: closestStopIdx,
                 onSelectAction: selectTripStopAction
             ).typeErased
@@ -352,79 +412,32 @@ class TripFloatingPanelController: UIViewController,
     // MARK: - Trip Progress
 
     private func updateProgressView() {
-        guard let tripDetails = tripDetails else {
-            tripProgressView.isHidden = true
+        guard
+            isPanelExpandedEnoughForProgress,
+            let tripDetails = tripDetails,
+            let currentIndex = closestStopIndex(in: tripDetails)
+        else {
+            tripProgressWrapper.isHidden = true
             return
         }
 
-        let totalStops = tripDetails.stopTimes.count
-        guard totalStops > 0 else {
-            tripProgressView.isHidden = true
+        let arrivalDeparture = tripConvertible?.arrivalDeparture
+        let userStopIndex = arrivalDeparture.flatMap { ad in
+            tripDetails.stopTimes.firstIndex { $0.stopID == ad.stopID }
+        }
+
+        guard let vm = TripProgressViewModel(
+            closestStopIndex: currentIndex,
+            totalStops: tripDetails.stopTimes.count,
+            userStopIndex: userStopIndex,
+            arrivalDepartureMinutes: arrivalDeparture?.arrivalDepartureMinutes
+        ) else {
+            tripProgressWrapper.isHidden = true
             return
         }
 
-        guard let currentIndex = closestStopIndex(in: tripDetails) else {
-            tripProgressView.isHidden = true
-            return
-        }
-
-        // 1-based stop number for display
-        let currentStopNumber = currentIndex + 1
-        let progress = Float(currentStopNumber) / Float(totalStops)
-
-        let stopCountText = String(
-            format: OBALoc(
-                "trip_progress.stop_count_fmt",
-                value: "Stop %d of %d",
-                comment: "Shows the current stop position. e.g. Stop 5 of 18"
-            ),
-            currentStopNumber,
-            totalStops
-        )
-
-        // Compute ETA to user's destination stop, if available.
-        // Uses arrivalDepartureMinutes from ArrivalDeparture which already
-        // accounts for predicted/real-time arrival — same value as the "Xm" badge.
-        var etaText: String?
-        if let arrivalDeparture = tripConvertible?.arrivalDeparture {
-            let userStopIndex = tripDetails.stopTimes.firstIndex { $0.stopID == arrivalDeparture.stopID }
-            if let userStopIndex = userStopIndex {
-                if userStopIndex < currentIndex {
-                    etaText = OBALoc(
-                        "trip_progress.passed_your_stop",
-                        value: "Passed your stop",
-                        comment: "Shown when the vehicle has already passed the user's destination stop"
-                    )
-                } else if userStopIndex == currentIndex {
-                    etaText = OBALoc(
-                        "trip_progress.arriving_now",
-                        value: "Arriving now",
-                        comment: "Shown when the vehicle is arriving at the user's stop"
-                    )
-                } else {
-                    let minutes = arrivalDeparture.arrivalDepartureMinutes
-                    if minutes > 0 {
-                        etaText = String(
-                            format: OBALoc(
-                                "trip_progress.eta_to_stop_fmt",
-                                value: "~%d min to your stop",
-                                comment: "Estimated time of arrival to the user's stop. e.g. ~8 min to your stop"
-                            ),
-                            minutes
-                        )
-                    } else {
-                        etaText = OBALoc(
-                            "trip_progress.arriving_now",
-                            value: "Arriving now",
-                            comment: "Shown when the vehicle is arriving at the user's stop"
-                        )
-                    }
-                }
-            }
-        }
-
-        tripProgressView.configure(stopCountText: stopCountText, etaText: etaText, progress: progress)
-        tripProgressView.isHidden = false
+        tripProgressView.configure(stopCountText: vm.stopCountText, etaText: vm.etaText, progress: vm.progress)
+        tripProgressWrapper.isHidden = false
     }
 
     // MARK: - TripStop actions
@@ -563,7 +576,7 @@ final class TripProgressView: UIView {
         stopCountLabel.text = stopCountText
         etaLabel.text = etaText
         etaLabel.isHidden = etaText == nil
-        progressBar.setProgress(progress, animated: true)
+        progressBar.setProgress(progress, animated: false)
 
         accessibilityLabel = [stopCountText, etaText].compactMap { $0 }.joined(separator: ". ")
     }

--- a/OBAKit/Trip/TripSegmentView.swift
+++ b/OBAKit/Trip/TripSegmentView.swift
@@ -45,6 +45,9 @@ class TripSegmentView: UIView {
 
     var routeType: Route.RouteType = .unknown
 
+    /// The temporal state of this stop relative to the vehicle's current position.
+    var temporalState: TripStopTemporalState = .future
+
     private var isUserDestination: Bool = false
     private var isCurrentVehicleLocation: Bool = false
 
@@ -60,6 +63,10 @@ class TripSegmentView: UIView {
 
     override public var intrinsicContentSize: CGSize {
         CGSize(width: circleRadius + (2.0 * lineWidth), height: UIView.noIntrinsicMetric)
+    }
+
+    private var pastLineColor: UIColor {
+        ThemeColors.shared.secondaryLabel.withAlphaComponent(0.4)
     }
 
     override public func draw(_ rect: CGRect) {
@@ -94,10 +101,25 @@ class TripSegmentView: UIView {
     }
 
     private func drawRegularTripSegment(_ rect: CGRect, context: CGContext?) {
+        // Top line color depends on temporal state:
+        // past/current → gray (the vehicle has reached or passed here)
+        // future → brand color
+        let topColor: UIColor
+        switch temporalState {
+        case .past, .current:
+            topColor = pastLineColor
+        case .future:
+            topColor = lineColor
+        }
+
+        topColor.setFill()
         let topLine = UIBezierPath(rect: CGRect(origin: CGPoint(x: rect.midX - (lineWidth / 2.0), y: rect.minY), size: CGSize(width: lineWidth, height: rect.midY - halfRadius)))
         topLine.fill()
 
         let bezierFrame = CGRect(origin: CGPoint(x: rect.midX - halfRadius, y: rect.midY - halfRadius), size: CGSize(width: circleRadius, height: circleRadius))
+
+        let strokeColor: UIColor = temporalState == .past ? pastLineColor : lineColor
+        strokeColor.setStroke()
 
         let bezierPath = UIBezierPath(roundedRect: bezierFrame, cornerRadius: ThemeMetrics.compactCornerRadius)
         bezierPath.lineWidth = lineWidth
@@ -112,6 +134,9 @@ class TripSegmentView: UIView {
 
         bezierPath.stroke()
 
+        // Bottom line: past → gray, current/future → brand color
+        let bottomColor: UIColor = temporalState == .past ? pastLineColor : lineColor
+        bottomColor.setFill()
         let bottomLine = UIBezierPath(rect: CGRect(origin: CGPoint(x: rect.midX - (lineWidth / 2.0), y: rect.midY + halfRadius), size: CGSize(width: lineWidth, height: rect.midY - halfRadius)))
         bottomLine.fill()
     }

--- a/OBAKit/Trip/TripSegmentView.swift
+++ b/OBAKit/Trip/TripSegmentView.swift
@@ -46,7 +46,9 @@ class TripSegmentView: UIView {
     var routeType: Route.RouteType = .unknown
 
     /// The temporal state of this stop relative to the vehicle's current position.
-    var temporalState: TripStopTemporalState = .future
+    var temporalState: TripStopTemporalState = .future {
+        didSet { setNeedsDisplay() }
+    }
 
     private var isUserDestination: Bool = false
     private var isCurrentVehicleLocation: Bool = false

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -10,6 +10,15 @@
 import UIKit
 import OBAKitCore
 
+// MARK: - Temporal State
+
+/// Describes whether a trip stop is in the past, present, or future relative to the vehicle's current position.
+enum TripStopTemporalState: Hashable {
+    case past
+    case current
+    case future
+}
+
 fileprivate let tripStopCellMinimumHeight: CGFloat = 48.0
 
 nonisolated struct TripStopListItemRowConfiguration: OBAContentConfiguration {
@@ -44,6 +53,15 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
     /// Is this the trip stop where the user is intending to go?
     let isUserDestination: Bool
 
+    /// Whether this stop is in the past, present, or future relative to the vehicle position.
+    let temporalState: TripStopTemporalState
+
+    /// Zero-based index of this stop within the trip.
+    let stopIndex: Int
+
+    /// Total number of stops in the trip.
+    let totalStops: Int
+
     /// The title of this item. e.g., "15th Ave E & E Galer St"
     let title: String
 
@@ -58,8 +76,17 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
 
     let stopTime: TripStopTime
 
-    init(stopTime: TripStopTime, arrivalDeparture: ArrivalDeparture?, onSelectAction: OBAListViewAction<TripStopViewModel>?) {
+    init(
+        stopTime: TripStopTime,
+        arrivalDeparture: ArrivalDeparture?,
+        stopIndex: Int,
+        totalStops: Int,
+        closestStopIndex: Int?,
+        onSelectAction: OBAListViewAction<TripStopViewModel>?
+    ) {
         self.stopTime = stopTime
+        self.stopIndex = stopIndex
+        self.totalStops = totalStops
 
         stop = stopTime.stop
 
@@ -77,6 +104,18 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
             isCurrentVehicleLocation = false
         }
 
+        if let closestStopIndex = closestStopIndex {
+            if stopIndex < closestStopIndex {
+                temporalState = .past
+            } else if stopIndex == closestStopIndex {
+                temporalState = .current
+            } else {
+                temporalState = .future
+            }
+        } else {
+            temporalState = .future
+        }
+
         title = stopTime.stop.name
         date = stopTime.arrivalDate
         routeType = stopTime.stop.prioritizedRouteTypeForDisplay
@@ -88,6 +127,9 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         hasher.combine(id)
         hasher.combine(isCurrentVehicleLocation)
         hasher.combine(isUserDestination)
+        hasher.combine(temporalState)
+        hasher.combine(stopIndex)
+        hasher.combine(totalStops)
         hasher.combine(title)
         hasher.combine(date)
         hasher.combine(routeType)
@@ -96,6 +138,9 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
     static func == (lhs: TripStopViewModel, rhs: TripStopViewModel) -> Bool {
         return lhs.isCurrentVehicleLocation == rhs.isCurrentVehicleLocation &&
             lhs.isUserDestination == rhs.isUserDestination &&
+            lhs.temporalState == rhs.temporalState &&
+            lhs.stopIndex == rhs.stopIndex &&
+            lhs.totalStops == rhs.totalStops &&
             lhs.title == rhs.title &&
             lhs.date == rhs.date &&
             lhs.routeType == rhs.routeType
@@ -125,9 +170,13 @@ final class TripStopCell: OBAListViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         titleLabel.text = nil
+        titleLabel.font = .preferredFont(forTextStyle: .body)
+        titleLabel.textColor = ThemeColors.shared.label
         timeLabel.text = nil
+        timeLabel.textColor = ThemeColors.shared.secondaryLabel
         tripSegmentView.image = nil
         tripSegmentView.adjacentTripOrder = nil
+        tripSegmentView.temporalState = .future
         accessibilityLabel = nil
         accessibilityValue = nil
     }
@@ -198,26 +247,60 @@ final class TripStopCell: OBAListViewCell {
     }
 
     private func apply(tripStopListItemConfiguration config: TripStopListItemRowConfiguration) {
-        titleLabel.text = config.viewModel.title
-        timeLabel.text = config.formatters?.timeFormatter.string(from: config.viewModel.date) ?? ""
-        tripSegmentView.routeType = config.viewModel.routeType
-        tripSegmentView.setDestinationStatus(user: config.viewModel.isUserDestination, vehicle: config.viewModel.isCurrentVehicleLocation)
+        let viewModel = config.viewModel
 
-        let labels = [config.viewModel.title, config.formatters?.timeFormatter.string(from: config.viewModel.date)]
+        titleLabel.text = viewModel.title
+        timeLabel.text = config.formatters?.timeFormatter.string(from: viewModel.date) ?? ""
+        tripSegmentView.routeType = viewModel.routeType
+        tripSegmentView.temporalState = viewModel.temporalState
+        tripSegmentView.setDestinationStatus(user: viewModel.isUserDestination, vehicle: viewModel.isCurrentVehicleLocation)
+
+        applyTemporalStateStyling(viewModel)
+
+        let labels = [viewModel.title, config.formatters?.timeFormatter.string(from: viewModel.date)]
         accessibilityLabel = labels.compactMap { $0 }.joined(separator: "; ")
 
         var accessibilityValueFlags: [String] = []
 
-        if config.viewModel.isUserDestination {
+        switch viewModel.temporalState {
+        case .past:
+            accessibilityValueFlags.append(OBALoc("trip_stop.passed_stop.accessibility_label", value: "Passed stop", comment: "Voiceover text explaining that the vehicle has already passed this stop"))
+        case .current:
+            break
+        case .future:
+            break
+        }
+
+        if viewModel.isUserDestination {
             accessibilityValueFlags.append(OBALoc("trip_stop.user_destination.accessibility_label", value: "Your destination", comment: "Voiceover text explaining that this stop is the user's destination"))
         }
 
-        if config.viewModel.isCurrentVehicleLocation {
+        if viewModel.isCurrentVehicleLocation {
             accessibilityValueFlags.append(OBALoc("trip_stop.vehicle_location.accessibility_label", value: "Vehicle is here", comment: "Voiceover text explaining that the vehicle is currently at this stop"))
         }
 
         let joined = accessibilityValueFlags.joined(separator: ", ")
         accessibilityValue = joined.isEmpty ? nil : joined
+    }
+
+    private func applyTemporalStateStyling(_ viewModel: TripStopViewModel) {
+        switch viewModel.temporalState {
+        case .past:
+            titleLabel.textColor = ThemeColors.shared.secondaryLabel
+            timeLabel.textColor = ThemeColors.shared.secondaryLabel
+
+        case .current:
+            titleLabel.font = .preferredFont(forTextStyle: .headline)
+            titleLabel.textColor = ThemeColors.shared.label
+            timeLabel.textColor = ThemeColors.shared.label
+
+        case .future:
+            if viewModel.isUserDestination {
+                titleLabel.font = .preferredFont(forTextStyle: .headline)
+            }
+            titleLabel.textColor = ThemeColors.shared.label
+            timeLabel.textColor = ThemeColors.shared.secondaryLabel
+        }
     }
 
     private func apply(adjacentTripConfiguration config: AdjacentTripRowConfiguration) {

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -13,7 +13,7 @@ import OBAKitCore
 // MARK: - Temporal State
 
 /// Describes whether a trip stop is in the past, present, or future relative to the vehicle's current position.
-enum TripStopTemporalState: Hashable {
+nonisolated enum TripStopTemporalState: Hashable {
     case past
     case current
     case future
@@ -148,8 +148,10 @@ final class TripStopCell: OBAListViewCell {
         titleLabel.text = nil
         titleLabel.font = .preferredFont(forTextStyle: .body)
         titleLabel.textColor = ThemeColors.shared.label
+        titleLabel.alpha = 1.0
         timeLabel.text = nil
         timeLabel.textColor = ThemeColors.shared.secondaryLabel
+        timeLabel.alpha = 1.0
         tripSegmentView.image = nil
         tripSegmentView.adjacentTripOrder = nil
         tripSegmentView.temporalState = .future
@@ -262,21 +264,30 @@ final class TripStopCell: OBAListViewCell {
     private func applyTemporalStateStyling(_ viewModel: TripStopViewModel) {
         switch viewModel.temporalState {
         case .past:
+            // Reduced opacity supplements the secondaryLabel color so past stops
+            // remain distinguishable for low-vision users not running VoiceOver,
+            // where a color change alone would not be perceivable.
             titleLabel.font = .preferredFont(forTextStyle: .body)
             titleLabel.textColor = ThemeColors.shared.secondaryLabel
+            titleLabel.alpha = 0.7
             timeLabel.textColor = ThemeColors.shared.secondaryLabel
+            timeLabel.alpha = 0.7
 
         case .current:
             titleLabel.font = .preferredFont(forTextStyle: .headline)
             titleLabel.textColor = ThemeColors.shared.label
+            titleLabel.alpha = 1.0
             timeLabel.textColor = ThemeColors.shared.label
+            timeLabel.alpha = 1.0
 
         case .future:
             titleLabel.font = viewModel.isUserDestination
                 ? .preferredFont(forTextStyle: .headline)
                 : .preferredFont(forTextStyle: .body)
             titleLabel.textColor = ThemeColors.shared.label
+            titleLabel.alpha = 1.0
             timeLabel.textColor = ThemeColors.shared.secondaryLabel
+            timeLabel.alpha = 1.0
         }
     }
 

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -17,6 +17,13 @@ enum TripStopTemporalState: Hashable {
     case past
     case current
     case future
+
+    static func classify(stopIndex: Int, closestStopIndex: Int?) -> TripStopTemporalState {
+        guard let closestStopIndex else { return .future }
+        if stopIndex < closestStopIndex { return .past }
+        if stopIndex == closestStopIndex { return .current }
+        return .future
+    }
 }
 
 fileprivate let tripStopCellMinimumHeight: CGFloat = 48.0
@@ -56,12 +63,6 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
     /// Whether this stop is in the past, present, or future relative to the vehicle position.
     let temporalState: TripStopTemporalState
 
-    /// Zero-based index of this stop within the trip.
-    let stopIndex: Int
-
-    /// Total number of stops in the trip.
-    let totalStops: Int
-
     /// The title of this item. e.g., "15th Ave E & E Galer St"
     let title: String
 
@@ -80,41 +81,20 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         stopTime: TripStopTime,
         arrivalDeparture: ArrivalDeparture?,
         stopIndex: Int,
-        totalStops: Int,
         closestStopIndex: Int?,
         onSelectAction: OBAListViewAction<TripStopViewModel>?
     ) {
         self.stopTime = stopTime
-        self.stopIndex = stopIndex
-        self.totalStops = totalStops
 
         stop = stopTime.stop
 
-        if let arrivalDeparture = arrivalDeparture {
-            isUserDestination = stopTime.stopID == arrivalDeparture.stopID
-        }
-        else {
-            isUserDestination = false
-        }
+        isUserDestination = arrivalDeparture.map { stopTime.stopID == $0.stopID } ?? false
 
-        if let closestStopID = arrivalDeparture?.tripStatus?.closestStopID {
-            isCurrentVehicleLocation = stopTime.stopID == closestStopID
-        }
-        else {
-            isCurrentVehicleLocation = false
-        }
+        // Derive isCurrentVehicleLocation from the same closestStopIndex used for
+        // temporalState so both properties always agree on which stop is "current".
+        isCurrentVehicleLocation = closestStopIndex.map { stopIndex == $0 } ?? false
 
-        if let closestStopIndex = closestStopIndex {
-            if stopIndex < closestStopIndex {
-                temporalState = .past
-            } else if stopIndex == closestStopIndex {
-                temporalState = .current
-            } else {
-                temporalState = .future
-            }
-        } else {
-            temporalState = .future
-        }
+        temporalState = TripStopTemporalState.classify(stopIndex: stopIndex, closestStopIndex: closestStopIndex)
 
         title = stopTime.stop.name
         date = stopTime.arrivalDate
@@ -128,8 +108,6 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         hasher.combine(isCurrentVehicleLocation)
         hasher.combine(isUserDestination)
         hasher.combine(temporalState)
-        hasher.combine(stopIndex)
-        hasher.combine(totalStops)
         hasher.combine(title)
         hasher.combine(date)
         hasher.combine(routeType)
@@ -139,8 +117,6 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         return lhs.isCurrentVehicleLocation == rhs.isCurrentVehicleLocation &&
             lhs.isUserDestination == rhs.isUserDestination &&
             lhs.temporalState == rhs.temporalState &&
-            lhs.stopIndex == rhs.stopIndex &&
-            lhs.totalStops == rhs.totalStops &&
             lhs.title == rhs.title &&
             lhs.date == rhs.date &&
             lhs.routeType == rhs.routeType
@@ -286,6 +262,7 @@ final class TripStopCell: OBAListViewCell {
     private func applyTemporalStateStyling(_ viewModel: TripStopViewModel) {
         switch viewModel.temporalState {
         case .past:
+            titleLabel.font = .preferredFont(forTextStyle: .body)
             titleLabel.textColor = ThemeColors.shared.secondaryLabel
             timeLabel.textColor = ThemeColors.shared.secondaryLabel
 
@@ -295,9 +272,9 @@ final class TripStopCell: OBAListViewCell {
             timeLabel.textColor = ThemeColors.shared.label
 
         case .future:
-            if viewModel.isUserDestination {
-                titleLabel.font = .preferredFont(forTextStyle: .headline)
-            }
+            titleLabel.font = viewModel.isUserDestination
+                ? .preferredFont(forTextStyle: .headline)
+                : .preferredFont(forTextStyle: .body)
             titleLabel.textColor = ThemeColors.shared.label
             timeLabel.textColor = ThemeColors.shared.secondaryLabel
         }

--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -1,0 +1,128 @@
+//
+//  TripStopListItemTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+// MARK: - TripStopTemporalState.classify
+
+class TripStopTemporalStateTests: XCTestCase {
+
+    // closestStopIndex nil → every stop is .future
+    func test_classify_nilClosestStop_returnsFuture() {
+        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: nil)) == .future
+        expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: nil)) == .future
+    }
+
+    func test_classify_stopBeforeClosest_returnsPast() {
+        expect(TripStopTemporalState.classify(stopIndex: 3, closestStopIndex: 5)) == .past
+        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 1)) == .past
+    }
+
+    func test_classify_stopAtClosest_returnsCurrent() {
+        expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: 5)) == .current
+        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0)) == .current
+    }
+
+    func test_classify_stopAfterClosest_returnsFuture() {
+        expect(TripStopTemporalState.classify(stopIndex: 6, closestStopIndex: 5)) == .future
+        expect(TripStopTemporalState.classify(stopIndex: 9, closestStopIndex: 5)) == .future
+    }
+
+    // Boundary: vehicle at the first stop
+    func test_classify_vehicleAtFirstStop() {
+        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0)) == .current
+        expect(TripStopTemporalState.classify(stopIndex: 1, closestStopIndex: 0)) == .future
+    }
+
+    // Boundary: vehicle at the last stop
+    func test_classify_vehicleAtLastStop() {
+        let last = 9
+        expect(TripStopTemporalState.classify(stopIndex: last - 1, closestStopIndex: last)) == .past
+        expect(TripStopTemporalState.classify(stopIndex: last, closestStopIndex: last)) == .current
+    }
+}
+
+// MARK: - TripProgressViewModel
+
+class TripProgressViewModelTests: XCTestCase {
+
+    // No stops → nil view model
+    func test_init_zeroTotalStops_returnsNil() {
+        let vm = TripProgressViewModel(closestStopIndex: 0, totalStops: 0, userStopIndex: nil, arrivalDepartureMinutes: nil)
+        expect(vm).to(beNil())
+    }
+
+    // Stop 1 of 10: closestStopIndex=0
+    func test_stopCount_firstStop() {
+        let vm = TripProgressViewModel(closestStopIndex: 0, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
+        expect(vm).notTo(beNil())
+        expect(vm?.stopCountText).to(contain("1 of 10"))
+        expect(vm?.progress).to(beCloseTo(0.1, within: 0.001))
+    }
+
+    // Stop 10 of 10: closestStopIndex=9
+    func test_stopCount_lastStop() {
+        let vm = TripProgressViewModel(closestStopIndex: 9, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
+        expect(vm?.progress).to(beCloseTo(1.0, within: 0.001))
+    }
+
+    // No user stop → etaText is nil
+    func test_eta_noUserStop_isNil() {
+        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: 8)
+        expect(vm?.etaText).to(beNil())
+    }
+
+    // User stop already passed
+    func test_eta_userStopPassed() {
+        let vm = TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 3, arrivalDepartureMinutes: nil)
+        expect(vm?.etaText).notTo(beNil())
+        expect(vm?.etaText).to(contain("Passed"))
+    }
+
+    // Vehicle at user's stop
+    func test_eta_vehicleAtUserStop() {
+        let vm = TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 5, arrivalDepartureMinutes: 0)
+        expect(vm?.etaText).notTo(beNil())
+        expect(vm?.etaText).to(contain("Arriving now"))
+    }
+
+    // ETA with positive minutes
+    func test_eta_withPositiveMinutes() {
+        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 8)
+        expect(vm?.etaText).notTo(beNil())
+        expect(vm?.etaText).to(contain("8"))
+    }
+
+    // minutes <= 0 → "Arriving now" fallback
+    func test_eta_zeroMinutes_arrivingNow() {
+        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 0)
+        expect(vm?.etaText).to(contain("Arriving now"))
+    }
+
+    // No real-time data (nil minutes) but user stop is ahead → "Arriving now" fallback
+    func test_eta_nilMinutesWithUserStopAhead_arrivingNow() {
+        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: nil)
+        expect(vm?.etaText).to(contain("Arriving now"))
+    }
+
+    // Negative minutes falls through the same else branch as zero → "Arriving now"
+    func test_eta_negativeMinutes_arrivingNow() {
+        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: -3)
+        expect(vm?.etaText).to(contain("Arriving now"))
+    }
+
+    // Progress fraction: Stop 5 of 10 → 0.5
+    func test_progress_midTrip() {
+        let vm = TripProgressViewModel(closestStopIndex: 4, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
+        expect(vm?.progress).to(beCloseTo(0.5, within: 0.001))
+    }
+}

--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -7,122 +7,144 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
-import Nimble
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
-// MARK: - TripStopTemporalState.classify
+@MainActor
+@Suite(.serialized)
+final class TripStopTemporalStateTests {
 
-class TripStopTemporalStateTests: XCTestCase {
-
-    // closestStopIndex nil → every stop is .future
-    func test_classify_nilClosestStop_returnsFuture() {
-        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: nil)) == .future
-        expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: nil)) == .future
+    @Test func `Nil closest stop classifies every stop as future`() {
+        #expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: nil) == .future)
+        #expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: nil) == .future)
     }
 
-    func test_classify_stopBeforeClosest_returnsPast() {
-        expect(TripStopTemporalState.classify(stopIndex: 3, closestStopIndex: 5)) == .past
-        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 1)) == .past
+    @Test func `Stop before closest is past`() {
+        #expect(TripStopTemporalState.classify(stopIndex: 3, closestStopIndex: 5) == .past)
+        #expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 1) == .past)
     }
 
-    func test_classify_stopAtClosest_returnsCurrent() {
-        expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: 5)) == .current
-        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0)) == .current
+    @Test func `Stop at closest is current`() {
+        #expect(TripStopTemporalState.classify(stopIndex: 5, closestStopIndex: 5) == .current)
+        #expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0) == .current)
     }
 
-    func test_classify_stopAfterClosest_returnsFuture() {
-        expect(TripStopTemporalState.classify(stopIndex: 6, closestStopIndex: 5)) == .future
-        expect(TripStopTemporalState.classify(stopIndex: 9, closestStopIndex: 5)) == .future
+    @Test func `Stop after closest is future`() {
+        #expect(TripStopTemporalState.classify(stopIndex: 6, closestStopIndex: 5) == .future)
+        #expect(TripStopTemporalState.classify(stopIndex: 9, closestStopIndex: 5) == .future)
     }
 
-    // Boundary: vehicle at the first stop
-    func test_classify_vehicleAtFirstStop() {
-        expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0)) == .current
-        expect(TripStopTemporalState.classify(stopIndex: 1, closestStopIndex: 0)) == .future
+    @Test func `Vehicle at first stop boundary`() {
+        #expect(TripStopTemporalState.classify(stopIndex: 0, closestStopIndex: 0) == .current)
+        #expect(TripStopTemporalState.classify(stopIndex: 1, closestStopIndex: 0) == .future)
     }
 
-    // Boundary: vehicle at the last stop
-    func test_classify_vehicleAtLastStop() {
+    @Test func `Vehicle at last stop boundary`() {
         let last = 9
-        expect(TripStopTemporalState.classify(stopIndex: last - 1, closestStopIndex: last)) == .past
-        expect(TripStopTemporalState.classify(stopIndex: last, closestStopIndex: last)) == .current
+        #expect(TripStopTemporalState.classify(stopIndex: last - 1, closestStopIndex: last) == .past)
+        #expect(TripStopTemporalState.classify(stopIndex: last, closestStopIndex: last) == .current)
+    }
+
+    /// Trip details with `status: null` (no real-time data) must classify every stop
+    /// as `.future` and never mark a stop as the vehicle's current location.
+    @Test func `Status-less trip details renders all stops as future`() throws {
+        let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
+        let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
+        let tripDetails = response.entry
+
+        #expect(tripDetails.status == nil)
+        #expect(!tripDetails.stopTimes.isEmpty)
+
+        let firstStopTime = try #require(tripDetails.stopTimes.first)
+        let viewModel = TripStopViewModel(
+            stopTime: firstStopTime,
+            arrivalDeparture: nil,
+            stopIndex: 0,
+            closestStopIndex: nil,
+            onSelectAction: nil
+        )
+        #expect(viewModel.temporalState == .future)
+        #expect(viewModel.isCurrentVehicleLocation == false)
     }
 }
 
-// MARK: - TripProgressViewModel
+@MainActor
+@Suite(.serialized)
+final class TripProgressViewModelTests {
 
-class TripProgressViewModelTests: XCTestCase {
-
-    // No stops → nil view model
-    func test_init_zeroTotalStops_returnsNil() {
+    @Test func `Zero total stops returns nil`() {
         let vm = TripProgressViewModel(closestStopIndex: 0, totalStops: 0, userStopIndex: nil, arrivalDepartureMinutes: nil)
-        expect(vm).to(beNil())
+        #expect(vm == nil)
     }
 
-    // Stop 1 of 10: closestStopIndex=0
-    func test_stopCount_firstStop() {
-        let vm = TripProgressViewModel(closestStopIndex: 0, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
-        expect(vm).notTo(beNil())
-        expect(vm?.stopCountText).to(contain("1 of 10"))
-        expect(vm?.progress).to(beCloseTo(0.1, within: 0.001))
+    @Test func `First stop displays one-based stop count`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 0, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil))
+        #expect(vm.stopCountText.contains("1 of 10"))
+        #expect(abs(vm.progress - 0.1) < 0.001)
     }
 
-    // Stop 10 of 10: closestStopIndex=9
-    func test_stopCount_lastStop() {
-        let vm = TripProgressViewModel(closestStopIndex: 9, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
-        expect(vm?.progress).to(beCloseTo(1.0, within: 0.001))
+    @Test func `Last stop reaches full progress`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 9, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil))
+        #expect(vm.stopCountText.contains("10 of 10"))
+        #expect(abs(vm.progress - 1.0) < 0.001)
     }
 
-    // No user stop → etaText is nil
-    func test_eta_noUserStop_isNil() {
-        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: 8)
-        expect(vm?.etaText).to(beNil())
+    @Test func `Mid trip progress is proportional`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 4, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil))
+        #expect(abs(vm.progress - 0.5) < 0.001)
     }
 
-    // User stop already passed
-    func test_eta_userStopPassed() {
-        let vm = TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 3, arrivalDepartureMinutes: nil)
-        expect(vm?.etaText).notTo(beNil())
-        expect(vm?.etaText).to(contain("Passed"))
+    @Test func `No user stop omits ETA`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: 8))
+        #expect(vm.etaText == nil)
     }
 
-    // Vehicle at user's stop
-    func test_eta_vehicleAtUserStop() {
-        let vm = TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 5, arrivalDepartureMinutes: 0)
-        expect(vm?.etaText).notTo(beNil())
-        expect(vm?.etaText).to(contain("Arriving now"))
+    @Test func `User stop behind vehicle reads passed`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 3, arrivalDepartureMinutes: nil))
+        #expect(vm.etaText?.contains("Passed") == true)
     }
 
-    // ETA with positive minutes
-    func test_eta_withPositiveMinutes() {
-        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 8)
-        expect(vm?.etaText).notTo(beNil())
-        expect(vm?.etaText).to(contain("8"))
+    @Test func `Vehicle at user stop reads arriving now`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 5, totalStops: 10, userStopIndex: 5, arrivalDepartureMinutes: 0))
+        #expect(vm.etaText?.contains("Arriving now") == true)
     }
 
-    // minutes <= 0 → "Arriving now" fallback
-    func test_eta_zeroMinutes_arrivingNow() {
-        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 0)
-        expect(vm?.etaText).to(contain("Arriving now"))
+    @Test func `Positive minutes shows ETA text`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 8))
+        #expect(vm.etaText?.contains("8") == true)
     }
 
-    // No real-time data (nil minutes) but user stop is ahead → "Arriving now" fallback
-    func test_eta_nilMinutesWithUserStopAhead_arrivingNow() {
-        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: nil)
-        expect(vm?.etaText).to(contain("Arriving now"))
+    @Test func `Positive minutes wins over adjacency`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 4, arrivalDepartureMinutes: 2))
+        #expect(vm.etaText?.contains("2") == true)
     }
 
-    // Negative minutes falls through the same else branch as zero → "Arriving now"
-    func test_eta_negativeMinutes_arrivingNow() {
-        let vm = TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: -3)
-        expect(vm?.etaText).to(contain("Arriving now"))
+    @Test func `Zero minutes at adjacent stop reads arriving now`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 4, arrivalDepartureMinutes: 0))
+        #expect(vm.etaText?.contains("Arriving now") == true)
     }
 
-    // Progress fraction: Stop 5 of 10 → 0.5
-    func test_progress_midTrip() {
-        let vm = TripProgressViewModel(closestStopIndex: 4, totalStops: 10, userStopIndex: nil, arrivalDepartureMinutes: nil)
-        expect(vm?.progress).to(beCloseTo(0.5, within: 0.001))
+    @Test func `Nil minutes at adjacent stop reads arriving now`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 4, arrivalDepartureMinutes: nil))
+        #expect(vm.etaText?.contains("Arriving now") == true)
+    }
+
+    /// A stale prediction (zero or negative minutes) with the vehicle still several
+    /// stops away must not claim "Arriving now" — the ETA is omitted instead.
+    @Test func `Zero minutes far from stop omits ETA`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: 0))
+        #expect(vm.etaText == nil)
+    }
+
+    @Test func `Negative minutes far from stop omits ETA`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: -3))
+        #expect(vm.etaText == nil)
+    }
+
+    @Test func `Nil minutes far from stop omits ETA`() throws {
+        let vm = try #require(TripProgressViewModel(closestStopIndex: 3, totalStops: 10, userStopIndex: 7, arrivalDepartureMinutes: nil))
+        #expect(vm.etaText == nil)
     }
 }


### PR DESCRIPTION
Closes #571 , #444

## Summary

- Add **TripProgressView** to the floating panel header showing "Stop X of Y" with a progress bar and ETA to the user's destination stop
- **Dim past stops** in the stop list using `secondaryLabel` text color so users instantly see where the vehicle is relative to their stop
- **Color-code the spine line** in `TripSegmentView` — gray for past stops, brand color for upcoming stops

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/9a711f92-9daa-41f6-a306-6fb5a8654a75" width="300"/> | <img src="https://github.com/user-attachments/assets/a627a66d-5fdf-4eb6-ad5c-bfd983223821" width="300"/> |


## Changes

### `OBAKit/Trip/TripStopListItem.swift`
- Added `TripStopTemporalState` enum (`.past`, `.current`, `.future`)
- Extended `TripStopViewModel` with `temporalState`, `stopIndex`, `totalStops`; init accepts `closestStopIndex` to compute temporal state
- Updated `hash(into:)` and `==` to include all new fields
- Added `applyTemporalStateStyling()` — past stops use `secondaryLabel` text color (not alpha dimming, which washes out in light mode), current stop uses bold `.headline` font, user destination uses bold
- Added "Passed stop" VoiceOver accessibility label for past stops
- Reset font, textColor, and `temporalState` in `prepareForReuse()`

### `OBAKit/Trip/TripSegmentView.swift`
- Added `temporalState` property and `pastLineColor` computed property (`secondaryLabel` at 40% opacity)
- `drawRegularTripSegment()` draws gray spine line and squircle stroke for past stops, brand color for current/future
- Top line: gray for `.past`/`.current`, brand for `.future`
- Bottom line and squircle stroke: gray for `.past`, brand for `.current`/`.future`

### `OBAKit/Trip/TripFloatingPanelController.swift`
- Added `TripProgressView` (stop count label, ETA label, `UIProgressView`) — `isAccessibilityElement = true` with combined label
- Added `tripProgressWrapper` with readable content guide constraints
- Extracted `closestStopIndex(in:)` helper to avoid duplicate computation between list section and progress view
- Updated `tripStopListSection()` to compute and pass `closestStopIndex`, `stopIndex`, `totalStops` to each `TripStopViewModel`
- Progress view hidden in `.tip` panel state, shown in `.half`/`.full`
- ETA uses `arrivalDeparture.arrivalDepartureMinutes` — the same real-time predicted value displayed in the "Xm" badge at the top of the card
- Three ETA states: "~X min to your stop", "Arriving now", "Passed your stop"
- Progress view hidden entirely when no real-time data (`closestStopID` unavailable)

## Edge cases handled

- No real-time data → all stops show as future, progress bar hidden
- Bus already passed user's stop → shows "Passed your stop"
- Bus at user's stop → shows "Arriving now"
- Bus late (predicted arrival is negative or zero minutes) → shows "Arriving now"
- No `arrivalDeparture` (opened from vehicle view) → shows "Stop X of Y" only, no ETA
- Empty stop times / missing `closestStopID` → progress bar hidden



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a trip progress header showing the current stop count and ETA.
  * Added a visual progress bar to track journey progress.
  * Enhanced stop displays with distinct past, current, and upcoming states.
  * Improved accessibility labels for progress details and passed stops.

* **Tests**
  * Added coverage for progress calculations, ETA messaging, and stop-state classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->