### PR TITLE
feat: Migrate walk time and transfer arrival banners to SwiftUI

### DIFF
--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalWalkItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalWalkItem.swift
@@ -5,6 +5,7 @@
 //  Created by Alan Chu on 2/24/21.
 //
 
+import SwiftUI
 import OBAKitCore
 import CoreLocation
 
@@ -49,13 +50,13 @@ struct StopArrivalWalkContentConfiguration: OBAContentConfiguration {
 }
 
 class StopArrivalWalkCell: OBAListViewCell {
-    let walkTimeView = WalkTimeView.autolayoutNew()
+
+    private var hostingController: UIHostingController<WalkTimeBanner>?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        contentView.addSubview(walkTimeView)
-        walkTimeView.pinToSuperview(.edges)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -63,8 +64,36 @@ class StopArrivalWalkCell: OBAListViewCell {
     }
 
     override func apply(_ config: OBAContentConfiguration) {
-        guard let config = config as? StopArrivalWalkContentConfiguration else { return }
-        walkTimeView.formatters = config.formatters
-        walkTimeView.set(distance: config.distance, timeToWalk: config.timeToWalk)
+        guard let config = config as? StopArrivalWalkContentConfiguration,
+              let formatters = config.formatters else { return }
+
+        let banner = WalkTimeBanner(
+            content: .walk(distance: config.distance, timeToWalk: config.timeToWalk),
+            formatters: formatters
+        )
+
+        if let hc = hostingController {
+            hc.rootView = banner
+        } else {
+            let hc = UIHostingController(rootView: banner)
+            hc.view.backgroundColor = .clear
+            hc.view.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(hc.view)
+            NSLayoutConstraint.activate([
+                hc.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+                hc.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                hc.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                hc.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            ])
+            hostingController = hc
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        hostingController?.rootView = WalkTimeBanner(
+            content: .walk(distance: 0, timeToWalk: 0),
+            formatters: Formatters(locale: .current, calendar: .current, themeColors: ThemeColors.shared)
+        )
     }
 }

--- a/OBAKit/Stops/Sections/StopArrival/TransferArrivalItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/TransferArrivalItem.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import SwiftUI
 import OBAKitCore
 
 // MARK: - List Item
@@ -56,16 +57,16 @@ struct TransferArrivalContentConfiguration: OBAContentConfiguration {
     }
 }
 
-// MARK: - Cell (reuses WalkTimeView for identical look)
+// MARK: - Cell (reuses WalkTimeBanner for identical look)
 
 class TransferArrivalCell: OBAListViewCell {
-    let walkTimeView = WalkTimeView.autolayoutNew()
+
+    private var hostingController: UIHostingController<WalkTimeBanner>?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        contentView.addSubview(walkTimeView)
-        walkTimeView.pinToSuperview(.edges)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -73,8 +74,28 @@ class TransferArrivalCell: OBAListViewCell {
     }
 
     override func apply(_ config: OBAContentConfiguration) {
-        guard let config = config as? TransferArrivalContentConfiguration else { return }
-        walkTimeView.formatters = config.formatters
-        walkTimeView.setTransferArrival(arrivalTime: config.arrivalTime, routeDisplay: config.routeDisplay)
+        guard let config = config as? TransferArrivalContentConfiguration,
+              let formatters = config.formatters else { return }
+
+        let banner = WalkTimeBanner(
+            content: .transfer(arrivalTime: config.arrivalTime, routeDisplay: config.routeDisplay),
+            formatters: formatters
+        )
+
+        if let hc = hostingController {
+            hc.rootView = banner
+        } else {
+            let hc = UIHostingController(rootView: banner)
+            hc.view.backgroundColor = .clear
+            hc.view.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(hc.view)
+            NSLayoutConstraint.activate([
+                hc.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+                hc.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                hc.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                hc.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            ])
+            hostingController = hc
+        }
     }
 }

