### PR TITLE
Add destination stop picker for trip sharing

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -203,6 +203,7 @@ struct DepartureRowActions {
     let onSchedule: () -> Void
     let onBookmark: () -> Void
     let onShowTrip: () -> Void
+    let onShareTrip: () -> Void
     /// Lazily builds the long-press preview (a `TripViewController` embedded via a
     /// representable). Built by the hosting VC so `Application`/UIKit stay out of
     /// the view layer; `AnyView` is acceptable here because it lives inside the
@@ -229,6 +230,9 @@ extension View {
                 }
                 Button(action: actions.onBookmark) {
                     Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+                Button(action: actions.onShareTrip) {
+                    Label(OBALoc("stop_page.row.share_trip", value: "Share Trip", comment: "Context menu action that shares the trip after choosing a destination stop"), systemImage: "square.and.arrow.up")
                 }
             }, preview: {
                 actions.makePreview()

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -34,6 +34,9 @@ struct StopPageNavigationHandler {
     /// Opens the bookmark editor: `nil` for a stop-level bookmark, an
     /// `ArrivalDeparture` for a trip-level bookmark (row swipe/menu).
     let showBookmarkEditor: (ArrivalDeparture?) -> Void
+    /// Starts the trip-sharing flow for a departure (row context menu):
+    /// destination stop picker, then the system share sheet.
+    let shareTrip: (ArrivalDeparture) -> Void
     /// Presents the alarm lead-time picker bulletin for a departure (the trip
     /// panel's Set-an-alarm button), reusing `AlarmBuilder` from the legacy
     /// stop screen.
@@ -525,6 +528,7 @@ struct StopPageView: View {
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },
             onShowTrip: { navigation.showTrip(departure) },
+            onShareTrip: { navigation.shareTrip(departure) },
             makePreview: { navigation.makeTripPreview(departure) }
         )
     }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -195,6 +195,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showWalkingDirections: {},
         showAlertDetail: { _ in },
         showBookmarkEditor: { _ in },
+        shareTrip: { _ in },
         showAlarmPicker: { _ in },
         startLiveActivity: { _ in },
         showExternalSurveyError: {},
@@ -207,6 +208,10 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showReportProblem: {},
         closeSheet: {}
     )
+
+    /// Owns the picker → share-sheet trip-sharing flow. Holds `self` weakly,
+    /// so retaining it for the controller's lifetime creates no cycle.
+    private lazy var tripSharingCoordinator = TripSharingCoordinator(application: application, presenter: self)
 
     private func makeNavigationHandler() -> StopPageNavigationHandler {
         StopPageNavigationHandler(
@@ -223,6 +228,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
                 self.application.viewRouter.navigateTo(alert: alert, from: self)
             },
             showBookmarkEditor: { [weak self] departure in self?.showBookmarkEditor(for: departure) },
+            shareTrip: { [weak self] departure in self?.tripSharingCoordinator.start(arrivalDeparture: departure) },
             showAlarmPicker: { [weak self] departure in self?.showAlarmPicker(for: departure) },
             startLiveActivity: { [weak self] departure in self?.startLiveActivity(for: departure) },
             showExternalSurveyError: { [weak self] in self?.showExternalSurveyError() },

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1065,6 +1065,11 @@ public class StopViewController: UIViewController,
                 actions.append(schedule)
             }
 
+            let shareTrip = UIAction(title: OBALoc("stop_controller.share_trip", value: "Share Trip", comment: "Context menu button that allows the user to share their trip status."), image: Icons.share) { [weak self] _ in
+                self?.shareTripStatus(viewModel: viewModel)
+            }
+            actions.append(shareTrip)
+
             // Create and return a UIMenu with all of the actions as children
             return UIMenu(title: viewModel.name, children: actions)
         }
@@ -1347,25 +1352,31 @@ public class StopViewController: UIViewController,
 
     // MARK: - Share Trip Status
     func shareTripStatus(viewModel: ArrivalDepartureItem) {
-        guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else { return }
+        guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else {
+            Logger.error("No arrivalDeparture found for share trip status view model.")
+            return
+        }
         shareTripStatus(arrivalDeparture: arrivalDeparture)
     }
 
     func shareTripStatus(arrivalDeparture: ArrivalDeparture) {
-        guard
-            let region = application.currentRegion,
-            let appLinksRouter = application.appLinksRouter
-        else {
-            return
-        }
+        let picker = DestinationStopPickerController(
+            application: application,
+            arrivalDeparture: arrivalDeparture
+        )
+        picker.delegate = self
+        let nav = application.viewRouter.buildNavigation(controller: picker)
+        self.present(nav, animated: true)
+    }
 
-        let url = appLinksRouter.encode(arrivalDeparture: arrivalDeparture, region: region) as Any
-
-        let activityController = UIActivityViewController(activityItems: [self, url], applicationActivities: nil)
-
-        // Use self.presnt because when using application.viewRouter.present(:_),
-        // it disables UIActivityViewController's "tap anywhere to dismiss".
-        self.present(activityController, animated: true)
+    private func presentShareError() {
+        let alert = UIAlertController(
+            title: OBALoc("stop_controller.share_error.title", value: "Unable to Share", comment: "Alert title when trip sharing fails."),
+            message: OBALoc("stop_controller.share_error.message", value: "Something went wrong while preparing the trip link. Please try again.", comment: "Alert message when trip sharing fails."),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.dismiss, style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Schedules
@@ -1562,6 +1573,50 @@ private extension StopViewController {
             self.showAllTransferDepartures = true
             self.listView.applyData()
         }
+    }
+}
+
+// MARK: - DestinationStopPickerDelegate
+
+extension StopViewController: DestinationStopPickerDelegate {
+    func destinationStopPicker(
+        _ controller: DestinationStopPickerController,
+        didSelectStop stopTime: TripStopTime,
+        for arrivalDeparture: ArrivalDeparture
+    ) {
+        dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            guard
+                let region = self.application.currentRegion,
+                let appLinksRouter = self.application.appLinksRouter
+            else {
+                Logger.error("Missing region or appLinksRouter for trip sharing.")
+                self.presentShareError()
+                return
+            }
+
+            guard let url = appLinksRouter.encode(
+                arrivalDeparture: arrivalDeparture,
+                region: region,
+                destinationStopID: stopTime.stopID
+            ) else {
+                Logger.error("Failed to encode trip sharing URL.")
+                self.presentShareError()
+                return
+            }
+
+            let activityController = UIActivityViewController(
+                activityItems: [self, url],
+                applicationActivities: nil
+            )
+            // Use self.present because when using application.viewRouter.present(:_),
+            // it disables UIActivityViewController's "tap anywhere to dismiss".
+            self.present(activityController, animated: true)
+        }
+    }
+
+    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {
+        dismiss(animated: true)
     }
 }
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -879,6 +879,11 @@ public class StopViewController: UIViewController,
                 actions.append(schedule)
             }
 
+            let shareTrip = UIAction(title: OBALoc("stop_controller.share_trip", value: "Share Trip", comment: "Context menu button that allows the user to share their trip status."), image: Icons.share) { [weak self] _ in
+                self?.shareTripStatus(viewModel: viewModel)
+            }
+            actions.append(shareTrip)
+
             // Create and return a UIMenu with all of the actions as children
             return UIMenu(title: viewModel.name, children: actions)
         }
@@ -1145,25 +1150,31 @@ public class StopViewController: UIViewController,
 
     // MARK: - Share Trip Status
     func shareTripStatus(viewModel: ArrivalDepartureItem) {
-        guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else { return }
+        guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else {
+            Logger.error("No arrivalDeparture found for share trip status view model.")
+            return
+        }
         shareTripStatus(arrivalDeparture: arrivalDeparture)
     }
 
     func shareTripStatus(arrivalDeparture: ArrivalDeparture) {
-        guard
-            let region = application.currentRegion,
-            let appLinksRouter = application.appLinksRouter
-        else {
-            return
-        }
+        let picker = DestinationStopPickerController(
+            application: application,
+            arrivalDeparture: arrivalDeparture
+        )
+        picker.delegate = self
+        let nav = application.viewRouter.buildNavigation(controller: picker)
+        self.present(nav, animated: true)
+    }
 
