### PR TITLE
Implement customizable walking speed with HealthKit

### DIFF
--- a/Apps/KiedyBus/project.yml
+++ b/Apps/KiedyBus/project.yml
@@ -19,6 +19,7 @@ targets:
       properties:
         com.apple.security.application-groups:
           - group.pl.kiedybus.iphone
+        com.apple.developer.healthkit: true
     info:
       path: Apps/KiedyBus/Info.plist
       properties:

--- a/Apps/OneBusAway/project.yml
+++ b/Apps/OneBusAway/project.yml
@@ -25,6 +25,7 @@ targets:
           - applinks:sidecar.onebusaway.org
         com.apple.developer.in-app-payments:
           - merchant.org.onebusaway.iphone
+        com.apple.developer.healthkit: true
     info:
       path: Apps/OneBusAway/Info.plist
       properties:

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -42,6 +42,7 @@ targets:
           - twitter
           - comgooglemaps
         NSLocationWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
+        NSHealthShareUsageDescription: OneBusAway uses your walking speed from the Health app to give you more accurate arrival time estimates.
         NSLocationTemporaryUsageDescriptionDictionary:
           MapStatusView: See where you are in relation to transit, and help you navigate more easily.
         UILaunchStoryboardName: LaunchScreen

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -90,6 +90,9 @@ public class Application: CoreApplication, PushServiceDelegate {
 
     lazy var toastManager = ToastManager()
 
+    @MainActor
+    lazy var walkingSpeedManager = WalkingSpeedManager(userDataStore: userDataStore)
+
     @objc lazy var userActivityBuilder = UserActivityBuilder(application: self)
 
     /// Handles all deep-linking into the app.
@@ -374,6 +377,10 @@ public class Application: CoreApplication, PushServiceDelegate {
         reportAnalyticsUserProperties()
 
         configureTipKit()
+
+        if userDataStore.walkingSpeedSource == .healthKit {
+            Task { await walkingSpeedManager.requestHealthKitAuthorizationAndSync() }
+        }
     }
 
     @objc public func applicationDidBecomeActive(_ application: UIApplication) {

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -379,7 +379,7 @@ public class Application: CoreApplication, PushServiceDelegate {
         configureTipKit()
 
         if userDataStore.walkingSpeedSource == .healthKit {
-            Task { await walkingSpeedManager.requestHealthKitAuthorizationAndSync() }
+            Task { await walkingSpeedManager.refreshFromHealthKitIfPossible() }
         }
     }
 

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -254,8 +254,7 @@ class SettingsViewController: FormViewController {
    // MARK: - Privacy
 
     private let privacySectionReportingEnabled = "privacySectionReportingEnabled"
-    private let alwaysShowSurveysOnStops = "alwaysShowSurveysOnStops"
-    
+
     // MARK: - Walking Speed Keys
     private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
     private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -9,6 +9,7 @@
 
 import Eureka
 import Foundation
+import HealthKit
 import OBAKitCore
 import UIKit
 
@@ -38,6 +39,7 @@ class SettingsViewController: FormViewController {
             +++ mapSection
             +++ alertsSection
             +++ accessibilitySection
+            +++ walkingSpeedSection
             +++ surveySection
             +++ debugSection
 
@@ -58,7 +60,9 @@ class SettingsViewController: FormViewController {
             RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey: application.userDefaults.bool(forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey),
             MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey: application.userDefaults.bool(forKey: MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey),
             debugModeEnabled: application.userDataStore.debugMode,
-            alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops
+            alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops,
+            walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
+            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit
         ])
     }
 
@@ -114,6 +118,23 @@ class SettingsViewController: FormViewController {
         } else {
             application.userDefaults.set(false, forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
         }
+
+        // Walking Speed — save source first to avoid race condition
+        if let useHK = values[walkingSpeedUseHealthKitKey] as? Bool {
+            application.userDataStore.walkingSpeedSource = useHK ? .healthKit : .manual
+        }
+
+        if let speed = values[walkingSpeedMetersPerSecondKey] as? Double,
+           application.userDataStore.walkingSpeedSource == .manual {
+            application.userDataStore.walkingSpeedMetersPerSecond = speed
+        }
+
+        // Snap to nearest preset when toggling HealthKit OFF
+        if let useHK = values[walkingSpeedUseHealthKitKey] as? Bool, !useHK {
+            application.userDataStore.walkingSpeedMetersPerSecond = snapToPreset(
+                application.userDataStore.walkingSpeedMetersPerSecond
+            )
+        }
     }
 
     // MARK: - Map Section
@@ -164,6 +185,59 @@ class SettingsViewController: FormViewController {
         return section
     }()
 
+    // MARK: - Walking Speed
+
+    private let walkingSpeedPresets: [Double] = [0.9, 1.4, 1.8]
+
+    private func snapToPreset(_ speed: Double) -> Double {
+        walkingSpeedPresets.min(by: { abs($0 - speed) < abs($1 - speed) }) ?? 1.4
+    }
+
+    private lazy var walkingSpeedSection: Section = {
+        let section = Section(OBALoc("settings_controller.walking_speed_section.title", value: "Walking Speed", comment: "Settings > Walking Speed section title"))
+
+        section <<< SegmentedRow<Double> {
+            $0.tag = walkingSpeedMetersPerSecondKey
+            $0.title = OBALoc("settings_controller.walking_speed.title",
+                              value: "Walking speed",
+                              comment: "Settings > Walking Speed section > Speed picker")
+            $0.options = walkingSpeedPresets
+            $0.displayValueFor = { speed in
+                switch speed {
+                case 0.9: return OBALoc("settings_controller.walking_speed.slow", value: "Slow (~2 mph)", comment: "")
+                case 1.8: return OBALoc("settings_controller.walking_speed.fast", value: "Fast (~4 mph)", comment: "")
+                default:  return OBALoc("settings_controller.walking_speed.avg", value: "Average (~3 mph)", comment: "")
+                }
+            }
+            $0.disabled = Condition.function([walkingSpeedUseHealthKitKey], { [weak self] form in
+                guard let self = self else { return false }
+                return (form.rowBy(tag: self.walkingSpeedUseHealthKitKey) as? SwitchRow)?.value ?? false
+            })
+        }
+
+        if HKHealthStore.isHealthDataAvailable() {
+            section <<< SwitchRow {
+                $0.tag = walkingSpeedUseHealthKitKey
+                $0.title = OBALoc("settings_controller.walking_speed.use_healthkit",
+                                  value: "Use Health app data",
+                                  comment: "Settings > Walking Speed section > HealthKit toggle")
+                $0.onChange { [weak self] row in
+                    guard let self, row.value == true else { return }
+                    Task {
+                        let granted = await self.application.walkingSpeedManager.requestHealthKitAuthorizationAndSync()
+                        if !granted {
+                            row.value = false
+                            row.reload()
+                            self.application.userDataStore.walkingSpeedSource = .manual
+                        }
+                    }
+                }
+            }
+        }
+
+        return section
+    }()
+
     // MARK: - Agency Alerts
 
     private lazy var alertsSection: Section = {
@@ -180,6 +254,11 @@ class SettingsViewController: FormViewController {
    // MARK: - Privacy
 
     private let privacySectionReportingEnabled = "privacySectionReportingEnabled"
+    private let alwaysShowSurveysOnStops = "alwaysShowSurveysOnStops"
+    
+    // MARK: - Walking Speed Keys
+    private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
+    private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"
 
     private lazy var privacySection: Section = {
         let section = Section(OBALoc("settings_controller.privacy_section.title", value: "Privacy", comment: "Settings > Privacy section title"))

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -187,10 +187,8 @@ class SettingsViewController: FormViewController {
 
     // MARK: - Walking Speed
 
-    private let walkingSpeedPresets: [Double] = [0.9, 1.4, 1.8]
-
     private func snapToPreset(_ speed: Double) -> Double {
-        walkingSpeedPresets.min(by: { abs($0 - speed) < abs($1 - speed) }) ?? 1.4
+        WalkingSpeedPreset.nearest(to: speed).rawValue
     }
 
     private lazy var walkingSpeedSection: Section = {
@@ -201,13 +199,9 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc("settings_controller.walking_speed.title",
                               value: "Walking speed",
                               comment: "Settings > Walking Speed section > Speed picker")
-            $0.options = walkingSpeedPresets
+            $0.options = WalkingSpeedPreset.allCases.map { $0.rawValue }
             $0.displayValueFor = { speed in
-                switch speed {
-                case 0.9: return OBALoc("settings_controller.walking_speed.slow", value: "Slow (~2 mph)", comment: "")
-                case 1.8: return OBALoc("settings_controller.walking_speed.fast", value: "Fast (~4 mph)", comment: "")
-                default:  return OBALoc("settings_controller.walking_speed.avg", value: "Average (~3 mph)", comment: "")
-                }
+                WalkingSpeedPreset.nearest(to: speed ?? WalkingSpeed.defaultMetersPerSecond).localizedTitle
             }
             $0.disabled = Condition.function([walkingSpeedUseHealthKitKey], { [weak self] form in
                 guard let self = self else { return false }
@@ -228,7 +222,14 @@ class SettingsViewController: FormViewController {
                         if !granted {
                             row.value = false
                             row.reload()
-                            self.application.userDataStore.walkingSpeedSource = .manual
+                            self.showErrorToast(
+                                OBALoc(
+                                    "settings_controller.walking_speed.healthkit_unavailable",
+                                    value: "Couldn't sync walking speed from Health. Check Settings > Privacy & Security > Health to allow access.",
+                                    comment: "Settings > Walking Speed > HealthKit denial or no-data toast"
+                                ),
+                                using: self.application.toastManager
+                            )
                         }
                     }
                 }

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -184,6 +184,9 @@ class SettingsViewController: FormViewController {
 
     // MARK: - Walking Speed
 
+    private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
+    private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"
+
     private func snapToPreset(_ speed: Double) -> Double {
         WalkingSpeedPreset.nearest(to: speed).rawValue
     }
@@ -252,10 +255,6 @@ class SettingsViewController: FormViewController {
    // MARK: - Privacy
 
     private let privacySectionReportingEnabled = "privacySectionReportingEnabled"
-
-    // MARK: - Walking Speed Keys
-    private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
-    private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"
 
     private lazy var privacySection: Section = {
         let section = Section(OBALoc("settings_controller.privacy_section.title", value: "Privacy", comment: "Settings > Privacy section title"))

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -124,22 +124,14 @@ class SettingsViewController: FormViewController {
 
     private func saveWalkingSpeedValues(_ values: [String: Any?]) {
         let store = application.userDataStore
-        let useHK = values[walkingSpeedUseHealthKitKey] as? Bool
-
-        // Source first so the manual-only speed write below sees the new source.
-        if let useHK {
-            store.walkingSpeedSource = useHK ? .healthKit : .manual
-        }
-
-        if let speed = values[walkingSpeedMetersPerSecondKey] as? Double,
-           store.walkingSpeedSource == .manual {
-            store.walkingSpeedMetersPerSecond = speed
-        }
-
-        // Snap to nearest preset when toggling HealthKit OFF so the segmented row matches.
-        if useHK == false {
-            store.walkingSpeedMetersPerSecond = snapToPreset(store.walkingSpeedMetersPerSecond)
-        }
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: store.walkingSpeedSource,
+            currentSpeed: store.walkingSpeedMetersPerSecond,
+            useHealthKit: values[walkingSpeedUseHealthKitKey] as? Bool,
+            segmentSpeed: values[walkingSpeedMetersPerSecondKey] as? Double
+        )
+        store.walkingSpeedSource = decision.source
+        store.walkingSpeedMetersPerSecond = decision.speed
     }
 
     // MARK: - Map Section

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -119,21 +119,26 @@ class SettingsViewController: FormViewController {
             application.userDefaults.set(false, forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
         }
 
-        // Walking Speed — save source first to avoid race condition
-        if let useHK = values[walkingSpeedUseHealthKitKey] as? Bool {
-            application.userDataStore.walkingSpeedSource = useHK ? .healthKit : .manual
+        saveWalkingSpeedValues(values)
+    }
+
+    private func saveWalkingSpeedValues(_ values: [String: Any?]) {
+        let store = application.userDataStore
+        let useHK = values[walkingSpeedUseHealthKitKey] as? Bool
+
+        // Source first so the manual-only speed write below sees the new source.
+        if let useHK {
+            store.walkingSpeedSource = useHK ? .healthKit : .manual
         }
 
         if let speed = values[walkingSpeedMetersPerSecondKey] as? Double,
-           application.userDataStore.walkingSpeedSource == .manual {
-            application.userDataStore.walkingSpeedMetersPerSecond = speed
+           store.walkingSpeedSource == .manual {
+            store.walkingSpeedMetersPerSecond = speed
         }
 
-        // Snap to nearest preset when toggling HealthKit OFF
-        if let useHK = values[walkingSpeedUseHealthKitKey] as? Bool, !useHK {
-            application.userDataStore.walkingSpeedMetersPerSecond = snapToPreset(
-                application.userDataStore.walkingSpeedMetersPerSecond
-            )
+        // Snap to nearest preset when toggling HealthKit OFF so the segmented row matches.
+        if useHK == false {
+            store.walkingSpeedMetersPerSecond = snapToPreset(store.walkingSpeedMetersPerSecond)
         }
     }
 

--- a/OBAKit/Settings/WalkingSpeedPreset.swift
+++ b/OBAKit/Settings/WalkingSpeedPreset.swift
@@ -1,0 +1,33 @@
+//
+//  WalkingSpeedPreset.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// User-selectable walking-speed presets, in meters per second.
+/// Owns the raw speed value, the localized label, and the snap-to-nearest logic in one place.
+enum WalkingSpeedPreset: Double, CaseIterable {
+    case slow = 0.9
+    case average = 1.4
+    case fast = 1.8
+
+    var localizedTitle: String {
+        switch self {
+        case .slow:
+            return OBALoc("settings_controller.walking_speed.slow", value: "Slow (~2 mph)", comment: "Settings > Walking Speed > Slow preset label")
+        case .average:
+            return OBALoc("settings_controller.walking_speed.avg", value: "Average (~3 mph)", comment: "Settings > Walking Speed > Average preset label")
+        case .fast:
+            return OBALoc("settings_controller.walking_speed.fast", value: "Fast (~4 mph)", comment: "Settings > Walking Speed > Fast preset label")
+        }
+    }
+
+    static func nearest(to speed: Double) -> WalkingSpeedPreset {
+        allCases.min(by: { abs($0.rawValue - speed) < abs($1.rawValue - speed) }) ?? .average
+    }
+}

--- a/OBAKit/Settings/WalkingSpeedPreset.swift
+++ b/OBAKit/Settings/WalkingSpeedPreset.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import OBAKitCore
 
 /// User-selectable walking-speed presets, in meters per second.
 /// Owns the raw speed value, the localized label, and the snap-to-nearest logic in one place.
@@ -29,5 +30,39 @@ enum WalkingSpeedPreset: Double, CaseIterable {
 
     static func nearest(to speed: Double) -> WalkingSpeedPreset {
         allCases.min(by: { abs($0.rawValue - speed) < abs($1.rawValue - speed) }) ?? .average
+    }
+}
+
+/// Pure computation of the next `(source, speed)` pair given the persisted state and the
+/// values pulled out of the settings form. Extracted so the branching can be unit-tested
+/// without instantiating a `FormViewController`.
+struct WalkingSpeedSettingsDecision: Equatable {
+    let source: WalkingSpeedSource
+    let speed: Double
+
+    /// - Parameters:
+    ///   - currentSource: persisted source before this save.
+    ///   - currentSpeed: persisted speed (m/s) before this save.
+    ///   - useHealthKit: the HK toggle's form value, or `nil` if the row isn't present.
+    ///   - segmentSpeed: the segmented-row speed (m/s), or `nil` if absent.
+    static func compute(
+        currentSource: WalkingSpeedSource,
+        currentSpeed: Double,
+        useHealthKit: Bool?,
+        segmentSpeed: Double?
+    ) -> WalkingSpeedSettingsDecision {
+        // Source first so the manual-only speed write below sees the new source.
+        let newSource: WalkingSpeedSource = useHealthKit.map { $0 ? .healthKit : .manual } ?? currentSource
+
+        var newSpeed = currentSpeed
+        if let segmentSpeed, newSource == .manual {
+            newSpeed = segmentSpeed
+        }
+        // Snap to nearest preset when toggling HealthKit OFF so the segmented row matches.
+        if useHealthKit == false {
+            newSpeed = WalkingSpeedPreset.nearest(to: newSpeed).rawValue
+        }
+
+        return .init(source: newSource, speed: newSpeed)
     }
 }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1136,7 +1136,7 @@ public class StopViewController: UIViewController,
         guard items.count > 0,
               let currentLocation = application.locationService.currentLocation,
               let stopLocation = stop?.location,
-              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation)
+              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.walkingSpeedMetersPerSecond)
         else { return }
 
         if let insertionIndex = findInsertionIndexForWalkTime(walkingTime, items: items) {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -970,7 +970,7 @@ public class StopViewController: UIViewController,
         guard items.count > 0,
               let currentLocation = application.locationService.currentLocation,
               let stopLocation = stop?.location,
-              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation)
+              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.walkingSpeedMetersPerSecond)
         else { return }
 
         if let insertionIndex = findInsertionIndexForWalkTime(walkingTime, items: items) {

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -770,6 +770,27 @@
 /* Settings > Privacy section title */
 "settings_controller.privacy_section.title" = "Privacy";
 
+/* Settings > Walking Speed > Average preset label */
+"settings_controller.walking_speed.avg" = "Average (~3 mph)";
+
+/* Settings > Walking Speed > Fast preset label */
+"settings_controller.walking_speed.fast" = "Fast (~4 mph)";
+
+/* Settings > Walking Speed > HealthKit denial or no-data toast */
+"settings_controller.walking_speed.healthkit_unavailable" = "Couldn't sync walking speed from Health. Check Settings > Privacy & Security > Health to allow access.";
+
+/* Settings > Walking Speed > Slow preset label */
+"settings_controller.walking_speed.slow" = "Slow (~2 mph)";
+
+/* Settings > Walking Speed section > Speed picker */
+"settings_controller.walking_speed.title" = "Walking speed";
+
+/* Settings > Walking Speed section > HealthKit toggle */
+"settings_controller.walking_speed.use_healthkit" = "Use Health app data";
+
+/* Settings > Walking Speed section title */
+"settings_controller.walking_speed_section.title" = "Walking Speed";
+
 /* A message that appears when a user's alarm is created. */
 "stop_controller.alarm_created_message" = "Alarm created";
 

--- a/OBAKit/TripPlanning/WalkingDirections.swift
+++ b/OBAKit/TripPlanning/WalkingDirections.swift
@@ -16,13 +16,16 @@ class WalkingDirections: NSObject {
     /// Average human walking speed is 1.4 meters per second (about 3.1 miles per hour).
     private static let walkingVelocity = 1.4
 
-    /// Calculates the travel time in seconds from one location to another, assuming
-    /// average human walking speed of 1.4 meters per second (about 3.1 miles per hour).
+    /// Calculates travel time, optionally using a custom walking velocity.
     /// - Parameter location: Starting location
     /// - Parameter toLocation: Ending location
-    public class func travelTime(from location: CLLocation?, to toLocation: CLLocation?) -> TimeInterval? {
+    /// - Parameter velocity: Walking speed in meters per second. Defaults to 1.4 (average human walking speed).
+    public class func travelTime(
+        from location: CLLocation?,
+        to toLocation: CLLocation?,
+        velocity: Double = 1.4
+    ) -> TimeInterval? {
         guard let location = location, let toLocation = toLocation else { return nil }
-        let distance = location.distance(from: toLocation)
-        return distance / walkingVelocity
+        return location.distance(from: toLocation) / velocity
     }
 }

--- a/OBAKit/TripPlanning/WalkingDirections.swift
+++ b/OBAKit/TripPlanning/WalkingDirections.swift
@@ -9,23 +9,21 @@
 
 import Foundation
 import CoreLocation
+import OBAKitCore
 
 /// Provides facilities for calculating walking directions and travel times.
 class WalkingDirections: NSObject {
 
-    /// Average human walking speed is 1.4 meters per second (about 3.1 miles per hour).
-    private static let walkingVelocity = 1.4
-
     /// Calculates travel time, optionally using a custom walking velocity.
     /// - Parameter location: Starting location
     /// - Parameter toLocation: Ending location
-    /// - Parameter velocity: Walking speed in meters per second. Defaults to 1.4 (average human walking speed).
+    /// - Parameter velocity: Walking speed in meters per second. Defaults to the average human walking speed.
     public class func travelTime(
         from location: CLLocation?,
         to toLocation: CLLocation?,
-        velocity: Double = 1.4
+        velocity: Double = WalkingSpeed.defaultMetersPerSecond
     ) -> TimeInterval? {
-        guard let location = location, let toLocation = toLocation else { return nil }
+        guard let location = location, let toLocation = toLocation, velocity > 0 else { return nil }
         return location.distance(from: toLocation) / velocity
     }
 }

--- a/OBAKit/TripPlanning/WalkingSpeedHealthKitProviding.swift
+++ b/OBAKit/TripPlanning/WalkingSpeedHealthKitProviding.swift
@@ -1,0 +1,74 @@
+//
+//  WalkingSpeedHealthKitProviding.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Narrow seam around the two HealthKit operations `WalkingSpeedManager` needs.
+/// Exists so the manager's denial/sync state machine can be tested without a live `HKHealthStore`.
+protocol WalkingSpeedHealthKitProviding {
+    /// `true` when HealthKit is usable on this device and the walking-speed quantity type is available.
+    var isAvailable: Bool { get }
+
+    /// Requests read authorization for walking-speed samples.
+    /// May complete successfully even when the user denies — denial is detected by the absence of samples.
+    func requestAuthorization() async throws
+
+    /// Returns the most recent walking-speed sample (m/s) from the last 30 days, or `nil` if none exists or the query fails.
+    /// Does not apply range validation; the caller decides what counts as a usable sample.
+    func fetchLatestWalkingSpeed() async -> Double?
+}
+
+struct HKHealthStoreWalkingSpeedProvider: WalkingSpeedHealthKitProviding {
+    private let healthStore = HKHealthStore()
+
+    private static var walkingSpeedType: HKQuantityType? {
+        HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
+    }
+
+    var isAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable() && Self.walkingSpeedType != nil
+    }
+
+    func requestAuthorization() async throws {
+        guard let type = Self.walkingSpeedType else { return }
+        try await healthStore.requestAuthorization(toShare: [], read: [type])
+    }
+
+    func fetchLatestWalkingSpeed() async -> Double? {
+        guard let type = Self.walkingSpeedType else { return nil }
+
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? .distantPast
+        let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    Logger.error("WalkingSpeedManager: HealthKit sample query failed: \(error)")
+                    continuation.resume(returning: nil)
+                    return
+                }
+                guard let sample = samples?.first as? HKQuantitySample else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let mps = sample.quantity.doubleValue(for: HKUnit.meter().unitDivided(by: .second()))
+                continuation.resume(returning: mps)
+            }
+            healthStore.execute(query)
+        }
+    }
+}

--- a/OBAKit/TripPlanning/WalkingSpeedManager.swift
+++ b/OBAKit/TripPlanning/WalkingSpeedManager.swift
@@ -1,0 +1,88 @@
+//
+//  WalkingSpeedManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Resolves the user's walking speed from HealthKit (if authorized) or falls back to a user preference.
+@MainActor
+final class WalkingSpeedManager {
+    private let healthStore = HKHealthStore()
+    private let userDataStore: UserDataStore
+
+    init(userDataStore: UserDataStore) {
+        self.userDataStore = userDataStore
+    }
+
+    /// Requests HealthKit authorization and attempts to sync the latest walking speed.
+    /// Returns `true` if the authorization request completed without error.
+    /// Returns `false` only if HealthKit is unavailable or the authorization request threw an error.
+    @discardableResult
+    func requestHealthKitAuthorizationAndSync() async -> Bool {
+        guard HKHealthStore.isHealthDataAvailable(),
+              let speedType = HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
+        else { return false }
+
+        do {
+            try await healthStore.requestAuthorization(toShare: [], read: [speedType])
+        } catch {
+            Logger.error("WalkingSpeedManager: HealthKit requestAuthorization failed: \(error)")
+            userDataStore.walkingSpeedSource = .manual
+            return false
+        }
+
+        await syncLatestWalkingSpeed(speedType: speedType)
+        return true
+    }
+
+    /// Queries HealthKit for the most recent walking speed sample from the last 30 days.
+    /// If a valid sample is found, writes it to UserDataStore.
+    /// If no sample is found or it's out of range, does nothing (keeps current manual preset).
+    @discardableResult
+    private func syncLatestWalkingSpeed(speedType: HKQuantityType) async -> Bool {
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
+        let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        // Snapshot the static range outside the closure to make the non-capture explicit.
+        let validRange = 0.5...5.0
+
+        let validSpeed: Double? = await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: speedType,
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, _ in
+                // This callback runs on a background thread. No self captured here.
+                guard let sample = samples?.first as? HKQuantitySample else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let mps = sample.quantity.doubleValue(for: HKUnit.meter().unitDivided(by: .second()))
+
+                guard validRange.contains(mps) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                continuation.resume(returning: mps)
+            }
+            healthStore.execute(query)
+        }
+
+        if let speed = validSpeed {
+            userDataStore.walkingSpeedMetersPerSecond = speed
+            return true
+        }
+        return false
+    }
+}

--- a/OBAKit/TripPlanning/WalkingSpeedManager.swift
+++ b/OBAKit/TripPlanning/WalkingSpeedManager.swift
@@ -53,6 +53,19 @@ final class WalkingSpeedManager {
         return didSync
     }
 
+    /// Passive refresh used at launch when the user already opted into HealthKit previously.
+    /// Updates `walkingSpeedMetersPerSecond` if a fresh sample is available, but never
+    /// flips `walkingSpeedSource` to `.manual` — an idle user (e.g. left their Apple Watch
+    /// at home for a month) keeps their previously-synced value and their stated intent.
+    /// Only the active toggle-on path in Settings can downgrade the source.
+    func refreshFromHealthKitIfPossible() async {
+        guard HKHealthStore.isHealthDataAvailable(),
+              let speedType = HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
+        else { return }
+
+        await syncLatestWalkingSpeed(speedType: speedType)
+    }
+
     /// Queries HealthKit for the most recent walking speed sample from the last 30 days.
     /// If a valid sample is found, writes it to UserDataStore.
     /// If no sample is found or it's out of range, does nothing (keeps current manual preset).

--- a/OBAKit/TripPlanning/WalkingSpeedManager.swift
+++ b/OBAKit/TripPlanning/WalkingSpeedManager.swift
@@ -22,13 +22,21 @@ final class WalkingSpeedManager {
     }
 
     /// Requests HealthKit authorization and attempts to sync the latest walking speed.
-    /// Returns `true` if the authorization request completed without error.
-    /// Returns `false` only if HealthKit is unavailable or the authorization request threw an error.
+    ///
+    /// Apple's HealthKit privacy model does not surface read-permission denials: the
+    /// authorization request succeeds even when the user taps "Don't Allow", and a
+    /// subsequent query just returns no samples. To avoid leaving the toggle stuck ON
+    /// for a denying user, success here is defined as "actually retrieved a usable
+    /// sample". A user who genuinely granted access but has no recent walking-speed
+    /// samples (e.g. no Apple Watch) is also routed to `.manual` — that's intentional.
     @discardableResult
     func requestHealthKitAuthorizationAndSync() async -> Bool {
         guard HKHealthStore.isHealthDataAvailable(),
               let speedType = HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
-        else { return false }
+        else {
+            userDataStore.walkingSpeedSource = .manual
+            return false
+        }
 
         do {
             try await healthStore.requestAuthorization(toShare: [], read: [speedType])
@@ -38,8 +46,11 @@ final class WalkingSpeedManager {
             return false
         }
 
-        await syncLatestWalkingSpeed(speedType: speedType)
-        return true
+        let didSync = await syncLatestWalkingSpeed(speedType: speedType)
+        if !didSync {
+            userDataStore.walkingSpeedSource = .manual
+        }
+        return didSync
     }
 
     /// Queries HealthKit for the most recent walking speed sample from the last 30 days.
@@ -50,9 +61,7 @@ final class WalkingSpeedManager {
         let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
         let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
         let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
-
-        // Snapshot the static range outside the closure to make the non-capture explicit.
-        let validRange = 0.5...5.0
+        let validRange = WalkingSpeed.validRange
 
         let validSpeed: Double? = await withCheckedContinuation { continuation in
             let query = HKSampleQuery(
@@ -60,8 +69,13 @@ final class WalkingSpeedManager {
                 predicate: predicate,
                 limit: 1,
                 sortDescriptors: [sort]
-            ) { _, samples, _ in
-                // This callback runs on a background thread. No self captured here.
+            ) { _, samples, error in
+                if let error {
+                    Logger.error("WalkingSpeedManager: HealthKit sample query failed: \(error)")
+                    continuation.resume(returning: nil)
+                    return
+                }
+
                 guard let sample = samples?.first as? HKQuantitySample else {
                     continuation.resume(returning: nil)
                     return
@@ -81,6 +95,7 @@ final class WalkingSpeedManager {
 
         if let speed = validSpeed {
             userDataStore.walkingSpeedMetersPerSecond = speed
+            userDataStore.walkingSpeedSource = .healthKit
             return true
         }
         return false

--- a/OBAKit/TripPlanning/WalkingSpeedManager.swift
+++ b/OBAKit/TripPlanning/WalkingSpeedManager.swift
@@ -14,11 +14,12 @@ import OBAKitCore
 /// Resolves the user's walking speed from HealthKit (if authorized) or falls back to a user preference.
 @MainActor
 final class WalkingSpeedManager {
-    private let healthStore = HKHealthStore()
+    private let healthKit: WalkingSpeedHealthKitProviding
     private let userDataStore: UserDataStore
 
-    init(userDataStore: UserDataStore) {
+    init(userDataStore: UserDataStore, healthKit: WalkingSpeedHealthKitProviding = HKHealthStoreWalkingSpeedProvider()) {
         self.userDataStore = userDataStore
+        self.healthKit = healthKit
     }
 
     /// Requests HealthKit authorization and attempts to sync the latest walking speed.
@@ -31,22 +32,20 @@ final class WalkingSpeedManager {
     /// samples (e.g. no Apple Watch) is also routed to `.manual` — that's intentional.
     @discardableResult
     func requestHealthKitAuthorizationAndSync() async -> Bool {
-        guard HKHealthStore.isHealthDataAvailable(),
-              let speedType = HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
-        else {
+        guard healthKit.isAvailable else {
             userDataStore.walkingSpeedSource = .manual
             return false
         }
 
         do {
-            try await healthStore.requestAuthorization(toShare: [], read: [speedType])
+            try await healthKit.requestAuthorization()
         } catch {
             Logger.error("WalkingSpeedManager: HealthKit requestAuthorization failed: \(error)")
             userDataStore.walkingSpeedSource = .manual
             return false
         }
 
-        let didSync = await syncLatestWalkingSpeed(speedType: speedType)
+        let didSync = await syncLatestWalkingSpeed()
         if !didSync {
             userDataStore.walkingSpeedSource = .manual
         }
@@ -59,58 +58,23 @@ final class WalkingSpeedManager {
     /// at home for a month) keeps their previously-synced value and their stated intent.
     /// Only the active toggle-on path in Settings can downgrade the source.
     func refreshFromHealthKitIfPossible() async {
-        guard HKHealthStore.isHealthDataAvailable(),
-              let speedType = HKQuantityType.quantityType(forIdentifier: .walkingSpeed)
-        else { return }
-
-        await syncLatestWalkingSpeed(speedType: speedType)
+        guard healthKit.isAvailable else { return }
+        await syncLatestWalkingSpeed()
     }
 
-    /// Queries HealthKit for the most recent walking speed sample from the last 30 days.
-    /// If a valid sample is found, writes it to UserDataStore.
-    /// If no sample is found or it's out of range, does nothing (keeps current manual preset).
+    /// Fetches the latest walking-speed sample and writes it to the store if it's in `WalkingSpeed.validRange`.
+    /// Returns `true` on a successful write; otherwise leaves the stored speed and source untouched
+    /// and returns `false`. Callers decide how to react to a `false` result.
     @discardableResult
-    private func syncLatestWalkingSpeed(speedType: HKQuantityType) async -> Bool {
-        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
-        let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
-        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
-        let validRange = WalkingSpeed.validRange
-
-        let validSpeed: Double? = await withCheckedContinuation { continuation in
-            let query = HKSampleQuery(
-                sampleType: speedType,
-                predicate: predicate,
-                limit: 1,
-                sortDescriptors: [sort]
-            ) { _, samples, error in
-                if let error {
-                    Logger.error("WalkingSpeedManager: HealthKit sample query failed: \(error)")
-                    continuation.resume(returning: nil)
-                    return
-                }
-
-                guard let sample = samples?.first as? HKQuantitySample else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-
-                let mps = sample.quantity.doubleValue(for: HKUnit.meter().unitDivided(by: .second()))
-
-                guard validRange.contains(mps) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-
-                continuation.resume(returning: mps)
-            }
-            healthStore.execute(query)
+    private func syncLatestWalkingSpeed() async -> Bool {
+        guard let mps = await healthKit.fetchLatestWalkingSpeed(),
+              WalkingSpeed.validRange.contains(mps)
+        else {
+            return false
         }
 
-        if let speed = validSpeed {
-            userDataStore.walkingSpeedMetersPerSecond = speed
-            userDataStore.walkingSpeedSource = .healthKit
-            return true
-        }
-        return false
+        userDataStore.walkingSpeedMetersPerSecond = mps
+        userDataStore.walkingSpeedSource = .healthKit
+        return true
     }
 }

--- a/OBAKit/project.yml
+++ b/OBAKit/project.yml
@@ -11,6 +11,7 @@ targets:
       - package: FloatingPanel
       - package: MarqueeLabel
       - package: OTPKit
+      - sdk: HealthKit.framework
     postBuildScripts:
       - path: "../scripts/swiftlint.sh"
         name: Swiftlint

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -14,6 +14,11 @@ import MapKit
     case map, recentStops, bookmarks, vehicles, settings
 }
 
+@objc public enum WalkingSpeedSource: Int {
+    case manual    // user picked a preset
+    case healthKit // synced from HealthKit
+}
+
 public extension Notification.Name {
     /// Posted whenever bookmarks are added, updated, or deleted in the UserDataStore.
     static let bookmarksDidChange = Notification.Name("UserDataStore.bookmarksDidChange")
@@ -282,6 +287,14 @@ public protocol UserDataStore: NSObjectProtocol {
     ///   - agencyIDs: All agency IDs to update.
     func setAllAgenciesEnabledForVehicleFeed(_ enabled: Bool, agencyIDs: [String])
 
+    // MARK: - Walking Speed
+
+    /// The user's preferred walking speed in meters per second.
+    var walkingSpeedMetersPerSecond: Double { get set }
+
+    /// The source of the walking speed value (manual preset or HealthKit).
+    var walkingSpeedSource: WalkingSpeedSource { get set }
+
 }
 
 // MARK: - Survey Tracking Data Models
@@ -356,12 +369,18 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let isSurveyEnabled = "UserDataStore.isSurveyEnabled"
         static let nextSurveyReminderDate = "UserDataStore.nextSurveyReminderDate"
         static let alwaysShowSurveysOnStops = "UserDataStore.alwaysShowSurveysOnStops"
+        static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
+        static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
     }
 
     public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
 
-        self.userDefaults.register(defaults: [UserDefaultsKeys.debugMode: false])
+        self.userDefaults.register(defaults: [
+            UserDefaultsKeys.debugMode: false,
+            UserDefaultsKeys.walkingSpeedMetersPerSecond: 1.4,
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
+        ])
     }
 
     // MARK: - Debug Mode
@@ -1001,6 +1020,26 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             disabledVehicleFeedAgencyIDs = []
         } else {
             disabledVehicleFeedAgencyIDs = Set(agencyIDs)
+        }
+    }
+
+    // MARK: - Walking Speed
+
+    public var walkingSpeedMetersPerSecond: Double {
+        get {
+            userDefaults.double(forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+        }
+    }
+
+    public var walkingSpeedSource: WalkingSpeedSource {
+        get {
+            WalkingSpeedSource(rawValue: userDefaults.integer(forKey: UserDefaultsKeys.walkingSpeedSource)) ?? .manual
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.walkingSpeedSource)
         }
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -14,6 +14,11 @@ import MapKit
     case map, recentStops, bookmarks, vehicles, settings
 }
 
+@objc public enum WalkingSpeedSource: Int {
+    case manual    // user picked a preset
+    case healthKit // synced from HealthKit
+}
+
 public extension Notification.Name {
     /// Posted whenever bookmarks are added, updated, or deleted in the UserDataStore.
     static let bookmarksDidChange = Notification.Name("UserDataStore.bookmarksDidChange")
@@ -282,6 +287,14 @@ public protocol UserDataStore: NSObjectProtocol {
     ///   - agencyIDs: All agency IDs to update.
     func setAllAgenciesEnabledForVehicleFeed(_ enabled: Bool, agencyIDs: [String])
 
+    // MARK: - Walking Speed
+
+    /// The user's preferred walking speed in meters per second.
+    var walkingSpeedMetersPerSecond: Double { get set }
+
+    /// The source of the walking speed value (manual preset or HealthKit).
+    var walkingSpeedSource: WalkingSpeedSource { get set }
+
 }
 
 // MARK: - Survey Tracking Data Models
@@ -356,12 +369,18 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let isSurveyEnabled = "UserDataStore.isSurveyEnabled"
         static let nextSurveyReminderDate = "UserDataStore.nextSurveyReminderDate"
         static let alwaysShowSurveysOnStops = "UserDataStore.alwaysShowSurveysOnStops"
+        static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
+        static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
     }
 
     public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
 
-        self.userDefaults.register(defaults: [UserDefaultsKeys.debugMode: false])
+        self.userDefaults.register(defaults: [
+            UserDefaultsKeys.debugMode: false,
+            UserDefaultsKeys.walkingSpeedMetersPerSecond: 1.4,
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
+        ])
     }
 
     // MARK: - Debug Mode
@@ -1009,6 +1028,26 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             disabledVehicleFeedAgencyIDs = []
         } else {
             disabledVehicleFeedAgencyIDs = Set(agencyIDs)
+        }
+    }
+
+    // MARK: - Walking Speed
+
+    public var walkingSpeedMetersPerSecond: Double {
+        get {
+            userDefaults.double(forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+        }
+    }
+
+    public var walkingSpeedSource: WalkingSpeedSource {
+        get {
+            WalkingSpeedSource(rawValue: userDefaults.integer(forKey: UserDefaultsKeys.walkingSpeedSource)) ?? .manual
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.walkingSpeedSource)
         }
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -14,22 +14,6 @@ import MapKit
     case map, recentStops, bookmarks, vehicles, settings
 }
 
-// Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
-@objc public enum WalkingSpeedSource: Int {
-    case manual = 0    // user picked a preset
-    case healthKit = 1 // synced from HealthKit
-}
-
-/// Shared constants for walking speed handling.
-public enum WalkingSpeed {
-    /// Average human walking speed (≈3.1 mph).
-    public static let defaultMetersPerSecond: Double = 1.4
-
-    /// Acceptable range for a stored walking speed, in meters per second.
-    /// Values outside this range are treated as invalid (divide-hostile or implausible).
-    public static let validRange: ClosedRange<Double> = 0.5...5.0
-}
-
 public extension Notification.Name {
     /// Posted whenever bookmarks are added, updated, or deleted in the UserDataStore.
     static let bookmarksDidChange = Notification.Name("UserDataStore.bookmarksDidChange")

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -14,9 +14,20 @@ import MapKit
     case map, recentStops, bookmarks, vehicles, settings
 }
 
+// Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
 @objc public enum WalkingSpeedSource: Int {
-    case manual    // user picked a preset
-    case healthKit // synced from HealthKit
+    case manual = 0    // user picked a preset
+    case healthKit = 1 // synced from HealthKit
+}
+
+/// Shared constants for walking speed handling.
+public enum WalkingSpeed {
+    /// Average human walking speed (≈3.1 mph).
+    public static let defaultMetersPerSecond: Double = 1.4
+
+    /// Acceptable range for a stored walking speed, in meters per second.
+    /// Values outside this range are treated as invalid (divide-hostile or implausible).
+    public static let validRange: ClosedRange<Double> = 0.5...5.0
 }
 
 public extension Notification.Name {
@@ -378,7 +389,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
 
         self.userDefaults.register(defaults: [
             UserDefaultsKeys.debugMode: false,
-            UserDefaultsKeys.walkingSpeedMetersPerSecond: 1.4,
+            UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
             UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
         ])
     }
@@ -1038,7 +1049,8 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             userDefaults.double(forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
         }
         set {
-            userDefaults.set(newValue, forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+            let clamped = min(max(newValue, WalkingSpeed.validRange.lowerBound), WalkingSpeed.validRange.upperBound)
+            userDefaults.set(clamped, forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
         }
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -1030,7 +1030,8 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
 
     public var walkingSpeedMetersPerSecond: Double {
         get {
-            userDefaults.double(forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+            let stored = userDefaults.double(forKey: UserDefaultsKeys.walkingSpeedMetersPerSecond)
+            return min(max(stored, WalkingSpeed.validRange.lowerBound), WalkingSpeed.validRange.upperBound)
         }
         set {
             let clamped = min(max(newValue, WalkingSpeed.validRange.lowerBound), WalkingSpeed.validRange.upperBound)

--- a/OBAKitCore/Models/UserData/WalkingSpeed.swift
+++ b/OBAKitCore/Models/UserData/WalkingSpeed.swift
@@ -1,0 +1,26 @@
+//
+//  WalkingSpeed.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+// Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
+@objc public enum WalkingSpeedSource: Int {
+    case manual = 0    // user picked a preset
+    case healthKit = 1 // synced from HealthKit
+}
+
+/// Shared constants for walking speed handling.
+public enum WalkingSpeed {
+    /// Average human walking speed (≈3.1 mph).
+    public static let defaultMetersPerSecond: Double = 1.4
+
+    /// Acceptable range for a stored walking speed, in meters per second.
+    /// Values outside this range are treated as invalid (divide-hostile or implausible).
+    public static let validRange: ClosedRange<Double> = 0.5...5.0
+}

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -81,13 +81,14 @@ class LocationServiceTests: XCTestCase {
 
         expect(service.currentLocation).to(beNil())
 
-        service.locationManager(locManager, didUpdateLocations: [TestData.mockSeattleLocation])
-        expect(service.currentLocation) == TestData.mockSeattleLocation
+        let seattle = CLLocation(coordinate: TestData.seattleCoordinate, altitude: 100.0, horizontalAccuracy: 10.0, verticalAccuracy: 10.0, timestamp: Date())
+        service.locationManager(locManager, didUpdateLocations: [seattle])
+        expect(service.currentLocation) == seattle
 
         let badLocation = CLLocation(coordinate: TestData.tampaCoordinate, altitude: 10.0, horizontalAccuracy: 1000, verticalAccuracy: 1000, timestamp: Date())
         service.locationManager(locManager, didUpdateLocations: [badLocation])
 
-        expect(service.currentLocation) == TestData.mockSeattleLocation
+        expect(service.currentLocation) == seattle
     }
 
     func test_stopUpdates_disablesUpdates() {

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -245,4 +245,33 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(self.userDefaultsStore.shouldShowSurveyLater(surveyId: 1, userIdentifier: "user1")).to(beFalse())
     }
 
+    // MARK: - Walking Speed
+
+    func test_walkingSpeed_defaultValue() {
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.4))
+    }
+
+    func test_walkingSpeed_roundTrip() {
+        userDefaultsStore.walkingSpeedMetersPerSecond = 0.9
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(0.9))
+
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.8
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.8))
+
+        let newStore = UserDefaultsStore(userDefaults: userDefaults)
+        expect(newStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.8))
+    }
+
+    func test_walkingSpeedSource_defaultValue() {
+        expect(self.userDefaultsStore.walkingSpeedSource) == .manual
+    }
+
+    func test_walkingSpeedSource_roundTrip() {
+        userDefaultsStore.walkingSpeedSource = .healthKit
+        expect(self.userDefaultsStore.walkingSpeedSource) == .healthKit
+
+        userDefaultsStore.walkingSpeedSource = .manual
+        expect(self.userDefaultsStore.walkingSpeedSource) == .manual
+    }
+
 }

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -268,4 +268,33 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(self.userDefaultsStore.shouldShowSurveyLater(surveyId: 1, userIdentifier: "user1")).to(beFalse())
     }
 
+    // MARK: - Walking Speed
+
+    func test_walkingSpeed_defaultValue() {
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.4))
+    }
+
+    func test_walkingSpeed_roundTrip() {
+        userDefaultsStore.walkingSpeedMetersPerSecond = 0.9
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(0.9))
+
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.8
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.8))
+
+        let newStore = UserDefaultsStore(userDefaults: userDefaults)
+        expect(newStore.walkingSpeedMetersPerSecond).to(beCloseTo(1.8))
+    }
+
+    func test_walkingSpeedSource_defaultValue() {
+        expect(self.userDefaultsStore.walkingSpeedSource) == .manual
+    }
+
+    func test_walkingSpeedSource_roundTrip() {
+        userDefaultsStore.walkingSpeedSource = .healthKit
+        expect(self.userDefaultsStore.walkingSpeedSource) == .healthKit
+
+        userDefaultsStore.walkingSpeedSource = .manual
+        expect(self.userDefaultsStore.walkingSpeedSource) == .manual
+    }
+
 }

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -297,4 +297,14 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(self.userDefaultsStore.walkingSpeedSource) == .manual
     }
 
+    func test_walkingSpeedMetersPerSecond_clampsBelowRange() {
+        userDefaultsStore.walkingSpeedMetersPerSecond = 0.1
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(WalkingSpeed.validRange.lowerBound))
+    }
+
+    func test_walkingSpeedMetersPerSecond_clampsAboveRange() {
+        userDefaultsStore.walkingSpeedMetersPerSecond = 10.0
+        expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(WalkingSpeed.validRange.upperBound))
+    }
+
 }

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
@@ -1,0 +1,67 @@
+//
+//  WalkingDirectionsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+import CoreLocation
+@testable import OBAKit
+
+class WalkingDirectionsTests: XCTestCase {
+
+    // Two locations exactly 140 meters apart
+    private let locationA = CLLocation(latitude: 47.6062, longitude: -122.3321)
+    private lazy var locationB: CLLocation = {
+        // Shift north by ~140m (approx 0.00126 degrees latitude)
+        CLLocation(latitude: locationA.coordinate.latitude + 0.00126, longitude: locationA.coordinate.longitude)
+    }()
+
+    private var knownDistance: Double {
+        locationA.distance(from: locationB)
+    }
+
+    // MARK: - Default Velocity
+
+    func test_travelTime_defaultVelocity() {
+        let time = WalkingDirections.travelTime(from: locationA, to: locationB)
+        expect(time).toNot(beNil())
+        expect(time).to(beCloseTo(knownDistance / 1.4, within: 0.01))
+    }
+
+    // MARK: - Custom Velocity
+
+    func test_travelTime_customVelocity() {
+        let slowTime = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 0.9)
+        let fastTime = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 1.8)
+
+        expect(slowTime).toNot(beNil())
+        expect(fastTime).toNot(beNil())
+        expect(slowTime).to(beCloseTo(knownDistance / 0.9, within: 0.01))
+        expect(fastTime).to(beCloseTo(knownDistance / 1.8, within: 0.01))
+
+        // Slower speed should yield a longer travel time
+        expect(slowTime!) > fastTime!
+    }
+
+    // MARK: - Nil Locations
+
+    func test_travelTime_nilFromLocation() {
+        let time = WalkingDirections.travelTime(from: nil, to: locationB)
+        expect(time).to(beNil())
+    }
+
+    func test_travelTime_nilToLocation() {
+        let time = WalkingDirections.travelTime(from: locationA, to: nil)
+        expect(time).to(beNil())
+    }
+
+    func test_travelTime_bothNil() {
+        let time = WalkingDirections.travelTime(from: nil, to: nil)
+        expect(time).to(beNil())
+    }
+}

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
@@ -64,4 +64,16 @@ class WalkingDirectionsTests: XCTestCase {
         let time = WalkingDirections.travelTime(from: nil, to: nil)
         expect(time).to(beNil())
     }
