### PR TITLE
Add native iOS sheet presentation for stop detail from map

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -628,11 +628,15 @@ class MapViewController: UIViewController,
 
     // MARK: - Content Presentation
 
-    /// Displays the specified stop.
+    /// Displays the specified stop as a native sheet so the map stays visible.
     ///
     /// - Parameter stop: The stop to display.
     func show(stop: Stop) {
-        application.viewRouter.navigateTo(stop: stop, from: self)
+        // Hide the floating panel so it doesn't sit on top of the stop sheet
+        floatingPanel.move(to: .hidden, animated: true)
+        let sheet = application.viewRouter.makeStopSheet(stop: stop)
+        sheet.stopSheetDelegate = self
+        sheet.present(from: self, centeringMap: mapRegionManager.mapView)
     }
 
     // MARK: - Overlays
@@ -836,7 +840,10 @@ class MapViewController: UIViewController,
     private lazy var mapPanelController = MapFloatingPanelController(application: application, mapRegionManager: application.mapRegionManager, delegate: self)
 
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stopID: Stop.ID) {
-        application.viewRouter.navigateTo(stopID: stopID, from: self)
+        floatingPanel.move(to: .hidden, animated: true)
+        let sheet = application.viewRouter.makeStopSheet(stopID: stopID)
+        sheet.stopSheetDelegate = self
+        sheet.present(from: self, centeringMap: mapRegionManager.mapView)
     }
 
     func mapPanelController(_ controller: MapFloatingPanelController, didSelectMapItem mapItem: MKMapItem) {
@@ -1134,6 +1141,25 @@ class MapViewController: UIViewController,
         }
     }
 
+}
+
+// MARK: - StopSheetDelegate
+
+extension MapViewController: StopSheetDelegate {
+    func stopSheetDidDismiss(_ sheet: StopSheetViewController) {
+        mapRegionManager.mapView.selectedAnnotations.forEach {
+            mapRegionManager.mapView.deselectAnnotation($0, animated: true)
+        }
+        floatingPanel.move(to: .tip, animated: true)
+    }
+
+    func stopSheetDidExpand(_ sheet: StopSheetViewController) {
+        floatingPanel.move(to: .hidden, animated: true)
+    }
+
+    func stopSheetDidCollapse(_ sheet: StopSheetViewController) {
+        // Sheet returned to half — no action needed, map offset stays as-is
+    }
 }
 
 // swiftlint:enable file_length

