### PR TITLE
Added ETA distance and stops-away panel to trip floating panel

### DIFF
--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -161,7 +161,7 @@ class TripFloatingPanelController: UIViewController,
             stopArrivalView.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: ThemeMetrics.padding),
             stopArrivalView.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
             stopArrivalView.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor),
-            stopArrivalView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -ThemeMetrics.compactPadding)
+            stopArrivalView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor)
         ])
         return wrapper
     }()
@@ -183,7 +183,44 @@ class TripFloatingPanelController: UIViewController,
         return view
     }()
 
-    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, separatorView, listView])
+    // MARK: - ETA Info Panel
+    // Displays distance from stop and number of stops away for the arriving vehicle.
+    // Added to address feature #2 in issue #1109.
+    private lazy var etaInfoPanel: UIView = {
+        let distanceLabel = UILabel.autolayoutNew()
+        distanceLabel.font = .preferredFont(forTextStyle: .footnote)
+        distanceLabel.textColor = ThemeColors.shared.label
+        distanceLabel.textAlignment = .natural
+
+        let stopsLabel = UILabel.autolayoutNew()
+        stopsLabel.font = .preferredFont(forTextStyle: .footnote)
+        stopsLabel.textColor = ThemeColors.shared.label
+        stopsLabel.textAlignment = .right
+
+        if let arrDep = tripConvertible?.arrivalDeparture {
+            let meters = arrDep.distanceFromStop
+            let distance = meters >= 1000
+                ? String(format: "%.1f km away", meters / 1000)
+                : String(format: "%.0f m away", meters)
+            distanceLabel.text = "\(distance)"
+            stopsLabel.text = "\(arrDep.numberOfStopsAway) stop(s) away"
+        }
+
+        let stack = UIStackView.horizontalStack(arrangedSubviews: [distanceLabel, stopsLabel])
+        stack.distribution = .fillEqually
+        stack.spacing = ThemeMetrics.compactPadding
+
+        let wrapper = stack.embedInWrapperView(setConstraints: false)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: wrapper.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor)
+        ])
+        return wrapper
+    }()
+
+    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, etaInfoPanel, separatorView, listView])
 
     // MARK: - ListAdapterDataSource (Data Loading)
     func canCollapseSection(_ listView: OBAListView, section: OBAListViewSection) -> Bool {

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -32,6 +32,7 @@ class TripFloatingPanelController: UIViewController,
         didSet {
             if isLoadedAndOnScreen, let arrivalDeparture = tripConvertible?.arrivalDeparture {
                 stopArrivalView.arrivalDeparture = arrivalDeparture
+                updateETAInfoPanel(with: arrivalDeparture)
             }
         }
     }
@@ -145,6 +146,9 @@ class TripFloatingPanelController: UIViewController,
 
     var collapsedSections: Set<OBAListViewSection.ID> = []
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator? = UISelectionFeedbackGenerator()
+    
+    private var etaDistanceLabel: UILabel?
+    private var etaStopsLabel: UILabel?
 
     private lazy var stopArrivalView: StopArrivalView = {
         let view = StopArrivalView.autolayoutNew()
@@ -186,24 +190,31 @@ class TripFloatingPanelController: UIViewController,
     // MARK: - ETA Info Panel
     // Displays distance from stop and number of stops away for the arriving vehicle.
     // Added to address feature #2 in issue #1109.
+    private func updateETAInfoPanel(with arrDep: ArrivalDeparture) {
+        let distance = application.formatters.distanceFormatter.string(fromDistance: arrDep.distanceFromStop)
+        etaDistanceLabel?.text = distance
+        let stopCount = arrDep.numberOfStopsAway
+        let stopsFormat = stopCount == 1
+            ? OBALoc("trip_floating_panel.one_stop_away", value: "%d stop away", comment: "One stop away from the vehicle")
+            : OBALoc("trip_floating_panel.multiple_stops_away", value: "%d stops away", comment: "Multiple stops away from the vehicle")
+        etaStopsLabel?.text = String(format: stopsFormat, stopCount)
+    }
+    
     private lazy var etaInfoPanel: UIView = {
         let distanceLabel = UILabel.autolayoutNew()
+        etaDistanceLabel = distanceLabel
         distanceLabel.font = .preferredFont(forTextStyle: .footnote)
         distanceLabel.textColor = ThemeColors.shared.label
         distanceLabel.textAlignment = .natural
 
         let stopsLabel = UILabel.autolayoutNew()
+        etaStopsLabel = stopsLabel
         stopsLabel.font = .preferredFont(forTextStyle: .footnote)
         stopsLabel.textColor = ThemeColors.shared.label
         stopsLabel.textAlignment = .right
 
         if let arrDep = tripConvertible?.arrivalDeparture {
-            let meters = arrDep.distanceFromStop
-            let distance = meters >= 1000
-                ? String(format: "%.1f km away", meters / 1000)
-                : String(format: "%.0f m away", meters)
-            distanceLabel.text = "\(distance)"
-            stopsLabel.text = "\(arrDep.numberOfStopsAway) stop(s) away"
+            updateETAInfoPanel(with: arrDep)
         }
 
         let stack = UIStackView.horizontalStack(arrangedSubviews: [distanceLabel, stopsLabel])

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -155,11 +155,12 @@ class TripFloatingPanelController: UIViewController,
             return label
         }()
 
-        private lazy var etaStopsLabel: UILabel = {
+    private lazy var etaStopsLabel: UILabel = {
             let label = UILabel.autolayoutNew()
             label.font = .preferredFont(forTextStyle: .footnote)
             label.textColor = ThemeColors.shared.label
             label.textAlignment = .natural
+            label.isAccessibilityElement = false
             return label
         }()
 
@@ -218,7 +219,7 @@ class TripFloatingPanelController: UIViewController,
             }
             etaStopsLabel.text = stopsText
 
-        etaInfoPanel.accessibilityLabel = "\(distance), \(stopsText)"
+        etaDistanceLabel.accessibilityLabel = "\(distance), \(stopsText)"
         }
 
     private lazy var etaInfoPanel: UIView = {
@@ -237,7 +238,6 @@ class TripFloatingPanelController: UIViewController,
             stack.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor)
         ])