+
+    // MARK: - Invalid Velocity
+
+    func test_travelTime_zeroVelocity_returnsNil() {
+        let time = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 0)
+        expect(time).to(beNil())
+    }
+
+    func test_travelTime_negativeVelocity_returnsNil() {
+        let time = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: -1.5)
+        expect(time).to(beNil())
+    }
 }

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import Nimble
 import CoreLocation
 @testable import OBAKit
+@testable import OBAKitCore
 
 class WalkingDirectionsTests: XCTestCase {
 
@@ -30,7 +31,7 @@ class WalkingDirectionsTests: XCTestCase {
     func test_travelTime_defaultVelocity() {
         let time = WalkingDirections.travelTime(from: locationA, to: locationB)
         expect(time).toNot(beNil())
-        expect(time).to(beCloseTo(knownDistance / 1.4, within: 0.01))
+        expect(time).to(beCloseTo(knownDistance / WalkingSpeed.defaultMetersPerSecond, within: 0.01))
     }
 
     // MARK: - Custom Velocity

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedManagerTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedManagerTests.swift
@@ -1,0 +1,168 @@
+//
+//  WalkingSpeedManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+@MainActor
+final class WalkingSpeedManagerTests: OBATestCase {
+
+    private struct FakeProvider: WalkingSpeedHealthKitProviding {
+        var isAvailable: Bool = true
+        var authorizationError: Error?
+        var sampleSpeed: Double?
+
+        func requestAuthorization() async throws {
+            if let authorizationError {
+                throw authorizationError
+            }
+        }
+
+        func fetchLatestWalkingSpeed() async -> Double? {
+            sampleSpeed
+        }
+    }
+
+    private struct DummyError: Error {}
+
+    private var store: UserDefaultsStore {
+        UserDefaultsStore(userDefaults: userDefaults)
+    }
+
+    // MARK: - requestHealthKitAuthorizationAndSync
+
+    func test_requestAndSync_whenSampleMissing_returnsFalseAndForcesManual() async {
+        store.walkingSpeedSource = .healthKit
+        store.walkingSpeedMetersPerSecond = 1.6
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.walkingSpeedSource) == .manual
+        // Speed left untouched even on failure.
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.6))
+    }
+
+    func test_requestAndSync_whenSampleInRange_writesValueAndMarksHealthKit() async {
+        store.walkingSpeedSource = .manual
+        store.walkingSpeedMetersPerSecond = 1.4
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 1.65)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == true
+        expect(self.store.walkingSpeedSource) == .healthKit
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.65))
+    }
+
+    func test_requestAndSync_whenSampleOutOfRange_doesNotWriteAndForcesManual() async {
+        store.walkingSpeedSource = .healthKit
+        store.walkingSpeedMetersPerSecond = 1.4
+
+        // 10 m/s sits well outside WalkingSpeed.validRange (0.5...5.0).
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 10.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.walkingSpeedSource) == .manual
+        // Stored speed unchanged — the out-of-range sample must not leak in.
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.4))
+    }
+
+    func test_requestAndSync_whenAuthorizationThrows_forcesManual() async {
+        store.walkingSpeedSource = .healthKit
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(authorizationError: DummyError(), sampleSpeed: 1.5)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.walkingSpeedSource) == .manual
+    }
+
+    func test_requestAndSync_whenHealthKitUnavailable_forcesManual() async {
+        store.walkingSpeedSource = .healthKit
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(isAvailable: false, sampleSpeed: 1.5)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.walkingSpeedSource) == .manual
+    }
+
+    // MARK: - refreshFromHealthKitIfPossible
+
+    func test_passiveRefresh_withNoSample_leavesSourceAndSpeedUntouched() async {
+        store.walkingSpeedSource = .healthKit
+        store.walkingSpeedMetersPerSecond = 1.65
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        // The asymmetry: passive refresh must never downgrade source to .manual.
+        expect(self.store.walkingSpeedSource) == .healthKit
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.65))
+    }
+
+    func test_passiveRefresh_withInRangeSample_updatesSpeed() async {
+        store.walkingSpeedSource = .healthKit
+        store.walkingSpeedMetersPerSecond = 1.4
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 1.7)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.walkingSpeedSource) == .healthKit
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.7))
+    }
+
+    func test_passiveRefresh_withOutOfRangeSample_isNoOp() async {
+        store.walkingSpeedSource = .healthKit
+        store.walkingSpeedMetersPerSecond = 1.4
+
+        let manager = WalkingSpeedManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 0.1)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.walkingSpeedSource) == .healthKit
+        expect(self.store.walkingSpeedMetersPerSecond).to(beCloseTo(1.4))
+    }
+}

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedPresetTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedPresetTests.swift
@@ -1,0 +1,37 @@
+//
+//  WalkingSpeedPresetTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+
+class WalkingSpeedPresetTests: XCTestCase {
+
+    func test_nearest_exactMatch() {
+        expect(WalkingSpeedPreset.nearest(to: 0.9)) == .slow
+        expect(WalkingSpeedPreset.nearest(to: 1.4)) == .average
+        expect(WalkingSpeedPreset.nearest(to: 1.8)) == .fast
+    }
+
+    func test_nearest_picksClosestPreset() {
+        // 1.0 → halfway-ish, closer to 0.9 (slow)
+        expect(WalkingSpeedPreset.nearest(to: 1.0)) == .slow
+        // 1.3 closer to 1.4 (average)
+        expect(WalkingSpeedPreset.nearest(to: 1.3)) == .average
+        // 1.7 closer to 1.8 (fast)
+        expect(WalkingSpeedPreset.nearest(to: 1.7)) == .fast
+    }
+
+    func test_nearest_outOfRange_clampsToNearestEnd() {
+        // Below slow → still slow
+        expect(WalkingSpeedPreset.nearest(to: 0.1)) == .slow
+        // Above fast → still fast
+        expect(WalkingSpeedPreset.nearest(to: 5.0)) == .fast
+    }
+}

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedSettingsDecisionTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedSettingsDecisionTests.swift
@@ -1,0 +1,81 @@
+//
+//  WalkingSpeedSettingsDecisionTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+final class WalkingSpeedSettingsDecisionTests: XCTestCase {
+
+    // MARK: - Toggle absent (form row not shown)
+
+    func test_noToggle_segmentSpeed_updatesManualSpeed() {
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: .manual,
+            currentSpeed: 1.4,
+            useHealthKit: nil,
+            segmentSpeed: 0.9
+        )
+        expect(decision.source) == .manual
+        expect(decision.speed).to(beCloseTo(0.9))
+    }
+
+    func test_noToggle_noSegmentSpeed_leavesEverythingUntouched() {
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: .healthKit,
+            currentSpeed: 1.65,
+            useHealthKit: nil,
+            segmentSpeed: nil
+        )
+        expect(decision.source) == .healthKit
+        expect(decision.speed).to(beCloseTo(1.65))
+    }
+
+    // MARK: - Toggle ON
+
+    func test_toggleOn_keepsCurrentSpeedAndSwitchesToHealthKit() {
+        // When HK is toggled on, the manager has already written the synced speed.
+        // saveWalkingSpeedValues must not overwrite it with the (now-disabled) segment value.
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: .manual,
+            currentSpeed: 1.65,
+            useHealthKit: true,
+            segmentSpeed: 1.4
+        )
+        expect(decision.source) == .healthKit
+        expect(decision.speed).to(beCloseTo(1.65))
+    }
+
+    // MARK: - Toggle OFF
+
+    func test_toggleOff_snapsCurrentSpeedToNearestPreset() {
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: .healthKit,
+            currentSpeed: 1.73,   // closer to .fast (1.8)
+            useHealthKit: false,
+            segmentSpeed: nil
+        )
+        expect(decision.source) == .manual
+        expect(decision.speed).to(beCloseTo(WalkingSpeedPreset.fast.rawValue))
+    }
+
+    func test_toggleOff_withSegmentSpeed_prefersSegmentThenSnaps() {
+        // When the toggle flips off, the segment row also has whatever the user landed on —
+        // it should win over currentSpeed, then snap.
+        let decision = WalkingSpeedSettingsDecision.compute(
+            currentSource: .healthKit,
+            currentSpeed: 1.65,
+            useHealthKit: false,
+            segmentSpeed: 0.9
+        )
+        expect(decision.source) == .manual
+        expect(decision.speed).to(beCloseTo(WalkingSpeedPreset.slow.rawValue))
+    }
+}


