### PR TITLE
feat: Maps-style sheet-based UI — replace tab bar with persistent bottom sheet

### DIFF
--- a/Apps/KiedyBus/AppDelegate.m
+++ b/Apps/KiedyBus/AppDelegate.m
@@ -14,7 +14,7 @@
 @interface AppDelegate ()<OBAApplicationDelegate>
 @property(nonatomic,strong) OBAApplication *app;
 @property(nonatomic,strong) NSUserDefaults *userDefaults;
-@property(nonatomic,strong) OBAClassicApplicationRootController *rootController;
+@property(nonatomic,strong) OBAMapsStyleRootController *rootController;
 @end
 
 @implementation AppDelegate
@@ -85,7 +85,7 @@
 }
 
 - (void)applicationReloadRootInterface:(OBAApplication*)application {
-    self.rootController = [[OBAClassicApplicationRootController alloc] initWithApplication:application];
+    self.rootController = [[OBAMapsStyleRootController alloc] initWithApplication:application];
     self.window.rootViewController = self.rootController;
 }
 

--- a/Apps/OneBusAway/AppDelegate.m
+++ b/Apps/OneBusAway/AppDelegate.m
@@ -16,7 +16,7 @@
 @interface AppDelegate ()<OBAApplicationDelegate>
 @property(nonatomic,strong) OBAApplication *app;
 @property(nonatomic,strong) NSUserDefaults *userDefaults;
-@property(nonatomic,strong) OBAClassicApplicationRootController *rootController;
+@property(nonatomic,strong) OBAMapsStyleRootController *rootController;
 @property(nonatomic,strong) OBAAnalyticsOrchestrator *analyticsClient;
 @property(nonatomic,strong) OBACloudPushService *pushService;
 @end