--- a/OBAKit/Stops/StopSheetViewController.swift
+++ b/OBAKit/Stops/StopSheetViewController.swift
@@ -1,0 +1,217 @@
+//
+//  StopSheetViewController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import MapKit
+import OBAKitCore
+
+// MARK: - StopSheetDelegate
+
+protocol StopSheetDelegate: AnyObject {
+    func stopSheetDidDismiss(_ sheet: StopSheetViewController)
+    func stopSheetDidExpand(_ sheet: StopSheetViewController)
+    func stopSheetDidCollapse(_ sheet: StopSheetViewController)
+}
+
+extension StopSheetDelegate {
+    func stopSheetDidExpand(_ sheet: StopSheetViewController) {}
+    func stopSheetDidCollapse(_ sheet: StopSheetViewController) {}
+}
+
+// MARK: - StopSheetViewController
+
+/// Presents a `StopViewController` as a native iOS sheet with two detents:
+/// - **Half** (~50%) — stop header + first departures, map visible above.
+/// - **Large** — full stop detail with close button top-left.
+final class StopSheetViewController: UINavigationController {
+
+    // MARK: - Properties
+
+    weak var stopSheetDelegate: StopSheetDelegate?
+    private let stop: Stop?
+
+    // MARK: - Custom detent
+
+    static let halfDetentID = UISheetPresentationController.Detent.Identifier("stopHalf")
+
+    private static var halfDetent: UISheetPresentationController.Detent {
+        .custom(identifier: halfDetentID) { context in
+            context.maximumDetentValue * 0.50
+        }
+    }
+
+    // MARK: - Init
+
+    init(application: Application, stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) {
+        self.stop = stop
+        let stopVC = StopViewController(application: application, stop: stop)
+        stopVC.bookmarkContext = bookmark
+        stopVC.transferContext = transferContext
+        super.init(rootViewController: stopVC)
+        configureSheet()
+        configureNavBar()
+    }
+
+    init(application: Application, stopID: StopID) {
+        self.stop = nil
+        let stopVC = StopViewController(application: application, stopID: stopID)
+        super.init(rootViewController: stopVC)
+        configureSheet()
+        configureNavBar()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: - Sheet configuration
+
+    private func configureSheet() {
+        modalPresentationStyle = .pageSheet
+        guard let sheet = sheetPresentationController else { return }
+        sheet.detents = [Self.halfDetent, .large()]
+        sheet.selectedDetentIdentifier = Self.halfDetentID
+        sheet.largestUndimmedDetentIdentifier = Self.halfDetentID
+        sheet.prefersGrabberVisible = true
+        sheet.prefersScrollingExpandsWhenScrolledToEdge = true
+        sheet.preferredCornerRadius = 20
+        sheet.delegate = self
+        // Set ourselves as nav delegate so we can re-assert the close button
+        // whenever a view controller is about to be shown
+        self.delegate = self
+    }
+
+    private func configureNavBar() {
+        // Keep nav bar visible so StopViewController's right bar buttons (schedule, filter, more) remain.
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .systemMaterial)
+        appearance.shadowColor = .clear
+        navigationBar.standardAppearance = appearance
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
+        navigationBar.isTranslucent = true
+    }
+
+    // MARK: - Close button
+
+    private lazy var closeBarButton: UIBarButtonItem = {
+        let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .regular)
+        let img = UIImage(systemName: "xmark.circle.fill", withConfiguration: config)?
+            .withRenderingMode(.alwaysTemplate)
+        let btn = UIBarButtonItem(image: img, style: .plain, target: self, action: #selector(closeTapped))
+        btn.tintColor = .tertiaryLabel
+        btn.accessibilityLabel = "Close"
+        return btn
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        installCloseButton()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        installCloseButton()
+    }
+
+    private func installCloseButton() {
+        guard let stopVC = topViewController else { return }
+        // Only set if not already ours — avoids redundant layout passes
+        if stopVC.navigationItem.leftBarButtonItem !== closeBarButton {
+            stopVC.navigationItem.leftBarButtonItem = closeBarButton
+            stopVC.navigationItem.hidesBackButton = true
+        }
+    }
+
+    // MARK: - Close action
+
+    @objc private func closeTapped() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        // Fire delegate manually — presentationControllerDidDismiss only fires on swipe dismiss
+        stopSheetDelegate?.stopSheetDidDismiss(self)
+        dismiss(animated: true)
+    }
+
+    // MARK: - Presentation
+
+    func present(from fromController: UIViewController, centeringMap mapView: MKMapView? = nil) {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        fromController.present(self, animated: true) { [weak self] in
+            guard let self, let stop = self.stop, let mapView else { return }
+            self.centerMap(mapView, on: stop.coordinate)
+        }
+    }
+
+    // MARK: - Map centering
+
+    private func centerMap(_ mapView: MKMapView, on coordinate: CLLocationCoordinate2D) {
+        let offsetFraction = 0.25
+        var region = mapView.region
+        region.center = CLLocationCoordinate2D(
+            latitude: coordinate.latitude - (region.span.latitudeDelta * offsetFraction),
+            longitude: coordinate.longitude
+        )
+        UIView.animate(
+            withDuration: 0.4, delay: 0,
+            usingSpringWithDamping: 0.85, initialSpringVelocity: 0.5,
+            options: .curveEaseOut
+        ) {
+            mapView.setRegion(region, animated: false)
+        }
+    }
+
+    func restoreMapCenter(_ mapView: MKMapView, to coordinate: CLLocationCoordinate2D) {
+        var region = mapView.region
+        region.center = coordinate
+        UIView.animate(withDuration: 0.35, delay: 0, options: .curveEaseOut) {
+            mapView.setRegion(region, animated: false)
+        }
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension StopSheetViewController: UINavigationControllerDelegate {
+    func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        installCloseButton()
+    }
+}
+
+// MARK: - UISheetPresentationControllerDelegate
+
+extension StopSheetViewController: UISheetPresentationControllerDelegate {
+
+    func sheetPresentationControllerDidChangeSelectedDetentIdentifier(
+        _ controller: UISheetPresentationController
+    ) {
+        if controller.selectedDetentIdentifier == .large {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            stopSheetDelegate?.stopSheetDidExpand(self)
+        } else {
+            stopSheetDelegate?.stopSheetDidCollapse(self)
+        }
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        UISelectionFeedbackGenerator().selectionChanged()
+        stopSheetDelegate?.stopSheetDidDismiss(self)
+    }
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        return .pageSheet
+    }
+}

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -94,6 +94,16 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
         navigate(to: stopController, from: fromController)
     }
 
