### PR TITLE
feat: Migrate Bookmarks and Recent Stops screens to SwiftUI

### DIFF
--- a/OBAKit/Bookmarks/BookmarksView.swift
+++ b/OBAKit/Bookmarks/BookmarksView.swift
@@ -1,0 +1,394 @@
+//
+//  BookmarksView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+import WidgetKit
+
+// MARK: - Sort Mode
+
+enum BookmarkSortMode: String {
+    case byGroup   = "OBABookmarksController_SortBookmarksByGroup_group"
+    case byDistance = "OBABookmarksController_SortBookmarksByGroup_distance"
+}
+
+/// No-op delegate used only during BookmarkDataLoader init before `self` is available.
+private final class PlaceholderDelegate: NSObject, BookmarkDataDelegate {
+    static let shared = PlaceholderDelegate()
+    func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {}
+}
+
+// MARK: - Row model
+
+struct BookmarkRow: Identifiable {
+    let id: String          // bookmark id string
+    let name: String
+    let stopID: StopID
+    let bookmark: Bookmark
+    /// Up to 3 upcoming departures (nil = not a trip bookmark / not yet loaded)
+    let departures: [DepartureInfo]?
+
+    struct DepartureInfo: Identifiable {
+        let id: String      // tripID
+        let minutesText: String
+        let color: UIColor
+        let shouldHighlight: Bool
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+final class BookmarksSwiftUIViewModel: NSObject, ObservableObject, BookmarkDataDelegate {
+    @Published var sections: [(id: String, title: String, rows: [BookmarkRow])] = []
+    @Published var sortMode: BookmarkSortMode {
+        didSet {
+            application.userDefaults.set(sortMode == .byGroup, forKey: sortModeKey)
+            rebuildSections()
+        }
+    }
+    @Published var isEmpty: Bool = true
+    @Published var hasPendingMigration: Bool = false
+    /// Sections the user has collapsed (persisted to UserDefaults).
+    @Published var collapsedSections: Set<String> = []
+
+    private let application: Application
+    private let sortModeKey = "OBABookmarksController_SortBookmarksByGroup"
+    private let collapsedKey = "collapsedBookmarkSections"
+    private let dataLoader: BookmarkDataLoader
+    private var arrivalDepartureTimes: ArrivalDepartureTimes = [:]
+    private let feedbackGenerator = UISelectionFeedbackGenerator()
+    private lazy var dataLoadFeedback = DataLoadFeedbackGenerator(application: application)
+
+    init(application: Application) {
+        self.application = application
+        let legacyBool = application.userDefaults.bool(forKey: "OBABookmarksController_SortBookmarksByGroup")
+        self.sortMode = legacyBool ? .byGroup : .byDistance
+        hasPendingMigration = application.hasDataToMigrate
+        self.dataLoader = BookmarkDataLoader(application: application, delegate: PlaceholderDelegate.shared)
+        // Restore collapsed sections
+        if let data = application.userDefaults.data(forKey: "collapsedBookmarkSections"),
+           let decoded = try? JSONDecoder().decode(Set<String>.self, from: data) {
+            self.collapsedSections = decoded
+        }
+        super.init()
+        dataLoader.delegate = self
+    }
+
+    func loadData() {
+        dataLoader.loadData()
+        rebuildSections()
+    }
+
+    func cancelUpdates() {
+        dataLoader.cancelUpdates()
+    }
+
+    /// Nonisolated variant safe to call from `deinit`.
+    nonisolated func cancelUpdatesSync() {
+        dataLoader.cancelUpdates()
+    }
+
+    // BookmarkDataDelegate
+    nonisolated func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {
+        Task { @MainActor in
+            self.rebuildSections()
+            self.dataLoadFeedback.dataLoad(.success)
+        }
+    }
+
+    func rebuildSections() {
+        let currentRegionID = application.regionsService.currentRegion?.id
+        let allBookmarks = application.userDataStore.bookmarks
+            .filter { $0.regionIdentifier == currentRegionID }
+
+        isEmpty = allBookmarks.isEmpty
+        hasPendingMigration = application.hasDataToMigrate
+
+        let sorted: [(id: String, title: String, bookmarks: [Bookmark])]
+
+        if sortMode == .byDistance,
+           let location = application.locationService.currentLocation {
+            let distanceSorted = allBookmarks.sorted {
+                $0.stop.location.distance(from: location) < $1.stop.location.distance(from: location)
+            }
+            sorted = [(
+                id: "distance_sorted_group",
+                title: OBALoc("bookmarks_controller.sorted_by_distance_header",
+                              value: "Sorted by Distance",
+                              comment: "The table section header on the bookmarks controller for when bookmarks are sorted by distance."),
+                bookmarks: distanceSorted
+            )]
+        } else {
+            var groups: [(id: String, title: String, bookmarks: [Bookmark])] = application.userDataStore.bookmarkGroups.map { group in
+                (
+                    id: group.id.uuidString,
+                    title: group.name,
+                    bookmarks: application.userDataStore.bookmarksInGroup(group)
+                        .filter { $0.regionIdentifier == currentRegionID }
+                )
+            }
+            let ungrouped = application.userDataStore.bookmarksInGroup(nil)
+                .filter { $0.regionIdentifier == currentRegionID }
+            if !ungrouped.isEmpty {
+                groups.append((
+                    id: "unknown_group",
+                    title: OBALoc("bookmarks_controller.ungrouped_bookmarks_section.title",
+                                  value: "Bookmarks",
+                                  comment: "The title for the bookmarks controller section that shows bookmarks that aren't in a group."),
+                    bookmarks: ungrouped
+                ))
+            }
+            sorted = groups
+        }
+
+        sections = sorted.compactMap { group -> (id: String, title: String, rows: [BookmarkRow])? in
+            let rows = group.bookmarks.map { bookmark -> BookmarkRow in
+                var departures: [BookmarkRow.DepartureInfo]? = nil
+                if let key = TripBookmarkKey(bookmark: bookmark) {
+                    let arrDeps = dataLoader.dataForKey(key)
+                    if !arrDeps.isEmpty {
+                        departures = arrDeps.prefix(3).map { arrDep in
+                            let highlight = shouldHighlight(arrivalDeparture: arrDep)
+                            return BookmarkRow.DepartureInfo(
+                                id: arrDep.tripID,
+                                minutesText: application.formatters.shortFormattedTime(until: arrDep),
+                                color: application.formatters.colorForScheduleStatus(arrDep.scheduleStatus),
+                                shouldHighlight: highlight
+                            )
+                        }
+                    }
+                }
+                return BookmarkRow(
+                    id: bookmark.id.uuidString,
+                    name: bookmark.name,
+                    stopID: bookmark.stopID,
+                    bookmark: bookmark,
+                    departures: departures
+                )
+            }
+            guard !rows.isEmpty else { return nil }
+            return (id: group.id, title: group.title, rows: rows)
+        }
+    }
+
+    private func shouldHighlight(arrivalDeparture: ArrivalDeparture) -> Bool {
+        var highlight = false
+        if let last = arrivalDepartureTimes[arrivalDeparture.tripID] {
+            highlight = last != arrivalDeparture.arrivalDepartureMinutes
+        }
+        arrivalDepartureTimes[arrivalDeparture.tripID] = arrivalDeparture.arrivalDepartureMinutes
+        return highlight
+    }
+
+    func toggleCollapse(sectionID: String) {
+        feedbackGenerator.selectionChanged()
+        if collapsedSections.contains(sectionID) {
+            collapsedSections.remove(sectionID)
+        } else {
+            collapsedSections.insert(sectionID)
+        }
+        if let data = try? JSONEncoder().encode(collapsedSections) {
+            application.userDefaults.set(data, forKey: collapsedKey)
+        }
+    }
+
+    func delete(bookmark: Bookmark) {
+        if let routeID = bookmark.routeID, let headsign = bookmark.tripHeadsign {
+            application.analytics?.reportEvent(
+                pageURL: "app://localhost/bookmarks",
+                label: AnalyticsLabels.removeBookmark,
+                value: AnalyticsLabels.addRemoveBookmarkValue(
+                    routeID: routeID, headsign: headsign, stopID: bookmark.stopID))
+        }
+        application.userDataStore.delete(bookmark: bookmark)
+        rebuildSections()
+        reloadWidget()
+    }
+
+    func reloadWidget() {
+        WidgetCenter.shared.reloadTimelines(ofKind: "OBAWidget")
+    }
+}
+
+// MARK: - SwiftUI View
+
+struct BookmarksView: View {
+    @ObservedObject var viewModel: BookmarksSwiftUIViewModel
+    var hostViewController: UIViewController?
+    var application: Application?
+
+    var body: some View {
+        Group {
+            if viewModel.isEmpty {
+                emptyState
+            } else {
+                bookmarksList
+            }
+        }
+        .onAppear { viewModel.rebuildSections() }
+    }
+
+    // MARK: - List
+
+    private var bookmarksList: some View {
+        List {
+            ForEach(viewModel.sections, id: \.id) { section in
+                let isCollapsed = viewModel.collapsedSections.contains(section.id)
+                Section {
+                    if !isCollapsed {
+                        ForEach(section.rows) { row in
+                            bookmarkRow(row)
+                        }
+                    }
+                } header: {
+                    Button {
+                        viewModel.toggleCollapse(sectionID: section.id)
+                    } label: {
+                        HStack {
+                            Text(section.title)
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .refreshable {
+            viewModel.loadData()
+            viewModel.reloadWidget()
+        }
+    }
+
+    @ViewBuilder
+    private func bookmarkRow(_ row: BookmarkRow) -> some View {
+        Button {
+            guard let vc = hostViewController, let app = application else { return }
+            app.viewRouter.navigateTo(stop: row.bookmark.stop, from: vc, bookmark: row.bookmark)
+        } label: {
+            BookmarkRowView(row: row)
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                viewModel.delete(bookmark: row.bookmark)
+            } label: {
+                Label(Strings.delete, systemImage: "trash")
+            }
+            Button {
+                showEditBookmark(row.bookmark)
+            } label: {
+                Label(Strings.edit, systemImage: "square.and.pencil")
+            }
+            .tint(.blue)
+        }
+        .contextMenu {
+            Button {
+                showEditBookmark(row.bookmark)
+            } label: {
+                Label(Strings.edit, systemImage: "square.and.pencil")
+            }
+            Button(role: .destructive) {
+                viewModel.delete(bookmark: row.bookmark)
+            } label: {
+                Label(Strings.delete, systemImage: "trash")
+            }
+        } preview: {
+            StopPreviewRepresentable(application: application, stopID: row.stopID)
+        }
+        .accessibilityLabel(row.name)
+        .accessibilityHint(OBALoc("voiceover.bookmarks.row_hint",
+                                  value: "Tap to view stop arrivals",
+                                  comment: "VoiceOver hint for bookmark rows."))
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bookmark.slash")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(Strings.emptyBookmarkTitle)
+                .font(.title2.bold())
+
+            Text(viewModel.hasPendingMigration
+                 ? Strings.emptyBookmarkBodyWithPendingMigration
+                 : Strings.emptyBookmarkBody)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func showEditBookmark(_ bookmark: Bookmark) {
+        guard let vc = hostViewController, let app = application else { return }
+        let editor = EditBookmarkViewController(
+            application: app,
+            stop: bookmark.stop,
+            bookmark: bookmark,
+            delegate: vc as? BookmarkEditorDelegate
+        )
+        let nav = UINavigationController(rootViewController: editor)
+        app.viewRouter.present(nav, from: vc)
+    }
+}
+
+// MARK: - Bookmark Row subview
+
+private struct BookmarkRowView: View {
+    let row: BookmarkRow
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+            }
+            Spacer()
+            if let departures = row.departures, !departures.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(departures) { dep in
+                        Text(dep.minutesText)
+                            .font(.subheadline.bold())
+                            .foregroundStyle(Color(dep.color))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Stop preview for context menu
+
+private struct StopPreviewRepresentable: UIViewControllerRepresentable {
+    let application: Application?
+    let stopID: StopID
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        guard let app = application else { return UIViewController() }
+        return StopViewController(application: app, stopID: stopID)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -8,63 +8,36 @@
 //
 
 import UIKit
-import CoreLocation
+import SwiftUI
 import OBAKitCore
 import WidgetKit
 
 /// The view controller that powers the Bookmarks tab of the app.
+/// Hosts a SwiftUI BookmarksView while preserving all existing navigation,
+/// editing, and delegate behaviour.
 @objc(OBABookmarksViewController)
 public class BookmarksViewController: UIViewController,
                                       AppContext,
                                       BookmarkEditorDelegate,
-                                      BookmarkDataDelegate,
                                       ManageBookmarksDelegate,
-                                      ModalDelegate,
-                                      OBAListViewDataSource,
-                                      OBAListViewCollapsibleSectionsDelegate,
-                                      OBAListViewContextMenuDelegate {
+                                      ModalDelegate {
 
-    let application: Application
+    public let application: Application
 
-    // TODO: property wrapper??
-    public var collapsedSections: Set<OBAListViewSection.ID> {
-        get {
-            var sections: Set<OBAListViewSection.ID>?
-            do {
-                try sections = application.userDefaults.decodeUserDefaultsObjects(
-                    type: Set<OBAListViewSection.ID>.self,
-                    key: "collapsedBookmarkSections") ?? []
-            } catch let error {
-                Logger.error("Unable to decode toggledSections: \(error)")
-            }
-            return sections ?? []
-        } set {
-            do {
-                try application.userDefaults.encodeUserDefaultsObjects(newValue, key: "collapsedBookmarkSections")
-            } catch let error {
-                Logger.error("Unable to decode toggledSections: \(error)")
-            }
-        }
-    }
+    private let bookmarksViewModel: BookmarksSwiftUIViewModel
+    private var hostingController: UIHostingController<BookmarksView>!
 
-    public var selectionFeedbackGenerator: UISelectionFeedbackGenerator? = UISelectionFeedbackGenerator()
-    fileprivate lazy var dataLoadFeedbackGenerator = DataLoadFeedbackGenerator(application: application)
-
-    let listView = OBAListView()
+    // MARK: - Init
 
     public init(application: Application) {
         self.application = application
+        self.bookmarksViewModel = BookmarksSwiftUIViewModel(application: application)
+
         super.init(nibName: nil, bundle: nil)
 
         title = OBALoc("bookmarks_controller.title", value: "Bookmarks", comment: "Title of the Bookmarks tab")
         tabBarItem.image = Icons.bookmarksTabIcon
         tabBarItem.selectedImage = Icons.bookmarksSelectedTabIcon
-
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: OBALoc("bookmarks_controller.groups_button_title", value: "Edit", comment: "Groups button title in Bookmarks controller"), style: .plain, target: self, action: #selector(manageGroups))
-
-        application.userDefaults.register(defaults: [
-            userDefaultsKeys.sortBookmarksByGroup.rawValue: true
-        ])
     }
 
     required init?(coder: NSCoder) {
@@ -72,355 +45,135 @@ public class BookmarksViewController: UIViewController,
     }
 
     deinit {
-        dataLoader.cancelUpdates()
-    }
-
-    // MARK: - User Defaults
-
-    private enum userDefaultsKeys: String {
-        case sortBookmarksByGroup = "OBABookmarksController_SortBookmarksByGroup"
-    }
-
-    private var sortBookmarksByGroup: Bool {
-        get {
-            application.userDefaults.bool(forKey: userDefaultsKeys.sortBookmarksByGroup.rawValue)
-        }
-        set {
-            application.userDefaults.setValue(newValue, forKey: userDefaultsKeys.sortBookmarksByGroup.rawValue)
-            listView.applyData(animated: false)
-        }
+        bookmarksViewModel.cancelUpdatesSync()
     }
 
     // MARK: - UIViewController
+
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = ThemeColors.shared.systemBackground
-        listView.obaDataSource = self
-        listView.collapsibleSectionsDelegate = self
-        listView.contextMenuDelegate = self
-        listView.formatters = application.formatters
-        listView.register(listViewItem: BookmarkArrivalViewModel.self)
-        view.addSubview(listView)
-        listView.pinToSuperview(.edges)
+        // Left: Edit (manage groups/bookmarks)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: OBALoc("bookmarks_controller.groups_button_title",
+                          value: "Edit",
+                          comment: "Groups button title in Bookmarks controller"),
+            style: .plain,
+            target: self,
+            action: #selector(manageGroups)
+        )
 
+        // Right: Sort menu
         rebuildSortMenu()
 
-        dataLoader.loadData()
+        // Embed SwiftUI view
+        var swiftUIView = BookmarksView(viewModel: bookmarksViewModel)
+        swiftUIView.hostViewController = self
+        swiftUIView.application = application
+
+        hostingController = UIHostingController(rootView: swiftUIView)
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        hostingController.didMove(toParent: self)
+
+        bookmarksViewModel.loadData()
     }
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        application.notificationCenter.addObserver(self, selector: #selector(applicationEnteredBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
-
-        if application.userDataStore.bookmarks.count == 0 {
-            refreshControl.removeFromSuperview()
-        } else {
-            listView.addSubview(refreshControl)
-        }
-
-        listView.applyData(animated: false)
+        application.notificationCenter.addObserver(
+            self,
+            selector: #selector(applicationEnteredBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        bookmarksViewModel.rebuildSections()
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
-        application.notificationCenter.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-
-        dataLoader.cancelUpdates()
+        application.notificationCenter.removeObserver(
+            self,
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        bookmarksViewModel.cancelUpdates()
     }
 
-    // MARK: - Sorting
+    // MARK: - Sort Menu
 
     private func rebuildSortMenu() {
-        let groupTitle = OBALoc("bookmarks_controller.sort_menu.sort_by_group", value: "Sort by Group", comment: "A menu item that allows the user to sort their bookmarks into groups.")
-        let groupSortAction = UIAction(title: groupTitle, image: UIImage(systemName: "folder")) { _ in
-            self.sortBookmarksByGroup = true
-            self.rebuildSortMenu()
+        let groupAction = UIAction(
+            title: OBALoc("bookmarks_controller.sort_menu.sort_by_group",
+                          value: "Sort by Group",
+                          comment: "A menu item that allows the user to sort their bookmarks into groups."),
+            image: UIImage(systemName: "folder"),
+            state: bookmarksViewModel.sortMode == .byGroup ? .on : .off
+        ) { [weak self] _ in
+            self?.bookmarksViewModel.sortMode = .byGroup
+            self?.rebuildSortMenu()
         }
 
-        let distanceTitle = OBALoc("bookmarks_controller.sort_menu.sort_by_distance", value: "Sort by Distance", comment: "A menu item that allows the user to sort their bookmarks by distance from the user.")
-        let distanceSortAction = UIAction(title: distanceTitle, image: UIImage(systemName: "location.circle")) { _ in
-            self.sortBookmarksByGroup = false
-            self.rebuildSortMenu()
+        let distanceAction = UIAction(
+            title: OBALoc("bookmarks_controller.sort_menu.sort_by_distance",
+                          value: "Sort by Distance",
+                          comment: "A menu item that allows the user to sort their bookmarks by distance from the user."),
+            image: UIImage(systemName: "location.circle"),
+            state: bookmarksViewModel.sortMode == .byDistance ? .on : .off
+        ) { [weak self] _ in
+            self?.bookmarksViewModel.sortMode = .byDistance
+            self?.rebuildSortMenu()
         }
 
-        if self.sortBookmarksByGroup {
-            groupSortAction.state = .on
-            distanceSortAction.state = .off
-        }
-        else {
-            groupSortAction.state = .off
-            distanceSortAction.state = .on
-        }
-
-        let sortMenu = UIMenu(title: Strings.sort, options: .displayInline, children: [groupSortAction, distanceSortAction])
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "arrow.up.arrow.down.circle"), menu: sortMenu)
-    }
-
-    // MARK: Refresh Widget
-    func reloadWidget() {
-        Logger.info("Reloading the widget")
-        WidgetCenter.shared.reloadTimelines(ofKind: "OBAWidget")
-    }
-
-    // MARK: - Refresh Control
-
-    @objc private func refreshControlPulled() {
-        dataLoader.loadData()
-        refreshControl.beginRefreshing()
-        reloadWidget()
-
-        Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
-            guard let self = self else { return }
-            self.refreshControl.endRefreshing()
-        }
-    }
-
-    private lazy var refreshControl: UIRefreshControl = {
-        let refresh = UIRefreshControl()
-        refresh.addTarget(self, action: #selector(refreshControlPulled), for: .valueChanged)
-        return refresh
-    }()
-
-    // MARK: - List view
-    public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        if sortBookmarksByGroup {
-            return listItemsSortedByGroup()
-        }
-        else if application.locationService.currentLocation == nil {
-            return listItemsSortedByGroup()
-        }
-        else {
-            return listItemsSortedByDistance()
-        }
-    }
-
-    /// Creates an `OBAListViewSection` containing the specified bookmarks.
-    /// - Parameters:
-    ///   - bookmarks: The list of `Bookmark`s to include in this section.
-    ///   - id: The unique ID of the section. Used for diffing.
-    ///   - title: The section header title.
-    private func buildListSection(bookmarks: [Bookmark], id: String, title: String) -> OBAListViewSection? {
-        let arrivalData = bookmarks
-            .filter { $0.regionIdentifier == application.regionsService.currentRegion?.id }
-            .compactMap { bookmark -> BookmarkArrivalViewModel? in
-                var arrDeps: [BookmarkArrivalViewModel.ArrivalDepartureShouldHighlightPair] = []
-
-                if let key = TripBookmarkKey(bookmark: bookmark) {
-                    let data = dataLoader.dataForKey(key)
-                    arrDeps = data.map { arrDep -> BookmarkArrivalViewModel.ArrivalDepartureShouldHighlightPair in
-                        return (arrDep, shouldHighlight(arrivalDeparture: arrDep))
-                    }
-                }
-
-                return BookmarkArrivalViewModel(bookmark: bookmark, arrivalDepartures: arrDeps, onSelect: onSelectBookmark)
-            }
-
-        guard arrivalData.count > 0 else { return nil }
-
-        var section = OBAListViewSection(id: id, title: title, contents: arrivalData)
-        section.configuration = .appearance(.plain)
-        return section
-    }
-
-    public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        let title: String
-        let body: String
-
-        if application.hasDataToMigrate {
-            title = Strings.emptyBookmarkTitle
-            body = Strings.emptyBookmarkBodyWithPendingMigration
-        }
-        else if application.userDataStore.bookmarks.isEmpty {
-            title = Strings.emptyBookmarkTitle
-            body = Strings.emptyBookmarkBody
-        }
-        else {
-            // Don't show empty state if we have bookmarks
-            return nil
-        }
-
-        return .standard(.init(title: title, body: body))
-    }
-
-    // MARK: - Group Sort
-
-    private func listItemsSortedByGroup() -> [OBAListViewSection] {
-        // Add grouped bookmarks
-        var sections = application.userDataStore.bookmarkGroups.compactMap { buildListSection(group: $0) }
-
-        // Add ungrouped bookmarks
-        if let section = buildListSection(group: nil) {
-            sections.append(section)
-        }
-
-        return sections
-    }
-
-    /// Creates an `OBAListViewSection` containing the specified bookmark group's contents.
-    /// - Parameter group: The bookmark group to turn into an `OBAListViewSection`
-    private func buildListSection(group: BookmarkGroup?) -> OBAListViewSection? {
-        return buildListSection(
-            bookmarks: application.userDataStore.bookmarksInGroup(group),
-            id: group?.id.uuidString ?? "unknown_group",
-            title: group?.name ?? OBALoc("bookmarks_controller.ungrouped_bookmarks_section.title", value: "Bookmarks", comment: "The title for the bookmarks controller section that shows bookmarks that aren't in a group.")
+        let menu = UIMenu(title: Strings.sort, options: .displayInline, children: [groupAction, distanceAction])
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "MORE",
+            image: UIImage(systemName: "arrow.up.arrow.down.circle"),
+            menu: menu
         )
     }
 
-    // MARK: - Distance Sort
+    // MARK: - Manage Groups
 
-    /// Provides a way to check if the user wants to sort by distance, but cannot for whatever reason right now.
-    private var distanceSortRequestedButUnavailable: Bool {
-        !sortBookmarksByGroup && application.locationService.currentLocation == nil
+    @objc private func manageGroups() {
+        let manageController = ManageBookmarksAndGroupsViewController(application: application, delegate: self)
+        let nav = UINavigationController(rootViewController: manageController)
+        application.viewRouter.present(nav, from: self)
     }
 
-    /// Builds a single item array that contains a list of all bookmarks in the current region sorted by distance from the current user.
-    private func listItemsSortedByDistance() -> [OBAListViewSection] {
-        guard let currentLocation = application.locationService.currentLocation else {
-            return listItemsSortedByGroup()
-        }
+    // MARK: - Background notification
 
-        let bookmarks = application.userDataStore.bookmarks.sorted(by: {
-            $0.stop.location.distance(from: currentLocation) < $1.stop.location.distance(from: currentLocation)
-        })
-
-        return [buildListSection(
-            bookmarks: bookmarks,
-            id: "distance_sorted_group",
-            title: OBALoc("bookmarks_controller.sorted_by_distance_header", value: "Sorted by Distance", comment: "The table section header on the bookmarks controller for when bookmarks are sorted by distance.")
-        )].compactMap({$0})
-    }
-
-    // MARK: - Bookmark Actions
-    private func onSelectBookmark(_ viewModel: BookmarkArrivalViewModel) {
-        application.viewRouter.navigateTo(stop: viewModel.bookmark.stop, from: self, bookmark: viewModel.bookmark)
-    }
-
-    private func deleteAction(for viewModel: BookmarkArrivalViewModel) -> UIMenu {
-        let bookmark = viewModel.bookmark
-        let title = OBALoc("bookmarks_controller.delete_bookmark.actionsheet.title", value: "Delete Bookmark", comment: "The title to display to confirm the user's action to delete a bookmark.")
-
-        let deleteConfirmation = UIAction(title: Strings.confirmDelete, image: Icons.delete, attributes: .destructive) { _ in
-            // Report remove bookmark event to analytics
-            if let routeID = bookmark.routeID, let headsign = bookmark.tripHeadsign {
-                self.application.analytics?.reportEvent(
-                    pageURL: "app://localhost/bookmarks",
-                    label: AnalyticsLabels.removeBookmark,
-                    value: AnalyticsLabels.addRemoveBookmarkValue(
-                        routeID: routeID,
-                        headsign: headsign,
-                        stopID: bookmark.stopID))
-            }
-
-            // Delete bookmark
-            self.application.userDataStore.delete(bookmark: bookmark)
-            self.listView.applyData(animated: true)
-        }
-
-        return UIMenu(title: title, image: Icons.delete, options: .destructive, children: [deleteConfirmation])
-    }
-
-    private func editAction(for viewModel: BookmarkArrivalViewModel) -> UIAction {
-        return UIAction(title: Strings.edit, image: UIImage(systemName: "square.and.pencil")) { _ in
-            let bookmark = viewModel.bookmark
-            let bookmarkEditor = EditBookmarkViewController(application: self.application, stop: bookmark.stop, bookmark: bookmark, delegate: self)
-            let navigation = UINavigationController(rootViewController: bookmarkEditor)
-            self.application.viewRouter.present(navigation, from: self)
-        }
-    }
-
-    var currentPreviewingViewController: UIViewController?
-    public func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
-        guard let item = item.as(BookmarkArrivalViewModel.self) else { return nil }
-
-        let menu: OBAListViewMenuActions.MenuProvider = { _ -> UIMenu? in
-            let children: [UIMenuElement] = [self.editAction(for: item), self.deleteAction(for: item)]
-            return UIMenu(title: item.name, children: children)
-        }
-
-        let previewProvider: OBAListViewMenuActions.PreviewProvider = { () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: item.stopID)
-            self.currentPreviewingViewController = stopVC
-            return stopVC
-        }
-
-        let commitPreviewAction: VoidBlock = {
-            guard let vc = self.currentPreviewingViewController else { return }
-            self.application.viewRouter.navigate(to: vc, from: self)
-        }
-
-        return OBAListViewMenuActions(previewProvider: previewProvider,
-                                      performPreviewAction: commitPreviewAction,
-                                      contextMenuProvider: menu)
-    }
-
-    // MARK: - Arrival departure highlight updates
-    private var arrivalDepartureTimes = ArrivalDepartureTimes()
-
-    /// Used to determine if the highlight change label in the `ArrivalDeparture`'s collection cell should 'flash' when next rendered.
-    ///
-    /// This is used to indicate whether the departure time for the `ArrivalDeparture` object has changed.
-    ///
-    /// - Parameter arrivalDeparture: The ArrivalDeparture object
-    /// - Returns: Whether or not to highlight the ArrivalDeparture in its cell.
-    private func shouldHighlight(arrivalDeparture: ArrivalDeparture) -> Bool {
-        var highlight = false
-        if let lastMinutes = arrivalDepartureTimes[arrivalDeparture.tripID] {
-            highlight = lastMinutes != arrivalDeparture.arrivalDepartureMinutes
-        }
-
-        arrivalDepartureTimes[arrivalDeparture.tripID] = arrivalDeparture.arrivalDepartureMinutes
-
-        return highlight
+    @objc private func applicationEnteredBackground() {
+        bookmarksViewModel.cancelUpdates()
     }
 
     // MARK: - BookmarkEditorDelegate
 
-    func bookmarkEditorCancelled(_ viewController: UIViewController) {
-        viewController.dismiss(animated: true, completion: nil)
+    public func bookmarkEditorCancelled(_ viewController: UIViewController) {
+        viewController.dismiss(animated: true)
     }
 
-    func bookmarkEditor(_ viewController: UIViewController, editedBookmark bookmark: Bookmark, isNewBookmark: Bool) {
-        viewController.dismiss(animated: true, completion: nil)
-        listView.applyData(animated: false)
-    }
-
-    // MARK: - Data Loading
-
-    private lazy var dataLoader = BookmarkDataLoader(application: application, delegate: self)
-
-    public func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {
-        listView.applyData(animated: false)
-
-        // TOOD: handle error cases. currently, this view is not notified of an error.
-        dataLoadFeedbackGenerator.dataLoad(.success)
-    }
-
-    // MARK: - Notifications
-
-    @objc private func applicationEnteredBackground(note: Notification) {
-        dataLoader.cancelUpdates()
-    }
-
-    // MARK: - Bookmark Groups
-
-    @objc private func manageGroups() {
-        let manageGroupsController = ManageBookmarksAndGroupsViewController(application: application, delegate: self)
-        let navigation = UINavigationController(rootViewController: manageGroupsController)
-        application.viewRouter.present(navigation, from: self)
-    }
-
-    // MARK: - ModalDelegate
-
-    public func dismissModalController(_ controller: UIViewController) {
-        controller.dismiss(animated: true, completion: nil)
+    public func bookmarkEditor(_ viewController: UIViewController, editedBookmark bookmark: Bookmark, isNewBookmark: Bool) {
+        viewController.dismiss(animated: true)
+        bookmarksViewModel.rebuildSections()
     }
 
     // MARK: - ManageBookmarksDelegate
 
     func manageBookmarksReloadData(_ controller: ManageBookmarksAndGroupsViewController) {
-        listView.applyData(animated: false)
+        bookmarksViewModel.rebuildSections()
+    }
+
+    // MARK: - ModalDelegate
+
+    public func dismissModalController(_ controller: UIViewController) {
+        controller.dismiss(animated: true)
     }
 }

--- a/OBAKit/Recent/RecentStopsView.swift
+++ b/OBAKit/Recent/RecentStopsView.swift
@@ -1,0 +1,295 @@
+//
+//  RecentStopsView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - ViewModel
+
+@MainActor
+final class RecentStopsViewModel: ObservableObject {
+    @Published var alarms: [AlarmRow] = []
+    @Published var stops: [StopRow] = []
+    @Published var isLoadingDeepLink = false
+    @Published var errorMessage: String?
+
+    private let application: Application
+
+    struct AlarmRow: Identifiable {
+        let id: URL
+        let title: String
+        let alarm: Alarm
+        let deepLink: ArrivalDepartureDeepLink
+    }
+
+    struct StopRow: Identifiable {
+        let id: String   // stop.id
+        let name: String
+        let subtitle: String?
+        let routeType: Route.RouteType
+        let stop: Stop
+    }
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    func reload() {
+        application.userDataStore.deleteExpiredAlarms()
+
+        let currentRegion = application.currentRegion
+
+        alarms = application.userDataStore.alarms.compactMap { alarm in
+            guard let deepLink = alarm.deepLink else { return nil }
+            return AlarmRow(id: alarm.url, title: deepLink.title, alarm: alarm, deepLink: deepLink)
+        }
+
+        stops = application.userDataStore.recentStops
+            .filter { $0.regionIdentifier == currentRegion?.regionIdentifier }
+            .map { stop in
+                StopRow(
+                    id: stop.id,
+                    name: stop.name,
+                    subtitle: stop.subtitle,
+                    routeType: stop.prioritizedRouteTypeForDisplay,
+                    stop: stop
+                )
+            }
+    }
+
+    func deleteAllStops() {
+        application.userDataStore.deleteAllRecentStops()
+        reload()
+    }
+
+    func delete(stop: StopRow) {
+        application.userDataStore.delete(recentStop: stop.stop)
+        reload()
+    }
+
+    func delete(alarm: AlarmRow) {
+        Task {
+            try? await application.obacoService?.deleteAlarm(url: alarm.alarm.url)
+        }
+        application.userDataStore.delete(alarm: alarm.alarm)
+        reload()
+    }
+
+    func selectAlarm(_ alarm: AlarmRow, from vc: UIViewController) {
+        Task(priority: .userInitiated) {
+            guard let apiService = application.apiService else { return }
+            isLoadingDeepLink = true
+            defer { isLoadingDeepLink = false }
+            do {
+                let dl = alarm.deepLink
+                let response = try await apiService.getTripArrivalDepartureAtStop(
+                    stopID: dl.stopID,
+                    tripID: dl.tripID,
+                    serviceDate: dl.serviceDate,
+                    vehicleID: dl.vehicleID,
+                    stopSequence: dl.stopSequence)
+                application.viewRouter.navigateTo(arrivalDeparture: response.entry, from: vc)
+            } catch {
+                await application.displayError(error)
+            }
+        }
+    }
+
+    func selectStop(_ stop: StopRow, from vc: UIViewController) {
+        application.viewRouter.navigateTo(stopID: stop.id, from: vc)
+    }
+
+    func navigateToMap() {
+        application.viewRouter.rootNavigateTo(page: .map)
+    }
+}
+
+// MARK: - SwiftUI View
+
+struct RecentStopsView: View {
+    @ObservedObject var viewModel: RecentStopsViewModel
+    /// Passed directly — avoids weak/unowned issues in SwiftUI structs.
+    var hostViewController: UIViewController?
+    var application: Application?
+
+    var body: some View {
+        Group {
+            if viewModel.alarms.isEmpty && viewModel.stops.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .overlay {
+            if viewModel.isLoadingDeepLink {
+                ProgressView()
+                    .padding(20)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            }
+        }
+        .onAppear { viewModel.reload() }
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        List {
+            if !viewModel.alarms.isEmpty {
+                Section(OBALoc("recent_stops_controller.alarms_section.title",
+                               value: "Alarms",
+                               comment: "Title of the Alarms section of the Recents controller")) {
+                    ForEach(viewModel.alarms) { alarm in
+                        Button {
+                            guard let vc = hostViewController else { return }
+                            viewModel.selectAlarm(alarm, from: vc)
+                        } label: {
+                            Label(alarm.title, systemImage: "bell")
+                                .foregroundStyle(.primary)
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(role: .destructive) {
+                                viewModel.delete(alarm: alarm)
+                            } label: {
+                                Label(Strings.delete, systemImage: "trash")
+                            }
+                        }
+                        .accessibilityLabel(alarm.title)
+                        .accessibilityHint(OBALoc("voiceover.recent_stops.alarm_hint",
+                                                  value: "Tap to view trip details",
+                                                  comment: "VoiceOver hint for alarm rows in Recent Stops."))
+                    }
+                }
+            }
+
+            if !viewModel.stops.isEmpty {
+                if viewModel.alarms.isEmpty {
+                    Section {
+                        stopsRows
+                    }
+                } else {
+                    Section(Strings.recentStops) {
+                        stopsRows
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .refreshable { viewModel.reload() }
+    }
+
+    @ViewBuilder
+    private var stopsRows: some View {
+        ForEach(viewModel.stops) { stop in
+            Button {
+                guard let vc = hostViewController else { return }
+                viewModel.selectStop(stop, from: vc)
+            } label: {
+                StopRowView(stop: stop)
+            }
+            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                Button(role: .destructive) {
+                    viewModel.delete(stop: stop)
+                } label: {
+                    Label(Strings.delete, systemImage: "trash")
+                }
+            }
+            .contextMenu {
+                Button(role: .destructive) {
+                    viewModel.delete(stop: stop)
+                } label: {
+                    Label(Strings.delete, systemImage: "trash")
+                }
+            } preview: {
+                RecentStopPreviewRepresentable(
+                    application: application,
+                    stopID: stop.id
+                )
+            }
+            .accessibilityLabel(stop.name)
+            .accessibilityValue(stop.subtitle ?? "")
+            .accessibilityHint(OBALoc("voiceover.recent_stops.stop_hint",
+                                      value: "Tap to view stop arrivals",
+                                      comment: "VoiceOver hint for stop rows in Recent Stops."))
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(OBALoc("recent_stops.empty_set.title",
+                        value: "No Recent Stops",
+                        comment: "Title for the empty set indicator on the Recent Stops controller."))
+                .font(.title2.bold())
+
+            Text(OBALoc("recent_stops.empty_set.body",
+                        value: "Transit stops that you view in the app will appear here.",
+                        comment: "Body for the empty set indicator on the Recent Stops controller."))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button(OBALoc("recent_stops.empty_set.button",
+                          value: "Find Stops on Maps",
+                          comment: "The button title for taking the user to the map view to find stops.")) {
+                viewModel.navigateToMap()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Stop Row subview
+
+private struct StopRowView: View {
+    let stop: RecentStopsViewModel.StopRow
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(stop.name)
+                    .foregroundStyle(.primary)
+                if let subtitle = stop.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } icon: {
+            let icon = Icons.transportIcon(from: stop.routeType)
+            Image(uiImage: icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 24, height: 24)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+// MARK: - Stop peek preview for context menu
+
+private struct RecentStopPreviewRepresentable: UIViewControllerRepresentable {
+    let application: Application?
+    let stopID: StopID
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        guard let app = application else { return UIViewController() }
+        return StopViewController(application: app, stopID: stopID)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -6,30 +6,28 @@
 //
 
 import UIKit
+import SwiftUI
 import OBAKitCore
 
 /// Provides an interface to browse recently-viewed information, mostly `Stop`s.
-public class RecentStopsViewController: UIViewController,
-    AppContext,
-    OBAListViewDataSource,
-    OBAListViewContextMenuDelegate {
+public class RecentStopsViewController: UIViewController, AppContext {
 
-    let application: Application
+    public let application: Application
 
-    let listView = OBAListView()
+    private let viewModel: RecentStopsViewModel
+    private var hostingController: UIHostingController<RecentStopsView>!
 
     // MARK: - Init
 
     public init(application: Application) {
         self.application = application
+        self.viewModel = RecentStopsViewModel(application: application)
 
         super.init(nibName: nil, bundle: nil)
 
         title = OBALoc("recent_stops_controller.title", value: "Recent", comment: "The title of the Recent Stops controller.")
         tabBarItem.image = Icons.recentTabIcon
         tabBarItem.selectedImage = Icons.recentSelectedTabIcon
-
-        listView.obaDataSource = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -41,156 +39,47 @@ public class RecentStopsViewController: UIViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: OBALoc("recent_stops.delete_all", value: "Delete All", comment: "A button that deletes all of the recent stops in the app."), style: .plain, target: self, action: #selector(deleteAll))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: OBALoc("recent_stops.delete_all", value: "Delete All", comment: "A button that deletes all of the recent stops in the app."),
+            style: .plain,
+            target: self,
+            action: #selector(confirmDeleteAll)
+        )
 
-        view.backgroundColor = ThemeColors.shared.systemBackground
-        view.addSubview(listView)
-        listView.contextMenuDelegate = self
-        listView.pinToSuperview(.edges)
+        // Build SwiftUI view and embed it
+        var swiftUIView = RecentStopsView(viewModel: viewModel)
+        swiftUIView.hostViewController = self
+        swiftUIView.application = application
+
+        hostingController = UIHostingController(rootView: swiftUIView)
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        hostingController.didMove(toParent: self)
     }
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        application.userDataStore.deleteExpiredAlarms()
-        listView.applyData()
+        viewModel.reload()
     }
 
-    // MARK: - Actions
+    // MARK: - Delete All
 
-    @objc func deleteAll() {
-        let title = OBALoc("recent_stops.confirmation_alert.title", value: "Are you sure you want to delete all of your recent stops?", comment: "Title for a confirmation alert displayed before the user deletes all of their recent stops.")
-
-        let alertController = UIAlertController.deletionAlert(title: title) { [weak self] _ in
-            guard let self = self else { return }
-            self.application.userDataStore.deleteAllRecentStops()
-            self.listView.applyData(animated: true)
+    @objc private func confirmDeleteAll() {
+        let title = OBALoc(
+            "recent_stops.confirmation_alert.title",
+            value: "Are you sure you want to delete all of your recent stops?",
+            comment: "Title for a confirmation alert displayed before the user deletes all of their recent stops."
+        )
+        let alert = UIAlertController.deletionAlert(title: title) { [weak self] _ in
+            self?.viewModel.deleteAllStops()
         }
-
-        present(alertController, animated: true, completion: nil)
-    }
-
-    func onSelectAlarm(_ viewModel: AlarmViewModel) {
-        Task(priority: .userInitiated) {
-            await self.showDeepLink(deepLink: viewModel.deepLink)
-        }
-    }
-
-    func showDeepLink(deepLink: ArrivalDepartureDeepLink) async {
-        guard let apiService = self.application.apiService else { return }
-        await MainActor.run {
-            ProgressHUD.show()
-        }
-
-        defer {
-            Task { @MainActor in
-                ProgressHUD.dismiss()
-            }
-        }
-
-        do {
-            let response = try await apiService.getTripArrivalDepartureAtStop(
-                stopID: deepLink.stopID,
-                tripID: deepLink.tripID,
-                serviceDate: deepLink.serviceDate,
-                vehicleID: deepLink.vehicleID,
-                stopSequence: deepLink.stopSequence)
-
-            await MainActor.run {
-                self.application.viewRouter.navigateTo(arrivalDeparture: response.entry, from: self)
-            }
-        } catch {
-            await self.application.displayError(error)
-        }
-    }
-
-    func onDeleteAlarm(_ viewModel: AlarmViewModel) {
-        Task {
-            try? await self.application.obacoService?.deleteAlarm(url: viewModel.alarm.url)
-        }
-        self.application.userDataStore.delete(alarm: viewModel.alarm)
-        self.listView.applyData(animated: true)
-    }
-
-    // MARK: - Sections
-
-    private var alarms: OBAListViewSection? {
-        let alarms = application.userDataStore.alarms
-        guard alarms.count > 0 else {
-            return nil
-        }
-
-        let rows = alarms.compactMap { alarm in
-            return AlarmViewModel(withAlarm: alarm, onSelect: onSelectAlarm, onDelete: onDeleteAlarm)
-        }
-
-        let title = OBALoc("recent_stops_controller.alarms_section.title", value: "Alarms", comment: "Title of the Alarms section of the Recents controller")
-        return OBAListViewSection(id: "alarms", title: title, contents: rows)
-    }
-
-    private var stops: OBAListViewSection? {
-        guard let currentRegion = application.currentRegion else {
-            return nil
-        }
-
-        let stops = application.userDataStore.recentStops.filter { $0.regionIdentifier == currentRegion.regionIdentifier }
-        guard stops.count > 0 else {
-            return nil
-        }
-
-        let rows = stops.map { stop -> StopViewModel in
-            let onSelect: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
-                self.application.viewRouter.navigateTo(stopID: viewModel.stopID, from: self)
-            }
-
-            let onDelete: OBAListViewAction<StopViewModel> = { [unowned self] _ in
-                self.application.userDataStore.delete(recentStop: stop)
-                self.listView.applyData(animated: true)
-            }
-
-            return StopViewModel(withStop: stop, onSelect: onSelect, onDelete: onDelete)
-        }
-
-        let title = application.userDataStore.alarms.count > 0 ? Strings.recentStops : nil
-        return OBAListViewSection(id: "recent_stops", title: title, contents: rows)
-    }
-
-    // MARK: - OBAListView
-
-    public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        return [alarms, stops].compactMap { $0 }
-    }
-
-    public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        let title = OBALoc("recent_stops.empty_set.title", value: "No Recent Stops", comment: "Title for the empty set indicator on the Recent Stops controller.")
-        let subtitle = OBALoc("recent_stops.empty_set.body", value: "Transit stops that you view in the app will appear here.", comment: "Body for the empty set indicator on the Recent Stops controller.")
-        let buttonText = OBALoc("recent_stops.empty_set.button", value: "Find Stops on Maps", comment: "The button title for taking the user to the map view to find stops.")
-        let button = ActivityIndicatedButton.Configuration(
-            text: buttonText,
-            largeContentImage: Icons.mapTabIcon,
-            showsActivityIndicatorOnTap: false) {
-            self.application.viewRouter.rootNavigateTo(page: .map)
-        }
-
-        return .standard(.init(title: title, body: subtitle, buttonConfig: button))
-    }
-
-    fileprivate var currentPreviewingViewController: UIViewController?
-    public func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
-        guard let stopViewModel = item.as(StopViewModel.self) else { return nil }
-
-        let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.stopID)
-            self.currentPreviewingViewController = stopVC
-            return stopVC
-        }
-
-        let commitPreviewAction: VoidBlock = { [unowned self] in
-            guard let vc = self.currentPreviewingViewController else { return }
-            (vc as? Previewable)?.exitPreviewMode()
-            self.application.viewRouter.navigate(to: vc, from: self)
-        }
-
-        return OBAListViewMenuActions(previewProvider: previewProvider, performPreviewAction: commitPreviewAction, contextMenuProvider: nil)
+        present(alert, animated: true)
     }
 }


### PR DESCRIPTION
Replaces the UIKit + OBAListView implementations of BookmarksViewController and RecentStopsViewController with native SwiftUI views hosted via UIHostingController. Existing view controllers are retained as thin wrappers so the navigation stack, tab bar, deep links, and all delegate chains remain completely unaffected.

Part of the ongoing effort to modernize the OneBusAway iOS UI — moving screen-level views to SwiftUI while keeping the existing UIKit navigation architecture intact.

**Files Changed**

| File | Change |
|------|--------|
| RecentStopsView.swift | New — SwiftUI view + RecentStopsViewModel |
| RecentStopsViewController.swift | Modified — now a UIHostingController wrapper |
| BookmarksView.swift | New — SwiftUI view + BookmarksSwiftUIViewModel |
| BookmarksViewController.swift | Modified — now a UIHostingController wrapper |

---

**Recent Stops**

RecentStopsViewController now embeds a UIHostingController<RecentStopsView>. All data and navigation logic lives in RecentStopsViewModel (MainActor ObservableObject).

| Feature | Before | After |
|---------|--------|-------|
| Alarms section with deep link navigation | ✅ | ✅ |
| Recent stops list with transport icon + subtitle | ✅ | ✅ |
| Region filtering (current region only) | ✅ | ✅ |
| Swipe-to-delete on alarms and stops | ✅ | ✅ |
| Context menu with peek preview (StopViewController) | ✅ | ✅ |
| Delete All with confirmation alert | ✅ | ✅ |
| deleteExpiredAlarms() called on every appear | ✅ | ✅ |
| Empty state with "Find Stops on Maps" button | ✅ | ✅ |
| tabBarItem image and title | ✅ | ✅ |
| Pull-to-refresh | ❌ not present | ✅ added |
| ProgressView overlay while deep link API call is in flight | ❌ not present | ✅ added |
| VoiceOver accessibilityLabel / accessibilityHint on every row | ❌ not present | ✅ added |

---

**Bookmarks**

BookmarksViewController now embeds a UIHostingController<BookmarksView>. All data, sorting, collapsing, and live-refresh logic lives in BookmarksSwiftUIViewModel (@MainActor ObservableObject, inherits NSObject to satisfy BookmarkDataDelegate).

| Feature | Before | After |
|---------|--------|-------|
| Sort by Group / Sort by Distance (persisted to same UserDefaults key) | ✅ | ✅ |
| Collapsible sections with chevron toggle (persisted to UserDefaults) | ✅ | ✅ |
| DataLoadFeedbackGenerator haptic on BookmarkDataLoader update | ✅ | ✅ |
| UISelectionFeedbackGenerator haptic on section collapse/expand | ✅ | ✅ |
| Tap row → navigate to StopViewController via viewRouter | ✅ | ✅ |
| Swipe actions: delete and edit | ✅ | ✅ |
| Context menu: edit, delete, and peek preview of StopViewController | ✅ | ✅ |
| Delete bookmark with analytics event (removeBookmark) | ✅ | ✅ |
| Edit button → ManageBookmarksAndGroupsViewController | ✅ | ✅ |
| BookmarkEditorDelegate (edit/cancel callbacks) | ✅ | ✅ |
| ManageBookmarksDelegate (reload after manage) | ✅ | ✅ |
| ModalDelegate (dismiss) | ✅ | ✅ |
| BookmarkDataLoader 30-second live arrival auto-refresh | ✅ | ✅ |
| Up to 3 departure time badges per trip bookmark row | ✅ | ✅ |
| cancelUpdates() on viewWillDisappear and app background notification | ✅ | ✅ |
| deinit cancels loader safely via nonisolated cancelUpdatesSync() | ✅ | ✅ |
| WidgetCenter reload on pull-to-refresh and bookmark delete | ✅ | ✅ |
| Empty state with migration-aware body text | ✅ | ✅ |
| @objc(OBABookmarksViewController) ObjC name preserved | ✅ | ✅ |
| tabBarItem images and titles unchanged | ✅ | ✅ |

---

**Architecture Decisions**

- **UIHostingController wrapper pattern** — Existing UIViewController subclasses are kept as the public interface. They own the UIHostingController, embed it as a child view controller, and handle all UIKit-level concerns (bar buttons, alerts, delegate callbacks, notifications). SwiftUI views are purely presentational.

- **application and hostViewController as plain stored properties** — Passed as plain var properties on SwiftUI struct views rather than weak var. weak on a SwiftUI struct stored property is undefined behaviour in Swift (structs have value semantics; weak requires ARC reference counting) — this was the root cause of two EXC_BAD_ACCESS code=2 stack overflow crashes during development. The VC owns the hosting controller which owns the view, so VC lifetime always exceeds the view's lifetime, making plain references safe.

- **No responder-chain walking** — An earlier iteration walked the responder chain to find AppContext, causing infinite recursion (EXC_BAD_ACCESS code=2) because UIHostingController is in the chain but is not AppContext. Removed entirely — application is now injected directly.

- **BookmarksSwiftUIViewModel inherits NSObject** — Required to conform to BookmarkDataDelegate which inherits NSObjectProtocol. The PlaceholderDelegate pattern satisfies BookmarkDataLoader's non-optional delegate init parameter before self is fully initialised, with the real delegate assigned immediately after super.init().

- **UserDefaults key backward compatibility** — Sort preference persisted as a Bool to the existing key OBABookmarksController_SortBookmarksByGroup — identical to the original — so existing users' sort preference is preserved across the update.

**Testing**

- Both tabs load, navigate, delete, edit, and refresh correctly on simulator.
- No regressions to tab bar, deep links, or other screens.
- All delegate callbacks (BookmarkEditorDelegate, ManageBookmarksDelegate, ModalDelegate) fire correctly after edit/manage flows.