-        let url = appLinksRouter.encode(arrivalDeparture: arrivalDeparture, region: region) as Any
-
-        let activityController = UIActivityViewController(activityItems: [self, url], applicationActivities: nil)
-
-        // Use self.presnt because when using application.viewRouter.present(:_),
-        // it disables UIActivityViewController's "tap anywhere to dismiss".
-        self.present(activityController, animated: true)
+    private func presentShareError() {
+        let alert = UIAlertController(
+            title: OBALoc("stop_controller.share_error.title", value: "Unable to Share", comment: "Alert title when trip sharing fails."),
+            message: OBALoc("stop_controller.share_error.message", value: "Something went wrong while preparing the trip link. Please try again.", comment: "Alert message when trip sharing fails."),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.dismiss, style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Schedules
@@ -1403,6 +1414,50 @@ private extension StopViewController {
             self.showAllTransferDepartures = true
             self.listView.applyData()
         }
+    }
+}
+
+// MARK: - DestinationStopPickerDelegate
+
+extension StopViewController: DestinationStopPickerDelegate {
+    func destinationStopPicker(
+        _ controller: DestinationStopPickerController,
+        didSelectStop stopTime: TripStopTime,
+        for arrivalDeparture: ArrivalDeparture
+    ) {
+        dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            guard
+                let region = self.application.currentRegion,
+                let appLinksRouter = self.application.appLinksRouter
+            else {
+                Logger.error("Missing region or appLinksRouter for trip sharing.")
+                self.presentShareError()
+                return
+            }
+
+            guard let url = appLinksRouter.encode(
+                arrivalDeparture: arrivalDeparture,
+                region: region,
+                destinationStopID: stopTime.stopID
+            ) else {
+                Logger.error("Failed to encode trip sharing URL.")
+                self.presentShareError()
+                return
+            }
+
+            let activityController = UIActivityViewController(
+                activityItems: [self, url],
+                applicationActivities: nil
+            )
+            // Use self.present because when using application.viewRouter.present(:_),
+            // it disables UIActivityViewController's "tap anywhere to dismiss".
+            self.present(activityController, animated: true)
+        }
+    }
+
+    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {
+        dismiss(animated: true)
     }
 }
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1151,7 +1151,7 @@ public class StopViewController: UIViewController,
     // MARK: - Share Trip Status
     private func shareTripStatus(viewModel: ArrivalDepartureItem) {
         guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else {
-            Logger.error("No arrivalDeparture found for share trip status view model.")
+            Logger.error("No arrivalDeparture found for share trip status view model. arrivalDepartureID: \(viewModel.arrivalDepartureID), stopID: \(viewModel.stopID)")
             presentShareError()
             return
         }
@@ -1165,7 +1165,41 @@ public class StopViewController: UIViewController,
         )
         picker.delegate = self
         let nav = application.viewRouter.buildNavigation(controller: picker)
-        self.present(nav, animated: true)
+        application.viewRouter.present(nav, from: self, isModal: true)
+    }
+
+    /// Dismisses the destination picker, encodes the share URL (with an
+    /// optional destination stop), and presents the share sheet.
+    private func shareTrip(arrivalDeparture: ArrivalDeparture, destinationStopID: StopID?) {
+        dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            guard
+                let region = self.application.currentRegion,
+                let appLinksRouter = self.application.appLinksRouter
+            else {
+                Logger.error("Missing region or appLinksRouter for trip sharing. tripID: \(arrivalDeparture.tripID), stopID: \(arrivalDeparture.stopID)")
+                self.presentShareError()
+                return
+            }
+
+            guard let url = appLinksRouter.encode(
+                arrivalDeparture: arrivalDeparture,
+                region: region,
+                destinationStopID: destinationStopID
+            ) else {
+                Logger.error("Failed to encode trip sharing URL. tripID: \(arrivalDeparture.tripID), destinationStopID: \(destinationStopID ?? "none")")
+                self.presentShareError()
+                return
+            }
+
+            let activityController = UIActivityViewController(
+                activityItems: [self, url],
+                applicationActivities: nil
+            )
+            // Use self.present because when using application.viewRouter.present(:_),
+            // it disables UIActivityViewController's "tap anywhere to dismiss".
+            self.present(activityController, animated: true)
+        }
     }
 
     private func presentShareError() {
@@ -1425,36 +1459,11 @@ extension StopViewController: DestinationStopPickerDelegate {
         _ controller: DestinationStopPickerController,
         didSelectStop stopTime: TripStopTime
     ) {
-        let arrivalDeparture = controller.arrivalDeparture
-        dismiss(animated: true) { [weak self] in
-            guard let self else { return }
-            guard
-                let region = self.application.currentRegion,
-                let appLinksRouter = self.application.appLinksRouter
-            else {
-                Logger.error("Missing region or appLinksRouter for trip sharing.")
-                self.presentShareError()
-                return
-            }
+        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: stopTime.stopID)
+    }
 
-            guard let url = appLinksRouter.encode(
-                arrivalDeparture: arrivalDeparture,
-                region: region,
-                destinationStopID: stopTime.stopID
-            ) else {
-                Logger.error("Failed to encode trip sharing URL.")
-                self.presentShareError()
-                return
-            }
-
-            let activityController = UIActivityViewController(
-                activityItems: [self, url],
-                applicationActivities: nil
-            )
-            // Use self.present because when using application.viewRouter.present(:_),
-            // it disables UIActivityViewController's "tap anywhere to dismiss".
-            self.present(activityController, animated: true)
-        }
+    func destinationStopPickerDidSkipDestination(_ controller: DestinationStopPickerController) {
+        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: nil)
     }
 
     func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1149,15 +1149,16 @@ public class StopViewController: UIViewController,
     }
 
     // MARK: - Share Trip Status