@@ -111,7 +111,7 @@
 
 - (void)applicationReloadRootInterface:(OBAApplication*)application {
     void(^showRootController)(void) = ^{
-        self.rootController = [[OBAClassicApplicationRootController alloc] initWithApplication:application];
+        self.rootController = [[OBAMapsStyleRootController alloc] initWithApplication:application];
         self.window.rootViewController = self.rootController;
     };
 

--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -74,7 +74,7 @@ public class ClassicApplicationRootController: UITabBarController {
         application.userDataStore.lastSelectedView = selectedTab
     }
 
-    func navigate(to destination: Page) {
+    public func navigate(to destination: Page) {
         navigationController?.popToViewController(self, animated: true)
         selectedIndex = destination.rawValue
     }

--- a/OBAKit/ClassicUI/MapBottomSheetViewController.swift
+++ b/OBAKit/ClassicUI/MapBottomSheetViewController.swift
@@ -1,0 +1,546 @@
+//
+//  MapBottomSheetViewController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+import MapKit
+import SwiftUI
+
+// MARK: - Delegate
+
+protocol MapBottomSheetDelegate: AnyObject {
+    func mapBottomSheetDidTapRecent(_ sheet: MapBottomSheetViewController)
+    func mapBottomSheetDidTapBookmarks(_ sheet: MapBottomSheetViewController)
+    func mapBottomSheetDidTapMore(_ sheet: MapBottomSheetViewController)
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSubmitSearch request: SearchRequest)
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSelectMapItem mapItem: MKMapItem)
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSelectStop stop: Stop)
+    func mapBottomSheetDidCancelSearch(_ sheet: MapBottomSheetViewController)
+}
+
+// MARK: - MapBottomSheetViewController
+
+/// Apple Maps-style persistent bottom sheet.
+///
+/// Default state — pill (🔍 placeholder 🎤) + ☰ circle
+/// Search state  — same pill but with live UITextField + ☰ becomes cancel
+///                 + results table below (recent searches, quick search, placemarks)
+final class MapBottomSheetViewController: UIViewController {
+
+    // MARK: - Public
+
+    weak var delegate: MapBottomSheetDelegate?
+    var onSearchBecameActive: (() -> Void)?
+    var onDetailShown: (() -> Void)?
+
+    func setGrabHandleVisible(_ visible: Bool) {
+        grabHandle.isHidden = !visible
+    }
+
+    // MARK: - Private
+
+    private let application: Application
+    private var isInSearchMode = false
+
+    // MARK: - Shared pill container (used in both states)
+
+    private lazy var pillBlur: UIVisualEffectView = {
+        let effect: UIVisualEffect
+        if #available(iOS 26.0, *) {
+            effect = UIGlassEffect()
+        } else {
+            effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        }
+        let blur = UIVisualEffectView(effect: effect)
+        blur.translatesAutoresizingMaskIntoConstraints = false
+        blur.layer.cornerRadius = 20
+        blur.layer.cornerCurve = .continuous
+        blur.clipsToBounds = true
+        let tap = UITapGestureRecognizer(target: self, action: #selector(pillTapped))
+        tap.cancelsTouchesInView = false
+        blur.addGestureRecognizer(tap)
+        blur.isUserInteractionEnabled = true
+        return blur
+    }()
+
+    // Search icon — always visible inside the pill
+    private lazy var searchIcon: UIImageView = {
+        let iv = UIImageView(image: UIImage(systemName: "magnifyingglass"))
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        iv.tintColor = .secondaryLabel
+        iv.contentMode = .scaleAspectFit
+        iv.setContentHuggingPriority(.required, for: .horizontal)
+        return iv
+    }()
+
+    // Placeholder label — visible in default state
+    private lazy var placeholderLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.textColor = .secondaryLabel
+        l.font = UIFont.preferredFont(forTextStyle: .body)
+        l.adjustsFontForContentSizeCategory = true
+        return l
+    }()
+
+    // Live text field — visible in search state, same font/color as placeholder
+    private lazy var searchTextField: UITextField = {
+        let tf = UITextField()
+        tf.translatesAutoresizingMaskIntoConstraints = false
+        tf.font = UIFont.preferredFont(forTextStyle: .body)
+        tf.textColor = .label
+        tf.returnKeyType = .search
+        tf.clearButtonMode = .always
+        tf.delegate = self
+        tf.isHidden = true
+        tf.addTarget(self, action: #selector(searchTextChanged), for: .editingChanged)
+        return tf
+    }()
+
+    // Mic button — kept as property but not shown
+    private lazy var micButton: UIButton = {
+        let btn = UIButton(type: .system)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+
+    // MARK: - Right-side button (☰ default / cancel in search)
+
+    private lazy var rightButton: UIButton = {
+        let btn = UIButton(type: .system)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.setImage(UIImage(systemName: "line.3.horizontal"), for: .normal)
+        btn.tintColor = .label
+        btn.menu = makeNavigationMenu()
+        btn.showsMenuAsPrimaryAction = true
+        btn.accessibilityLabel = OBALoc(
+            "map_controller.menu_button.accessibility_label",
+            value: "Navigation menu",
+            comment: "Accessibility label for the navigation menu button."
+        )
+        return btn
+    }()
+
+    private lazy var rightButtonContainer: UIVisualEffectView = {
+        let effect: UIVisualEffect
+        if #available(iOS 26.0, *) {
+            effect = UIGlassEffect()
+        } else {
+            effect = UIBlurEffect(style: .systemUltraThinMaterial)
+        }
+        let blur = UIVisualEffectView(effect: effect)
+        blur.translatesAutoresizingMaskIntoConstraints = false
+        blur.layer.cornerRadius = 20
+        blur.layer.cornerCurve = .circular
+        blur.clipsToBounds = true
+        blur.contentView.addSubview(rightButton)
+        NSLayoutConstraint.activate([
+            rightButton.topAnchor.constraint(equalTo: blur.contentView.topAnchor),
+            rightButton.bottomAnchor.constraint(equalTo: blur.contentView.bottomAnchor),
+            rightButton.leadingAnchor.constraint(equalTo: blur.contentView.leadingAnchor),
+            rightButton.trailingAnchor.constraint(equalTo: blur.contentView.trailingAnchor)
+        ])
+        return blur
+    }()
+
+    private lazy var grabHandle: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.backgroundColor = UIColor.tertiaryLabel
+        v.layer.cornerRadius = 2.5
+        v.clipsToBounds = true
+        v.isAccessibilityElement = false
+        return v
+    }()
+
+    // MARK: - Results table (search mode only)
+
+    private lazy var resultsTable: UITableView = {
+        let tv = UITableView(frame: .zero, style: .insetGrouped)
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        tv.dataSource = self
+        tv.delegate = self
+        tv.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tv.backgroundColor = .clear
+        tv.isHidden = true
+        tv.keyboardDismissMode = .onDrag
+        return tv
+    }()
+
+    // Detail view container — shown when a map item is selected
+    private lazy var detailContainer: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.isHidden = true
+        return v
+    }()
+
+    private var embeddedDetailVC: UIViewController?
+
+    // MARK: - Search data
+
+    private lazy var searchInteractor = SearchInteractor(application: application, delegate: self)
+    private var searchSections: [OBAListViewSection] = []
+
+    // MARK: - Init
+
+    init(application: Application) {
+        self.application = application
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        // Build pill content: [🔍] [placeholder / textfield]
+        let pillRow = UIStackView(arrangedSubviews: [searchIcon, placeholderLabel, searchTextField])
+        pillRow.translatesAutoresizingMaskIntoConstraints = false
+        pillRow.axis = .horizontal
+        pillRow.spacing = 10
+        pillRow.alignment = .center
+        pillBlur.contentView.addSubview(pillRow)
+
+        NSLayoutConstraint.activate([
+            pillRow.topAnchor.constraint(equalTo: pillBlur.contentView.topAnchor),
+            pillRow.bottomAnchor.constraint(equalTo: pillBlur.contentView.bottomAnchor),
+            pillRow.leadingAnchor.constraint(equalTo: pillBlur.contentView.leadingAnchor, constant: 14),
+            pillRow.trailingAnchor.constraint(equalTo: pillBlur.contentView.trailingAnchor, constant: -12),
+            searchIcon.widthAnchor.constraint(equalToConstant: 17),
+            searchIcon.heightAnchor.constraint(equalToConstant: 17)
+        ])
+
+        view.addSubview(grabHandle)
+        view.addSubview(rightButtonContainer)
+        view.addSubview(pillBlur)
+        view.addSubview(resultsTable)
+        view.addSubview(detailContainer)
+
+        NSLayoutConstraint.activate([
+            grabHandle.topAnchor.constraint(equalTo: view.topAnchor, constant: 6),
+            grabHandle.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            grabHandle.widthAnchor.constraint(equalToConstant: 36),
+            grabHandle.heightAnchor.constraint(equalToConstant: 5),
+
+            rightButtonContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            rightButtonContainer.topAnchor.constraint(equalTo: grabHandle.bottomAnchor, constant: 6),
+            rightButtonContainer.widthAnchor.constraint(equalToConstant: 40),
+            rightButtonContainer.heightAnchor.constraint(equalToConstant: 40),
+
+            pillBlur.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            pillBlur.trailingAnchor.constraint(equalTo: rightButtonContainer.leadingAnchor, constant: -8),
+            pillBlur.centerYAnchor.constraint(equalTo: rightButtonContainer.centerYAnchor),
+            pillBlur.heightAnchor.constraint(equalToConstant: 40),
+
+            resultsTable.topAnchor.constraint(equalTo: pillBlur.bottomAnchor, constant: 8),
+            resultsTable.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            resultsTable.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            resultsTable.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            detailContainer.topAnchor.constraint(equalTo: pillBlur.bottomAnchor, constant: 8),
+            detailContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            detailContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            detailContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        updateSearchPlaceholder()
+        application.regionsService.addDelegate(self)
+    }
+
+    deinit {
+        application.regionsService.removeDelegate(self)
+    }
+
+    // MARK: - Search mode transitions
+
+    @objc private func pillTapped() {
+        guard !isInSearchMode else { return }
+        enterSearchMode()
+    }
+
+    func enterSearchMode() {
+        guard !isInSearchMode else { return }
+        isInSearchMode = true
+
+        // Swap placeholder → text field
+        placeholderLabel.isHidden = true
+        searchTextField.isHidden = false
+        searchTextField.text = ""
+
+        // ☰ stays as-is — clear is handled by the text field's built-in X button
+        // No changes to rightButton
+
+        // Load recent searches immediately
+        reloadSearchResults(text: "")
+        resultsTable.isHidden = false
+
+        DispatchQueue.main.async {
+            self.searchTextField.becomeFirstResponder()
+            self.onSearchBecameActive?()
+        }
+    }
+
+    func exitSearchMode() {
+        guard isInSearchMode else { return }
+        isInSearchMode = false
+
+        searchTextField.resignFirstResponder()
+        searchTextField.text = ""
+        searchTextField.isHidden = true
+        resultsTable.isHidden = true
+        searchSections = []
+
+        placeholderLabel.isHidden = false
+    }
+
+    // MARK: - Map item detail (inline, no separate sheet)
+
+    func showMapItemDetail(_ mapItem: MKMapItem) {
+        // Remove any existing detail VC
+        embeddedDetailVC?.willMove(toParent: nil)
+        embeddedDetailVC?.view.removeFromSuperview()
+        embeddedDetailVC?.removeFromParent()
+        embeddedDetailVC = nil
+
+        let vm = MapItemViewModel(
+            mapItem: mapItem,
+            application: application,
+            delegate: self,
+            removePinHandler: nil,
+            planTripHandler: {}
+        )
+        let detailVC = MapItemViewController(vm)
+
+        addChild(detailVC)
+        detailVC.view.translatesAutoresizingMaskIntoConstraints = false
+        detailContainer.addSubview(detailVC.view)
+        NSLayoutConstraint.activate([
+            detailVC.view.topAnchor.constraint(equalTo: detailContainer.topAnchor),
+            detailVC.view.leadingAnchor.constraint(equalTo: detailContainer.leadingAnchor),
+            detailVC.view.trailingAnchor.constraint(equalTo: detailContainer.trailingAnchor),
+            detailVC.view.bottomAnchor.constraint(equalTo: detailContainer.bottomAnchor)
+        ])
+        detailVC.didMove(toParent: self)
+        embeddedDetailVC = detailVC
+
+        // Hide search results, show detail
+        resultsTable.isHidden = true
+        detailContainer.isHidden = false
+    }
+
+    @objc private func dismissDetail() {
+        embeddedDetailVC?.willMove(toParent: nil)
+        embeddedDetailVC?.view.removeFromSuperview()
+        embeddedDetailVC?.removeFromParent()
+        embeddedDetailVC = nil
+        detailContainer.isHidden = true
+
+        if isInSearchMode {
+            resultsTable.isHidden = false
+            onSearchBecameActive?()  // snap back to medium
+        }
+    }
+
+    @objc private func searchTextChanged() {
+        reloadSearchResults(text: searchTextField.text ?? "")
+    }
+
+    private func reloadSearchResults(text: String) {
+        let sections = searchInteractor.searchModeObjects(text: text)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.searchSections = sections
+            self.resultsTable.reloadData()
+        }
+    }
+
+    // MARK: - Navigation menu
+
+    private func makeNavigationMenu() -> UIMenu {
+        let recentAction = UIAction(
+            title: OBALoc("recent_stops_controller.title", value: "Recent", comment: ""),
+            image: Icons.recentTabIcon
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.mapBottomSheetDidTapRecent(self)
+        }
+        let bookmarksAction = UIAction(
+            title: OBALoc("bookmarks_controller.title", value: "Bookmarks", comment: ""),
+            image: Icons.bookmarksTabIcon
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.mapBottomSheetDidTapBookmarks(self)
+        }
+        let moreAction = UIAction(
+            title: OBALoc("more_controller.title", value: "More", comment: ""),
+            image: Icons.moreTabIcon
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.mapBottomSheetDidTapMore(self)
+        }
+        return UIMenu(children: [recentAction, bookmarksAction, moreAction])
+    }
+
+    // MARK: - Placeholder
+
+    func updateSearchPlaceholder() {
+        let text: String
+        if application.features.tripPlanning == .running {
+            text = OBALoc("map_floating_panel.where_are_you_going", value: "Where are you going?", comment: "")
+        } else if let region = application.regionsService.currentRegion {
+            text = Formatters.searchPlaceholderText(region: region)
+        } else {
+            text = OBALoc("map_floating_panel.search_prompt", value: "Search stops, routes, addresses", comment: "")
+        }
+        placeholderLabel.text = text
+        searchTextField.placeholder = text
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension MapBottomSheetViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let text = textField.text, !text.isEmpty else { return false }
+        textField.resignFirstResponder()
+        delegate?.mapBottomSheet(self, didSubmitSearch: SearchRequest(query: text, type: .address))
+        return true
+    }
+
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        // If field is already empty, X acts as cancel to exit search mode
+        if textField.text?.isEmpty == true {
+            exitSearchMode()
+            delegate?.mapBottomSheetDidCancelSearch(self)
+            return false
+        }
+        // Otherwise just clear the text and reload empty results
+        reloadSearchResults(text: "")
+        return true
+    }
+}
+
+// MARK: - SearchDelegate
+
+extension MapBottomSheetViewController: SearchDelegate {
+    var isVehicleSearchAvailable: Bool {
+        application.features.obaco == .running
+    }
+
+    func performSearch(request: SearchRequest) {
+        searchTextField.resignFirstResponder()
+        delegate?.mapBottomSheet(self, didSubmitSearch: request)
+    }
+
+    func showMapItem(_ mapItem: MKMapItem) {
+        application.userDataStore.addRecentMapItem(mapItem)
+        searchTextField.resignFirstResponder()
+        delegate?.mapBottomSheet(self, didSelectMapItem: mapItem)
+        showMapItemDetail(mapItem)
+        onDetailShown?()
+    }
+
+    func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) {
+        delegate?.mapBottomSheet(self, didSelectStop: stop)
+        // Don't exit search mode — let the stop VC push onto the nav stack
+    }
+
+    func searchInteractorNewResultsAvailable(_ searchInteractor: SearchInteractor) {
+        reloadSearchResults(text: searchTextField.text ?? "")
+    }
+
+    func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) {
+        let alert = UIAlertController.deletionAlert(title: Strings.clearRecentSearchesConfirmation) { [weak self] _ in
+            self?.application.userDataStore.deleteAllRecentMapItems()
+            self?.reloadSearchResults(text: self?.searchTextField.text ?? "")
+        }
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource & Delegate
+
+extension MapBottomSheetViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        searchSections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard section < searchSections.count else { return 0 }
+        return searchSections[section].contents.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard section < searchSections.count else { return nil }
+        return searchSections[section].title
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        guard indexPath.section < searchSections.count,
+              indexPath.row < searchSections[indexPath.section].contents.count else {
+            return cell
+        }
+
+        let item = searchSections[indexPath.section].contents[indexPath.row]
+        var config = cell.defaultContentConfiguration()
+
+        if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
+            switch vm.title {
+            case .string(let s):     config.text = s
+            case .attributed(let a): config.attributedText = a
+            }
+            config.image = vm.image
+            cell.accessoryType = vm.accessoryType == .disclosureIndicator ? .disclosureIndicator : .none
+        } else if let vm = item.as(SearchPlacemarkViewModel.self) {
+            config.text = vm.mapItem.name
+            config.secondaryText = vm.mapItem.placemark.title
+            config.image = UIImage(systemName: "mappin.circle.fill")
+            cell.accessoryType = .disclosureIndicator
+        }
+
+        cell.contentConfiguration = config
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section < searchSections.count,
+              indexPath.row < searchSections[indexPath.section].contents.count else { return }
+
+        let item = searchSections[indexPath.section].contents[indexPath.row]
+
+        if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
+            vm.onSelectAction?(vm)
+        } else if let vm = item.as(SearchPlacemarkViewModel.self) {
+            vm.onSelectAction?(vm)
+        }
+    }
+}
+
+// MARK: - ModalDelegate
+
+extension MapBottomSheetViewController: ModalDelegate {
+    public func dismissModalController(_ controller: UIViewController) {
+        dismissDetail()
+    }
+}
+
+// MARK: - RegionsServiceDelegate
+
+extension MapBottomSheetViewController: RegionsServiceDelegate {
+    func regionsService(_ service: RegionsService, updatedRegion region: Region) {
+        updateSearchPlaceholder()
+    }
+}