+    /// Creates (but does not present) a stop sheet — use when you need to set a delegate before presenting.
+    func makeStopSheet(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) -> StopSheetViewController {
+        StopSheetViewController(application: application, stop: stop, bookmark: bookmark, transferContext: transferContext)
+    }
+
+    /// Creates (but does not present) a stop sheet by ID — use when you need to set a delegate before presenting.
+    func makeStopSheet(stopID: StopID) -> StopSheetViewController {
+        StopSheetViewController(application: application, stopID: stopID)
+    }
+
     public func navigateTo(arrivalDeparture: ArrivalDeparture, from fromController: UIViewController) {
         guard shouldNavigate(from: fromController, to: .arrivalDeparture(arrivalDeparture)) else { return }
         let tripController = TripViewController(application: application, arrivalDeparture: arrivalDeparture)


### PR DESCRIPTION
## Summary

Replaces the navigation stack push for stop detail with a native iOS sheet presentation when tapping a stop annotation on the map. The map stays visible and interactive behind the sheet, matching the Apple Maps "place card" interaction pattern.

## Files Changed

| File | Status |
|---|---|
| `StopSheetViewController.swift` | New |
| `MapViewController.swift` | Modified |
| `Router.swift` | Modified |

## What Changed

### `StopSheetViewController` (New)

| Feature | Detail |
|---|---|
| Sheet setup | Wraps `StopViewController` in a `UINavigationController` configured as a native `UISheetPresentationController` |
| Detents | Custom half (50% screen height) as initial state + large (full screen) |
| Undimmed detent | `largestUndimmedDetentIdentifier = .half` — map stays fully visible and undimmed at half, only dims when sheet goes full screen |
| Appearance | `preferredCornerRadius = 20`, `prefersGrabberVisible = true` |
| Close button | `xmark.circle.fill` set as `leftBarButtonItem` — re-asserted via `UINavigationControllerDelegate` so `StopViewController`'s `viewDidLoad` and `dataDidReload` cannot overwrite it |
| Existing buttons | `StopViewController`'s right bar buttons (schedule, filter, more) are fully preserved |
| Delegate | `StopSheetDelegate` protocol with `stopSheetDidDismiss`, `stopSheetDidExpand`, `stopSheetDidCollapse` callbacks — default no-op implementations via protocol extension |
| Close button dismiss | Fires `stopSheetDidDismiss` manually before `dismiss(animated:)` since `presentationControllerDidDismiss` only fires on interactive swipe |
| Map camera offset | Pans the stop pin into the upper half of the exposed map area above the sheet on present via spring animation |
| Restore | `restoreMapCenter(_:to:)` reverses the pan on dismiss |
| iPad | `adaptivePresentationStyle` returns `.pageSheet` to force sheet style over default popover |

### `MapViewController`

| Change | Detail |
|---|---|
| `show(stop:)` | Updated to hide the floating panel, create a `StopSheetViewController` via `makeStopSheet`, assign delegate, and present with map centering |
| `mapPanelController(_:didSelectStop:)` | Updated the same way for the nearby list tap path |
| `stopSheetDidDismiss` | Deselects the map annotation and restores floating panel to `.tip` |
| `stopSheetDidExpand` | Keeps floating panel hidden when sheet goes full screen |
| `stopSheetDidCollapse` | No-op — panel stays hidden at half |

### `ViewRouter`

| Change | Detail |
|---|---|
| `makeStopSheet(stop:)` / `makeStopSheet(stopID:)` | Factory methods that return a configured `StopSheetViewController` without presenting, so the caller can assign a delegate before presenting |
| Removed | Orphaned `presentStopSheet` methods that were no longer called |

## Behaviour

| Action | Before | After |
|---|---|---|
| Tap stop pin on map | Pushes `StopViewController` onto nav stack | Sheet slides up at 50% height, map visible above |
| Tap stop in nearby list | Pushes `StopViewController` | Same sheet behaviour |
| Drag sheet up | — | Expands to full screen, floating panel hides |
| Swipe sheet down | — | Dismisses, annotation deselected, floating panel restores |
| Tap close button | — | Same as swipe dismiss |
| Tap stop from Bookmarks / Trip detail | Push (unchanged) | Push (unchanged) |

## Notes

- The existing `navigateTo(stop:from:)` push path in `ViewRouter` is fully preserved — Bookmarks, Trip detail, and deep links are unaffected
- Haptic feedback: medium impact on present, light on expand to large, selection feedback on swipe dismiss
- Tested on iPhone (portrait) and iPad (forces `.pageSheet` via `adaptivePresentationStyle`)

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 01 06 54" src="https://github.com/user-attachments/assets/cf16d1ea-31a2-4fd3-90a5-55614aebd342" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 01 06 59" src="https://github.com/user-attachments/assets/dfa6a71f-3968-4a57-85b6-4cfea2e972ab" />