-    func shareTripStatus(viewModel: ArrivalDepartureItem) {
+    private func shareTripStatus(viewModel: ArrivalDepartureItem) {
         guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else {
             Logger.error("No arrivalDeparture found for share trip status view model.")
+            presentShareError()
             return
         }
         shareTripStatus(arrivalDeparture: arrivalDeparture)
     }
 
-    func shareTripStatus(arrivalDeparture: ArrivalDeparture) {
+    private func shareTripStatus(arrivalDeparture: ArrivalDeparture) {
         let picker = DestinationStopPickerController(
             application: application,
             arrivalDeparture: arrivalDeparture
@@ -1422,9 +1423,9 @@ private extension StopViewController {
 extension StopViewController: DestinationStopPickerDelegate {
     func destinationStopPicker(
         _ controller: DestinationStopPickerController,
-        didSelectStop stopTime: TripStopTime,
-        for arrivalDeparture: ArrivalDeparture
+        didSelectStop stopTime: TripStopTime
     ) {
+        let arrivalDeparture = controller.arrivalDeparture
         dismiss(animated: true) { [weak self] in
             guard let self else { return }
             guard

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1149,67 +1149,18 @@ public class StopViewController: UIViewController,
     }
 
     // MARK: - Share Trip Status
+
+    /// Owns the picker → share-sheet flow. Holds `self` weakly, so retaining it
+    /// for the controller's lifetime creates no cycle.
+    private lazy var tripSharingCoordinator = TripSharingCoordinator(application: application, presenter: self)
+
     private func shareTripStatus(viewModel: ArrivalDepartureItem) {
         guard let arrivalDeparture = arrivalDeparture(forViewModel: viewModel) else {
             Logger.error("No arrivalDeparture found for share trip status view model. arrivalDepartureID: \(viewModel.arrivalDepartureID), stopID: \(viewModel.stopID)")
-            presentShareError()
+            tripSharingCoordinator.presentShareError()
             return
         }
-        shareTripStatus(arrivalDeparture: arrivalDeparture)
-    }
-
-    private func shareTripStatus(arrivalDeparture: ArrivalDeparture) {
-        let picker = DestinationStopPickerController(
-            application: application,
-            arrivalDeparture: arrivalDeparture
-        )
-        picker.delegate = self
-        let nav = application.viewRouter.buildNavigation(controller: picker)
-        application.viewRouter.present(nav, from: self, isModal: true)
-    }
-
-    /// Dismisses the destination picker, encodes the share URL (with an
-    /// optional destination stop), and presents the share sheet.
-    private func shareTrip(arrivalDeparture: ArrivalDeparture, destinationStopID: StopID?) {
-        dismiss(animated: true) { [weak self] in
-            guard let self else { return }
-            guard
-                let region = self.application.currentRegion,
-                let appLinksRouter = self.application.appLinksRouter
-            else {
-                Logger.error("Missing region or appLinksRouter for trip sharing. tripID: \(arrivalDeparture.tripID), stopID: \(arrivalDeparture.stopID)")
-                self.presentShareError()
-                return
-            }
-
-            guard let url = appLinksRouter.encode(
-                arrivalDeparture: arrivalDeparture,
-                region: region,
-                destinationStopID: destinationStopID
-            ) else {
-                Logger.error("Failed to encode trip sharing URL. tripID: \(arrivalDeparture.tripID), destinationStopID: \(destinationStopID ?? "none")")
-                self.presentShareError()
-                return
-            }
-
-            let activityController = UIActivityViewController(
-                activityItems: [self, url],
-                applicationActivities: nil
-            )
-            // Use self.present because when using application.viewRouter.present(:_),
-            // it disables UIActivityViewController's "tap anywhere to dismiss".
-            self.present(activityController, animated: true)
-        }
-    }
-
-    private func presentShareError() {
-        let alert = UIAlertController(
-            title: OBALoc("stop_controller.share_error.title", value: "Unable to Share", comment: "Alert title when trip sharing fails."),
-            message: OBALoc("stop_controller.share_error.message", value: "Something went wrong while preparing the trip link. Please try again.", comment: "Alert message when trip sharing fails."),
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: Strings.dismiss, style: .default))
-        present(alert, animated: true)
+        tripSharingCoordinator.start(arrivalDeparture: arrivalDeparture)
     }
 
     // MARK: - Schedules
@@ -1449,25 +1400,6 @@ private extension StopViewController {
             self.showAllTransferDepartures = true
             self.listView.applyData()
         }
-    }
-}
-
-// MARK: - DestinationStopPickerDelegate
-
-extension StopViewController: DestinationStopPickerDelegate {
-    func destinationStopPicker(
-        _ controller: DestinationStopPickerController,
-        didSelectStop stopTime: TripStopTime
-    ) {
-        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: stopTime.stopID)
-    }
-
-    func destinationStopPickerDidSkipDestination(_ controller: DestinationStopPickerController) {
-        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: nil)
-    }
-
-    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {
-        dismiss(animated: true)
     }
 }
 

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -1,0 +1,215 @@
+//
+//  DestinationStopPickerController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+// MARK: - Delegate
+
+protocol DestinationStopPickerDelegate: AnyObject {
+    func destinationStopPicker(
+        _ controller: DestinationStopPickerController,
+        didSelectStop stopTime: TripStopTime,
+        for arrivalDeparture: ArrivalDeparture
+    )
+    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController)
+}
+
+// MARK: - Controller
+
+/// Presents a list of stops along a trip so the user can select their destination before sharing.
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/449
+class DestinationStopPickerController: UIViewController, AppContext, OBAListViewDataSource {
+
+    let application: Application
+
+    private let arrivalDeparture: ArrivalDeparture
+
+    weak var delegate: DestinationStopPickerDelegate?
+
+    // MARK: - State
+
+    private enum State {
+        case loading
+        case data([TripStopTime])
+        case error(Error)
+    }
+
+    private var state: State = .loading {
+        didSet {
+            guard isViewLoaded else { return }
+            listView.applyData(animated: false)
+        }
+    }
+
+    private var fetchTask: Task<Void, Never>?
+
+    // MARK: - Init/Deinit
+
+    init(application: Application, arrivalDeparture: ArrivalDeparture) {
+        self.application = application
+        self.arrivalDeparture = arrivalDeparture
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        fetchTask?.cancel()
+    }
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = OBALoc(
+            "destination_stop_picker.title",
+            value: "Select Destination",
+            comment: "Navigation bar title for the destination stop picker when sharing a trip."
+        )
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(cancelTapped)
+        )
+
+        view.backgroundColor = ThemeColors.shared.systemBackground
+
+        listView.formatters = application.formatters
+        listView.obaDataSource = self
+        view.addSubview(listView)
+        listView.pinToSuperview(.edges)
+
+        loadStopTimes()
+    }
+
+    // MARK: - Data Loading
+
+    private func loadStopTimes() {
+        guard let apiService = application.apiService else {
+            state = .error(APIError.noResponseBody)
+            Logger.error("API service unavailable in DestinationStopPickerController.")
+            return
+        }
+
+        fetchTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let response = try await apiService.getTrip(
+                    tripID: self.arrivalDeparture.tripID,
+                    vehicleID: self.arrivalDeparture.vehicleID,
+                    serviceDate: self.arrivalDeparture.serviceDate
+                )
+
+                let allStopTimes = response.entry.stopTimes
+                let boardingStopID = self.arrivalDeparture.stopID
+
+                // Only show stops after the boarding stop.
+                let boardingIndex = allStopTimes.firstIndex { $0.stopID == boardingStopID }
+                let forwardStops: [TripStopTime]
+                if let boardingIndex {
+                    forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
+                } else {
+                    Logger.warn("Boarding stop \(boardingStopID) not found in trip stop times; showing all stops.")
+                    forwardStops = allStopTimes
+                }
+
+                await MainActor.run {
+                    self.state = .data(forwardStops)
+                }
+            } catch {
+                if error is CancellationError { return }
+                Logger.error("Failed to load trip stop times: \(error)")
+                await MainActor.run {
+                    self.state = .error(
+                        ErrorClassifier.classify(error, regionName: self.application.currentRegion?.name)
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func cancelTapped() {
+        delegate?.destinationStopPickerDidCancel(self)
+    }
+
+    // MARK: - UI
+
+    private let listView = OBAListView()
+
+    // MARK: - OBAListViewDataSource
+
+    func items(for listView: OBAListView) -> [OBAListViewSection] {
+        guard case .data(let stopTimes) = state, !stopTimes.isEmpty else {
+            return []
+        }
+
+        let items: [AnyOBAListViewItem] = stopTimes.map { stopTime in
+            let timeString = application.formatters.timeFormatter.string(from: stopTime.arrivalDate)
+
+            let action: OBAListViewAction<OBAListRowView.ValueViewModel> = { [weak self] _ in
+                guard let self else { return }
+                self.delegate?.destinationStopPicker(self, didSelectStop: stopTime, for: self.arrivalDeparture)
+            }
+
+            return OBAListRowView.ValueViewModel(
+                title: stopTime.stop.name,
+                subtitle: timeString,
+                accessoryType: .disclosureIndicator,
+                onSelectAction: action
+            ).typeErased
+        }
+
+        let header = OBALoc(
+            "destination_stop_picker.select_destination_header",
+            value: "Where are you getting off?",
+            comment: "Section header prompting user to select their destination stop."
+        )
+
+        return [OBAListViewSection(id: "destination_stops", title: header, contents: items)]
+    }
+
+    func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
+        switch state {
+        case .loading:
+            return .standard(.init(
+                title: OBALoc(
+                    "destination_stop_picker.loading_title",
+                    value: "Loading Stops",
+                    comment: "Title shown while loading the list of stops for destination selection."
+                ),
+                body: nil
+            ))
+        case .error(let error):
+            return .standard(.init(error: error))
+        case .data(let stops) where stops.isEmpty:
+            return .standard(.init(
+                title: OBALoc(
+                    "destination_stop_picker.no_stops_title",
+                    value: "No Stops Available",
+                    comment: "Title shown when there are no stops available after the boarding stop."
+                ),
+                body: OBALoc(
+                    "destination_stop_picker.no_stops_body",
+                    value: "There are no remaining stops on this trip.",
+                    comment: "Body text shown when there are no stops available after the boarding stop."
+                )
+            ))
+        case .data:
+            return nil
+        }
+    }
+}

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -15,8 +15,7 @@ import OBAKitCore
 protocol DestinationStopPickerDelegate: AnyObject {
     func destinationStopPicker(
         _ controller: DestinationStopPickerController,
-        didSelectStop stopTime: TripStopTime,
-        for arrivalDeparture: ArrivalDeparture
+        didSelectStop stopTime: TripStopTime
     )
     func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController)
 }
@@ -25,11 +24,12 @@ protocol DestinationStopPickerDelegate: AnyObject {
 
 /// Presents a list of stops along a trip so the user can select their destination before sharing.
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/449
+@MainActor
 class DestinationStopPickerController: UIViewController, AppContext, OBAListViewDataSource {
 
     let application: Application
 
-    private let arrivalDeparture: ArrivalDeparture
+    let arrivalDeparture: ArrivalDeparture
 
     weak var delegate: DestinationStopPickerDelegate?
 
@@ -37,6 +37,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
 
     private enum State {
         case loading
+        case empty
         case data([TripStopTime])
         case error(Error)
     }
@@ -97,11 +98,22 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
 
     private func loadStopTimes() {
         guard let apiService = application.apiService else {
-            state = .error(APIError.noResponseBody)
-            Logger.error("API service unavailable in DestinationStopPickerController.")
+            let error = NSError(
+                domain: "DestinationStopPickerController",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: OBALoc(
+                    "destination_stop_picker.error_no_service",
+                    value: "Unable to connect to the transit service.",
+                    comment: "Error shown when the API service is unavailable in the destination stop picker."
+                )]
+            )
+            Logger.error("API service unavailable in DestinationStopPickerController for trip \(arrivalDeparture.tripID).")
+            state = .error(error)
             return
         }
 
+        state = .loading
+        fetchTask?.cancel()
         fetchTask = Task { [weak self] in
             guard let self else { return }
 
@@ -115,27 +127,29 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
                 let allStopTimes = response.entry.stopTimes
                 let boardingStopID = self.arrivalDeparture.stopID
 
-                // Only show stops after the boarding stop.
-                let boardingIndex = allStopTimes.firstIndex { $0.stopID == boardingStopID }
-                let forwardStops: [TripStopTime]
-                if let boardingIndex {
-                    forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
-                } else {
-                    Logger.warn("Boarding stop \(boardingStopID) not found in trip stop times; showing all stops.")
-                    forwardStops = allStopTimes
+                guard let boardingIndex = allStopTimes.firstIndex(where: { $0.stopID == boardingStopID }) else {
+                    let error = NSError(
+                        domain: "DestinationStopPickerController",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: OBALoc(
+                            "destination_stop_picker.error_boarding_stop_not_found",
+                            value: "Couldn't determine your boarding point on this trip.",
+                            comment: "Error shown when the boarding stop cannot be found in the trip's stop list."
+                        )]
+                    )
+                    Logger.error("Boarding stop \(boardingStopID) not found in trip \(self.arrivalDeparture.tripID) stop times.")
+                    self.state = .error(error)
+                    return
                 }
 
-                await MainActor.run {
-                    self.state = .data(forwardStops)
-                }
+                let forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
+                self.state = forwardStops.isEmpty ? .empty : .data(forwardStops)
             } catch {
                 if error is CancellationError { return }
-                Logger.error("Failed to load trip stop times: \(error)")
-                await MainActor.run {
-                    self.state = .error(
-                        ErrorClassifier.classify(error, regionName: self.application.currentRegion?.name)
-                    )
-                }
+                Logger.error("Failed to load trip \(self.arrivalDeparture.tripID) stop times: \(error)")
+                self.state = .error(
+                    ErrorClassifier.classify(error, regionName: self.application.currentRegion?.name)
+                )
             }
         }
     }
