### PR TITLE
feat: Add "Share Stop" action to StopViewController more menu

### DIFF
--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -422,7 +422,26 @@ public class StopViewController: UIViewController,
             alertsAction.attributes = .disabled
         }
 
-        return UIMenu(title: "File", options: .displayInline, children: [bookmarkAction, alertsAction])
+        var menuChildren: [UIMenuElement] = [bookmarkAction, alertsAction]
+
+        // Share stop link — only available when the region provides a sidecar URL.
+        if let stop = stop,
+           let region = application.currentRegion,
+           let url = application.appLinksRouter?.url(for: stop, region: region) {
+            let shareAction = UIAction(
+                title: OBALoc("stops_controller.share_stop", value: "Share Stop", comment: "Menu item to share a link to this stop"),
+                image: UIImage(systemName: "square.and.arrow.up")
+            ) { [weak self] _ in
+                guard let self else { return }
+                let activity = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                // On iPad, UIActivityViewController requires a source view/bar button item.
+                activity.popoverPresentationController?.barButtonItem = self.moreMenuButton
+                self.present(activity, animated: true)
+            }
+            menuChildren.append(shareAction)
+        }
+
+        return UIMenu(title: "File", options: .displayInline, children: menuChildren)
     }
 
     fileprivate func locationMenu() -> UIMenu {


### PR DESCRIPTION
## What

Adds a **Share Stop** item to the `...` more menu on the Stop detail screen, letting riders share a direct link to any stop via the system share sheet.

## Why

There was no way to share a stop with another person. The deep link URL infrastructure (`AppLinksRouter`, `UserActivityBuilder`) was already fully built — this just surfaces it to the user.

## Changes

| File | Change |
|---|---|
| `StopViewController.swift` | Added `shareAction` to `fileMenu()` — ~20 lines |

## Behavior

| Condition | Result |
|---|---|
| Region has sidecar URL configured | **Share Stop** appears in the menu |
| Region has no sidecar URL | Menu item is silently absent — no crash |
| iPhone | Share sheet presents modally |
| iPad | Share sheet anchors to the `...` bar button item (no popover crash) |

## Notes

- No new files, no new dependencies
- Zero impact on regions without a sidecar URL
- `[weak self]` used to avoid retain cycle with `UIActivityViewController`