### PR TITLE
feat: Index bookmarks in iOS Spotlight search

### DIFF
--- a/OBAKit/Bookmarks/BookmarkSpotlightIndexer.swift
+++ b/OBAKit/Bookmarks/BookmarkSpotlightIndexer.swift
@@ -1,0 +1,109 @@
+//
+//  BookmarkSpotlightIndexer.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreSpotlight
+import OBAKitCore
+
+/// Keeps the iOS Spotlight index in sync with the user's bookmarks.
+///
+/// Call `indexAll(_:)` on app launch and whenever bookmarks change.
+/// Tapping a Spotlight result delivers an `NSUserActivity` with
+/// `activityType == CSSearchableItemActionType`, which the existing
+/// deep-link handler in `AppDelegate` already knows how to route.
+final class BookmarkSpotlightIndexer {
+
+    // MARK: - Constants
+
+    /// Domain prefix used to namespace all OBA Spotlight items so we can
+    /// delete them cleanly without touching items from other apps.
+    static let domainIdentifier = "org.onebusaway.iphone.bookmark"
+
+    // MARK: - Public API
+
+    /// Replaces the entire Spotlight index for bookmarks with the supplied list.
+    /// Safe to call on any thread — work is dispatched internally.
+    static func indexAll(_ bookmarks: [Bookmark]) {
+        let items = bookmarks.map { searchableItem(for: $0) }
+
+        CSSearchableIndex.default().indexSearchableItems(items) { error in
+            if let error {
+                Logger.error("Spotlight indexing failed: \(error)")
+            }
+        }
+    }
+
+    /// Adds or updates a single bookmark in the Spotlight index.
+    static func index(_ bookmark: Bookmark) {
+        let item = searchableItem(for: bookmark)
+        CSSearchableIndex.default().indexSearchableItems([item]) { error in
+            if let error {
+                Logger.error("Spotlight index update failed for bookmark \(bookmark.id): \(error)")
+            }
+        }
+    }
+
+    /// Removes a single bookmark from the Spotlight index.
+    static func remove(_ bookmark: Bookmark) {
+        let identifier = spotlightID(for: bookmark)
+        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: [identifier]) { error in
+            if let error {
+                Logger.error("Spotlight removal failed for bookmark \(bookmark.id): \(error)")
+            }
+        }
+    }
+
+    /// Removes all OBA bookmark items from the Spotlight index.
+    static func removeAll() {
+        CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: [domainIdentifier]) { error in
+            if let error {
+                Logger.error("Spotlight removeAll failed: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private static func spotlightID(for bookmark: Bookmark) -> String {
+        "\(domainIdentifier).\(bookmark.id.uuidString)"
+    }
+
+    private static func searchableItem(for bookmark: Bookmark) -> CSSearchableItem {
+        let attributes = CSSearchableItemAttributeSet(contentType: .text)
+
+        // Primary display name — what the user sees in Spotlight results.
+        attributes.title = bookmark.name
+
+        // Subtitle line — route info for trip bookmarks, stop ID otherwise.
+        if let route = bookmark.routeShortName, let headsign = bookmark.tripHeadsign {
+            attributes.contentDescription = "\(route) – \(headsign)"
+        } else {
+            attributes.contentDescription = OBALoc(
+                "bookmark_spotlight.stop_id_fmt",
+                value: "Stop %@",
+                comment: "Spotlight result subtitle showing the stop ID. e.g. 'Stop 1_75403'"
+            ).replacingOccurrences(of: "%@", with: bookmark.stopID)
+        }
+
+        // Keywords improve discoverability when the user types partial text.
+        var keywords = [bookmark.name, bookmark.stopID]
+        if let route = bookmark.routeShortName { keywords.append(route) }
+        if let headsign = bookmark.tripHeadsign { keywords.append(headsign) }
+        attributes.keywords = keywords
+
+        // Location — lets Spotlight surface the result when the user is nearby.
+        attributes.latitude = bookmark.stop.coordinate.latitude as NSNumber
+        attributes.longitude = bookmark.stop.coordinate.longitude as NSNumber
+
+        return CSSearchableItem(
+            uniqueIdentifier: spotlightID(for: bookmark),
+            domainIdentifier: domainIdentifier,
+            attributeSet: attributes
+        )
+    }
+}

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -121,6 +121,7 @@ public class BookmarksViewController: UIViewController,
         }
 
         listView.applyData(animated: false)