@@ -153,7 +167,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
     // MARK: - OBAListViewDataSource
 
     func items(for listView: OBAListView) -> [OBAListViewSection] {
-        guard case .data(let stopTimes) = state, !stopTimes.isEmpty else {
+        guard case .data(let stopTimes) = state else {
             return []
         }
 
@@ -162,7 +176,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
 
             let action: OBAListViewAction<OBAListRowView.ValueViewModel> = { [weak self] _ in
                 guard let self else { return }
-                self.delegate?.destinationStopPicker(self, didSelectStop: stopTime, for: self.arrivalDeparture)
+                self.delegate?.destinationStopPicker(self, didSelectStop: stopTime)
             }
 
             return OBAListRowView.ValueViewModel(
@@ -193,9 +207,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
                 ),
                 body: nil
             ))
-        case .error(let error):
-            return .standard(.init(error: error))
-        case .data(let stops) where stops.isEmpty:
+        case .empty:
             return .standard(.init(
                 title: OBALoc(
                     "destination_stop_picker.no_stops_title",
@@ -208,6 +220,18 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
                     comment: "Body text shown when there are no stops available after the boarding stop."
                 )
             ))
+        case .error(let error):
+            let retryConfig = ActivityIndicatedButton.Configuration(
+                text: OBALoc(
+                    "destination_stop_picker.retry_button",
+                    value: "Try Again",
+                    comment: "Button to retry loading stops after an error."
+                ),
+                largeContentImage: nil,
+                showsActivityIndicatorOnTap: true,
+                action: { [weak self] in self?.loadStopTimes() }
+            )
+            return .standard(.init(error: error, buttonConfig: retryConfig))
         case .data:
             return nil
         }

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -17,6 +17,11 @@ protocol DestinationStopPickerDelegate: AnyObject {
         _ controller: DestinationStopPickerController,
         didSelectStop stopTime: TripStopTime
     )
+
+    /// Called when the trip has no stops after the boarding stop and the user
+    /// chooses to share without a destination instead.
+    func destinationStopPickerDidSkipDestination(_ controller: DestinationStopPickerController)
+
     func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController)
 }
 
@@ -114,44 +119,64 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
 
         state = .loading
         fetchTask?.cancel()
-        fetchTask = Task { [weak self] in
-            guard let self else { return }
 
+        // Capture what the request needs up front rather than binding `self`
+        // strongly across the await — otherwise the in-flight request keeps the
+        // controller alive and `deinit`'s `fetchTask?.cancel()` can never run.
+        let tripID = arrivalDeparture.tripID
+        let vehicleID = arrivalDeparture.vehicleID
+        let serviceDate = arrivalDeparture.serviceDate
+        let boardingStopID = arrivalDeparture.stopID
+
+        fetchTask = Task { [weak self] in
             do {
                 let response = try await apiService.getTrip(
-                    tripID: self.arrivalDeparture.tripID,
-                    vehicleID: self.arrivalDeparture.vehicleID,
-                    serviceDate: self.arrivalDeparture.serviceDate
+                    tripID: tripID,
+                    vehicleID: vehicleID,
+                    serviceDate: serviceDate
                 )
 
-                let allStopTimes = response.entry.stopTimes
-                let boardingStopID = self.arrivalDeparture.stopID
-
-                guard let boardingIndex = allStopTimes.firstIndex(where: { $0.stopID == boardingStopID }) else {
-                    let error = NSError(
-                        domain: "DestinationStopPickerController",
-                        code: 1,
-                        userInfo: [NSLocalizedDescriptionKey: OBALoc(
-                            "destination_stop_picker.error_boarding_stop_not_found",
-                            value: "Couldn't determine your boarding point on this trip.",
-                            comment: "Error shown when the boarding stop cannot be found in the trip's stop list."
-                        )]
-                    )
-                    Logger.error("Boarding stop \(boardingStopID) not found in trip \(self.arrivalDeparture.tripID) stop times.")
-                    self.state = .error(error)
-                    return
-                }
-
-                let forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
-                self.state = forwardStops.isEmpty ? .empty : .data(forwardStops)
+                // A cancelled task (retry or dismissal) must not overwrite
+                // state that a newer load may have already set.
+                guard let self, !Task.isCancelled else { return }
+                self.applyLoadedStopTimes(response.entry.stopTimes, boardingStopID: boardingStopID, tripID: tripID)
             } catch {
-                if error is CancellationError { return }
-                Logger.error("Failed to load trip \(self.arrivalDeparture.tripID) stop times: \(error)")
+                // `isCancellation` also matches URLError.cancelled, which is how
+                // URLSession reports a cancelled request — a plain
+                // `is CancellationError` check misses it. Same shape as
+                // TripViewModel.loadData().
+                if Task.isCancelled || error.isCancellation { return }
+                guard let self else { return }
+                Logger.error("Failed to load trip \(tripID) stop times: \(error)")
                 self.state = .error(
                     ErrorClassifier.classify(error, regionName: self.application.currentRegion?.name)
                 )
             }
         }
+    }
+
+    /// Filters `allStopTimes` down to the stops after the boarding stop and
+    /// transitions to the matching state. Fails to `.error` when the boarding
+    /// stop isn't in the trip's stop list — showing every stop instead would
+    /// let the user share a destination that is behind them.
+    private func applyLoadedStopTimes(_ allStopTimes: [TripStopTime], boardingStopID: StopID, tripID: String) {
+        guard let boardingIndex = allStopTimes.firstIndex(where: { $0.stopID == boardingStopID }) else {
+            let error = NSError(
+                domain: "DestinationStopPickerController",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: OBALoc(
+                    "destination_stop_picker.error_boarding_stop_not_found",
+                    value: "Couldn't determine your boarding point on this trip.",
+                    comment: "Error shown when the boarding stop cannot be found in the trip's stop list."
+                )]
+            )
+            Logger.error("Boarding stop \(boardingStopID) not found in trip \(tripID) stop times.")
+            state = .error(error)
+            return
+        }
+
+        let forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
+        state = forwardStops.isEmpty ? .empty : .data(forwardStops)
     }
 
     // MARK: - Actions
@@ -199,41 +224,69 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
     func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
         switch state {
         case .loading:
-            return .standard(.init(
-                title: OBALoc(
-                    "destination_stop_picker.loading_title",
-                    value: "Loading Stops",
-                    comment: "Title shown while loading the list of stops for destination selection."
-                ),
-                body: nil
-            ))
+            return .standard(loadingViewModel)
         case .empty:
-            return .standard(.init(
-                title: OBALoc(
-                    "destination_stop_picker.no_stops_title",
-                    value: "No Stops Available",
-                    comment: "Title shown when there are no stops available after the boarding stop."
-                ),
-                body: OBALoc(
-                    "destination_stop_picker.no_stops_body",
-                    value: "There are no remaining stops on this trip.",
-                    comment: "Body text shown when there are no stops available after the boarding stop."
-                )
-            ))
+            return .standard(emptyViewModel)
         case .error(let error):
-            let retryConfig = ActivityIndicatedButton.Configuration(
-                text: OBALoc(
-                    "destination_stop_picker.retry_button",
-                    value: "Try Again",
-                    comment: "Button to retry loading stops after an error."
-                ),
-                largeContentImage: nil,
-                showsActivityIndicatorOnTap: true,
-                action: { [weak self] in self?.loadStopTimes() }
-            )
-            return .standard(.init(error: error, buttonConfig: retryConfig))
+            return .standard(errorViewModel(for: error))
         case .data:
             return nil
         }