--- a/OBAKit/ClassicUI/MapBottomSheetViewController.swift
+++ b/OBAKit/ClassicUI/MapBottomSheetViewController.swift
@@ -186,7 +186,7 @@ final class MapBottomSheetViewController: UIViewController {
     // MARK: - Search data
 
     private lazy var searchInteractor = SearchInteractor(application: application, delegate: self)
-    private var searchSections: [OBAListViewSection] = []
+    private var searchSections: [SearchListSection] = []
 
     // MARK: - Init
 
@@ -356,10 +356,10 @@ final class MapBottomSheetViewController: UIViewController {
     }
 
     private func reloadSearchResults(text: String) {
-        let sections = searchInteractor.searchModeObjects(text: text)
+        searchInteractor.searchModeObjects(text: text)
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.searchSections = sections
+            self.searchSections = self.searchInteractor.sections
             self.resultsTable.reloadData()
         }
     }
@@ -478,7 +478,7 @@ extension MapBottomSheetViewController: UITableViewDataSource, UITableViewDelega
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard section < searchSections.count else { return 0 }
-        return searchSections[section].contents.count
+        return searchSections[section].content.count
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -489,27 +489,30 @@ extension MapBottomSheetViewController: UITableViewDataSource, UITableViewDelega
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         guard indexPath.section < searchSections.count,
-              indexPath.row < searchSections[indexPath.section].contents.count else {
+              indexPath.row < searchSections[indexPath.section].content.count else {
             return cell
         }
 
-        let item = searchSections[indexPath.section].contents[indexPath.row]
+        let row = searchSections[indexPath.section].content[indexPath.row]
         var config = cell.defaultContentConfiguration()
 
-        if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
-            switch vm.title {
-            case .string(let s):     config.text = s
-            case .attributed(let a): config.attributedText = a
-            }
-            config.image = vm.image
-            cell.accessoryType = vm.accessoryType == .disclosureIndicator ? .disclosureIndicator : .none
-        } else if let vm = item.as(SearchPlacemarkViewModel.self) {
-            config.text = vm.mapItem.name
-            config.secondaryText = vm.mapItem.placemark.title
-            config.image = UIImage(systemName: "mappin.circle.fill")
-            cell.accessoryType = .disclosureIndicator
+        if let attributed = row.attributedTitle {
+            config.attributedText = attributed
+        } else {
+            config.text = row.title
+        }
+        config.secondaryText = row.subtitle
+
+        switch row.icon {
+        case .system(let name):
+            config.image = UIImage(systemName: name)
+        case .uiImage(let image):
+            config.image = image
+        case nil:
+            config.image = nil
         }
 
+        cell.accessoryType = row.accessory == .disclosureIndicator ? .disclosureIndicator : .none
         cell.contentConfiguration = config
         return cell
     }
@@ -517,15 +520,10 @@ extension MapBottomSheetViewController: UITableViewDataSource, UITableViewDelega
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         guard indexPath.section < searchSections.count,
-              indexPath.row < searchSections[indexPath.section].contents.count else { return }
+              indexPath.row < searchSections[indexPath.section].content.count else { return }
 
-        let item = searchSections[indexPath.section].contents[indexPath.row]
-
-        if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
-            vm.onSelectAction?(vm)
-        } else if let vm = item.as(SearchPlacemarkViewModel.self) {
-            vm.onSelectAction?(vm)
-        }
+        let row = searchSections[indexPath.section].content[indexPath.row]
+        row.action?()
     }
 }
 

