### PR TITLE
Show arrival times in the region's timezone.

### DIFF
--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -132,6 +132,14 @@ public class StopViewController: UIViewController,
                 dataDidReload() // Refresh UI to reflect the change
             }
         }
+
+        updateTimeZone()
+    }
+
+    private func updateTimeZone() {
+        if let timeZone = stop?.routes.first?.agency.regionTimeZone {
+            application.formatters.updateTimeZone(timeZone: timeZone)
+        }
     }
 
     /// Arrival/Departure data for this stop.

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -88,6 +88,10 @@ class TripViewController: UIViewController,
         let appearance = UINavigationBarAppearance()
         appearance.configureWithDefaultBackground()
         navigationItem.scrollEdgeAppearance = appearance
+
+        if let regionTimeZone = tripConvertible.arrivalDeparture?.route.agency.regionTimeZone {
+            application.formatters.updateTimeZone(timeZone: regionTimeZone)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -61,7 +61,9 @@ public class BookmarkDataLoader: NSObject {
             bookmark.isTripBookmark
         else { return }
 
-        Task(priority: .userInitiated) {
+        Task(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+
             do {
                 let stopArrivals = try await apiService.getArrivalsAndDeparturesForStop(id: bookmark.stopID, minutesBefore: 0, minutesAfter: 60).entry
 
@@ -72,6 +74,13 @@ public class BookmarkDataLoader: NSObject {
                     }
 
                     self.delegate?.dataLoaderDidUpdate(self)
+
+                    // All bookmarks belong to the user's currently selected region, so every
+                    // concurrent load here resolves to the same agency timezone. Writing it
+                    // multiple times is harmless — each write is an identical value.
+                    if let regionTimeZone = stopArrivals.stop.routes.first?.agency.regionTimeZone {
+                        self.application.formatters.updateTimeZone(timeZone: regionTimeZone)
+                    }
                 }
             } catch {
                 await self.application.displayError(error)

--- a/OBAKitCore/Extensions/TimeZone.swift
+++ b/OBAKitCore/Extensions/TimeZone.swift
@@ -1,0 +1,21 @@
+//
+//  TimeZone.swift
+//  OBAKit
+//
+//  Created by Mohamed Sliem on 11/03/2026.
+//
+
+import Foundation
+
+public extension TimeZone {
+    /// A short, English abbreviation for this time zone when it differs from the user's current time zone.
+    ///
+    /// Returns the time zone's localized "short generic" name (for example, "PT" or "ET") using the `en_US` locale.
+    /// If this time zone has the same GMT offset as the device's current time zone, `nil` is returned so callers
+    /// can omit redundant information.
+    var timeZoneAbbreviation: String? {
+        guard TimeZone.current.secondsFromGMT(for: Date.now) != self.secondsFromGMT(for: Date.now) else { return nil }
+        return self.localizedName(for: .shortGeneric, locale: Locale(identifier: "en_US"))
+    }
+}
+

--- a/OBAKitCore/Models/REST/References/Agency.swift
+++ b/OBAKitCore/Models/REST/References/Agency.swift
@@ -81,4 +81,18 @@ public class Agency: NSObject, Identifiable, Codable {
         guard let cleaned = cleanedPhoneNumber() else { return nil }
         return URL(string: "tel://\(cleaned)")
     }
+
+    /// Returns this agency's time zone as a `TimeZone`, if the `timeZone` identifier is valid.
+    ///
+    /// The agency's raw `timeZone` property is an IANA time zone identifier (e.g., "America/Los_Angeles").
+    /// If the identifier is empty or cannot be resolved, this property returns `nil` instead of falling back
+    /// to the device's current time zone.
+    public var regionTimeZone: TimeZone? {
+        guard !timeZone.isEmpty,
+              let resolvedTimeZone = TimeZone(identifier: timeZone)
+        else { return nil }
+
+        return resolvedTimeZone
+    }
+
 }

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -15,6 +15,12 @@ public class Formatters: NSObject {
     private let themeColors: ThemeColors
     private let calendar: Calendar
 
+    private var timeZone: TimeZone? {
+        didSet {
+            timeFormatter = makeTimeFormatter()
+        }
+    }
+
     /// Creates a new `Formatters` object that will use the provided `Calendar` and `Locale` for locale-specific customization.
     ///
     /// - Note: You probably should pass in the `autoupdatingCurrent` instances of `Locale` and `Calendar` to this method.
@@ -36,6 +42,15 @@ public class Formatters: NSObject {
     }()
 
     // MARK: - Formatted Times
+
+    /// Updates the timezone used when formatting times.
+    ///
+    /// `Formatters` is created once by `Application` and shared across all view controllers,
+    /// so reassigning `timeFormatter` here is immediately reflected everywhere — no caller
+    /// caches the underlying `DateFormatter` directly.
+    public func updateTimeZone(timeZone: TimeZone?) {
+        self.timeZone = timeZone
+    }
 
     /// Returns a representation of `date` that varies depending on whether `date` happens to be from today or another day.
     ///
@@ -61,15 +76,7 @@ public class Formatters: NSObject {
         return formatter
     }()
 
-    /// Converts a date into a human-readable time string that conforms to the user's locale.
-    public lazy var timeFormatter: DateFormatter = {
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateStyle = .none
-        timeFormatter.timeStyle = .short
-        timeFormatter.locale = locale
-
-        return timeFormatter
-    }()
+    public lazy var timeFormatter: DateFormatter = makeTimeFormatter()
 
     public lazy var dateIntervalFormatter: DateIntervalFormatter = {
         let formatter = DateIntervalFormatter()
@@ -105,6 +112,24 @@ public class Formatters: NSObject {
         formatter.unitsStyle = .full
         return formatter
     }()
+
+    /// Converts a date into a human-readable time string that conforms to the user's locale.
+    private func makeTimeFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.locale = locale
+        formatter.timeZone = timeZone ?? .current
+
+        if let abbreviation = timeZone?.timeZoneAbbreviation {
+            let timeFormatTemplate = DateFormatter.dateFormat(fromTemplate: "jm", options: 0, locale: locale) ?? "h:mm a"
+            formatter.dateFormat = "\(timeFormatTemplate) '\(abbreviation)'"
+        } else {
+            formatter.setLocalizedDateFormatFromTemplate("jm")
+        }
+
+        return formatter
+    }
 
     // MARK: - ArrivalDeparture
     // MARK: Full attributed explanation
@@ -696,3 +721,4 @@ public class Formatters: NSObject {
         return String(format: fmt, region.name)
     }
 }
+


### PR DESCRIPTION
## Summary

Closes #332

When a user's device timezone differs from the transit agency's timezone,
arrival and departure times now display with the agency's timezone
abbreviation (e.g. "3:45 PM ET"), so users travelling across regions
always see times in the correct local context.

## Changes

- **`Agency+regionTimeZone`** — new computed property that safely resolves
  the agency's raw IANA timezone string into a `TimeZone`, returning `nil`
  if empty or invalid
- **`TimeZone+timeZoneAbbreviation`** — new extension that returns a short
  label (e.g. "PT", "ET") only when the agency timezone differs from the
  device's current timezone, suppressing redundant labels
- **`Formatters.updateTimeZone(_:)`** — new method to update the shared
  formatter's timezone; backed by `makeTimeFormatter()` which appends the
  abbreviation to the format string when needed
- **`StopViewController`**, **`TripViewController`**, **`BookmarkDataLoader`**
  — each calls `updateTimeZone` once agency data is available
  
## Screenshots 
<img width="170" height="360" alt="Simulator Screenshot - iPhone 16 - 2026-03-15 at 01 35 21" src="https://github.com/user-attachments/assets/6786ed69-80a1-42d5-84d3-ab9c28ef8c39" />
<img width="170" height="360" alt="Simulator Screenshot - iPhone 16 - 2026-03-15 at 01 35 16" src="https://github.com/user-attachments/assets/a5b4fa5c-b824-431a-9b96-b72d314349cc" />
<img width="170" height="360" alt="Simulator Screenshot - iPhone 16 - 2026-03-15 at 01 35 08" src="https://github.com/user-attachments/assets/8c71e990-f9db-43ba-86a5-11e7615917e4" />

## Test

- [x] Open a stop in local timezone — times show without abbreviation
- [x] Open a stop in a different timezone — times show with abbreviation (e.g. "3:45 PM PT")
- [x] Open the Trip view — times reflect the region's timezone
- [x] Open Bookmarks — times reflect the region's timezone