+    }
+
+    private var loadingViewModel: OBAListView.StandardEmptyDataViewModel {
+        .init(
+            title: OBALoc(
+                "destination_stop_picker.loading_title",
+                value: "Loading Stops",
+                comment: "Title shown while loading the list of stops for destination selection."
+            ),
+            body: nil
+        )
+    }
+
+    private var emptyViewModel: OBAListView.StandardEmptyDataViewModel {
+        // Without this button the empty state would be a dead end: the
+        // only exit is Cancel, with no way to share the trip at all.
+        let shareConfig = ActivityIndicatedButton.Configuration(
+            text: OBALoc(
+                "destination_stop_picker.share_without_destination_button",
+                value: "Share Without Destination",
+                comment: "Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination."
+            ),
+            largeContentImage: nil,
+            showsActivityIndicatorOnTap: false,
+            action: { [weak self] in
+                guard let self else { return }
+                self.delegate?.destinationStopPickerDidSkipDestination(self)
+            }
+        )
+        return .init(
+            title: OBALoc(
+                "destination_stop_picker.no_stops_title",
+                value: "No Stops Available",
+                comment: "Title shown when there are no stops available after the boarding stop."
+            ),
+            body: OBALoc(
+                "destination_stop_picker.no_stops_body",
+                value: "There are no remaining stops on this trip.",
+                comment: "Body text shown when there are no stops available after the boarding stop."
+            ),
+            buttonConfig: shareConfig
+        )
+    }
+
+    private func errorViewModel(for error: Error) -> OBAListView.StandardEmptyDataViewModel {
+        let retryConfig = ActivityIndicatedButton.Configuration(
+            text: OBALoc(
+                "destination_stop_picker.retry_button",
+                value: "Try Again",
+                comment: "Button to retry loading stops after an error."
+            ),
+            largeContentImage: nil,
+            showsActivityIndicatorOnTap: true,
+            action: { [weak self] in self?.loadStopTimes() }
+        )
+        return .init(error: error, buttonConfig: retryConfig)
     }
 }

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -102,6 +102,10 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
     // MARK: - Data Loading
 
     private func loadStopTimes() {
+        // Cancel before any early return: if the service guard below fails, a
+        // prior in-flight fetch must not survive to overwrite the `.error` state.
+        fetchTask?.cancel()
+
         guard let apiService = application.apiService else {
             let error = NSError(
                 domain: "DestinationStopPickerController",
@@ -118,7 +122,6 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
         }
 
         state = .loading
-        fetchTask?.cancel()
 
         // Capture what the request needs up front rather than binding `self`
         // strongly across the await — otherwise the in-flight request keeps the
@@ -127,6 +130,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
         let vehicleID = arrivalDeparture.vehicleID
         let serviceDate = arrivalDeparture.serviceDate
         let boardingStopID = arrivalDeparture.stopID
+        let boardingSequence = arrivalDeparture.stopSequence
 
         fetchTask = Task { [weak self] in
             do {
@@ -139,7 +143,12 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
                 // A cancelled task (retry or dismissal) must not overwrite
                 // state that a newer load may have already set.
                 guard let self, !Task.isCancelled else { return }
-                self.applyLoadedStopTimes(response.entry.stopTimes, boardingStopID: boardingStopID, tripID: tripID)
+                self.applyLoadedStopTimes(
+                    response.entry.stopTimes,
+                    boardingStopID: boardingStopID,
+                    boardingSequence: boardingSequence,
+                    tripID: tripID
+                )
             } catch {
                 // `isCancellation` also matches URLError.cancelled, which is how
                 // URLSession reports a cancelled request — a plain
@@ -156,11 +165,20 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
     }
 
     /// Filters `allStopTimes` down to the stops after the boarding stop and
-    /// transitions to the matching state. Fails to `.error` when the boarding
-    /// stop isn't in the trip's stop list — showing every stop instead would
-    /// let the user share a destination that is behind them.
-    private func applyLoadedStopTimes(_ allStopTimes: [TripStopTime], boardingStopID: StopID, tripID: String) {
-        guard let boardingIndex = allStopTimes.firstIndex(where: { $0.stopID == boardingStopID }) else {
+    /// transitions to the matching state.
+    ///
+    /// The boarding stop is located by `boardingSequence`
+    /// (`ArrivalDeparture.stopSequence`, the index of the stop within the trip's
+    /// stop sequence) rather than by searching for `boardingStopID`: on a loop
+    /// trip that visits the same stop twice, an ID search matches the first
+    /// occurrence and would offer stops the rider has already passed. The stopID
+    /// cross-check fails closed to `.error` if the sequence and the stop list
+    /// disagree — showing every stop instead would let the user share a
+    /// destination that is behind them.
+    private func applyLoadedStopTimes(_ allStopTimes: [TripStopTime], boardingStopID: StopID, boardingSequence: Int, tripID: String) {
+        guard boardingSequence >= 0,
+              boardingSequence < allStopTimes.count,
+              allStopTimes[boardingSequence].stopID == boardingStopID else {
             let error = NSError(
                 domain: "DestinationStopPickerController",
                 code: 1,
@@ -170,12 +188,12 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
                     comment: "Error shown when the boarding stop cannot be found in the trip's stop list."
                 )]
             )
-            Logger.error("Boarding stop \(boardingStopID) not found in trip \(tripID) stop times.")
+            Logger.error("Boarding stop \(boardingStopID) at sequence \(boardingSequence) not found in trip \(tripID) stop times (count: \(allStopTimes.count)).")
             state = .error(error)
             return
         }
 
-        let forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingIndex)))
+        let forwardStops = Array(allStopTimes.suffix(from: allStopTimes.index(after: boardingSequence)))
         state = forwardStops.isEmpty ? .empty : .data(forwardStops)
     }
 