--- a/OBAKit/ClassicUI/MapBottomSheetViewController.swift
+++ b/OBAKit/ClassicUI/MapBottomSheetViewController.swift
@@ -46,7 +46,7 @@ final class MapBottomSheetViewController: UIViewController {
     // MARK: - Private
 
     private let application: Application
-    private var isInSearchMode = false
+    private(set) var isInSearchMode = false
 
     // MARK: - Shared pill container (used in both states)
 
@@ -201,7 +201,7 @@ final class MapBottomSheetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .clear
 
         // Build pill content: [🔍] [placeholder / textfield]
         let pillRow = UIStackView(arrangedSubviews: [searchIcon, placeholderLabel, searchTextField])
@@ -265,10 +265,10 @@ final class MapBottomSheetViewController: UIViewController {
 
     @objc private func pillTapped() {
         guard !isInSearchMode else { return }
-        enterSearchMode()
+        enterSearchMode(focusTextField: true)
     }
 
-    func enterSearchMode() {
+    func enterSearchMode(focusTextField: Bool = true) {
         guard !isInSearchMode else { return }
         isInSearchMode = true
 
@@ -277,16 +277,15 @@ final class MapBottomSheetViewController: UIViewController {
         searchTextField.isHidden = false
         searchTextField.text = ""
 
-        // ☰ stays as-is — clear is handled by the text field's built-in X button
-        // No changes to rightButton
-
         // Load recent searches immediately
         reloadSearchResults(text: "")
         resultsTable.isHidden = false
 
-        DispatchQueue.main.async {
-            self.searchTextField.becomeFirstResponder()
-            self.onSearchBecameActive?()
+        if focusTextField {
+            DispatchQueue.main.async {
+                self.searchTextField.becomeFirstResponder()
+                self.onSearchBecameActive?()
+            }
         }
     }
 

--- a/OBAKit/ClassicUI/MapsStyleRootController.swift
+++ b/OBAKit/ClassicUI/MapsStyleRootController.swift
@@ -1,0 +1,310 @@
+//
+//  MapsStyleRootController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import MapKit
+import OBAKitCore
+
+// MARK: - Protocol
+
+/// Abstracts the root controller so ViewRouter works with both
+/// ClassicApplicationRootController and MapsStyleRootController.
+@MainActor
+public protocol ApplicationRootController: UIViewController {
+    func navigate(to destination: ClassicApplicationRootController.Page)
+}
+
+// MARK: - MapsStyleRootController
+
+/// A Maps-style root controller where the map fills the entire screen and a
+/// persistent bottom sheet (Apple Maps style) floats above it.
+///
+/// Sheet detents:
+///   - compact  (~90pt)  — grab handle + search pill only, map fully interactive
+///   - medium   (~50%)   — search pill + scrollable bookmarks/recent content
+///   - large    (full)   — full-screen content
+@objc(OBAMapsStyleRootController)
+public class MapsStyleRootController: UIViewController, ApplicationRootController {
+
+    // MARK: - Child controllers
+
+    let mapController: MapViewController
+    let moreController: MoreViewController
+
+    private let application: Application
+
+    /// The persistent Apple Maps-style bottom sheet.
+    private lazy var bottomSheet = MapBottomSheetViewController(application: application)
+    /// Nav controller wrapping the bottom sheet so embedded VCs can push onto it.
+    private lazy var bottomSheetNav: UINavigationController = {
+        let nav = UINavigationController(rootViewController: bottomSheet)
+        nav.setNavigationBarHidden(true, animated: false)
+        nav.delegate = self
+        return nav
+    }()
+
+    // MARK: - Compact detent height
+    // grab handle (5) + gaps (6+6) + search pill (40) + bottom safe area padding = ~75pt
+    private static let compactDetentHeight: CGFloat = 75
+    private static let compactDetentID = UISheetPresentationController.Detent.Identifier("compact")
+
+    // MARK: - Init
+
+    @objc public init(application: Application) {
+        self.application = application
+        self.mapController = MapViewController(application: application)
+        self.moreController = MoreViewController(application: application)
+
+        super.init(nibName: nil, bundle: nil)
+
+        application.viewRouter.rootController = self
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: - UIViewController
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        embedMapController()
+        presentBottomSheet()
+
+        // When search results are shown on the map, exit search mode in the sheet.
+        mapController.onSearchDismissed = { [weak self] in
+            self?.bottomSheet.exitSearchMode()
+            self?.snapSheetToCompact(animated: true)
+        }
+
+        // When searchManager returns a map item in mapsStyleMode, show it inline in the sheet.
+        mapController.onSearchMapItem = { [weak self] mapItem in
+            guard let self else { return }
+            self.bottomSheet.showMapItemDetail(mapItem)
+            if let sheet = self.bottomSheetNav.sheetPresentationController {
+                sheet.animateChanges { sheet.selectedDetentIdentifier = .medium }
+            }
+        }
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if bottomSheetNav.presentingViewController == nil {
+            presentBottomSheet()
+        }
+    }
+
+    // MARK: - Map embedding
+
+    private func embedMapController() {
+        mapController.hideFloatingPanelSearchBar()
+        mapController.mapsStyleMode = true
+
+        let mapNav = application.viewRouter.buildNavigation(
+            controller: mapController,
+            prefersLargeTitles: false
+        )
+        addChild(mapNav)
+        view.addSubview(mapNav.view)
+        mapNav.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            mapNav.view.topAnchor.constraint(equalTo: view.topAnchor),
+            mapNav.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapNav.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mapNav.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        mapNav.didMove(toParent: self)
+        mapController.navigationItem.leftBarButtonItem = nil
+        mapController.navigationItem.rightBarButtonItem = nil
+
+        // Reserve space at the bottom so map controls (scale, legal) stay above the sheet.
+        mapController.additionalSafeAreaInsets = UIEdgeInsets(
+            top: 0, left: 0,
+            bottom: Self.compactDetentHeight + 8,  // +8 for the sheet's floating gap above safe area
+            right: 0
+        )
+    }
+
+    // MARK: - Bottom sheet presentation
+
+    private func presentBottomSheet() {
+        bottomSheet.delegate = self
+        bottomSheetNav.isModalInPresentation = true
+        bottomSheetNav.modalPresentationStyle = .pageSheet
+
+        bottomSheet.onSearchBecameActive = { [weak self] in
+            guard let self, let sheet = self.bottomSheetNav.sheetPresentationController else { return }
+            sheet.animateChanges { sheet.selectedDetentIdentifier = .medium }
+        }
+
+        bottomSheet.onDetailShown = { [weak self] in
+            guard let self, let sheet = self.bottomSheetNav.sheetPresentationController else { return }
+            sheet.animateChanges { sheet.selectedDetentIdentifier = .medium }
+        }
+
+        if let sheet = bottomSheetNav.sheetPresentationController {
+            configureSheetDetents(sheet)
+        }
+
+        present(bottomSheetNav, animated: false)
+    }
+
+    private func configureSheetDetents(_ sheet: UISheetPresentationController) {
+        let compactDetent = UISheetPresentationController.Detent.custom(
+            identifier: Self.compactDetentID
+        ) { _ in
+            MapsStyleRootController.compactDetentHeight
+        }
+
+        sheet.detents = [compactDetent, .medium(), .large()]
+        sheet.selectedDetentIdentifier = Self.compactDetentID
+        sheet.prefersGrabberVisible = false          // we draw our own grab handle
+        sheet.prefersScrollingExpandsWhenScrolledToEdge = true
+        sheet.largestUndimmedDetentIdentifier = .medium
+        sheet.prefersEdgeAttachedInCompactHeight = true
+        sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
+        sheet.delegate = self
+    }
+
+    private func snapSheetToCompact(animated: Bool) {
+        guard let sheet = bottomSheetNav.sheetPresentationController else { return }
+        sheet.animateChanges {
+            sheet.selectedDetentIdentifier = Self.compactDetentID
+        }
+    }
+
+    // MARK: - Navigation menu (More sheet)
+
+    private func showMoreSheet() {
+        let nav = application.viewRouter.buildNavigation(controller: moreController)
+        moreController.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            systemItem: .close,
+            primaryAction: UIAction { [weak nav] _ in nav?.dismiss(animated: true) }
+        )
+        nav.modalPresentationStyle = .pageSheet
+        if let sheetPresentation = nav.sheetPresentationController {
+            sheetPresentation.detents = [.medium(), .large()]
+            sheetPresentation.prefersGrabberVisible = true
+        }
+        bottomSheetNav.present(nav, animated: true)
+    }
+
+    // MARK: - ApplicationRootController
+
+    public func navigate(to destination: ClassicApplicationRootController.Page) {
+        switch destination {
+        case .map:
+            snapSheetToCompact(animated: true)
+        case .recentStops, .bookmarks:
+            guard let sheet = bottomSheetNav.sheetPresentationController else { return }
+            sheet.animateChanges {
+                sheet.selectedDetentIdentifier = .medium
+            }
+        case .more:
+            showMoreSheet()
+        }
+    }
+}
+
+// MARK: - MapBottomSheetDelegate
+
+extension MapsStyleRootController: MapBottomSheetDelegate {
+    func mapBottomSheetDidTapRecent(_ sheet: MapBottomSheetViewController) {
+        showFullScreenSheet(RecentStopsViewController(application: application))
+    }
+
+    func mapBottomSheetDidTapBookmarks(_ sheet: MapBottomSheetViewController) {
+        showFullScreenSheet(BookmarksViewController(application: application))
+    }
+
+    func mapBottomSheetDidTapMore(_ sheet: MapBottomSheetViewController) {
+        showMoreSheet()
+    }
+
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSubmitSearch request: SearchRequest) {
+        Task { await application.searchManager.search(request: request) }
+    }
+
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSelectMapItem mapItem: MKMapItem) {
+        // Just center the map — detail is shown inline in the sheet
+        let coord = mapItem.placemark.coordinate
+        mapController.mapRegionManager.mapView.setCenter(coord, animated: true)
+    }
+
+    func mapBottomSheet(_ sheet: MapBottomSheetViewController, didSelectStop stop: Stop) {
+        mapController.handleStopSelection(stopID: stop.id)
+        snapSheetToCompact(animated: true)
+    }
+
+    func mapBottomSheetDidCancelSearch(_ sheet: MapBottomSheetViewController) {
+        snapSheetToCompact(animated: true)
+    }
+
+    private func showFullScreenSheet(_ vc: UIViewController) {
+        let nav = application.viewRouter.buildNavigation(controller: vc)
+        vc.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            systemItem: .close,
+            primaryAction: UIAction { [weak nav] _ in nav?.dismiss(animated: true) }
+        )
+        nav.modalPresentationStyle = .pageSheet
+        if let sheetPresentation = nav.sheetPresentationController {
+            sheetPresentation.detents = [.medium(), .large()]
+            sheetPresentation.prefersGrabberVisible = true
+            sheetPresentation.prefersScrollingExpandsWhenScrolledToEdge = true
+        }
+        bottomSheetNav.present(nav, animated: true)
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension MapsStyleRootController: UINavigationControllerDelegate {
+    public func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        // Hide nav bar on the root sheet, show it on any pushed VC (gives back button + title)
+        let isRoot = viewController === bottomSheet
+        navigationController.setNavigationBarHidden(isRoot, animated: animated)
+
+        // Show grab handle only on root
+        bottomSheet.setGrabHandleVisible(isRoot)
+    }
+}
+
+// MARK: - UISheetPresentationControllerDelegate
+
+extension MapsStyleRootController: UISheetPresentationControllerDelegate {
+    public func sheetPresentationControllerDidChangeSelectedDetentIdentifier(
+        _ sheetPresentationController: UISheetPresentationController
+    ) {
+        // Update map bottom inset so controls stay above the sheet at all detents.
+        // At compact the sheet is ~90pt; at medium it's ~50% of screen height.
+        // We keep a fixed inset equal to the compact height — the map is still
+        // usable at medium because largestUndimmedDetentIdentifier = .medium.
+        let isExpanded = sheetPresentationController.selectedDetentIdentifier != Self.compactDetentID
+        mapController.additionalSafeAreaInsets = UIEdgeInsets(
+            top: 0, left: 0,
+            bottom: isExpanded ? 0 : Self.compactDetentHeight,
+            right: 0
+        )
+    }
+}
+
+// MARK: - RegionsServiceDelegate
+
+extension MapsStyleRootController: RegionsServiceDelegate {
+    public func regionsService(_ service: RegionsService, updatedRegion region: Region) {
+        bottomSheet.updateSearchPlaceholder()
+    }
+}
+
+// MARK: - ClassicApplicationRootController conformance
+
+extension ClassicApplicationRootController: ApplicationRootController {}

--- a/OBAKit/ClassicUI/MapsStyleRootController.swift
+++ b/OBAKit/ClassicUI/MapsStyleRootController.swift
@@ -284,16 +284,20 @@ extension MapsStyleRootController: UISheetPresentationControllerDelegate {
     public func sheetPresentationControllerDidChangeSelectedDetentIdentifier(
         _ sheetPresentationController: UISheetPresentationController
     ) {
-        // Update map bottom inset so controls stay above the sheet at all detents.
-        // At compact the sheet is ~90pt; at medium it's ~50% of screen height.
-        // We keep a fixed inset equal to the compact height — the map is still
-        // usable at medium because largestUndimmedDetentIdentifier = .medium.
         let isExpanded = sheetPresentationController.selectedDetentIdentifier != Self.compactDetentID
         mapController.additionalSafeAreaInsets = UIEdgeInsets(
             top: 0, left: 0,
             bottom: isExpanded ? 0 : Self.compactDetentHeight,
             right: 0
         )
+
+        // When the user drags the sheet up to medium/large without tapping the search bar,
+        // enter search mode so the sheet has content (recent searches) instead of being blank.
+        if isExpanded && !bottomSheet.isInSearchMode {
+            bottomSheet.enterSearchMode(focusTextField: false)
+        } else if !isExpanded {
+            bottomSheet.exitSearchMode()
+        }
     }
 }
 

--- a/OBAKit/Controls/FloatingPanel/Layouts.swift
+++ b/OBAKit/Controls/FloatingPanel/Layouts.swift
@@ -24,6 +24,22 @@ final class MapPanelLayout: FloatingPanelBottomLayout {
     }
 }
 
+/// Layout used in Maps-style mode: no tip state, panel starts hidden.
+/// The floating search row at the bottom is the only persistent UI.
+final class MapPanelMapsStyleLayout: FloatingPanelLayout {
+    var position: FloatingPanelPosition = .bottom
+    var initialState: FloatingPanelState = .hidden
+
+    var anchors: [FloatingPanelState: FloatingPanelLayoutAnchoring] {
+        return [
+            .full: FloatingPanelLayoutAnchor(absoluteInset: 18.0, edge: .top, referenceGuide: .safeArea),
+            .half: FloatingPanelLayoutAnchor(fractionalInset: 0.5, edge: .bottom, referenceGuide: .safeArea)
+        ]
+    }
+
+    func backdropAlpha(for state: FloatingPanelState) -> CGFloat { 0.0 }
+}
+
 /// A layout object used with `FloatingPanel` on `MapViewController`.
 final class MapPanelLandscapeLayout: FloatingPanelLayout {
     static let WidthSize: CGFloat = 291

--- a/OBAKit/Controls/VisualEffectsShadow/HoverBar.swift
+++ b/OBAKit/Controls/VisualEffectsShadow/HoverBar.swift
@@ -70,7 +70,7 @@ class HoverBarPassThroughView: UIView {
     }
 
     fileprivate lazy var shadowView = self.lazyShadowView()
-    fileprivate lazy var visualEffectView = self.lazyVisualEffectView()
+    lazy var visualEffectView = self.lazyVisualEffectView()
 
     convenience init() {
         self.init(frame: CGRect())

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -17,8 +17,6 @@ import SwiftUI
 protocol MapPanelDelegate: NSObjectProtocol {
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stopID: Stop.ID)
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectMapItem mapItem: MKMapItem)
-    func mapPanelControllerDidChangeChildViewController(_ controller: MapFloatingPanelController)
-    func mapPanelControllerDisplaySearch(_ controller: MapFloatingPanelController)
     func mapPanelController(_ controller: MapFloatingPanelController, moveTo state: FloatingPanelState, animated: Bool)
 }
 
@@ -33,12 +31,12 @@ class MapFloatingPanelController: VisualEffectViewController,
     NearbyStopsListDataSource,
     NearbyStopsListDelegate,
     UISearchBarDelegate,
-    UIPopoverPresentationControllerDelegate {
+    UIPopoverPresentationControllerDelegate,
+    UISheetPresentationControllerDelegate {
 
     let mapRegionManager: MapRegionManager
 
     public weak var mapPanelDelegate: MapPanelDelegate?
-    public private(set) var currentScrollView: UIScrollView?
 
     public let application: Application
 
@@ -59,6 +57,10 @@ class MapFloatingPanelController: VisualEffectViewController,
     // Search
     private var searchListViewController: UIHostingController<SearchListView>!
     var searchBarText: String = ""
+
+    // Search Sheet (SwiftUI)
+    let searchSheetViewModel = MapSearchSheetViewModel()
+    private var searchSheetHostingController: UIHostingController<MapSearchSheet>?
 
     // MARK: - Init/Deinit
     init(application: Application, mapRegionManager: MapRegionManager, delegate: MapPanelDelegate) {
@@ -84,7 +86,7 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     // MARK: - UI
 
-    /// Used to hide or show content when the floating panel disappears behind the tab bar on iOS 26.
+    /// Used to hide or show content when the floating panel is collapsed to tip state.
     func didCollapse(_ collapsed: Bool) {
         childContentContainerView.isHidden = collapsed
         nearbyStopsListViewController.view.isHidden = collapsed
@@ -92,28 +94,111 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     private var childContentContainerView: UIView!
 
-    func toggleSearch(showingSearch: Bool) {
-        let oldViewController: UIViewController = showingSearch ? nearbyStopsListViewController : searchListViewController
-        let newViewController: UIViewController = showingSearch ? searchListViewController : nearbyStopsListViewController
+    // MARK: - Search Sheet
 
-        oldViewController.willMove(toParent: nil)
-        oldViewController.view.removeFromSuperview()
-        oldViewController.removeFromParent()
+    /// Converts the current SearchInteractor results into SwiftUI-renderable sections
+    /// and pushes them onto the view model.
+    private func refreshSearchSheetSections() {
+        let rawSections = searchInteractor.searchModeObjects(text: searchBarText)
+        searchSheetViewModel.sections = rawSections.map { section in
+            let rows = section.contents.compactMap { item -> SearchResultRow? in
+                // OBAListRowView.DefaultViewModel — stops, bookmarks, quick search, recent
+                if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
+                    let title: AttributedString
+                    switch vm.title {
+                    case .string(let str):
+                        title = AttributedString(str ?? "")
+                    case .attributed(let attr):
+                        title = (try? AttributedString(attr ?? NSAttributedString(), including: \.uiKit)) ?? AttributedString(attr?.string ?? "")
+                    }
+                    return SearchResultRow(
+                        id: vm.id.description,
+                        title: title,
+                        subtitle: nil,
+                        image: vm.image,
+                        action: { [weak self] in
+                            vm.onSelectAction?(vm)
+                            self?.exitSearchMode()
+                        }
+                    )
+                }
+                // SearchPlacemarkViewModel — geocoded map items
+                if let vm = item.as(SearchPlacemarkViewModel.self) {
+                    let name = vm.mapItem.name ?? ""
+                    let subtitle = vm.mapItem.placemark.title
+                    return SearchResultRow(
+                        id: vm.id.description,
+                        title: AttributedString(name),
+                        subtitle: subtitle,
+                        image: UIImage(systemName: "mappin.circle.fill"),
+                        action: { [weak self] in
+                            vm.onSelectAction?(vm)
+                        }
+                    )
+                }
+                return nil
+            }
+            return SearchResultSection(id: section.id, title: section.title, rows: rows)
+        }.filter { !$0.rows.isEmpty }
+    }
 
-        newViewController.willMove(toParent: self)
-        addChild(newViewController)
-        childContentContainerView.addSubview(newViewController.view)
-        newViewController.view.pinToSuperview(.edges)
-        newViewController.didMove(toParent: self)
+    private func presentSearchSheet() {
+        guard searchSheetHostingController == nil else { return }
 
-        // Update the current scroll view, so FloatingPanel can track the newly installed view.
-        if let scrollableViewController = newViewController as? Scrollable {
-            currentScrollView = scrollableViewController.scrollView
-        } else {
-            currentScrollView = nil
+        searchSheetViewModel.searchText = searchBarText
+        searchSheetViewModel.sections = []
+
+        searchSheetViewModel.onSearchTextChanged = { [weak self] text in
+            guard let self else { return }
+            self.searchBarText = text
+            self.refreshSearchSheetSections()
+        }
+        searchSheetViewModel.onCancel = { [weak self] in
+            self?.exitSearchMode()
         }
 
-        mapPanelDelegate?.mapPanelControllerDidChangeChildViewController(self)
+        // Populate immediately so recent searches show before the user types.
+        refreshSearchSheetSections()
+
+        let sheet = MapSearchSheet(viewModel: searchSheetViewModel)
+        let hostingController = UIHostingController(rootView: sheet)
+        hostingController.modalPresentationStyle = .pageSheet
+        hostingController.view.backgroundColor = .clear
+
+        if let sheetPresentation = hostingController.sheetPresentationController {
+            // Small detent: just tall enough to show the search bar row (~100pt),
+            // matching the Apple Maps "pill expands into sheet" behaviour.
+            let searchBarDetent = UISheetPresentationController.Detent.custom(identifier: .init("searchBar")) { context in
+                return 100
+            }
+            sheetPresentation.detents = [searchBarDetent, .medium(), .large()]
+            sheetPresentation.selectedDetentIdentifier = .init("searchBar")
+            sheetPresentation.prefersGrabberVisible = true
+            sheetPresentation.prefersScrollingExpandsWhenScrolledToEdge = true
+            sheetPresentation.largestUndimmedDetentIdentifier = .medium
+            sheetPresentation.prefersEdgeAttachedInCompactHeight = true
+            // Detect interactive swipe-to-dismiss so we can reset state.
+            sheetPresentation.delegate = self
+        }
+
+        searchSheetHostingController = hostingController
+
+        // Find the topmost presented VC that isn't already presenting something else,
+        // so the search sheet always stacks correctly above the persistent bottom sheet
+        // in mapsStyleMode without being blocked by it.
+        let root = sequence(first: self as UIViewController, next: { $0.parent })
+            .first(where: { $0.parent == nil }) ?? self
+        var presenter: UIViewController = root
+        while let next = presenter.presentedViewController, !next.isBeingDismissed {
+            presenter = next
+        }
+        presenter.present(hostingController, animated: true)
+    }
+
+    private func dismissSearchSheet() {
+        guard let hostingController = searchSheetHostingController else { return }
+        hostingController.dismiss(animated: true)
+        searchSheetHostingController = nil
     }
 
     // MARK: - UI/Search
@@ -122,15 +207,24 @@ class MapFloatingPanelController: VisualEffectViewController,
         didSet {
             if inSearchMode {
                 application.analytics?.reportEvent(pageURL: "app://localhost/map", label: AnalyticsLabels.searchSelected, value: nil)
-                mapPanelDelegate?.mapPanelControllerDisplaySearch(self)
-            }
-            else {
+                presentSearchSheet()
+            } else {
+                dismissSearchSheet()
                 mapPanelDelegate?.mapPanelController(self, moveTo: .tip, animated: true)
             }
-
-            toggleSearch(showingSearch: inSearchMode)
         }
     }
+
+    /// Programmatically enters search mode — used by MapsStyleRootController's search pill.
+    public func enterSearchMode() {
+        guard !inSearchMode else { return }
+        inSearchMode = true
+    }
+
+    /// When `true`, the built-in search bar is hidden and the content list
+    /// fills the full panel height. Set this when the host controller (e.g.
+    /// `MapsStyleRootController`) provides its own search entry point.
+    var hidesSearchBar: Bool = false
 
     private lazy var searchBar: UISearchBar = {
         let searchBar = UISearchBar.autolayoutNew()
@@ -144,24 +238,34 @@ class MapFloatingPanelController: VisualEffectViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Add search bar
+        // Add search bar — hidden when the host provides its own search UI.
         visualEffectView.contentView.addSubview(searchBar)
         searchBar.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            searchBar.topAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.topAnchor, constant: ThemeMetrics.floatingPanelTopInset),
-            searchBar.leadingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.leadingAnchor),
-            searchBar.trailingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.trailingAnchor)
-        ])
+        searchBar.isHidden = hidesSearchBar
 
         // Add child content container view
         childContentContainerView = UIView.autolayoutNew()
         visualEffectView.contentView.addSubview(childContentContainerView)
-        NSLayoutConstraint.activate([
-            childContentContainerView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: 0),
-            childContentContainerView.leadingAnchor.constraint(equalTo: visualEffectView.contentView.leadingAnchor),
-            childContentContainerView.trailingAnchor.constraint(equalTo: visualEffectView.contentView.trailingAnchor),
-            childContentContainerView.bottomAnchor.constraint(equalTo: visualEffectView.contentView.bottomAnchor)
-        ])
+
+        if hidesSearchBar {
+            // Pin content directly to the top — no search bar above it.
+            NSLayoutConstraint.activate([
+                childContentContainerView.topAnchor.constraint(equalTo: visualEffectView.contentView.topAnchor),
+                childContentContainerView.leadingAnchor.constraint(equalTo: visualEffectView.contentView.leadingAnchor),
+                childContentContainerView.trailingAnchor.constraint(equalTo: visualEffectView.contentView.trailingAnchor),
+                childContentContainerView.bottomAnchor.constraint(equalTo: visualEffectView.contentView.bottomAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                searchBar.topAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.topAnchor, constant: ThemeMetrics.floatingPanelTopInset),
+                searchBar.leadingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.leadingAnchor),
+                searchBar.trailingAnchor.constraint(equalTo: visualEffectView.contentView.safeAreaLayoutGuide.trailingAnchor),
+                childContentContainerView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
+                childContentContainerView.leadingAnchor.constraint(equalTo: visualEffectView.contentView.leadingAnchor),
+                childContentContainerView.trailingAnchor.constraint(equalTo: visualEffectView.contentView.trailingAnchor),
+                childContentContainerView.bottomAnchor.constraint(equalTo: visualEffectView.contentView.bottomAnchor)
+            ])
+        }
 
         // Initialize view controllers
         nearbyStopsListViewController = NearbyStopsListViewController()