--- a/OBAKit/Stops/SwiftUI/WalkTimeBanner.swift
+++ b/OBAKit/Stops/SwiftUI/WalkTimeBanner.swift
@@ -1,0 +1,151 @@
+//
+//  WalkTimeBanner.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import CoreLocation
+import OBAKitCore
+
+/// A SwiftUI banner showing walking distance and estimated arrival time at a stop.
+///
+/// Mirrors the UIKit `WalkTimeView` — hidden when the user is within 40 m of the stop.
+/// Supports both the standard walk-time mode and the transfer-arrival mode.
+struct WalkTimeBanner: View {
+
+    enum Content {
+        case walk(distance: CLLocationDistance, timeToWalk: TimeInterval)
+        case transfer(arrivalTime: Date, routeDisplay: String)
+    }
+
+    let content: Content
+    let formatters: Formatters
+
+    // MARK: - Body
+
+    var body: some View {
+        if let row = rowContent {
+            HStack(spacing: 8) {
+                Text(row.text)
+                    .font(.footnote)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+
+                Image(systemName: row.icon)
+                    .foregroundStyle(.white)
+                    .imageScale(.small)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color(ThemeColors.shared.brand))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(row.a11yLabel)
+            .accessibilityValue(row.a11yValue)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private struct RowContent {
+        let text: String
+        let icon: String
+        let a11yLabel: String
+        let a11yValue: String
+    }
+
+    private var rowContent: RowContent? {
+        switch content {
+        case .walk(let distance, let timeToWalk):
+            return walkRowContent(distance: distance, timeToWalk: timeToWalk)
+        case .transfer(let arrivalTime, let routeDisplay):
+            return transferRowContent(arrivalTime: arrivalTime, routeDisplay: routeDisplay)
+        }
+    }
+
+    private func walkRowContent(distance: CLLocationDistance, timeToWalk: TimeInterval) -> RowContent? {
+        guard distance > 40 else { return nil }
+
+        let distanceString = formatters.distanceFormatter.string(fromDistance: distance)
+        let arrivalTime = formatters.timeFormatter.string(from: Date().addingTimeInterval(timeToWalk))
+
+        let displayText: String
+        if let timeString = formatters.positionalTimeFormatter.string(from: timeToWalk) {
+            let fmt = OBALoc(
+                "walk_time_view.distance_time_fmt",
+                value: "%@, %@: arriving at %@",
+                comment: "Format string for distance, walk time, and arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M."
+            )
+            displayText = String(format: fmt, distanceString, timeString, arrivalTime)
+        } else {
+            displayText = distanceString
+        }
+
+        let a11yValue: String
+        if let timeString = formatters.accessibilityPositionalTimeFormatter.string(from: timeToWalk) {
+            let fmt = OBALoc(
+                "walk_time_view.accessibility_value",
+                value: "%@. Takes %@ to walk, arriving at %@",
+                comment: "Accessibility string for distance, walk time, and arrival time."
+            )
+            a11yValue = String(format: fmt, distanceString, timeString, arrivalTime)
+        } else {
+            a11yValue = distanceString
+        }
+
+        return RowContent(
+            text: displayText,
+            icon: "figure.walk",
+            a11yLabel: OBALoc(
+                "walk_time_view.accessibility_label",
+                value: "Time to walk to stop",
+                comment: "Accessibility label for the walk time banner."
+            ),
+            a11yValue: a11yValue
+        )
+    }
+
+    private func transferRowContent(arrivalTime: Date, routeDisplay: String) -> RowContent? {
+        let text = formatters.transferArrivalBannerText(arrivalTime: arrivalTime, routeDisplay: routeDisplay)
+        return RowContent(
+            text: text,
+            icon: "arrow.triangle.swap",
+            a11yLabel: OBALoc(
+                "walk_time_view.transfer_accessibility_label",
+                value: "Transfer arrival time",
+                comment: "Accessibility label for the transfer arrival banner."
+            ),
+            a11yValue: text
+        )
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Walking — 800 m away") {
+    WalkTimeBanner(
+        content: .walk(distance: 800, timeToWalk: 600),
+        formatters: .init(locale: .current, calendar: .current, themeColors: ThemeColors.shared)
+    )
+}
+
+#Preview("Walking — too close, hidden") {
+    WalkTimeBanner(
+        content: .walk(distance: 30, timeToWalk: 20),
+        formatters: .init(locale: .current, calendar: .current, themeColors: ThemeColors.shared)
+    )
+}
+
+#Preview("Transfer arrival") {
+    WalkTimeBanner(
+        content: .transfer(arrivalTime: Date().addingTimeInterval(300), routeDisplay: "Route 10"),
+        formatters: .init(locale: .current, calendar: .current, themeColors: ThemeColors.shared)
+    )
+}
+#endif


### PR DESCRIPTION
## What

Replaces the UIKit `WalkTimeView` rendering in the Stop detail screen with a new SwiftUI `WalkTimeBanner` view, integrated via `UIHostingController` into the existing `OBAListView` cell system.

## Why

`OBAKit/Stops/SwiftUI/` was empty. This is the first view to fill it — a clean SwiftUI port of the walk time banner that supports both walk-time and transfer-arrival modes, with proper Dynamic Type and accessibility built in from the start.

## Changes

| File | Type | Change |
|---|---|---|
| `WalkTimeBanner.swift` | New | SwiftUI banner view covering both `.walk` and `.transfer` modes |
| `StopArrivalWalkItem.swift` | Modified | `StopArrivalWalkCell` now renders `WalkTimeBanner` via `UIHostingController` |
| `TransferArrivalItem.swift` | Modified | `TransferArrivalCell` now renders `WalkTimeBanner` via `UIHostingController` |

## WalkTimeBanner — Detail

| Feature | Detail |
|---|---|
| `.walk` mode | Shows distance + walk time + predicted arrival time |
| `.transfer` mode | Shows transfer route and arrival time |
| Hidden when close | Renders nothing when distance ≤ 40 m (matches UIKit behaviour) |
| Accessibility | `.accessibilityLabel` + `.accessibilityValue` on both modes |
| Dynamic Type | Uses `.footnote` text style, scales automatically |
| Previews | 3 Xcode Previews — walk, too-close (hidden), transfer |

## Cell Integration

| Behaviour | Detail |
|---|---|
| Hosting controller reuse | `UIHostingController` is created once and `rootView` is updated on reuse — no recreation per cell |
| Background | Both cell and hosting view set to `.clear` to preserve the brand-color banner background |
| UIKit `WalkTimeView` | Retained untouched — no existing code removed |


<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 01 15 53" src="https://github.com/user-attachments/assets/6258ea8b-92b5-41aa-808e-03dc81d6bb92" />