### PR DESCRIPTION
Fixes #217
Previously, walking speed was hardcoded to 1.4 m/s. This PR allows users to customize their walking speed for more accurate arrival and trip planning estimates.
### Changes
* **Settings UI**: Added a new "Walking Speed" section where users can manually pick a speed preset (Slow, Average, Fast).
* **HealthKit Sync**: Added a toggle to sync actual walking speed directly from the Health app (fetches the latest valid speed from the past 30 days).
* **Trip Planning**: Updated `WalkingDirections` to calculate travel times using the newly customized velocity.
* **Auto-Sync**: Automatically syncs the latest HealthKit walking data in the background on app launch for opted-in users.
* **Config/Permissions**: Linked the `HealthKit` framework and added necessary usage description strings & entitlements for OneBusAway.
* **Tests**: Added coverage for `UserDataStore` persistence and `WalkingDirections` calculation edges cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Walking Speed settings: three presets (slow/average/fast), manual entry, and a Health app toggle that disables manual controls when enabled
  * App requests Health permission, can auto-sync walking speed (including on launch), and uses the value for walk-time estimates
  * HealthKit entitlement enabled for apps, HealthKit framework included, and iOS usage description/localized labels added; shows error toast on sync failure

* **Tests**
  * Added tests for settings decisions, sync behavior, validation/clamping, and travel-time calculations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->