@@ -200,8 +304,6 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        toggleSearch(showingSearch: false)
         updateSearchBarPlaceholderText()
     }
 
@@ -274,7 +376,8 @@ class MapFloatingPanelController: VisualEffectViewController,
         }
 
         searchBar.resignFirstResponder()
-        mapPanelDelegate?.mapPanelController(self, moveTo: .half, animated: true)
+        // Dismiss the search sheet — results will be shown on the map.
+        exitSearchMode()
 
         Task {
             await application.searchManager.search(request: request)
@@ -295,7 +398,7 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) {
         let alertController = UIAlertController.deletionAlert(title: Strings.clearRecentSearchesConfirmation) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.application.userDataStore.deleteAllRecentMapItems()
             self.searchInteractor.searchModeObjects(text: searchBarText)
         }
@@ -314,11 +417,8 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         inSearchMode = true
-        searchBar.showsCancelButton = true
-    }
-
-    public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        exitSearchMode()
+        // The sheet has its own Cancel button; hide the search bar's to avoid duplication.
+        searchBar.showsCancelButton = false
     }
 
     /// Cancels searching and exits search mode
@@ -327,10 +427,8 @@ class MapFloatingPanelController: VisualEffectViewController,
         searchBar.resignFirstResponder()
         searchBar.showsCancelButton = false
         inSearchMode = false