-        wrapper.isAccessibilityElement = true
         return wrapper
     }()
 

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -146,9 +146,22 @@ class TripFloatingPanelController: UIViewController,
 
     var collapsedSections: Set<OBAListViewSection.ID> = []
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator? = UISelectionFeedbackGenerator()
-    
-    private var etaDistanceLabel: UILabel?
-    private var etaStopsLabel: UILabel?
+
+    private lazy var etaDistanceLabel: UILabel = {
+            let label = UILabel.autolayoutNew()
+            label.font = .preferredFont(forTextStyle: .footnote)
+            label.textColor = ThemeColors.shared.label
+            label.textAlignment = .natural
+            return label
+        }()
+
+        private lazy var etaStopsLabel: UILabel = {
+            let label = UILabel.autolayoutNew()
+            label.font = .preferredFont(forTextStyle: .footnote)
+            label.textColor = ThemeColors.shared.label
+            label.textAlignment = .natural
+            return label
+        }()
 
     private lazy var stopArrivalView: StopArrivalView = {
         let view = StopArrivalView.autolayoutNew()
@@ -189,35 +202,31 @@ class TripFloatingPanelController: UIViewController,
 
     // MARK: - ETA Info Panel
     // Displays distance from stop and number of stops away for the arriving vehicle.
-    // Added to address feature #2 in issue #1109.
     private func updateETAInfoPanel(with arrDep: ArrivalDeparture) {
-        let distance = application.formatters.distanceFormatter.string(fromDistance: arrDep.distanceFromStop)
-        etaDistanceLabel?.text = distance
-        let stopCount = arrDep.numberOfStopsAway
-        let stopsFormat = stopCount == 1
-            ? OBALoc("trip_floating_panel.one_stop_away", value: "%d stop away", comment: "One stop away from the vehicle")
-            : OBALoc("trip_floating_panel.multiple_stops_away", value: "%d stops away", comment: "Multiple stops away from the vehicle")
-        etaStopsLabel?.text = String(format: stopsFormat, stopCount)
-    }
-    
-    private lazy var etaInfoPanel: UIView = {
-        let distanceLabel = UILabel.autolayoutNew()
-        etaDistanceLabel = distanceLabel
-        distanceLabel.font = .preferredFont(forTextStyle: .footnote)
-        distanceLabel.textColor = ThemeColors.shared.label
-        distanceLabel.textAlignment = .natural
+            let distance = application.formatters.distanceFormatter.string(fromDistance: arrDep.distanceFromStop)
+            etaDistanceLabel.text = distance
 
-        let stopsLabel = UILabel.autolayoutNew()
-        etaStopsLabel = stopsLabel
-        stopsLabel.font = .preferredFont(forTextStyle: .footnote)
-        stopsLabel.textColor = ThemeColors.shared.label
-        stopsLabel.textAlignment = .right
+            let stopCount = arrDep.numberOfStopsAway
+            let stopsText: String
+            if stopCount <= 0 {
+                stopsText = OBALoc("trip_floating_panel.at_stop", value: "At stop", comment: "The vehicle is at or has passed the selected stop")
+            } else {
+                let stopsFormat = stopCount == 1
+                    ? OBALoc("trip_floating_panel.one_stop_away", value: "%d stop away", comment: "One stop away from the vehicle")
+                    : OBALoc("trip_floating_panel.multiple_stops_away", value: "%d stops away", comment: "Multiple stops away from the vehicle")
+                stopsText = String(format: stopsFormat, stopCount)
+            }
+            etaStopsLabel.text = stopsText
 
-        if let arrDep = tripConvertible?.arrivalDeparture {
-            updateETAInfoPanel(with: arrDep)
+        etaInfoPanel.accessibilityLabel = "\(distance), \(stopsText)"
         }
 
-        let stack = UIStackView.horizontalStack(arrangedSubviews: [distanceLabel, stopsLabel])
+    private lazy var etaInfoPanel: UIView = {
+            if let arrDep = tripConvertible?.arrivalDeparture {
+                updateETAInfoPanel(with: arrDep)
+            }
+
+        let stack = UIStackView.horizontalStack(arrangedSubviews: [etaDistanceLabel, etaStopsLabel])
         stack.distribution = .fillEqually
         stack.spacing = ThemeMetrics.compactPadding
 
@@ -228,6 +237,7 @@ class TripFloatingPanelController: UIViewController,
             stack.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor)
         ])
+        wrapper.isAccessibilityElement = true
         return wrapper
     }()
 


### PR DESCRIPTION
Adds a new info panel below the arrival view in TripFloatingPanelController that displays the vehicle's distance from the stop and number of stops away.

- Shows distance in meters or km depending on value
- Shows number of stops between vehicle and selected stop
- Uses existing ArrivalDeparture data (distanceFromStop, numberOfStopsAway)

Addresses feature #2 in issue #1109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ETA info panel now displays distance and stop-count details in the trip view and is integrated into the panel layout.
  * Accessibility labels combine distance and stop-count for screen readers.

* **Improvements**
  * Improved formatting for distance and stop-ETA text, including "At stop" vs. "stop(s) away" messaging.
  * Adjusted trip panel spacing for consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->