### PR TITLE
Trip bottom sheet UI

### DIFF
--- a/OBAKit/Trip/TripDetailView.swift
+++ b/OBAKit/Trip/TripDetailView.swift
@@ -1,0 +1,109 @@
+//
+//  TripDetailView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import OBAKitCore
+
+// MARK: - TripDetailViewModel
+
+/// Observable view model that bridges `TripViewController`'s data loading
+/// into the SwiftUI `TripDetailView`.
+@MainActor
+final class TripDetailViewModel: ObservableObject {
+    @Published var tripDetails: TripDetails?
+    @Published var tripConvertible: TripConvertible
+
+    /// Called when the user taps a stop row — used to pan the map to that stop.
+    var onStopSelected: ((TripStopTime) -> Void)?
+
+    /// The view controller hosting this view model. Required for navigation.
+    weak var hostViewController: UIViewController?
+
+    private let application: Application
+
+    init(application: Application, tripConvertible: TripConvertible) {
+        self.application = application
+        self.tripConvertible = tripConvertible
+    }
+
+    /// Triggers a data reload from the API. Called by `TripViewController` after
+    /// refreshing `tripConvertible`.
+    func loadData() {
+        // Data loading is driven by TripViewController; this method exists as a
+        // hook so the VC can signal the VM to re-publish after updating tripConvertible.
+        objectWillChange.send()
+    }
+
+    // MARK: - Derived display data
+
+    var headerViewModel: TripPanelHeaderViewModel? {
+        guard let arrDep = tripConvertible.arrivalDeparture else { return nil }
+        return TripPanelHeaderViewModel(arrivalDeparture: arrDep, formatters: application.formatters)
+    }
+
+    var stopViewModels: [TripStopRowViewModel] {
+        guard let details = tripDetails else { return [] }
+        return TripStopRowViewModel.viewModels(
+            from: details,
+            arrivalDeparture: tripConvertible.arrivalDeparture,
+            formatters: application.formatters,
+            onSelect: { [weak self] _ in }
+        )
+    }
+
+    func selectStop(_ viewModel: TripStopRowViewModel) {
+        guard let details = tripDetails,
+              let stopTime = details.stopTimes.first(where: { $0.stopID == viewModel.id }),
+              let hostVC = hostViewController
+        else { return }
+
+        let transferContext = buildTransferContext(for: stopTime)
+        application.viewRouter.navigateTo(stop: stopTime.stop, from: hostVC, transferContext: transferContext)
+    }
+
+    // MARK: - Helpers
+
+    private func buildTransferContext(for stopTime: TripStopTime) -> TransferContext? {
+        guard let arrivalDeparture = tripConvertible.arrivalDeparture else { return nil }
+        // Don't offer a transfer context for the user's own boarding stop
+        guard stopTime.stopID != arrivalDeparture.stopID else { return nil }
+        return .from(arrivalDeparture: arrivalDeparture, arrivalDate: stopTime.arrivalDate)
+    }
+}
+
+// MARK: - TripDetailView
+
+/// SwiftUI view used as the floating panel content inside `TripViewController`.
+/// Wraps `TripStopListView` and drives it from `TripDetailViewModel`.
+struct TripDetailView: View {
+    @ObservedObject var viewModel: TripDetailViewModel
+
+    var body: some View {
+        if let header = viewModel.headerViewModel {
+            TripStopListView(
+                header: header,
+                stops: viewModel.stopViewModels,
+                onSelectStop: { viewModel.selectStop($0) }
+            )
+        } else {
+            // Minimal placeholder while data loads
+            VStack(spacing: 0) {
+                Capsule()
+                    .fill(Color(.tertiaryLabel))
+                    .frame(width: 36, height: 5)
+                    .padding(.top, 8)
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+            .background(Color(.systemBackground))
+        }
+    }
+}

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import SwiftUI
 import OBAKitCore
 import FloatingPanel
 
@@ -23,15 +24,23 @@ class TripFloatingPanelController: UIViewController,
     var tripDetails: TripDetails? {
         didSet {
             if isLoadedAndOnScreen {
-                listView.applyData(animated: false)
+                if useModernUI {
+                    refreshModernUI()
+                } else {
+                    listView.applyData(animated: false)
+                }
             }
         }
     }
 
     var tripConvertible: TripConvertible? {
         didSet {
-            if isLoadedAndOnScreen, let arrivalDeparture = tripConvertible?.arrivalDeparture {
-                stopArrivalView.arrivalDeparture = arrivalDeparture
+            if isLoadedAndOnScreen {
+                if useModernUI {
+                    refreshModernUI()
+                } else if let arrivalDeparture = tripConvertible?.arrivalDeparture {
+                    stopArrivalView.arrivalDeparture = arrivalDeparture
+                }
             }
         }
     }
@@ -72,21 +81,122 @@ class TripFloatingPanelController: UIViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        listView.formatters = application.formatters
-        listView.obaDataSource = self
-        listView.collapsibleSectionsDelegate = self
-        listView.contextMenuDelegate = self
-        listView.register(listViewItem: TripStopViewModel.self)
-
         view.backgroundColor = ThemeColors.shared.systemBackground
-        view.addSubview(outerStack)
-        outerStack.pinToSuperview(.edges)
+
+        if useModernUI {
+            installModernUI()
+        } else {
+            listView.formatters = application.formatters
+            listView.obaDataSource = self
+            listView.collapsibleSectionsDelegate = self
+            listView.contextMenuDelegate = self
+            listView.register(listViewItem: TripStopViewModel.self)
+            view.addSubview(outerStack)
+            outerStack.pinToSuperview(.edges)
+        }
     }
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        listView.applyData(animated: false)
+        if useModernUI {
+            refreshModernUI()
+        } else {
+            listView.applyData(animated: false)
+        }
+    }
+
+    // MARK: - Modern SwiftUI UI
+
+    /// Set to `true` to use the new SwiftUI-based trip stop list.
+    /// Defaults to `true`; set to `false` to fall back to the legacy UIKit layout.
+    var useModernUI: Bool = true
+
+    private var modernHostingController: UIHostingController<TripStopListView>?
+
+    private func installModernUI() {
+        let view = buildModernView()
+        let hosting = UIHostingController(rootView: view)
+        hosting.view.backgroundColor = .clear
+        addChild(hosting)
+        self.view.addSubview(hosting.view)
+        hosting.view.pinToSuperview(.edges)
+        hosting.didMove(toParent: self)
+        modernHostingController = hosting
+    }
+
+    private func refreshModernUI() {
+        guard let hosting = modernHostingController else { return }
+        hosting.rootView = buildModernView()
+    }
+
+    private func buildModernView() -> TripStopListView {
+        let headerVM: TripPanelHeaderViewModel
+        if let arrDep = tripConvertible?.arrivalDeparture {
+            headerVM = TripPanelHeaderViewModel(arrivalDeparture: arrDep, formatters: application.formatters)
+        } else {
+            headerVM = TripPanelHeaderViewModel(
+                routeHeadsign: tripDetails?.trip.routeHeadsign ?? "",
+                scheduledTime: "",
+                statusText: "",
+                minutesUntilArrival: nil,
+                isRealTime: false
+            )
+        }
+
+        let stopVMs: [TripStopRowViewModel]
+        if let details = tripDetails {
+            stopVMs = TripStopRowViewModel.viewModels(
+                from: details,
+                arrivalDeparture: tripConvertible?.arrivalDeparture,
+                formatters: application.formatters,
+                onSelect: { [weak self] _ in }
+            )
+        } else {
+            stopVMs = []
+        }
+
+        // Service alert strings for the banner
+        let alertStrings: [String] = tripDetails?.serviceAlerts.compactMap { $0.summary?.value } ?? []
+
+        var listView = TripStopListView(header: headerVM, stops: stopVMs) { [weak self] stopVM in
+            guard let self, let details = self.tripDetails else { return }
+            if let stopTime = details.stopTimes.first(where: { $0.stopID == stopVM.id }) {
+                let transferContext: TransferContext?
+                if let arrDep = self.tripConvertible?.arrivalDeparture, stopTime.stopID != arrDep.stopID {
+                    transferContext = TransferContext.from(arrivalDeparture: arrDep, arrivalDate: stopTime.arrivalDate)
+                } else {
+                    transferContext = nil
+                }
+                self.application.viewRouter.navigateTo(stop: stopTime.stop, from: self, transferContext: transferContext)
+            }
+        }
+
+        listView.serviceAlerts = alertStrings
+
+        if parentTripViewController != nil {
+            listView.onShowOnMap = { [weak self] stopVM in
+                guard let self, let stopTime = self.tripDetails?.stopTimes.first(where: { $0.stopID == stopVM.id }) else { return }
+                self.parentTripViewController?.showStopOnMap(stopTime)
+            }
+        }
+
+        listView.refreshAction = { [weak self] in
+            guard let self, let apiService = self.application.apiService,
+                  let details = self.tripDetails else { return }
+            do {
+                let result = try await apiService.getTrip(
+                    tripID: details.trip.id,
+                    vehicleID: details.status?.vehicleID,
+                    serviceDate: details.serviceDate
+                )
+                await MainActor.run { self.tripDetails = result.entry }
+            } catch {
+                await self.application.displayError(error)
+            }
+        }
+
+        return listView
     }
 
     // MARK: - Public Methods