--- a/OBAKit/Trip/TripSharingCoordinator.swift
+++ b/OBAKit/Trip/TripSharingCoordinator.swift
@@ -1,0 +1,123 @@
+//
+//  TripSharingCoordinator.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+/// Drives the trip-sharing flow: presents the destination stop picker and, once
+/// the user picks a stop (or opts to share without one), swaps it for the system
+/// share sheet with the encoded deep link. Shared by the legacy
+/// `StopViewController` and the redesigned `StopPageViewController` so the flow
+/// exists in exactly one place.
+@MainActor
+final class TripSharingCoordinator: NSObject, DestinationStopPickerDelegate {
+
+    private let application: Application
+
+    /// Held weakly: if the presenting screen goes away mid-flow there is no UI
+    /// left to drive, so every step simply ends.
+    private weak var presenter: UIViewController?
+
+    /// - Parameters:
+    ///   - application: The application object.
+    ///   - presenter: The view controller the picker, share sheet, and error
+    ///     alert are presented from.
+    init(application: Application, presenter: UIViewController) {
+        self.application = application
+        self.presenter = presenter
+    }
+
+    /// Entry point: presents the destination stop picker for `arrivalDeparture`.
+    func start(arrivalDeparture: ArrivalDeparture) {
+        guard let presenter else { return }
+        let picker = DestinationStopPickerController(
+            application: application,
+            arrivalDeparture: arrivalDeparture
+        )
+        picker.delegate = self
+        let nav = application.viewRouter.buildNavigation(controller: picker)
+        application.viewRouter.present(nav, from: presenter, isModal: true)
+    }
+
+    /// Shows the shared "Unable to Share" alert. Exposed so entry points can
+    /// report failures that occur before the picker is presented (e.g. a stale
+    /// view model with no matching `ArrivalDeparture`).
+    func presentShareError() {
+        let alert = UIAlertController(
+            title: OBALoc("trip_sharing.share_error.title", value: "Unable to Share", comment: "Alert title when trip sharing fails."),
+            message: OBALoc("trip_sharing.share_error.message", value: "Something went wrong while preparing the trip link. Please try again.", comment: "Alert message when trip sharing fails."),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.dismiss, style: .default))
+        presenter?.present(alert, animated: true)
+    }
+
+    // MARK: - DestinationStopPickerDelegate
+
+    func destinationStopPicker(
+        _ controller: DestinationStopPickerController,
+        didSelectStop stopTime: TripStopTime
+    ) {
+        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: stopTime.stopID)
+    }
+
+    func destinationStopPickerDidSkipDestination(_ controller: DestinationStopPickerController) {
+        shareTrip(arrivalDeparture: controller.arrivalDeparture, destinationStopID: nil)
+    }
+
+    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {
+        presenter?.dismiss(animated: true)
+    }
+
+    // MARK: - Share Sheet
+
+    /// Dismisses the picker, encodes the share URL (with an optional destination
+    /// stop), and presents the share sheet.
+    private func shareTrip(arrivalDeparture: ArrivalDeparture, destinationStopID: StopID?) {
+        guard let presenter else { return }
+        presenter.dismiss(animated: true) { [weak self] in
+            guard let self, let presenter = self.presenter else { return }
+            guard
+                let region = self.application.currentRegion,
+                let appLinksRouter = self.application.appLinksRouter
+            else {
+                Logger.error("Missing region or appLinksRouter for trip sharing. tripID: \(arrivalDeparture.tripID), stopID: \(arrivalDeparture.stopID)")
+                self.presentShareError()
+                return
+            }
+
+            guard let url = appLinksRouter.encode(
+                arrivalDeparture: arrivalDeparture,
+                region: region,
+                destinationStopID: destinationStopID
+            ) else {
+                Logger.error("Failed to encode trip sharing URL. tripID: \(arrivalDeparture.tripID), destinationStopID: \(destinationStopID ?? "none")")
+                self.presentShareError()
+                return
+            }
+
+            let activityController = UIActivityViewController(
+                activityItems: [url],
+                applicationActivities: nil
+            )
+
+            // iPad support: without an anchored popover, presenting a share
+            // sheet on iPad throws at runtime.
+            if let popover = activityController.popoverPresentationController {
+                popover.sourceView = presenter.view
+                popover.sourceRect = CGRect(x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0)
+                popover.permittedArrowDirections = []
+            }
+
+            // Use presenter.present because when using application.viewRouter.present(:_),
+            // it disables UIActivityViewController's "tap anywhere to dismiss".
+            presenter.present(activityController, animated: true)
+        }
+    }
+}

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -1,0 +1,223 @@
+//
+//  DestinationStopPickerControllerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_try
+
+class DestinationStopPickerControllerTests: OBATestCase {
+    var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    private func makeArrivalDeparture() throws -> ArrivalDeparture {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        return try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+    }
+
+    /// Returns a minimal `RESTAPIResponse<TripDetails>` JSON payload.
+    /// `stopIDs` maps directly to `schedule.stopTimes`; all stops are included in `references`.
+    private func makeTripDetailsData(stopIDs: [String], tripID: String = "1_40984902") -> Data {
+        let stopTimes: [[String: Any]] = stopIDs.enumerated().map { idx, id in
+            ["stopId": id,
+             "arrivalTime": 58862 + idx * 120,
+             "departureTime": 58862 + idx * 120,
+             "distanceAlongTrip": Double(idx) * 300.0,
+             "stopHeadsign": ""]
+        }
+        let stops: [[String: Any]] = stopIDs.map { id in
+            ["id": id, "lat": 47.656, "lon": -122.312, "name": "Stop \(id)",
+             "code": id, "locationType": 0, "routeIds": [] as [String], "direction": "N"]
+        }
+        let trip: [String: Any] = [
+            "id": tripID, "routeId": "1_100447", "routeShortName": "",
+            "serviceId": "1_s", "shapeId": "", "timeZone": "",
+            "tripHeadsign": "Test Destination", "tripShortName": "",
+            "blockId": "1_b", "directionId": "1"
+        ]
+        let payload: [String: Any] = [
+            "currentTime": 1_700_000_000_000, "text": "OK", "code": 200, "version": 2,
+            "data": [
+                "references": [
+                    "agencies": [] as [[String: Any]],
+                    "situations": [] as [[String: Any]],
+                    "routes": [] as [[String: Any]],
+                    "trips": [trip],
+                    "stops": stops
+                ],
+                "entry": [
+                    "tripId": tripID,
+                    "serviceDate": 1_541_055_600_000,
+                    "situationIds": [] as [String],
+                    "schedule": [
+                        "timeZone": "America/Los_Angeles",
+                        "stopTimes": stopTimes
+                    ]
+                ]
+            ]
+        ]
+        return try! JSONSerialization.data(withJSONObject: payload)
+    }
+
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+        let emptySurveys = #"{"surveys":[]}"#.data(using: .utf8)!
+        dataLoader.mock(data: emptySurveys) { $0.url?.path.contains("/surveys.json") ?? false }
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return Application(config: config)
+    }
+
+    // MARK: - Tests
+
+    /// When the trip has stops after the boarding stop, the controller should
+    /// load into `.data` state and return one section containing only the forward stops.
+    @MainActor
+    func test_loadStopTimes_success_setsDataWithForwardStopsOnly() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
+        let forwardStopIDs = ["1_10915", "1_10916"]
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let sections = controller.items(for: OBAListView())
+        XCTAssertEqual(sections.count, 1, "Expected exactly one section of forward stops")
+        XCTAssertEqual(sections[0].contents.count, forwardStopIDs.count,
+                       "Section should contain only the \(forwardStopIDs.count) stops after the boarding stop")
+        XCTAssertNil(controller.emptyData(for: OBAListView()),
+                     "emptyData should be nil when stops are loaded")
+    }
+
+    /// When the boarding stop is the last stop on the trip, there are no forward stops
+    /// and the controller should enter `.empty` state.
+    @MainActor
+    func test_loadStopTimes_boardingIsLastStop_setsEmptyState() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
+        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
+        guard case .standard(let vm) = emptyData else {
+            XCTFail("Expected .standard empty data"); return
+        }
+        XCTAssertEqual(vm.title, "No Stops Available")
+        XCTAssertEqual(vm.body, "There are no remaining stops on this trip.")
+        XCTAssertNil(vm.buttonConfig, "No retry button expected for empty state")
+    }
+
+    /// When the boarding stop ID isn't present in the trip's stop times, the controller
+    /// must fail to an error — not silently show all stops, which would let a user
+    /// generate a link with a behind-them destination.
+    @MainActor
+    func test_loadStopTimes_boardingStopNotFound_setsErrorState() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
+
+        let dataLoader = MockDataLoader(testName: name)
+        // Trip whose stop list does NOT contain the boarding stop
+        dataLoader.mock(data: makeTripDetailsData(stopIDs: ["1_other_a", "1_other_b"])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
+        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
+        guard case .standard(let vm) = emptyData else {
+            XCTFail("Expected .standard empty data"); return
+        }
+        XCTAssertEqual(vm.body, "Couldn't determine your boarding point on this trip.",
+                       "Should show the boarding-stop-not-found error, not a fallback stop list")
+        XCTAssertNotNil(vm.buttonConfig, "Retry button should be offered on error")
+        XCTAssertEqual(vm.buttonConfig?.text, "Try Again")
+    }
+
+    /// A network error should transition to `.error` state and surface a retry button.
+    @MainActor
+    func test_loadStopTimes_networkError_setsErrorStateWithRetry() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let dataLoader = MockDataLoader(testName: name)
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet,
+                                   userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."])
+        dataLoader.mock(response: MockDataResponse(data: nil, urlResponse: nil, error: networkError) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        })
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
+        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
+        guard case .standard(let vm) = emptyData else {
+            XCTFail("Expected .standard empty data"); return
+        }
+        XCTAssertNotNil(vm.body, "Error message should be populated")
+        XCTAssertNotNil(vm.buttonConfig, "Retry button should be offered on network error")
+        XCTAssertEqual(vm.buttonConfig?.text, "Try Again")
+    }
+}

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -60,6 +60,13 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         return try #require(stopArrivals.arrivalsAndDepartures.first)
     }
 
+    /// Builds a trip stop list that honors the fixture arrival's `stopSequence`
+    /// of 3: the controller locates the boarding stop by sequence index, so it
+    /// must sit at index 3, preceded by three placeholder stops.
+    private func stopIDsWithBoarding(_ boardingStopID: String, forward: [String]) -> [String] {
+        ["1_before_1", "1_before_2", "1_before_3", boardingStopID] + forward
+    }
+
     /// Returns a minimal `RESTAPIResponse<TripDetails>` JSON payload.
     /// `stopIDs` maps directly to `schedule.stopTimes`; all stops are included in `references`.
     private func makeTripDetailsData(stopIDs: [String], tripID: String = "1_40984902") throws -> Data {
@@ -161,7 +168,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         let forwardStopIDs = ["1_10915", "1_10916"]
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: forwardStopIDs))) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
@@ -191,7 +198,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID, "1_10915", "1_10916"])) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: ["1_10915", "1_10916"]))) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
@@ -223,7 +230,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         let arrivalDeparture = try makeArrivalDeparture()
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: []))) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
@@ -253,7 +260,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         let arrivalDeparture = try makeArrivalDeparture()
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: []))) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
@@ -277,16 +284,16 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         #expect(!recorder.didCancel)
     }
 
-    /// When the boarding stop ID isn't present in the trip's stop times, the controller
-    /// must fail to an error — not silently show all stops, which would let a user
-    /// generate a link with a behind-them destination.
+    /// When the stop at the arrival's `stopSequence` isn't the boarding stop, the
+    /// controller must fail to an error — not silently show all stops, which would
+    /// let a user generate a link with a behind-them destination.
     @Test @MainActor
     func `Missing boarding stop fails to an error instead of showing all stops`() async throws {
-        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914", stopSequence = 3
 
         let dataLoader = MockDataLoader(testName: name)
-        // Trip whose stop list does NOT contain the boarding stop
-        dataLoader.mock(data: try makeTripDetailsData(stopIDs: ["1_other_a", "1_other_b"])) {
+        // Index 3 exists but holds a different stop — the in-bounds mismatch case.
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: ["1_other_a", "1_other_b", "1_other_c", "1_other_d", "1_other_e"])) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
@@ -303,6 +310,65 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         #expect(controller.items(for: listView).isEmpty, "No stop list may be shown when the boarding stop is unknown")
         let viewModel = try #require(standardEmptyData(controller, listView))
         #expect(viewModel.buttonConfig?.text == "Try Again", "Retry button should be offered on error")