-    }
-
-    public func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-        inSearchMode = false
+        searchSheetViewModel.searchText = ""
+        searchSheetViewModel.onDismiss?()
     }
 
     lazy var searchInteractor = SearchInteractor(application: application, delegate: self)
@@ -370,5 +468,23 @@ extension MapFloatingPanelController: MapRegionDelegate {
 
     public func regionsService(_ service: RegionsService, updatedRegion region: Region) {
         updateSearchBarPlaceholderText()
+    }
+}
+
+// MARK: - UISheetPresentationControllerDelegate
+
+extension MapFloatingPanelController {
+    /// Called when the user swipe-dismisses the search sheet interactively.
+    /// Resets search state so the sheet can be opened again.
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        guard presentationController.presentedViewController === searchSheetHostingController else { return }
+        searchSheetHostingController = nil
+        // Reset without triggering dismissSearchSheet (sheet is already gone).
+        searchBar.text = nil
+        searchBar.resignFirstResponder()
+        searchBar.showsCancelButton = false
+        inSearchMode = false
+        searchSheetViewModel.searchText = ""
+        searchSheetViewModel.onDismiss?()
     }
 }

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -99,46 +99,38 @@ class MapFloatingPanelController: VisualEffectViewController,
     /// Converts the current SearchInteractor results into SwiftUI-renderable sections
     /// and pushes them onto the view model.
     private func refreshSearchSheetSections() {
-        let rawSections = searchInteractor.searchModeObjects(text: searchBarText)
+        searchInteractor.searchModeObjects(text: searchBarText)
+        let rawSections = searchInteractor.sections
         searchSheetViewModel.sections = rawSections.map { section in
-            let rows = section.contents.compactMap { item -> SearchResultRow? in
-                // OBAListRowView.DefaultViewModel — stops, bookmarks, quick search, recent
-                if let vm = item.as(OBAListRowView.DefaultViewModel.self) {
-                    let title: AttributedString
-                    switch vm.title {
-                    case .string(let str):
-                        title = AttributedString(str ?? "")
-                    case .attributed(let attr):
-                        title = (try? AttributedString(attr ?? NSAttributedString(), including: \.uiKit)) ?? AttributedString(attr?.string ?? "")
-                    }
-                    return SearchResultRow(
-                        id: vm.id.description,
-                        title: title,
-                        subtitle: nil,
-                        image: vm.image,
-                        action: { [weak self] in
-                            vm.onSelectAction?(vm)
+            let rows = section.content.compactMap { row -> SearchResultRow? in
+                let title: AttributedString
+                if let attributed = row.attributedTitle {
+                    title = (try? AttributedString(attributed, including: \.uiKit)) ?? AttributedString(attributed.string)
+                } else {
+                    title = AttributedString(row.title ?? "")
+                }
+
+                let image: UIImage?
+                switch row.icon {
+                case .system(let name): image = UIImage(systemName: name)
+                case .uiImage(let img): image = img
+                case nil:               image = nil
+                }
+
+                return SearchResultRow(
+                    id: row.id,
+                    title: title,
+                    subtitle: row.subtitle,
+                    image: image,
+                    action: { [weak self] in
+                        row.action?()
+                        if case .clearRecents = row.kind { } else {
                             self?.exitSearchMode()
                         }
-                    )
-                }
-                // SearchPlacemarkViewModel — geocoded map items
-                if let vm = item.as(SearchPlacemarkViewModel.self) {
-                    let name = vm.mapItem.name ?? ""
-                    let subtitle = vm.mapItem.placemark.title
-                    return SearchResultRow(
-                        id: vm.id.description,
-                        title: AttributedString(name),
-                        subtitle: subtitle,
-                        image: UIImage(systemName: "mappin.circle.fill"),
-                        action: { [weak self] in
-                            vm.onSelectAction?(vm)
-                        }
-                    )
-                }
-                return nil
+                    }
+                )
             }
-            return SearchResultSection(id: section.id, title: section.title, rows: rows)
+            return SearchResultSection(id: section.id.rawValue, title: section.title, rows: rows)
         }.filter { !$0.rows.isEmpty }
     }
 
@@ -400,7 +392,7 @@ class MapFloatingPanelController: VisualEffectViewController,
         let alertController = UIAlertController.deletionAlert(title: Strings.clearRecentSearchesConfirmation) { [weak self] _ in
             guard let self else { return }
             self.application.userDataStore.deleteAllRecentMapItems()
-            self.searchInteractor.searchModeObjects(text: searchBarText)
+            self.refreshSearchSheetSections()
         }
 
         present(alertController, animated: true, completion: nil)
@@ -412,7 +404,7 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         searchBarText = searchText
-        searchInteractor.searchModeObjects(text: searchBarText)
+        refreshSearchSheetSections()
     }
 
     public func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {

--- a/OBAKit/Mapping/MapSearchSheet.swift
+++ b/OBAKit/Mapping/MapSearchSheet.swift
@@ -1,0 +1,169 @@
+//
+//  MapSearchSheet.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+import MapKit
+
+// MARK: - ViewModel
+
+/// Observable state shared between the SwiftUI sheet and the UIKit SearchInteractor.
+@MainActor
+final class MapSearchSheetViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published var sections: [SearchResultSection] = []
+
+    var onCancel: (() -> Void)?
+    var onSearchTextChanged: ((String) -> Void)?
+    var onSelectStop: ((Stop.ID) -> Void)?
+    var onSelectMapItem: ((MKMapItem) -> Void)?
+    var onPerformSearch: ((SearchRequest) -> Void)?
+    var onClearRecentSearches: (() -> Void)?
+    var onDismiss: (() -> Void)?
+}
+
+// MARK: - Section model
+
+/// A flat, SwiftUI-renderable representation of one OBAListViewSection.
+struct SearchResultSection: Identifiable {
+    let id: String
+    let title: String?
+    let rows: [SearchResultRow]
+}
+
+struct SearchResultRow: Identifiable {
+    let id: String
+    let title: AttributedString
+    let subtitle: String?
+    let image: UIImage?
+    let action: () -> Void
+}
+
+// MARK: - Custom detent
+
+/// Matches the height of the search bar row — the sheet starts here, collapsed to just the search field.
+private struct SearchBarDetent: CustomPresentationDetent {
+    static func height(in context: Context) -> CGFloat? { 100 }
+}
+
+// MARK: - Sheet View
+
+/// A native SwiftUI bottom sheet for the map search experience.
+///
+/// Starts at a small "searchBar" detent (just the search row visible) and
+/// expands to medium/large — matching the Apple Maps sheet interaction model.
+struct MapSearchSheet: View {
+    @ObservedObject var viewModel: MapSearchSheetViewModel
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.searchText.isEmpty && viewModel.sections.isEmpty {
+                    emptyStateView
+                } else {
+                    resultsList
+                }
+            }
+            .navigationTitle(OBALoc(
+                "search_controller.title",
+                value: "Search",
+                comment: "Title for the search sheet."
+            ))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.cancel) {
+                        viewModel.onCancel?()
+                    }
+                }
+            }
+        }
+        .searchable(
+            text: $viewModel.searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: Text(OBALoc(
+                "map_floating_panel.search_prompt",
+                value: "Search stops, routes, addresses",
+                comment: "Search bar placeholder in the map search sheet."
+            ))
+        )
+        .onChange(of: viewModel.searchText) { _, newValue in
+            viewModel.onSearchTextChanged?(newValue)
+        }
+        .presentationDetents([.custom(SearchBarDetent.self), .medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+    }
+
+    // MARK: - Results List
+
+    private var resultsList: some View {
+        List {
+            ForEach(viewModel.sections) { section in
+                Section(header: section.title.map { Text($0) }) {
+                    ForEach(section.rows) { row in
+                        Button {
+                            row.action()
+                        } label: {
+                            Label {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(row.title)
+                                        .foregroundStyle(.primary)
+                                    if let subtitle = row.subtitle {
+                                        Text(subtitle)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            } icon: {
+                                if let image = row.image {
+                                    Image(uiImage: image)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(width: 24, height: 24)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(OBALoc(
+                "search_controller.empty_set.title",
+                value: "Search",
+                comment: "Title for the empty set indicator on the Search controller."
+            ))
+            .font(.title2.bold())
+            .foregroundStyle(.primary)
+
+            Text(OBALoc(
+                "search_controller.empty_set.body",
+                value: "Type in an address, route name, stop number, or vehicle here to search.",
+                comment: "Body for the empty set indicator on the Search controller."
+            ))
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -124,13 +124,18 @@ class MapViewController: UIViewController,
         // trailing constraint references toolbar.leadingAnchor.
         view.insertSubview(toolbar, aboveSubview: mapView)
 
+        // In mapsStyleMode apply Apple Maps-style dark glass look to the toolbar.
+        if mapsStyleMode {
+            applyGlassStyleToToolbar()
+        }
+
         // Toolbar: anchored to safe area top-right, independent of status pill.
         // This matches Apple Maps where right-side buttons stay fixed regardless
         // of whether a floating status element is visible.
         NSLayoutConstraint.activate([
             toolbar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -ThemeMetrics.controllerMargin),
             toolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: ThemeMetrics.controllerMargin),
-            toolbar.widthAnchor.constraint(equalToConstant: 42.0),
+            toolbar.widthAnchor.constraint(equalToConstant: mapsStyleMode ? 44.0 : 42.0),
             locationButton.heightAnchor.constraint(equalTo: locationButton.widthAnchor),
             weatherButton.heightAnchor.constraint(equalTo: weatherButton.widthAnchor),
             toggleMapTypeButton.heightAnchor.constraint(equalTo: toggleMapTypeButton.widthAnchor),
@@ -516,7 +521,7 @@ class MapViewController: UIViewController,
             self.dismissTripPlannerController()
         }
 
-        self.floatingPanel.move(to: .tip, animated: true)
+        if !mapsStyleMode { self.floatingPanel.move(to: .tip, animated: true) }
 
         let hostingController = UIHostingController(rootView: tripPlannerView)
         hostingController.view.backgroundColor = .clear
@@ -645,7 +650,8 @@ class MapViewController: UIViewController,
         if traitCollection.horizontalSizeClass == .regular {
             self.mapRegionManager.mapView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: MapPanelLandscapeLayout.WidthSize + ThemeMetrics.padding, bottom: 0, trailing: 0)
         } else {
-            self.mapRegionManager.mapView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: MapPanelLayout.EstimatedDrawerTipStateHeight, trailing: 0)
+            let bottomInset: CGFloat = mapsStyleMode ? 0 : MapPanelLayout.EstimatedDrawerTipStateHeight
+            self.mapRegionManager.mapView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: bottomInset, trailing: 0)
         }
     }
 
@@ -715,6 +721,9 @@ class MapViewController: UIViewController,
     }()
 
     public func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout {
+        if mapsStyleMode {
+            return MapPanelMapsStyleLayout()
+        }
         switch newCollection.horizontalSizeClass {
         case .regular:
             return MapPanelLandscapeLayout(initialState: .half)
@@ -727,7 +736,6 @@ class MapViewController: UIViewController,
         // Don't allow the status overlay to be shown when the
         // Floating Panel is fully open because it looks weird.
         let floatingPanelPositionIsCollapsed = vc.state == .tip || vc.state == .hidden
-        mapPanelController.currentScrollView?.accessibilityElementsHidden = floatingPanelPositionIsCollapsed
 
         if let controller = vc.contentViewController as? MapFloatingPanelController {
             controller.didCollapse(floatingPanelPositionIsCollapsed)
@@ -748,7 +756,7 @@ class MapViewController: UIViewController,
         mapRegionManager.preferredLoadDataRegionFudgeFactor = UIAccessibility.isVoiceOverRunning ? 1.5 : MapRegionManager.DefaultLoadDataRegionFudgeFactor
 
         if UIAccessibility.isVoiceOverRunning {
-            floatingPanel.move(to: .half, animated: true)
+            if !mapsStyleMode { floatingPanel.move(to: .half, animated: true) }
 
             if !floatingPanel.userHasSeenFullSheetVoiceoverChange {
                 self.present(floatingPanel.fullSheetVoiceoverAlert(), animated: true)
@@ -823,7 +831,7 @@ class MapViewController: UIViewController,
             self.semiModalPanel?.move(to: .tip, animated: false)
         }
 
-        self.floatingPanel.move(to: .tip, animated: true)
+        if !mapsStyleMode { self.floatingPanel.move(to: .tip, animated: true) }
 
         let mapItemController = MapItemViewController(viewModel)
         let semiModal = createSemiModalPanel(childController: mapItemController)
@@ -833,14 +841,95 @@ class MapViewController: UIViewController,
 
     // MARK: - Map Panel Controller
 
+    /// Called by MapsStyleRootController when the user selects a map item from the bottom sheet search.
+    func handleMapItemSelection(_ mapItem: MKMapItem) {
+        mapPanelController(mapPanelController, didSelectMapItem: mapItem)
+    }
+
+    /// Called by MapsStyleRootController when the user selects a stop from the bottom sheet search.
+    func handleStopSelection(stopID: Stop.ID) {
+        application.viewRouter.navigateTo(stopID: stopID, from: self)
+    }
+
+    /// Applies Apple Maps-style Liquid Glass appearance to the right-side toolbar.
+    private func applyGlassStyleToToolbar() {
+        if #available(iOS 26.0, *) {
+            // iOS 26: swap the existing blur effect to UIGlassEffect in-place.
+            // The HoverBar's visualEffectView already has the buttons in its contentView,
+            // so replacing the effect keeps icons visible on top of the glass material.
+            toolbar.visualEffectView.effect = UIGlassEffect()
+            toolbar.visualEffectView.layer.cornerRadius = 21
+            toolbar.visualEffectView.layer.cornerCurve = .continuous
+            toolbar.showShadow = false
+            toolbar.tintColor = .label
+        } else {
+            // iOS 17-25 fallback: dark ultra-thin blur pill
+            toolbar.visualEffectView.effect = UIBlurEffect(style: .systemUltraThinMaterialDark)
+            toolbar.visualEffectView.layer.cornerRadius = 21
+            toolbar.visualEffectView.layer.cornerCurve = .continuous
+            toolbar.showShadow = false
+            toolbar.tintColor = .white
+        }
+    }
+
+    /// In mapsStyleMode, MapsStyleRootController is already presenting bottomSheetNav,
+    /// so any presentation from MapViewController must go through bottomSheetNav instead.
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        guard mapsStyleMode else {
+            super.present(viewControllerToPresent, animated: flag, completion: completion)
+            return
+        }
+        // Walk up to find the topmost free presenter
+        var presenter: UIViewController = self
+        while let p = presenter.presentingViewController { presenter = p }
+        // presenter is now the root; walk down presented chain to find the top
+        var top: UIViewController = presenter
+        while let next = top.presentedViewController, !next.isBeingDismissed { top = next }
+        if top === self {
+            super.present(viewControllerToPresent, animated: flag, completion: completion)
+        } else {
+            top.present(viewControllerToPresent, animated: flag, completion: completion)
+        }
+    }
+
     private lazy var mapPanelController = MapFloatingPanelController(application: application, mapRegionManager: application.mapRegionManager, delegate: self)
+
+    /// Activates the search sheet — called by MapsStyleRootController when the search pill is tapped.
+    func activateSearch() {
+        // In mapsStyleMode the floating panel stays hidden; only the search sheet is presented.
+        if !mapsStyleMode {
+            floatingPanel.move(to: .half, animated: true)
+        }
+        // Forward the dismiss callback so MapsStyleRootController can restore its pill.
+        mapPanelController.searchSheetViewModel.onDismiss = onSearchDismissed
+        mapPanelController.enterSearchMode()
+    }
+
+    /// Hides the floating panel's built-in search bar.
+    /// Call this when the host (e.g. MapsStyleRootController) provides its own search entry point.
+    func hideFloatingPanelSearchBar() {
+        mapPanelController.hidesSearchBar = true
+    }
+
+    /// Switches the floating panel to Maps-style mode: no persistent tip state,
+    /// panel starts hidden and only appears on demand.
+    /// Must be called before the view loads.
+    var mapsStyleMode: Bool = false
+
+    /// Called when the search sheet is dismissed (cancel or swipe-down).
+    /// Set by MapsStyleRootController to restore the bottom pill.
+    var onSearchDismissed: (() -> Void)?
+
+    /// Called in mapsStyleMode when a search returns a MKMapItem result,
+    /// so the bottom sheet can show the detail inline.
+    var onSearchMapItem: ((MKMapItem) -> Void)?
 
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stopID: Stop.ID) {
         application.viewRouter.navigateTo(stopID: stopID, from: self)
     }
 
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectMapItem mapItem: MKMapItem) {
-        floatingPanel.move(to: .half, animated: false)
+        if !mapsStyleMode { floatingPanel.move(to: .half, animated: false) }
 
         let mapDestination = mapItem.placemark.coordinate
 
@@ -857,21 +946,9 @@ class MapViewController: UIViewController,
         displayMapItemController(mapItem)
     }
 
-    func mapPanelControllerDisplaySearch(_ controller: MapFloatingPanelController) {
-        floatingPanel.move(to: .full, animated: true)
-    }
-
-    func mapPanelControllerDidChangeChildViewController(_ controller: MapFloatingPanelController) {
-        // If there is a new scroll view, tell floating panel to track the new scroll view.
-        // Else, untrack its currently tracking scroll view.
-        if let newScrollView = controller.currentScrollView {
-            floatingPanel.track(scrollView: newScrollView)
-        } else if let currentTrackingScrollView = floatingPanel.trackingScrollView {
-            floatingPanel.untrack(scrollView: currentTrackingScrollView)
-        }
-    }
-
     func mapPanelController(_ controller: MapFloatingPanelController, moveTo state: FloatingPanelState, animated: Bool) {
+        // In Maps-style mode the floating panel is never shown — ignore all move requests.
+        guard !mapsStyleMode else { return }
         floatingPanel.move(to: state, animated: animated)
     }
 
@@ -968,7 +1045,12 @@ class MapViewController: UIViewController,
 
             switch result {
             case let result as MKMapItem:
-                // Check if this MapItem is associated with a user-dropped pin
+                // In mapsStyleMode the bottom sheet shows the detail inline — skip the floating panel.
+                if mapsStyleMode {
+                    mapRegionManager.mapView.setCenter(result.placemark.coordinate, animated: true)
+                    onSearchMapItem?(result)
+                    return
+                }
                 let userPin = manager.findUserPin(for: result)
                 displayMapItemController(result, userPin: userPin)
             case let result as StopsForRoute:

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -28,7 +28,7 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
 
     private let application: Application
 
-    var rootController: ClassicApplicationRootController?
+    var rootController: (any ApplicationRootController)?
 
     public init(application: Application) {
         self.application = application
@@ -101,8 +101,7 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     }
 
     public func rootNavigateTo(page: ClassicApplicationRootController.Page) {
-        guard let rootController = self.rootController else { return }
-        rootController.navigate(to: page)
+        rootController?.navigate(to: page)
     }
 
     public func navigateTo(alert: TransitAlertViewModel, locale: Locale = .current, from fromController: UIViewController) {


### PR DESCRIPTION
Replace tab bar with Apple Maps-style persistent bottom sheet

Replaces the legacy tab bar navigation with an Apple Maps-style persistent bottom sheet interface, bringing OneBusAway iOS in line with modern iOS design patterns.

**New Files**

- MapsStyleRootController.swift — New root controller presenting a UINavigationController-wrapped bottom sheet via UISheetPresentationController with three detents: compact (search bar only), medium, and large. Map fills the full screen behind it.
- MapBottomSheetViewController.swift — Persistent sheet content: glass-effect search pill with live UITextField (no separate sheet on tap), inline search results via SearchInteractor (recent searches, quick search, placemarks), inline MapItemViewController detail when a location is selected (no floating panel), a ☰ navigation menu for Bookmarks, Recent, and More, and UINavigationController stack support so Nearby Stops and other VCs push correctly.
- MapSearchSheet.swift — SwiftUI search sheet view and MapSearchSheetViewModel, retained for the non-maps-style floating panel mode.

**Modified Files**

| File | Change |
|------|--------|
| MapViewController.swift | Added mapsStyleMode, onSearchMapItem callback, handleMapItemSelection/StopSelection helpers, present() override to route through bottomSheetNav, applyGlassStyleToToolbar() using UIGlassEffect on iOS 26 / dark blur fallback on iOS 17–25, suppresses displayMapItemController in maps-style mode. |
| MapFloatingPanelController.swift | Topmost-presenter walk for search sheet so it stacks above bottomSheetNav correctly. |
| HoverBar.swift | Exposes visualEffectView as internal so MapViewController can swap the blur effect. |
| ClassicApplicationRootController.swift | ApplicationRootController protocol conformance. |
| Layouts.swift | MapPanelMapsStyleLayout — hidden floating panel layout for maps-style mode. |
| Router.swift | No logic change; navigate(to:from:) assertion respected by nav stack. |
| Apps/OneBusAway/AppDelegate.m | Wires MapsStyleRootController as the root. |
| Apps/KiedyBus/AppDelegate.m | Same wiring for KiedyBus target. |
| SearchListViewController.swift | Minor compatibility update. |

**Design Notes**

- Search bar is always visible at the top of the sheet in all states — no hiding or replacing.
- Location detail appears inline below the search bar, never as a separate floating sheet.
- Toolbar buttons use UIGlassEffect on iOS 26 (Liquid Glass) with a systemUltraThinMaterialDark blur fallback on iOS 17–25.
- isModalInPresentation = true on the sheet prevents accidental swipe-to-dismiss.
- largestUndimmedDetentIdentifier = .medium keeps the map interactive at compact and medium detents.

**Testing**

- Tested on iOS 17 simulator and iOS 26 device.
- Search, location selection, Nearby Stops push, and sheet detent transitions all verified.
- Both OneBusAway and KiedyBus targets build cleanly.

**Related**

GSoC 2026 project: Modernize the iOS App UI — eliminates the tab bar in favor of a Maps-style sheet-based interface that feels native to modern iOS.

**Screenshots**

<img width="390" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 26 48" src="https://github.com/user-attachments/assets/1746d29e-9731-4312-997d-13158d92bb82" />
<img width="390" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 25 40" src="https://github.com/user-attachments/assets/694a1496-af36-433f-be93-ccdc4e703901" />
<img width="390" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 25 58" src="https://github.com/user-attachments/assets/f611bee8-9113-494c-8c27-3ebc2f2ea6da" />
<img width="390" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 26 07" src="https://github.com/user-attachments/assets/87502ba0-3787-4a59-9f94-bb8dde273c3d" />
<img width="390" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 26 20" src="https://github.com/user-attachments/assets/b4c91ada-1d19-4f11-8e72-14ff3d666126" />