@@ -256,7 +366,8 @@ class TripFloatingPanelController: UIViewController,
     }
 
     private func showOnMap(_ tripStop: TripStopViewModel) {
-        parentTripViewController?.showStopOnMap(tripStop)
+        guard let stopTime = tripDetails?.stopTimes.first(where: { $0.stopID == tripStop.stop.id }) else { return }
+        parentTripViewController?.showStopOnMap(stopTime)
     }
 
     private func showOnList(_ tripStop: TripStopTime) {

--- a/OBAKit/Trip/TripPanelHeaderView.swift
+++ b/OBAKit/Trip/TripPanelHeaderView.swift
@@ -1,0 +1,300 @@
+//
+//  TripPanelHeaderView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - TripPanelHeaderView
+
+/// Modern Apple Maps-style bottom-sheet header.
+///
+/// Layout:
+/// ```
+/// ┌──────────────────────────────────────────────────┐
+/// │  SIM4C - MIDTOWN via CHURCH ST …   ● Live   26m  │
+/// │  9:46 PM · Scheduled/not real-time               │
+/// │  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  12 stops left │  ← progress + chip
+/// ├──────────────────────────────────────────────────┤
+/// │  WOODROW RD/VINELAND AV                       >  │  ← next stop callout
+/// │  9:45 PM                          +3 min late    │  ← delay badge
+/// └──────────────────────────────────────────────────┘
+/// ```
+struct TripPanelHeaderView: View {
+    let routeHeadsign: String
+    let scheduledTime: String
+    let statusText: String
+    let minutesUntilArrival: Int?
+    let isRealTime: Bool
+    var nextStopName: String? = nil
+    var nextStopTime: String? = nil
+    /// 0.0–1.0 fraction of stops already passed. `nil` hides the progress bar.
+    var routeProgress: Double? = nil
+    /// Number of stops remaining after the current vehicle position.
+    var stopsRemaining: Int? = nil
+    /// Positive = late, negative = early, nil = on-time / unknown.
+    var scheduleDeviationMinutes: Int? = nil
+    var onTapNextStop: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // ── Title row ────────────────────────────────────────────────
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(routeHeadsign)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(3)
+
+                    if !scheduledTime.isEmpty || !statusText.isEmpty {
+                        HStack(spacing: 0) {
+                            if !scheduledTime.isEmpty { Text(scheduledTime).monospacedDigit() }
+                            if !scheduledTime.isEmpty && !statusText.isEmpty { Text(" · ") }
+                            if !statusText.isEmpty { Text(statusText) }
+                        }
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer(minLength: 6)
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    if isRealTime { LiveIndicatorPill() }
+                    if let minutes = minutesUntilArrival {
+                        MinutesBadgeView(minutes: minutes, isRealTime: isRealTime)
+                    }
+                }
+                .padding(.top, 2)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, routeProgress != nil ? 8 : 14)
+
+            // ── Progress bar + stops-remaining chip ──────────────────────
+            if let progress = routeProgress {
+                HStack(alignment: .center, spacing: 10) {
+                    RouteProgressBar(progress: progress)
+
+                    if let remaining = stopsRemaining, remaining > 0 {
+                        Text("\(remaining) stop\(remaining == 1 ? "" : "s") left")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .fixedSize()
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+            }
+
+            // ── Next stop callout ────────────────────────────────────────
+            // No extra Divider here — the callout is visually part of the header block,
+            // separated only by the outer Divider in TripStopListView.
+            if let stopName = nextStopName {
+                Divider()
+                    .padding(.horizontal, 16)
+
+                Button { onTapNextStop?() } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(stopName)
+                                .font(.subheadline.weight(.bold))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            if let time = nextStopTime {
+                                HStack(spacing: 6) {
+                                    Text(time)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                        .monospacedDigit()
+                                    if let dev = scheduleDeviationMinutes, dev != 0 {
+                                        DelayBadge(minutes: dev)
+                                    }
+                                }
+                            }
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(nextStopA11yLabel)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(headerA11yLabel)
+    }
+
+    private var headerA11yLabel: String {
+        var parts = [routeHeadsign]
+        if !scheduledTime.isEmpty { parts.append(scheduledTime) }
+        if !statusText.isEmpty    { parts.append(statusText) }
+        if let m = minutesUntilArrival { parts.append("\(m) minutes") }
+        if isRealTime { parts.append("Real-time tracking") }
+        if let r = stopsRemaining { parts.append("\(r) stops remaining") }
+        return parts.joined(separator: ", ")
+    }
+
+    private var nextStopA11yLabel: String {
+        var parts: [String] = []
+        if let name = nextStopName { parts.append("Next stop: \(name)") }
+        if let time = nextStopTime { parts.append(time) }
+        if let dev = scheduleDeviationMinutes, dev != 0 {
+            parts.append(dev > 0 ? "\(dev) minutes late" : "\(abs(dev)) minutes early")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - DelayBadge
+
+/// Compact pill showing schedule deviation — red for late, green for early.
+struct DelayBadge: View {
+    let minutes: Int
+
+    private var isLate: Bool { minutes > 0 }
+    private var color: Color { isLate ? .red : Color(.systemGreen) }
+    private var label: String {
+        isLate ? "+\(minutes) min late" : "\(abs(minutes)) min early"
+    }
+
+    var body: some View {
+        Text(label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: Capsule())
+            .accessibilityLabel(isLate ? "\(minutes) minutes late" : "\(abs(minutes)) minutes early")
+    }
+}
+
+// MARK: - LiveIndicatorPill
+
+struct LiveIndicatorPill: View {
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(Color(.systemGreen))
+                .frame(width: 7, height: 7)
+                .scaleEffect(pulsing ? 1.3 : 1.0)
+                .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
+                .onAppear { pulsing = true }
+            Text("Live")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color(.systemGreen))
+        }
+        .accessibilityLabel("Real-time tracking active")
+    }
+}
+
+// MARK: - RouteProgressBar
+
+struct RouteProgressBar: View {
+    let progress: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color(.systemFill)).frame(height: 4)
+                Capsule()
+                    .fill(Color(.systemGreen))
+                    .frame(width: max(8, geo.size.width * progress), height: 4)
+                    .animation(.easeInOut(duration: 0.4), value: progress)
+            }
+        }
+        .frame(height: 4)
+        .accessibilityLabel("Route progress: \(Int(progress * 100)) percent")
+    }
+}
+
+// MARK: - MinutesBadgeView
+
+struct MinutesBadgeView: View {
+    let minutes: Int
+    let isRealTime: Bool
+
+    private var color: Color {
+        switch minutes {
+        case ..<2:  return .red
+        case 2..<5: return .orange
+        default:    return isRealTime ? Color(.systemGreen) : .orange
+        }
+    }
+
+    var body: some View {
+        Text("\(minutes)m")
+            .font(.system(size: 26, weight: .bold))
+            .foregroundStyle(color)
+            .monospacedDigit()
+            .accessibilityLabel("\(minutes) minutes")
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Scheduled — late") {
+    TripPanelHeaderView(
+        routeHeadsign: "SIM4C - MIDTOWN via CHURCH ST via MADISON AV",
+        scheduledTime: "9:46 PM",
+        statusText: "Scheduled/not real-time",
+        minutesUntilArrival: 26,
+        isRealTime: false,
+        nextStopName: "WOODROW RD/VINELAND AV",
+        nextStopTime: "9:45 PM",
+        routeProgress: 0.18,
+        stopsRemaining: 14,
+        scheduleDeviationMinutes: 3
+    )
+    .background(Color(.systemBackground))
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Real-time — on time") {
+    TripPanelHeaderView(
+        routeHeadsign: "SIM7 - GREENWICH VILLAGE via WEST ST",
+        scheduledTime: "6:57 PM",
+        statusText: "On time",
+        minutesUntilArrival: 8,
+        isRealTime: true,
+        nextStopName: "RICHMOND AV/KATAN AV",
+        nextStopTime: "6:58 PM",
+        routeProgress: 0.55,
+        stopsRemaining: 6,
+        scheduleDeviationMinutes: 0
+    )
+    .background(Color(.systemBackground))
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Real-time — early") {
+    TripPanelHeaderView(
+        routeHeadsign: "44 - Ballard via Fremont",
+        scheduledTime: "6:57 PM",
+        statusText: "2 min early",
+        minutesUntilArrival: 4,
+        isRealTime: true,
+        nextStopName: "ARDEN AV/HAMPTON GREEN",
+        nextStopTime: "6:55 PM",
+        routeProgress: 0.72,
+        stopsRemaining: 3,
+        scheduleDeviationMinutes: -2
+    )
+    .background(Color(.systemBackground))
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/OBAKit/Trip/TripStopListView.swift
+++ b/OBAKit/Trip/TripStopListView.swift
@@ -1,0 +1,515 @@
+//
+//  TripStopListView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - TripStopListView
+
+struct TripStopListView: View {
+    let header: TripPanelHeaderViewModel
+    let stops: [TripStopRowViewModel]
+    let onSelectStop: (TripStopRowViewModel) -> Void
+    var onShowOnMap: ((TripStopRowViewModel) -> Void)? = nil
+    var refreshAction: (() async -> Void)? = nil
+    var serviceAlerts: [String] = []
+
+    // MARK: - State
+
+    @State private var pastStopsExpanded = false
+    @State private var showJumpButton = false
+    /// Shared scroll proxy so the Jump button can actually scroll the list.
+    @State private var scrollProxy: ScrollViewProxy? = nil
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            grabberHandle
+
+            TripPanelHeaderView(
+                routeHeadsign: header.routeHeadsign,
+                scheduledTime: header.scheduledTime,
+                statusText: header.statusText,
+                minutesUntilArrival: header.minutesUntilArrival,
+                isRealTime: header.isRealTime,
+                nextStopName: nextStop?.stopName,
+                nextStopTime: nextStop?.arrivalTime,
+                routeProgress: routeProgress,
+                stopsRemaining: upcomingStops.count,
+                scheduleDeviationMinutes: nextStop?.delayMinutes
+            )
+
+            Divider()
+
+            if stops.isEmpty {
+                emptyState
+            } else {
+                ZStack(alignment: .bottom) {
+                    stopList
+                    if showJumpButton {
+                        jumpToNowButton
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                            .padding(.bottom, 16)
+                    }
+                }
+            }
+        }
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Stop list
+
+    private var stopList: some View {
+        ScrollViewReader { proxy in
+            List {
+                // ── Service alert banners ────────────────────────────────
+                if !serviceAlerts.isEmpty {
+                    Section {
+                        ForEach(serviceAlerts, id: \.self) { alert in
+                            ServiceAlertBanner(text: alert)
+                                .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                                .listRowSeparator(.hidden)
+                                .listRowBackground(Color(.systemBackground))
+                        }
+                    }
+                }
+
+                // ── Past stops (collapsible) ─────────────────────────────
+                if !pastStops.isEmpty {
+                    Section {
+                        if pastStopsExpanded {
+                            ForEach(pastStops) { stop in stopButton(stop) }
+                        }
+                    } header: {
+                        CollapsibleSectionHeader(
+                            title: "Passed stops (\(pastStops.count))",
+                            isExpanded: pastStopsExpanded
+                        ) {
+                            withAnimation(.easeInOut(duration: 0.22)) {
+                                pastStopsExpanded.toggle()
+                            }
+                        }
+                    }
+                }
+
+                // ── Current vehicle stop ─────────────────────────────────
+                if let current = currentStop {
+                    Section {
+                        stopButton(current).id("__current__")
+                    } header: {
+                        sectionLabel("Now", systemImage: "location.fill", color: Color(.systemGreen))
+                    }
+                }
+
+                // ── Upcoming stops ───────────────────────────────────────
+                if !upcomingStops.isEmpty {
+                    Section {
+                        ForEach(upcomingStops) { stop in
+                            stopButton(stop).id(stop.id)
+                        }
+                    } header: {
+                        // ⊙ matches the clock icon shown in the screenshot
+                        sectionLabel("Upcoming", systemImage: "clock.arrow.circlepath", color: .secondary)
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color(.systemBackground))
+            .applyRefreshable(action: refreshAction)
+            .onAppear {
+                scrollProxy = proxy
+                // Auto-scroll to vehicle or first upcoming stop
+                let focusID: String?
+                if currentStop != nil {
+                    focusID = "__current__"
+                } else {
+                    focusID = upcomingStops.first?.id
+                }
+                if let id = focusID {
+                    proxy.scrollTo(id, anchor: .top)
+                }
+            }
+            // Detect when "__current__" row scrolls out of view to show Jump button.
+            // We use a background anchor preference on a sentinel view placed at the
+            // current-stop row position.
+            .background(
+                GeometryReader { listGeo in
+                    Color.clear.preference(
+                        key: CurrentStopVisibilityKey.self,
+                        value: listGeo.frame(in: .global).minY
+                    )
+                }
+            )
+            .onPreferenceChange(CurrentStopVisibilityKey.self) { _ in
+                // Intentionally empty — visibility is tracked via the sentinel below
+            }
+        }
+        // Sentinel: invisible view anchored to the current stop row that reports
+        // whether it is on-screen. We approximate this by watching the list's
+        // own scroll offset via a named coordinate space.
+        .coordinateSpace(name: "tripList")
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(
+                    key: CurrentStopVisibilityKey.self,
+                    value: geo.frame(in: .named("tripList")).minY
+                )
+            }
+        )
+        .onPreferenceChange(CurrentStopVisibilityKey.self) { offset in
+            guard currentStop != nil else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                showJumpButton = offset < -80
+            }
+        }
+    }
+
+    // MARK: - Stop button
+
+    @ViewBuilder
+    private func stopButton(_ stop: TripStopRowViewModel) -> some View {
+        Button { onSelectStop(stop) } label: {
+            TripStopRow(viewModel: stop)
+        }
+        .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color(.systemBackground))
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if let onShowOnMap {
+                Button { onShowOnMap(stop) } label: {
+                    Label("Map", systemImage: "mappin.circle.fill")
+                }
+                .tint(.blue)
+            }
+        }
+    }
+
+    // MARK: - Section headers
+
+    private func sectionLabel(_ title: String, systemImage: String, color: Color) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: systemImage)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(color)
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(nil)
+        }
+        .padding(.leading, 56)
+        .padding(.vertical, 4)
+        .listRowInsets(EdgeInsets())
+    }
+
+    // MARK: - Jump to Now button
+
+    private var jumpToNowButton: some View {
+        Button {
+            withAnimation { scrollProxy?.scrollTo("__current__", anchor: .top) }
+            withAnimation(.easeInOut(duration: 0.2)) { showJumpButton = false }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "location.fill")
+                    .font(.caption.weight(.bold))
+                Text("Jump to Now")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(Color(.systemGreen), in: Capsule())
+            .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+        }
+        .accessibilityLabel("Jump to current vehicle position")
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "bus.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.tertiary)
+            Text("Loading trip details…")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityLabel("Loading trip details")
+    }
+
+    // MARK: - Grabber
+
+    private var grabberHandle: some View {
+        Capsule()
+            .fill(Color(.systemFill))
+            .frame(width: 36, height: 5)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Derived data
+
+    private var pastStops: [TripStopRowViewModel]     { stops.filter { $0.isPast } }
+    private var currentStop: TripStopRowViewModel?    { stops.first { $0.isCurrentVehicleLocation } }
+    private var upcomingStops: [TripStopRowViewModel] { stops.filter { !$0.isPast && !$0.isCurrentVehicleLocation } }
+    private var nextStop: TripStopRowViewModel?       { upcomingStops.first }
+
+    private var routeProgress: Double? {
+        guard !stops.isEmpty else { return nil }
+        let passed = pastStops.count + (currentStop != nil ? 1 : 0)
+        return Double(passed) / Double(stops.count)
+    }
+}
+
+// MARK: - CollapsibleSectionHeader
+
+private struct CollapsibleSectionHeader: View {
+    let title: String
+    let isExpanded: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 5) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 12)
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(nil)
+            }
+            .padding(.leading, 56)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets())
+        .accessibilityLabel(title)
+        .accessibilityHint(isExpanded ? "Tap to collapse" : "Tap to expand")
+    }
+}
+
+// MARK: - ServiceAlertBanner
+
+private struct ServiceAlertBanner: View {
+    let text: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.subheadline)
+                .foregroundStyle(.orange)
+                .padding(.top, 1)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.orange.opacity(colorScheme == .dark ? 0.18 : 0.10))
+        )
+        .accessibilityLabel("Service alert: \(text)")
+    }
+}
+
+// MARK: - CurrentStopVisibilityKey
+
+private struct CurrentStopVisibilityKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+// MARK: - Refreshable helper (avoids shadowing system modifier)
+
+private extension View {
+    @ViewBuilder
+    func applyRefreshable(action: (() async -> Void)?) -> some View {
+        if let action {
+            self.refreshable { await action() }
+        } else {
+            self
+        }
+    }
+}
+
+// MARK: - TripPanelHeaderViewModel
+
+struct TripPanelHeaderViewModel {
+    let routeHeadsign: String
+    let scheduledTime: String
+    let statusText: String
+    let minutesUntilArrival: Int?
+    let isRealTime: Bool
+
+    init(arrivalDeparture: ArrivalDeparture, formatters: Formatters) {
+        self.routeHeadsign = arrivalDeparture.routeAndHeadsign
+        self.scheduledTime = formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate)
+        self.isRealTime    = arrivalDeparture.predicted
+
+        let minutes = Int(arrivalDeparture.arrivalDepartureDate.timeIntervalSinceNow / 60)
+        self.minutesUntilArrival = minutes >= 0 ? minutes : nil
+
+        self.statusText = arrivalDeparture.predicted
+            ? formatters.formattedScheduleDeviation(for: arrivalDeparture)
+            : OBALoc("departure_status.scheduled",
+                     value: "Scheduled/not real-time",
+                     comment: "Indicates a departure time is from the schedule, not real-time data")
+    }
+
+    init(routeHeadsign: String, scheduledTime: String, statusText: String,
+         minutesUntilArrival: Int?, isRealTime: Bool) {
+        self.routeHeadsign       = routeHeadsign
+        self.scheduledTime       = scheduledTime
+        self.statusText          = statusText
+        self.minutesUntilArrival = minutesUntilArrival
+        self.isRealTime          = isRealTime
+    }
+}
+
+// MARK: - TripStopRowViewModel builder
+
+extension TripStopRowViewModel {
+    static func viewModels(
+        from tripDetails: TripDetails,
+        arrivalDeparture: ArrivalDeparture?,
+        formatters: Formatters,
+        onSelect: @escaping (TripStopRowViewModel) -> Void
+    ) -> [TripStopRowViewModel] {
+        let stopTimes = tripDetails.stopTimes
+        guard !stopTimes.isEmpty else { return [] }
+
+        let vehicleStopID = arrivalDeparture?.tripStatus?.closestStopID
+        let vehicleIndex  = stopTimes.firstIndex { $0.stopID == vehicleStopID }
+
+        let deviationMinutes: Int?
+        if let dev = arrivalDeparture?.tripStatus?.scheduleDeviation {
+            let mins = Int(dev / 60)
+            deviationMinutes = mins == 0 ? nil : mins
+        } else {
+            deviationMinutes = nil
+        }
+
+        var result: [TripStopRowViewModel] = []
+
+        // ── Previous trip row ────────────────────────────────────────────
+        if let prev = tripDetails.previousTrip {
+            result.append(TripStopRowViewModel(
+                id: "adjacent_prev_\(prev.id)",
+                stopName: prev.routeHeadsign,
+                arrivalTime: "",
+                segment: .adjacentPrev,
+                routeType: .bus,
+                isCurrentVehicleLocation: false,
+                isUserDestination: false,
+                isAdjacentTrip: true,
+                adjacentTripLabel: "Starts as"
+            ))
+        }
+
+        // ── Stop times ───────────────────────────────────────────────────
+        for (index, stopTime) in stopTimes.enumerated() {
+            let segment: TripRouteSegment
+            if index == 0                        { segment = .first }
+            else if index == stopTimes.count - 1 { segment = .last }
+            else                                 { segment = .middle }
+
+            let isPast = vehicleIndex.map { index < $0 } ?? false
+
+            result.append(TripStopRowViewModel(
+                id: stopTime.stopID,
+                stopName: stopTime.stop.name,
+                arrivalTime: formatters.timeFormatter.string(from: stopTime.arrivalDate),
+                segment: segment,
+                routeType: stopTime.stop.prioritizedRouteTypeForDisplay,
+                isCurrentVehicleLocation: vehicleStopID != nil && stopTime.stopID == vehicleStopID,
+                isUserDestination: arrivalDeparture.map { stopTime.stopID == $0.stopID } ?? false,
+                isAdjacentTrip: false,
+                adjacentTripLabel: nil,
+                isPast: isPast,
+                delayMinutes: isPast ? nil : deviationMinutes
+            ))
+        }
+
+        // ── Next trip row ────────────────────────────────────────────────
+        if let next = tripDetails.nextTrip {
+            result.append(TripStopRowViewModel(
+                id: "adjacent_next_\(next.id)",
+                stopName: next.routeHeadsign,
+                arrivalTime: "",
+                segment: .adjacentNext,
+                routeType: .bus,
+                isCurrentVehicleLocation: false,
+                isUserDestination: false,
+                isAdjacentTrip: true,
+                adjacentTripLabel: "Continues as"
+            ))
+        }
+
+        return result
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Full Sheet — late, with alerts, dark") {
+    let header = TripPanelHeaderViewModel(
+        routeHeadsign: "SIM33C - MIDTOWN via CHURCH via MADISON AV",
+        scheduledTime: "10:19 PM",
+        statusText: "Scheduled/not real-time",
+        minutesUntilArrival: 36,
+        isRealTime: false
+    )
+
+    let stops: [TripStopRowViewModel] = [
+        .init(id: "0", stopName: "Starts as SIM33",         arrivalTime: "", segment: .adjacentPrev, routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: true,  adjacentTripLabel: "Starts as",   isPast: false, delayMinutes: nil),
+        .init(id: "1", stopName: "SOUTH AV/RICHMOND TERR",  arrivalTime: "9:15 PM", segment: .first,  routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: true,  delayMinutes: nil),
+        .init(id: "2", stopName: "SOUTH AV/ARLINGTON PL",   arrivalTime: "9:16 PM", segment: .middle, routeType: .bus, isCurrentVehicleLocation: true,  isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: nil),
+        .init(id: "3", stopName: "GREENWICH ST/BATTERY PL", arrivalTime: "10:19 PM", segment: .middle, routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: true,  isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: nil),
+        .init(id: "4", stopName: "LAST STOP TERMINAL",      arrivalTime: "10:25 PM", segment: .last,   routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: nil),
+        .init(id: "5", stopName: "Continues as SIM34",      arrivalTime: "", segment: .adjacentNext, routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: true,  adjacentTripLabel: "Continues as", isPast: false, delayMinutes: nil),
+    ]
+
+    TripStopListView(
+        header: header,
+        stops: stops,
+        onSelectStop: { _ in },
+        serviceAlerts: ["Route SIM33C is experiencing delays due to traffic on Church St."]
+    )
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Empty state") {
+    TripStopListView(
+        header: TripPanelHeaderViewModel(
+            routeHeadsign: "Loading…",
+            scheduledTime: "", statusText: "",
+            minutesUntilArrival: nil, isRealTime: false
+        ),
+        stops: [],
+        onSelectStop: { _ in }
+    )
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/OBAKit/Trip/TripStopRow.swift
+++ b/OBAKit/Trip/TripStopRow.swift
@@ -1,0 +1,302 @@
+//
+//  TripStopRow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - TripRouteSegment
+
+enum TripRouteSegment {
+    case first          // line only below the dot
+    case middle         // line above and below
+    case last           // line only above the dot
+    case adjacentPrev   // "Starts as …" — line below only, no dot
+    case adjacentNext   // "Continues as …" — line above only, no dot
+}
+
+// MARK: - TripStopRowViewModel
+
+struct TripStopRowViewModel: Identifiable, Equatable {
+    let id: String
+    let stopName: String
+    let arrivalTime: String
+    let segment: TripRouteSegment
+    let routeType: Route.RouteType
+    let isCurrentVehicleLocation: Bool
+    let isUserDestination: Bool
+    let isAdjacentTrip: Bool
+    let adjacentTripLabel: String?
+    var isPast: Bool = false
+    /// Positive = late, negative = early, nil = on-time / scheduled.
+    var delayMinutes: Int? = nil
+}
+
+// MARK: - TripStopRow
+
+struct TripStopRow: View {
+    let viewModel: TripStopRowViewModel
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    private var isAccessibilitySize: Bool { dynamicTypeSize >= .accessibility1 }
+
+    var body: some View {
+        // Adjacent trip rows get a distinct compact layout
+        if viewModel.isAdjacentTrip {
+            adjacentTripRow
+        } else {
+            stopRow
+        }
+    }
+
+    // MARK: - Adjacent trip row (Starts as / Continues as)
+
+    private var adjacentTripRow: some View {
+        HStack(alignment: .center, spacing: 0) {
+            TripSegmentCanvas(
+                segment: viewModel.segment,
+                routeType: viewModel.routeType,
+                isCurrentVehicleLocation: false,
+                isUserDestination: false,
+                isPast: false
+            )
+            .frame(width: 56)
+            .frame(maxHeight: .infinity)
+
+            HStack(spacing: 4) {
+                if let label = viewModel.adjacentTripLabel {
+                    Text(label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text(viewModel.stopName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(.systemGreen))
+                    .lineLimit(1)
+                Image(systemName: "arrow.right.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(Color(.systemGreen).opacity(0.7))
+            }
+            .padding(.leading, 2)
+            .padding(.trailing, 16)
+            .padding(.vertical, 10)
+
+            Spacer()
+        }
+        .frame(minHeight: 40)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(viewModel.adjacentTripLabel ?? "") \(viewModel.stopName)")
+    }
+
+    // MARK: - Normal stop row
+
+    private var stopRow: some View {
+        HStack(alignment: .center, spacing: 0) {
+            TripSegmentCanvas(
+                segment: viewModel.segment,
+                routeType: viewModel.routeType,
+                isCurrentVehicleLocation: viewModel.isCurrentVehicleLocation,
+                isUserDestination: viewModel.isUserDestination,
+                isPast: viewModel.isPast
+            )
+            .frame(width: 56)
+            .frame(maxHeight: .infinity)
+
+            Group {
+                if isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 4) {
+                        stopNameText
+                        HStack(spacing: 6) { timeText; delayText }
+                    }
+                } else {
+                    HStack(alignment: .center, spacing: 8) {
+                        stopNameText
+                        Spacer(minLength: 8)
+                        HStack(spacing: 6) { delayText; timeText }
+                    }
+                }
+            }
+            .padding(.leading, 2)
+            .padding(.trailing, 16)
+            .padding(.vertical, 14)
+        }
+        .frame(minHeight: 58)
+        .opacity(viewModel.isPast ? 0.38 : 1.0)
+        .overlay(alignment: .leading) {
+            if viewModel.isCurrentVehicleLocation {
+                Rectangle()
+                    .fill(Color(.systemGreen))
+                    .frame(width: 3)
+                    .accessibilityHidden(true)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(a11yLabel)
+        .accessibilityValue(a11yValue ?? "")
+        .accessibilityAddTraits(viewModel.isCurrentVehicleLocation ? .isSelected : [])
+    }
+
+    // MARK: - Subviews
+
+    private var stopNameText: some View {
+        Text(viewModel.stopName)
+            .font(.subheadline.weight(viewModel.isCurrentVehicleLocation ? .bold : .medium))
+            .foregroundStyle(viewModel.isCurrentVehicleLocation ? Color(.systemGreen) : .primary)
+            .fixedSize(horizontal: false, vertical: true)
+            .lineLimit(2)
+    }
+
+    private var timeText: some View {
+        Text(viewModel.arrivalTime)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+            .fixedSize()
+    }
+
+    @ViewBuilder
+    private var delayText: some View {
+        if let delay = viewModel.delayMinutes, delay != 0, !viewModel.isPast {
+            Text(delay > 0 ? "+\(delay)m" : "\(delay)m")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(delay > 0 ? .red : Color(.systemGreen))
+                .monospacedDigit()
+                .fixedSize()
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private var a11yLabel: String {
+        [viewModel.stopName, viewModel.arrivalTime].filter { !$0.isEmpty }.joined(separator: ", ")
+    }
+
+    private var a11yValue: String? {
+        var flags: [String] = []
+        if viewModel.isUserDestination {
+            flags.append(OBALoc("trip_stop.user_destination.accessibility_label",
+                                value: "Your destination",
+                                comment: "Voiceover: this stop is the user's destination"))
+        }
+        if viewModel.isCurrentVehicleLocation {
+            flags.append(OBALoc("trip_stop.vehicle_location.accessibility_label",
+                                value: "Vehicle is here",
+                                comment: "Voiceover: the vehicle is currently at this stop"))
+        }
+        if viewModel.isPast {
+            flags.append(OBALoc("trip_stop.past_stop.accessibility_label",
+                                value: "Already passed",
+                                comment: "Voiceover: this stop has already been passed"))
+        }
+        if let delay = viewModel.delayMinutes, delay != 0, !viewModel.isPast {
+            flags.append(delay > 0 ? "\(delay) minutes late" : "\(abs(delay)) minutes early")
+        }
+        return flags.isEmpty ? nil : flags.joined(separator: ", ")
+    }
+}
+
+// MARK: - TripSegmentCanvas
+
+struct TripSegmentCanvas: View {
+    let segment: TripRouteSegment
+    let routeType: Route.RouteType
+    let isCurrentVehicleLocation: Bool
+    let isUserDestination: Bool
+    var isPast: Bool = false
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var activeColor: Color { Color(.systemGreen) }
+    private var lineColor: Color { isPast ? activeColor.opacity(0.28) : activeColor }
+    private let lineWidth: CGFloat = 4
+    private let squareSize: CGFloat = 26
+    private let cornerRadius: CGFloat = 7
+
+    var body: some View {
+        Canvas { ctx, size in
+            let cx = size.width / 2
+            let cy = size.height / 2
+            let half = squareSize / 2
+
+            if drawsTopLine {
+                var p = Path()
+                p.move(to: CGPoint(x: cx, y: 0))
+                p.addLine(to: CGPoint(x: cx, y: cy - half))
+                ctx.stroke(p, with: .color(lineColor), lineWidth: lineWidth)
+            }
+            if drawsBottomLine {
+                var p = Path()
+                p.move(to: CGPoint(x: cx, y: cy + half))
+                p.addLine(to: CGPoint(x: cx, y: size.height))
+                ctx.stroke(p, with: .color(lineColor), lineWidth: lineWidth)
+            }
+
+            guard !isAdjacentRow else { return }
+
+            let rect = CGRect(x: cx - half, y: cy - half, width: squareSize, height: squareSize)
+            let squarePath = Path(roundedRect: rect, cornerRadius: cornerRadius)
+
+            if isCurrentVehicleLocation {
+                ctx.fill(squarePath, with: .color(activeColor))
+                let icon = ctx.resolve(Image(systemName: transportIcon).symbolRenderingMode(.hierarchical))
+                ctx.draw(icon, in: rect.insetBy(dx: 5, dy: 5))
+            } else {
+                let bg: Color = colorScheme == .dark ? Color(.systemBackground) : .white
+                ctx.fill(squarePath, with: .color(bg))
+                ctx.stroke(squarePath, with: .color(lineColor), lineWidth: lineWidth - 1)
+
+                if isUserDestination {
+                    let bs: CGFloat = squareSize * 0.5
+                    let br = CGRect(x: rect.maxX - bs + 3, y: rect.maxY - bs + 3, width: bs, height: bs)
+                    ctx.fill(Path(roundedRect: br, cornerRadius: 4), with: .color(activeColor))
+                    let walk = ctx.resolve(Image(systemName: "figure.walk").symbolRenderingMode(.hierarchical))
+                    ctx.draw(walk, in: br.insetBy(dx: 2, dy: 2))
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var isAdjacentRow: Bool   { segment == .adjacentPrev || segment == .adjacentNext }
+    private var drawsTopLine: Bool    { segment != .first && segment != .adjacentPrev }
+    private var drawsBottomLine: Bool { segment != .last && segment != .adjacentNext }
+
+    private var transportIcon: String {
+        switch routeType {
+        case .bus:      return "bus.fill"
+        case .rail:     return "tram.fill"
+        case .subway:   return "tram.fill"
+        case .ferry:    return "ferry.fill"
+        case .cableCar: return "cablecar.fill"
+        default:        return "bus.fill"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+private let _previewStops: [TripStopRowViewModel] = [
+    .init(id: "1", stopName: "WOODROW RD/VINELAND AV",  arrivalTime: "9:45 PM", segment: .first,  routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: true,  delayMinutes: nil),
+    .init(id: "2", stopName: "WOODROW RD/HOLCOMB AV",   arrivalTime: "9:46 PM", segment: .middle, routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: true,  delayMinutes: nil),
+    .init(id: "3", stopName: "ARDEN AV/WOODROW RD",     arrivalTime: "9:47 PM", segment: .middle, routeType: .bus, isCurrentVehicleLocation: true,  isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: 3),
+    .init(id: "4", stopName: "ARDEN AV/HAMPTON GREEN",  arrivalTime: "9:48 PM", segment: .middle, routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: false, isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: 3),
+    .init(id: "5", stopName: "ARTHUR KILL RD/ARDEN AV", arrivalTime: "9:50 PM", segment: .last,   routeType: .bus, isCurrentVehicleLocation: false, isUserDestination: true,  isAdjacentTrip: false, adjacentTripLabel: nil, isPast: false, delayMinutes: -1),
+]
+
+#Preview("Stop Rows — dark") {
+    List(_previewStops) { stop in
+        TripStopRow(viewModel: stop)
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color(.systemBackground))
+    }
+    .listStyle(.plain)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import SwiftUI
 import MapKit
 import FloatingPanel
 import OBAKitCore
@@ -102,7 +103,8 @@ class TripViewController: UIViewController,
         beginUserActivity()
         startRefreshTimer()
 
-        setContentScrollView(tripDetailsController.listView, for: .bottom)
+        // For SwiftUI, we'll try to set the scroll view if possible, though it's more complex with UIHostingController.
+        // For now, we skip setContentScrollView as it's not strictly required for the panel to work.
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -148,8 +150,6 @@ class TripViewController: UIViewController,
             floatingPanel.addPanel(toParent: self)
             floatingPanel.move(to: .half, animated: true)
         }
-
-        tripDetailsController.listView.applyData()
     }
 
     // MARK: - Idle Timer
@@ -192,17 +192,25 @@ class TripViewController: UIViewController,
     var showTripDetails: Bool = false {
         didSet {
             guard oldValue != self.showTripDetails else { return }
-            UIView.animate(withDuration: 0.1) {
-                self.tripDetailsController.setListVisibility(isVisible: self.showTripDetails)
-            }
+            // In the modernized version, we don't animate the list visibility as it's part of the SwiftUI layout.
         }
     }
 
-    private lazy var tripDetailsController = TripFloatingPanelController(
-        application: application,
-        tripConvertible: tripConvertible,
-        parentTripViewController: self
-    )
+    private lazy var tripDetailViewModel: TripDetailViewModel = {
+        let vm = TripDetailViewModel(application: application, tripConvertible: tripConvertible)
+        vm.hostViewController = self
+        vm.onStopSelected = { [weak self] stopTime in
+            self?.showStopOnMap(stopTime)
+        }
+        return vm
+    }()
+
+    private lazy var tripDetailsHostingController: UIHostingController<TripDetailView> = {
+        let view = TripDetailView(viewModel: tripDetailViewModel)
+        let hc = UIHostingController(rootView: view)
+        hc.view.backgroundColor = .clear
+        return hc
+    }()
 
     /// The floating panel controller, which displays a drawer at the bottom of the map.
     private lazy var floatingPanel: OBAFloatingPanelController = {
@@ -212,7 +220,7 @@ class TripViewController: UIViewController,
         panel.contentMode = .fitToBounds
 
         // Set a content view controller.
-        panel.set(contentViewController: tripDetailsController)
+        panel.set(contentViewController: tripDetailsHostingController)
 
         return panel
     }()
@@ -235,7 +243,7 @@ class TripViewController: UIViewController,
 
     func floatingPanelDidChangeState(_ fpc: FloatingPanelController) {
         showTripDetails = fpc.state != .tip
-        tripDetailsController.configureView(for: fpc.state)
+        // Modernized version doesn't require configureView call as it uses SwiftUI layout.
 
         if fpc.state != .full {
             if traitCollection.horizontalSizeClass == .regular {
@@ -253,10 +261,10 @@ class TripViewController: UIViewController,
         }
     }
 
-    func showStopOnMap(_ tripStop: TripStopViewModel) {
+    func showStopOnMap(_ stopTime: TripStopTime) {
         self.floatingPanel.move(to: .half, animated: true) {
             self.skipNextStopTimeHighlight = true
-            self.selectedStopTime = tripStop.stopTime
+            self.selectedStopTime = stopTime
         }
     }
 
@@ -321,7 +329,7 @@ class TripViewController: UIViewController,
 
         await MainActor.run {
             self.tripConvertible = TripConvertible(arrivalDeparture: newArrDep)
-            self.tripDetailsController.tripConvertible = TripConvertible(arrivalDeparture: newArrDep)
+            self.tripDetailViewModel.loadData()
         }
     }
 
@@ -332,12 +340,12 @@ class TripViewController: UIViewController,
         }
 
         // Let the user still look at data if there was already details from a previous request.
-        self.floatingPanel.surfaceView.grabberHandle.isHidden = self.tripDetailsController.tripDetails == nil
+        self.floatingPanel.surfaceView.grabberHandle.isHidden = self.tripDetailViewModel.tripDetails == nil
 
         let trip = try await apiService.getTrip(tripID: tripConvertible.trip.id, vehicleID: tripConvertible.vehicleID, serviceDate: tripConvertible.serviceDate).entry
 
         await MainActor.run {
-            self.tripDetailsController.tripDetails = trip
+            self.tripDetailViewModel.tripDetails = trip
 
             self.mapView.updateAnnotations(with: trip.stopTimes)
 
@@ -490,7 +498,7 @@ class TripViewController: UIViewController,
         guard !skipNextStopTimeHighlight else { return }
 
         func mapViewAnnotationSelectionComplete() {
-            self.tripDetailsController.highlightStopInList(stopTime.stop)
+            // We can highlight the stop in the SwiftUI list if we implement that logic.
         }
 
         if self.mapView.hasBeenTouched {


### PR DESCRIPTION
## Summary

Replaces the legacy UIKit trip panel (`OBAListView` + `StopArrivalView`) with a fully SwiftUI sheet-based interface aligned with contemporary Apple design patterns — closer to Apple Maps in feel, interaction, and accessibility.

## Files Changed

| File | Status |
|---|---|
| `TripPanelHeaderView.swift` | New |
| `TripStopListView.swift` | New |
| `TripStopRow.swift` | New |
| `TripDetailView.swift` | New |
| `TripFloatingPanelController.swift` | Modified |
| `TripViewController.swift` | Modified |

## Header — `TripPanelHeaderView`

| Feature | Detail |
|---|---|
| Route title | Bold, multi-line support |
| Minutes badge | Large `26m` badge with urgency color — red < 2m, orange < 5m, green/orange based on real-time status |
| Live indicator | Pulsing pill shown only when real-time data is available |
| Progress bar | Thin green capsule showing how far through the route the vehicle has travelled |
| Stops remaining | Inline chip (e.g. `34 stops left`) alongside the progress bar |
| Next-stop callout | Bold stop name + scheduled time + inline delay badge (`+3 min late / 2 min early`) |
| `DelayBadge` | Color-coded capsule pill — red = late, green = early |

## Stop List — `TripStopListView`

| Feature | Detail |
|---|---|
| Sections | Passed stops (collapsible) / Now / Upcoming |
| Collapsible past stops | Collapsed by default — tap header to expand/collapse with animation |
| Jump to Now button | Green capsule appears when user scrolls away from current vehicle stop; tapping scrolls back instantly via shared `ScrollViewProxy` |
| Service alert banner | Orange warning card above the stop list, color-scheme adaptive |
| Pull-to-refresh | Re-fetches live trip data from the API |
| Adjacent trip rows | "Starts as" / "Continues as" rows at list boundaries when previous/next trips exist |
| Auto-scroll | Scrolls to current vehicle stop on sheet appear |
| Empty/loading state | Bus icon placeholder |

## Stop Rows — `TripStopRow` + `TripSegmentCanvas`

| Feature | Detail |
|---|---|
| Delay indicator | `+3m` red / `-1m` green shown left of arrival time for upcoming stops |
| Current vehicle row | Green leading-edge strip for instant visual anchoring |
| Past stops | Dimmed to 38% opacity |
| Current stop name | Rendered bold + green |
| Adjacent trip rows | Compact layout — label + route name + arrow icon |
| Swipe action | Trailing "Show on Map" on every stop row |
| Route line | Canvas-drawn vertical line with past-stop dimming (28% opacity) |
| User destination | Walk icon badge on the stop square |

## Accessibility

| Element | Behaviour |
|---|---|
| Past stops | Announces "Already passed" |
| Vehicle stop | Announces "Vehicle is here" + `.isSelected` trait |
| User destination | Announces "Your destination" |
| Delay | Announces "X minutes late / early" |
| Live pill | Announces "Real-time tracking active" |
| Progress bar | Announces "Route progress: X percent" |
| Collapsible header | Announces expand / collapse hint |
| Service alert | Prefixed with "Service alert:" |
| Jump to Now | Announces "Jump to current vehicle position" |
| Dynamic Type | Accessibility sizes stack stop name and time vertically |

## ViewModel Bridge — `TripDetailView` + `TripDetailViewModel`

| Change | Detail |
|---|---|
| `TripDetailViewModel` | `@MainActor ObservableObject` bridging `TripViewController`'s data loading into SwiftUI — exposes `headerViewModel`, `stopViewModels`, `selectStop()` |
| `TripDetailView` | SwiftUI view wrapping `TripStopListView`, driven by `TripDetailViewModel` |
| `TripViewController` | Updated to use `UIHostingController<TripDetailView>` in place of the legacy `TripFloatingPanelController` UIKit stack |
| `showStopOnMap` | Signature updated from `TripStopViewModel` to `TripStopTime` — direct model, no UIKit dependency |

## Controller — `TripFloatingPanelController`

| Change | Detail |
|---|---|
| `buildModernView()` | Wires all closures: `onSelectStop`, `onShowOnMap`, `refreshAction`, `serviceAlerts` |
| `refreshAction` | Re-fetches trip via `apiService.getTrip(...)` and updates `tripDetails` on `MainActor` |
| Service alerts | Extracted via `tripDetails.serviceAlerts.compactMap { $0.summary?.value }` |
| `useModernUI = false` | Retained for safe fallback to legacy UIKit layout |

## Testing

Each file includes `#Preview` macros covering:

- Scheduled (no real-time) with late delay + service alert — dark mode
- Real-time on-time and early variants — dark mode
- Empty / loading state
- Stop rows: past, current vehicle, user destination, adjacent trip

## Notes

- Legacy UIKit path (`useModernUI = false`) is fully preserved — no existing behaviour is broken
- `applyRefreshable(action:)` helper avoids shadowing the system `refreshable` modifier name
- `parentTripViewController` weak reference pattern is unchanged

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-03 at 21 42 36" src="https://github.com/user-attachments/assets/225dbb18-23e6-425f-ba35-7698e8d427d2" />