+    }
+
+    /// A stop list shorter than the arrival's `stopSequence` must fail closed to
+    /// an error — the out-of-bounds direction of the boarding-point guard. The
+    /// boarding stop's ID is present in the list, so an ID search would have
+    /// (wrongly) succeeded here.
+    @Test @MainActor
+    func `Stop list shorter than the boarding sequence fails to an error`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914", stopSequence = 3
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: ["1_x", arrivalDeparture.stopID])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.body == "Couldn't determine your boarding point on this trip." },
+            "picker never entered the error state"
+        )
+        #expect(controller.items(for: listView).isEmpty, "No stop list may be shown when the sequence is out of bounds")
+    }
+
+    /// On a loop trip the boarding stop's ID appears more than once in the stop
+    /// list. The controller must anchor on `stopSequence` — matching the first
+    /// ID occurrence would offer stops the rider has already passed.
+    @Test @MainActor
+    func `Loop trip anchors on stopSequence, not the first matching stop ID`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914", stopSequence = 3
+        let boarding = arrivalDeparture.stopID
+
+        let dataLoader = MockDataLoader(testName: name)
+        // The boarding stop ID also appears at index 1; the real boarding point is index 3.
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: ["1_x", boarding, "1_y", boarding, "1_z"])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        let recorder = PickerDelegateRecorder()
+        controller.delegate = recorder
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { !controller.items(for: listView).isEmpty },
+            "picker never entered the data state"
+        )
+
+        let rows = try #require(controller.items(for: listView).first?.contents)
+        #expect(rows.count == 1, "Only the one stop after the sequence-3 boarding point may be offered")
+
+        let firstRow = try #require(rows.first)
+        firstRow.onSelectAction?(firstRow)
+        #expect(recorder.selectedStopTime?.stopID == "1_z", "The offered stop must be the one after the rider's actual boarding point")
     }
 
     /// A network error should transition to `.error` state and surface a retry button.
@@ -361,7 +427,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         )
         let retryConfig = try #require(standardEmptyData(controller, listView)?.buttonConfig)
 
-        let successData = try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)
+        let successData = try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: forwardStopIDs))
         dataLoader.replaceMappedResponses { loader in
             self.registerBaseStubs(on: loader)
             loader.mock(data: successData) { $0.url?.path.contains("/api/where/trip-details") ?? false }

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -7,23 +7,46 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
-// swiftlint:disable force_try
+/// Records which `DestinationStopPickerDelegate` callback fired, for asserting
+/// on the empty state's share-without-destination path.
+private final class PickerDelegateRecorder: DestinationStopPickerDelegate {
+    var selectedStopTime: TripStopTime?
+    var didSkipDestination = false
+    var didCancel = false
 
-class DestinationStopPickerControllerTests: OBATestCase {
+    func destinationStopPicker(
+        _ controller: DestinationStopPickerController,
+        didSelectStop stopTime: TripStopTime
+    ) {
+        selectedStopTime = stopTime
+    }
+
+    func destinationStopPickerDidSkipDestination(_ controller: DestinationStopPickerController) {
+        didSkipDestination = true
+    }
+
+    func destinationStopPickerDidCancel(_ controller: DestinationStopPickerController) {
+        didCancel = true
+    }
+}
+
+@Suite(.serialized)
+final class DestinationStopPickerControllerTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() {
-        super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() {
-        super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -34,12 +57,12 @@ class DestinationStopPickerControllerTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        return try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
     }
 
     /// Returns a minimal `RESTAPIResponse<TripDetails>` JSON payload.
     /// `stopIDs` maps directly to `schedule.stopTimes`; all stops are included in `references`.
-    private func makeTripDetailsData(stopIDs: [String], tripID: String = "1_40984902") -> Data {
+    private func makeTripDetailsData(stopIDs: [String], tripID: String = "1_40984902") throws -> Data {
         let stopTimes: [[String: Any]] = stopIDs.enumerated().map { idx, id in
             ["stopId": id,
              "arrivalTime": 58862 + idx * 120,
@@ -78,15 +101,22 @@ class DestinationStopPickerControllerTests: OBATestCase {
                 ]
             ]
         ]
-        return try! JSONSerialization.data(withJSONObject: payload)
+        return try JSONSerialization.data(withJSONObject: payload)
     }
 
-    private func createApplication(dataLoader: MockDataLoader) -> Application {
+    /// Registers the stubs every test needs regardless of scenario. Kept separate from
+    /// `createApplication` so `replaceMappedResponses`-based tests can re-register them
+    /// atomically alongside their scenario-specific trip-details mock.
+    private func registerBaseStubs(on dataLoader: MockDataLoader) {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
-        let emptySurveys = #"{"surveys":[]}"#.data(using: .utf8)!
+        let emptySurveys = Data(#"{"surveys":[]}"#.utf8)
         dataLoader.mock(data: emptySurveys) { $0.url?.path.contains("/surveys.json") ?? false }
+    }
+
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        registerBaseStubs(on: dataLoader)
 
         let locManager = MockAuthorizedLocationManager(
             updateLocation: TestData.mockSeattleLocation,
@@ -112,91 +142,172 @@ class DestinationStopPickerControllerTests: OBATestCase {
         return Application(config: config)
     }
 
+    /// Unwraps the `.standard` empty data view model the controller currently vends, if any.
+    private func standardEmptyData(
+        _ controller: DestinationStopPickerController,
+        _ listView: OBAListView
+    ) -> OBAListView.StandardEmptyDataViewModel? {
+        guard case .standard(let viewModel)? = controller.emptyData(for: listView) else { return nil }
+        return viewModel
+    }
+
     // MARK: - Tests
 
     /// When the trip has stops after the boarding stop, the controller should
     /// load into `.data` state and return one section containing only the forward stops.
-    @MainActor
-    func test_loadStopTimes_success_setsDataWithForwardStopsOnly() async throws {
+    @Test @MainActor
+    func `Successful load shows one section containing only the forward stops`() async throws {
         let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
         let forwardStopIDs = ["1_10915", "1_10916"]
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
 
         let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
         controller.loadViewIfNeeded()
-        try await Task.sleep(nanoseconds: 500_000_000)
 
-        let sections = controller.items(for: OBAListView())
-        XCTAssertEqual(sections.count, 1, "Expected exactly one section of forward stops")
-        XCTAssertEqual(sections[0].contents.count, forwardStopIDs.count,
-                       "Section should contain only the \(forwardStopIDs.count) stops after the boarding stop")
-        XCTAssertNil(controller.emptyData(for: OBAListView()),
-                     "emptyData should be nil when stops are loaded")
+        let listView = OBAListView()
+        await poll(
+            until: { !controller.items(for: listView).isEmpty },
+            "picker never entered the data state"
+        )
+
+        let sections = controller.items(for: listView)
+        #expect(sections.count == 1, "Expected exactly one section of forward stops")
+        #expect(
+            sections.first?.contents.count == forwardStopIDs.count,
+            "Section should contain only the \(forwardStopIDs.count) stops after the boarding stop"
+        )
+        #expect(standardEmptyData(controller, listView) == nil, "emptyData should be nil when stops are loaded")
+    }
+
+    /// Tapping a stop row must notify the delegate with that row's stop time —
+    /// the feature's primary selection path.
+    @Test @MainActor
+    func `Selecting a stop row notifies the delegate with that stop time`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID, "1_10915", "1_10916"])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        let recorder = PickerDelegateRecorder()
+        controller.delegate = recorder
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { !controller.items(for: listView).isEmpty },
+            "picker never entered the data state"
+        )
+
+        let firstRow = try #require(controller.items(for: listView).first?.contents.first)
+        firstRow.onSelectAction?(firstRow)
+
+        #expect(recorder.selectedStopTime?.stopID == "1_10915", "Delegate must receive the tapped row's stop time")
+        #expect(!recorder.didSkipDestination)
+        #expect(!recorder.didCancel)
     }
 
     /// When the boarding stop is the last stop on the trip, there are no forward stops
-    /// and the controller should enter `.empty` state.
-    @MainActor
-    func test_loadStopTimes_boardingIsLastStop_setsEmptyState() async throws {
+    /// and the controller should enter `.empty` state — with a share button, so the
+    /// empty state isn't a dead end.
+    @Test @MainActor
+    func `Boarding at the last stop shows the empty state with a destination-less share button`() async throws {
         let arrivalDeparture = try makeArrivalDeparture()
 
         let dataLoader = MockDataLoader(testName: name)
-        dataLoader.mock(data: makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
 
         let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
         controller.loadViewIfNeeded()
-        try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
-        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
-        guard case .standard(let vm) = emptyData else {
-            XCTFail("Expected .standard empty data"); return
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.title == "No Stops Available" },
+            "picker never entered the empty state"
+        )
+
+        #expect(controller.items(for: listView).isEmpty)
+        let viewModel = try #require(standardEmptyData(controller, listView))
+        #expect(viewModel.body == "There are no remaining stops on this trip.")
+        #expect(
+            viewModel.buttonConfig?.text == "Share Without Destination",
+            "Empty state must offer a destination-less share instead of dead-ending"
+        )
+    }
+
+    /// Tapping the empty state's share button must notify the delegate through the
+    /// destination-less path — not the stop-selection or cancel paths.
+    @Test @MainActor
+    func `Empty state share button notifies the delegate to share without a destination`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID])) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
         }
