### PR TITLE
fix: Add persistent close button to StopViewController in PanelUI

### DIFF
--- a/OBAKit/PanelUI/Map/VehiclesMapView.swift
+++ b/OBAKit/PanelUI/Map/VehiclesMapView.swift
@@ -65,7 +65,7 @@ struct VehiclesMapView: View {
                     }
                 )
             } else if let stop = selectedStop {
-                StopViewControllerWrapper(
+                PanelStopViewControllerWrapper(
                     application: viewModel.application,
                     stop: stop,
                     onArrivalDepartureTapped: { arrivalDeparture in

--- a/OBAKit/PanelUI/Stops/PanelStopViewControllerWrapper.swift
+++ b/OBAKit/PanelUI/Stops/PanelStopViewControllerWrapper.swift
@@ -16,24 +16,27 @@ struct PanelStopViewControllerWrapper: UIViewControllerRepresentable {
     let application: Application
     let stop: Stop
     var onArrivalDepartureTapped: ((ArrivalDeparture) -> Void)?
-    /// Called when the close button is tapped.
-    var onClose: (() -> Void)?
-
-    @Environment(\.dismiss) private var dismiss
+    var onClose: () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(dismiss: dismiss, onClose: onClose)
+        Coordinator(onClose: onClose)
     }
 
     func makeUIViewController(context: Context) -> UINavigationController {
         let stopVC = StopViewController(application: application, stop: stop)
         stopVC.onArrivalDepartureTapped = onArrivalDepartureTapped
-        stopVC.navigationItem.largeTitleDisplayMode = .always
-        stopVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
+
+        let closeButton = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: context.coordinator,
             action: #selector(Coordinator.close)
         )
+        closeButton.accessibilityLabel = OBALoc(
+            "panel_stop_view_controller_wrapper.close_button.accessibility_label",
+            value: "Close",
+            comment: "Accessibility label for the close button on the stop panel."
+        )
+        stopVC.navigationItem.leftBarButtonItem = closeButton
 
         let navController = UINavigationController(rootViewController: stopVC)
         navController.navigationBar.prefersLargeTitles = true
@@ -42,23 +45,22 @@ struct PanelStopViewControllerWrapper: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        // Refresh callbacks so the coordinator always has the latest closures
+        context.coordinator.onClose = onClose
+        if let stopVC = uiViewController.viewControllers.first as? StopViewController {
+            stopVC.onArrivalDepartureTapped = onArrivalDepartureTapped
+        }
     }
 
     final class Coordinator {
-        let dismiss: DismissAction
-        let onClose: (() -> Void)?
+        var onClose: () -> Void
 
-        init(dismiss: DismissAction, onClose: (() -> Void)?) {
-            self.dismiss = dismiss
+        init(onClose: @escaping () -> Void) {
             self.onClose = onClose
         }
 
         @objc func close() {
-            if let onClose {
-                onClose()
-            } else {
-                dismiss()
-            }
+            onClose()
         }
     }
 }

--- a/OBAKit/PanelUI/Stops/PanelStopViewControllerWrapper.swift
+++ b/OBAKit/PanelUI/Stops/PanelStopViewControllerWrapper.swift
@@ -1,0 +1,64 @@
+//
+//  PanelStopViewControllerWrapper.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import SwiftUI
+import OBAKitCore
+
+///  A PanelUI wrapper around StopViewController with a leading close button.
+struct PanelStopViewControllerWrapper: UIViewControllerRepresentable {
+    let application: Application
+    let stop: Stop
+    var onArrivalDepartureTapped: ((ArrivalDeparture) -> Void)?
+    /// Called when the close button is tapped.
+    var onClose: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(dismiss: dismiss, onClose: onClose)
+    }
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let stopVC = StopViewController(application: application, stop: stop)
+        stopVC.onArrivalDepartureTapped = onArrivalDepartureTapped
+        stopVC.navigationItem.largeTitleDisplayMode = .always
+        stopVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .close,
+            target: context.coordinator,
+            action: #selector(Coordinator.close)
+        )
+
+        let navController = UINavigationController(rootViewController: stopVC)
+        navController.navigationBar.prefersLargeTitles = true
+
+        return navController
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+    }
+
+    final class Coordinator {
+        let dismiss: DismissAction
+        let onClose: (() -> Void)?
+
+        init(dismiss: DismissAction, onClose: (() -> Void)?) {
+            self.dismiss = dismiss
+            self.onClose = onClose
+        }
+
+        @objc func close() {
+            if let onClose {
+                onClose()
+            } else {
+                dismiss()
+            }
+        }
+    }
+}

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -41,8 +41,9 @@ public struct StopViewControllerWrapper: UIViewControllerRepresentable {
         // Configure large title to always be visible
         stopVC.navigationItem.largeTitleDisplayMode = .always
 
-        // Add close button on trailing side
-        stopVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
+        // Add close button on leading side so it remains visible when
+        // StopViewController configures right-side action buttons.
+        stopVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: context.coordinator,
             action: #selector(Coordinator.close)

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -41,9 +41,8 @@ public struct StopViewControllerWrapper: UIViewControllerRepresentable {
         // Configure large title to always be visible
         stopVC.navigationItem.largeTitleDisplayMode = .always
 
-        // Add close button on leading side so it remains visible when
-        // StopViewController configures right-side action buttons.
-        stopVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        // Add close button on trailing side
+        stopVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: context.coordinator,
             action: #selector(Coordinator.close)


### PR DESCRIPTION
## Problem

In the new sheet-based UI (`useNewUI`), tapping a stop opens `StopViewController` with no way to navigate back. The close button added by `StopViewControllerWrapper` was placed on the right side of the navigation bar, but `StopViewController.updateNavigationBarItems()` overwrites `rightBarButtonItems` on data load, removing the close button entirely.

## Fix

Moved the close button to `leftBarButtonItem`, which is never overwritten by `StopViewController`'s internal logic. This ensures users can always return to the Home panel.

## Testing

- Built and ran on physical device with `useNewUI` enabled
- Verified close button persists after stop data loads
- Verified tapping close returns to Home panel correctly