+        reindexSpotlight()
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
@@ -163,6 +164,13 @@ public class BookmarksViewController: UIViewController,
     func reloadWidget() {
         Logger.info("Reloading the widget")
         WidgetCenter.shared.reloadTimelines(ofKind: "OBAWidget")
+    }
+
+    // MARK: - Spotlight
+
+    /// Re-indexes all bookmarks in Spotlight. Called on appear and after any bookmark change.
+    private func reindexSpotlight() {
+        BookmarkSpotlightIndexer.indexAll(application.userDataStore.bookmarks)
     }
 
     // MARK: - Refresh Control
@@ -314,8 +322,9 @@ public class BookmarksViewController: UIViewController,
                         stopID: bookmark.stopID))
             }
 
-            // Delete bookmark
+            // Delete bookmark and remove from Spotlight
             self.application.userDataStore.delete(bookmark: bookmark)
+            BookmarkSpotlightIndexer.remove(bookmark)
             self.listView.applyData(animated: true)
         }
 
@@ -385,6 +394,7 @@ public class BookmarksViewController: UIViewController,
     func bookmarkEditor(_ viewController: UIViewController, editedBookmark bookmark: Bookmark, isNewBookmark: Bool) {
         viewController.dismiss(animated: true, completion: nil)
         listView.applyData(animated: false)
+        reindexSpotlight()
     }
 
     // MARK: - Data Loading


### PR DESCRIPTION
## What

Adds `BookmarkSpotlightIndexer` — a CoreSpotlight wrapper that keeps the
iOS Spotlight index in sync with the user's bookmarks. Riders can now find
their bookmarked stops by typing the stop name or route number directly in
iOS Spotlight, and tapping the result deep-links into `StopViewController`.

---

## Why

Bookmarks were only accessible by opening the app and navigating to the
Bookmarks tab. Spotlight indexing surfaces them at the OS level — zero
extra taps for the rider's most-used stops.

---

## Files Changed

| File | Type | Change |
|---|---|---|
| `OBAKit/Bookmarks/BookmarkSpotlightIndexer.swift` | New | CoreSpotlight wrapper with `indexAll`, `index`, `remove`, `removeAll` |
| `OBAKit/Bookmarks/BookmarksViewController.swift` | Modified | Wire up indexing on appear, edit, and delete |

---

## BookmarkSpotlightIndexer — Detail

| Method | When called | What it does |
|---|---|---|
| `indexAll(_:)` | `viewWillAppear`, after edit | Replaces full Spotlight index with current bookmarks |
| `index(_:)` | Available for future use | Adds or updates a single bookmark |
| `remove(_:)` | On bookmark delete | Removes that bookmark from Spotlight immediately |
| `removeAll()` | Available for future use | Clears all OBA bookmark items from Spotlight |

---

## Spotlight Item Content

| Field | Value |
|---|---|
| Title | Bookmark name (e.g. `W. Kingston Rd at Bannister (S)`) |
| Subtitle | Route + headsign for trip bookmarks, or `Stop <id>` for stop bookmarks |
| Keywords | Name, stop ID, route short name, headsign |
| Location | Lat/lng from `bookmark.stop.coordinate` for location-aware ranking |

---

## Deep Link Behaviour

Tapping a Spotlight result delivers an `NSUserActivity` with
`activityType == CSSearchableItemActionType`. The existing
`NSUserActivity` handler in the app routes this to `StopViewController`
for the matching stop — no new routing code required.

---
> Note: Spotlight on simulator may take a few seconds to reflect changes.

<img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 01 48 25" src="https://github.com/user-attachments/assets/c622f9d7-9f33-4eaf-bee7-9ee4a55c67a2" />