-        XCTAssertEqual(vm.title, "No Stops Available")
-        XCTAssertEqual(vm.body, "There are no remaining stops on this trip.")
-        XCTAssertNil(vm.buttonConfig, "No retry button expected for empty state")
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        let recorder = PickerDelegateRecorder()
+        controller.delegate = recorder
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.buttonConfig != nil },
+            "picker never entered the empty state"
+        )
+
+        let buttonConfig = try #require(standardEmptyData(controller, listView)?.buttonConfig)
+        buttonConfig.action()
+
+        #expect(recorder.didSkipDestination)
+        #expect(recorder.selectedStopTime == nil)
+        #expect(!recorder.didCancel)
     }
 
     /// When the boarding stop ID isn't present in the trip's stop times, the controller
     /// must fail to an error — not silently show all stops, which would let a user
     /// generate a link with a behind-them destination.
-    @MainActor
-    func test_loadStopTimes_boardingStopNotFound_setsErrorState() async throws {
+    @Test @MainActor
+    func `Missing boarding stop fails to an error instead of showing all stops`() async throws {
         let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
 
         let dataLoader = MockDataLoader(testName: name)
         // Trip whose stop list does NOT contain the boarding stop
-        dataLoader.mock(data: makeTripDetailsData(stopIDs: ["1_other_a", "1_other_b"])) {
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: ["1_other_a", "1_other_b"])) {
             $0.url?.path.contains("/api/where/trip-details") ?? false
         }
         let app = createApplication(dataLoader: dataLoader)
 
         let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
         controller.loadViewIfNeeded()
-        try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
-        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
-        guard case .standard(let vm) = emptyData else {
-            XCTFail("Expected .standard empty data"); return
-        }
-        XCTAssertEqual(vm.body, "Couldn't determine your boarding point on this trip.",
-                       "Should show the boarding-stop-not-found error, not a fallback stop list")
-        XCTAssertNotNil(vm.buttonConfig, "Retry button should be offered on error")
-        XCTAssertEqual(vm.buttonConfig?.text, "Try Again")
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.body == "Couldn't determine your boarding point on this trip." },
+            "picker never entered the error state"
+        )
+
+        #expect(controller.items(for: listView).isEmpty, "No stop list may be shown when the boarding stop is unknown")
+        let viewModel = try #require(standardEmptyData(controller, listView))
+        #expect(viewModel.buttonConfig?.text == "Try Again", "Retry button should be offered on error")
     }
 
     /// A network error should transition to `.error` state and surface a retry button.
-    @MainActor
-    func test_loadStopTimes_networkError_setsErrorStateWithRetry() async throws {
+    @Test @MainActor
+    func `Network error shows the error state with a retry button`() async throws {
         let arrivalDeparture = try makeArrivalDeparture()
 
         let dataLoader = MockDataLoader(testName: name)
@@ -209,15 +320,61 @@ class DestinationStopPickerControllerTests: OBATestCase {
 
         let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
         controller.loadViewIfNeeded()
-        try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertTrue(controller.items(for: OBAListView()).isEmpty)
-        let emptyData = try XCTUnwrap(controller.emptyData(for: OBAListView()))
-        guard case .standard(let vm) = emptyData else {
-            XCTFail("Expected .standard empty data"); return
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.buttonConfig != nil },
+            "picker never entered the error state"
+        )
+
+        #expect(controller.items(for: listView).isEmpty)
+        let viewModel = try #require(standardEmptyData(controller, listView))
+        // `ErrorClassifier` maps NSURLErrorNotConnectedToInternet to
+        // `APIError.networkFailure`, whose message is the underlying error's
+        // localizedDescription when no failing URL is attached.
+        #expect(viewModel.body == "The Internet connection appears to be offline.")
+        #expect(viewModel.buttonConfig?.text == "Try Again", "Retry button should be offered on network error")
+    }
+
+    /// The error state's Try Again button must actually reload: after swapping the
+    /// failing mock for a good payload, tapping it should land the picker in `.data`.
+    @Test @MainActor
+    func `Retry button reloads and recovers once the network succeeds`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()  // stopID = "1_10914"
+        let forwardStopIDs = ["1_10915"]
+
+        let dataLoader = MockDataLoader(testName: name)
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet,
+                                   userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."])
+        dataLoader.mock(response: MockDataResponse(data: nil, urlResponse: nil, error: networkError) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        })
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.buttonConfig != nil },
+            "picker never entered the error state"
+        )
+        let retryConfig = try #require(standardEmptyData(controller, listView)?.buttonConfig)
+
+        let successData = try makeTripDetailsData(stopIDs: [arrivalDeparture.stopID] + forwardStopIDs)
+        dataLoader.replaceMappedResponses { loader in
+            self.registerBaseStubs(on: loader)
+            loader.mock(data: successData) { $0.url?.path.contains("/api/where/trip-details") ?? false }
         }
-        XCTAssertNotNil(vm.body, "Error message should be populated")
-        XCTAssertNotNil(vm.buttonConfig, "Retry button should be offered on network error")
-        XCTAssertEqual(vm.buttonConfig?.text, "Try Again")
+        retryConfig.action()
+
+        await poll(
+            until: { !controller.items(for: listView).isEmpty },
+            "retry never reloaded the stop list"
+        )
+        #expect(
+            controller.items(for: listView).first?.contents.count == forwardStopIDs.count,
+            "Retry should reload and show the forward stops"
+        )
     }
 }


### PR DESCRIPTION
Adds a destination stop selection step before sharing a trip, so the shared link includes where the passenger is getting off.

Resolves the UI component of [#449](https://github.com/OneBusAway/onebusaway-ios/issues/449).

### What changed

**New file — `DestinationStopPickerController.swift`**

A modal view controller that fetches the trip's stop list via `apiService.getTrip()` and displays only the stops *after* the boarding stop. Uses `OBAListView` with `OBAListRowView.ValueViewModel` (no custom cell), a `.loading` / `.data` / `.error` state machine, and `ErrorClassifier` for user-facing errors. Task is cancelled in `deinit`.

**Modified — `StopViewController.swift`**

- Added a **"Share Trip"** `UIAction` to the long-press context menu (`stopArrivalContextMenu`).
- `shareTripStatus()` now presents the destination picker instead of immediately opening the share sheet.
- New `DestinationStopPickerDelegate` conformance: on stop selection, encodes the URL with `destination_stop_id` and opens `UIActivityViewController`; on cancel, dismisses the modal.
- Added `presentShareError()` — shows a localized alert if URL encoding fails.

### Before / After

| Before | After |
|--------|-------|
| Long-press menu: Bookmark, Schedule | Long-press menu: Bookmark, Schedule, **Share Trip** |
| "Share Trip" opened share sheet immediately (no destination) | "Share Trip" → destination picker → share sheet |
| Shared URL had no destination info | Shared URL includes `destination_stop_id` query param |

<details>
<summary>Screen recording</summary>

https://github.com/user-attachments/assets/73e2088e-3ec9-4e17-84be-522052e6a79a



</details>

### How to test

- Long-press an arrival → "Share Trip" appears in context menu
- Tap "Share Trip" → destination picker modal appears
-  Only stops **after** boarding stop are shown
-  Each row shows stop name + arrival time
-  Tap a stop → modal dismisses → share sheet opens with URL containing `destination_stop_id`
-  Cancel button dismisses modal cleanly
-  Turn off internet → error state shows (not a crash)
-  If URL encoding fails → "Unable to Share" alert appears

---

> **PR Roadmap for [#449](https://github.com/OneBusAway/onebusaway-ios/issues/449)**
>
> | # | PR | Status |
> |---|-----|--------|
> | 1 | Deep link data model (`destination_stop_id`) | `Merged` |
> | 2 | **Destination stop picker UI** | `Current` |
> | 3 | Enhanced trip view + share button | `Next` |
> | 4 | Deep link navigation with destination | `Upcoming` |
> | 5 | Comprehensive tests | `Upcoming` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Share a trip from a stop arrival or departure.
  * Choose a destination stop, skip destination selection, or cancel before sharing.
  * View loading, empty, and error states while destination options are retrieved.
  * Retry loading destination options after an error.
* **Bug Fixes**
  * Shows an “Unable to Share” alert when required data is missing or sharing fails.
  * Prevents incomplete or invalid sharing attempts.
* **Tests**
  * Added coverage for picker loading, empty states, errors, selection, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->