### PR TITLE
add: (SearchList) add tap-to-retry on error rows with enhanced visual…

### DIFF
--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -207,7 +207,7 @@ class SearchInteractor: NSObject {
                 DispatchQueue.main.async {
                     guard let self else { return }
                     if let error {
-                        if (error as NSError).code == NSURLErrorCancelled {
+                        if (error as? URLError)?.code == .cancelled {
                             return
                         }
                         self.placemarkSearchState = .error(error)
@@ -261,10 +261,13 @@ class SearchInteractor: NSObject {
         case .error(let error):
             let classified = ErrorClassifier.classify(error, regionName: application.currentRegionName)
             let icon = systemImageForError(classified)
+            let errorMessage = classified.localizedDescription
             items = [SearchListRow(
-                kind: .error(classified.localizedDescription, systemImage: icon),
-                title: classified.localizedDescription,
-                icon: .system(icon)
+                kind: .error(errorMessage, systemImage: icon),
+                title: errorMessage,
+                subtitle: OBALoc("search_controller.placemarks.error_retry", value: "Tap to retry", comment: "Subtitle on search error row prompting the user to retry."),
+                icon: .system(icon),
+                action: { [weak self] in self?.retryPlacemarkSearch() }
             )]
 
         case .noResults:
@@ -281,6 +284,11 @@ class SearchInteractor: NSObject {
         }
 
         return .init(id: .placemarks, title: sectionTitle, content: items)
+    }
+
+    private func retryPlacemarkSearch() {
+        lastSearchText = ""
+        searchModeObjects(text: lastQuery)
     }
 
     private func systemImageForError(_ error: Error) -> String {

--- a/OBAKit/Search/SearchList/SearchListRowView.swift
+++ b/OBAKit/Search/SearchList/SearchListRowView.swift
@@ -11,12 +11,16 @@ import OBAKitCore
 struct SearchListRowView: View {
     let row: SearchListRow
 
+    private let brandColor = Color(uiColor: ThemeColors.shared.brand)
+
     var body: some View {
         switch row.kind {
         case .loading:
             loadingRow
-        case .noResults, .error:
+        case .noResults:
             statusRow
+        case .error:
+            errorRow
         case .clearRecents:
             clearRecentsRow
         case .quickSearch, .recentStop, .bookmark, .placemark:
@@ -33,13 +37,13 @@ struct SearchListRowView: View {
         } label: {
             HStack(spacing: 12) {
                 leadingIcon
-                labelStack
+                labelStack()
                 Spacer()
                 if row.accessory == .disclosureIndicator {
                     Image(systemName: "chevron.right")
                         .font(.footnote)
                         .fontWeight(.semibold)
-                        .foregroundStyle(Color(uiColor: ThemeColors.shared.brand))
+                        .foregroundStyle(brandColor)
                 }
             }
             .contentShape(.rect)
@@ -47,14 +51,51 @@ struct SearchListRowView: View {
         .buttonStyle(.plain)
     }
 
-    /// Non-interactive status row — no results or error.
+    /// Non-interactive status row — no results.
     private var statusRow: some View {
         HStack(spacing: 12) {
             leadingIcon
-            labelStack
+            labelStack(titleColor: .secondary)
             Spacer()
         }
-        .foregroundStyle(.secondary)
+    }
+
+    /// Tappable error row — tapping retries the failed search.
+    private var errorRow: some View {
+        Button {
+            row.action?()
+        } label: {
+            HStack(spacing: 16) {
+                leadingIcon
+                labelStack(
+                    spacing: 4,
+                    titleFont: .subheadline,
+                    subtitleFont: .footnote.bold(),
+                    subtitleColor: brandColor
+                )
+
+                Spacer()
+
+                if row.action != nil {
+                    retryBadge
+                }
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .disabled(row.action == nil)
+    }
+
+    private var retryBadge: some View {
+        Image(systemName: "arrow.clockwise")
+            .font(.system(size: 14, weight: .bold))
+            .foregroundStyle(brandColor)
+            .padding(8)
+            .background(brandColor.opacity(0.1))
+            .clipShape(.circle)
+            .accessibilityHidden(true)
     }
 
     /// Animated loading indicator row.
@@ -96,26 +137,37 @@ struct SearchListRowView: View {
                 badgedIcon(icon, size: 32, imagePadding: 14)
             case .quickSearch, .recentStop, .bookmark:
                 badgedIcon(icon, size: 24, imagePadding: 8)
-            case .clearRecents, .loading, .noResults, .error:
+            case .error:
+                plainIcon(icon, size: 20, tint: .orange)
+            case .clearRecents, .loading, .noResults:
                 plainIcon(icon)
             }
         }
     }
 
-    private var labelStack: some View {
-        VStack(alignment: .leading, spacing: 2) {
+    @ViewBuilder
+    private func labelStack(
+        spacing: CGFloat = 2,
+        titleFont: Font = .body,
+        titleColor: Color = .primary,
+        subtitleFont: Font = .callout,
+        subtitleColor: Color = .secondary
+    ) -> some View {
+        VStack(alignment: .leading, spacing: spacing) {
             if let attributed = row.attributedTitle {
                 Text(AttributedString(attributed))
+                    .foregroundStyle(titleColor)
             } else if let title = row.title {
                 Text(title)
-                    .font(.body)
+                    .font(titleFont)
                     .fontWeight(row.kind.isPlacemark ? .semibold : .regular)
+                    .foregroundStyle(titleColor)
             }
 
             if let subtitle = row.subtitle {
                 Text(subtitle)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .font(subtitleFont)
+                    .foregroundStyle(subtitleColor)
             }
         }
     }
@@ -128,12 +180,13 @@ struct SearchListRowView: View {
             .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 8))
     }
 
-    /// Plain secondary icon — status rows, loading, etc.
+    /// Plain icon — status rows, loading, and error.
     @ViewBuilder
-    private func plainIcon(_ icon: SearchListRow.Icon) -> some View {
-        iconImage(icon, size: 16)
-            .frame(width: 32, height: 32)
-            .foregroundStyle(.secondary)
+    private func plainIcon(_ icon: SearchListRow.Icon, size: CGFloat = 16, tint: Color = .secondary) -> some View {
+        let frameSize = max(size, 32)
+        iconImage(icon, size: size)
+            .frame(width: frameSize, height: frameSize)
+            .foregroundStyle(tint)
     }
 
     /// Resolves Icon enum to a SwiftUI Image.

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -665,6 +665,9 @@
 /* No results message for placemark search */
 "search_controller.placemarks.no_results" = "No results found";
 
+/* Subtitle on search error row prompting the user to retry. */
+"search_controller.placemarks.error_retry" = "Tap to retry";
+
 /* Quick Search section header in search */
 "search_controller.quick_search.header" = "Quick Search";
 


### PR DESCRIPTION
Static error rows in placemark search now support tap-to-retry, with an enhanced visual design to communicate the failure and recovery action clearly.

## Changes
- `SearchInteractor`: added `retryPlacemarkSearch()` wired as the error row's action.
- `SearchListRowView`: `.error` renders as a tappable `Button` with orange icon, brand-coloured subtitle.
- Refactored `labelStack` into a parameterised function and extended `plainIcon` to eliminate duplicated layout code

## Video


https://github.com/user-attachments/assets/f4f8a775-b7b5-401d-aee5-e97b80744002

