### PR TITLE
Improve map stop clustering reliability and cluster selection UX 

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -70,6 +70,7 @@ public class MapRegionManager: NSObject,
     private let application: Application
 
     private var regionChangeRequestTimer: Timer?
+    private var stopHideTimer: Timer?
 
     private var userLocationAnnotationView: PulsingAnnotationView? {
         didSet {
@@ -223,6 +224,7 @@ public class MapRegionManager: NSObject,
         application.locationService.removeDelegate(self)
         application.regionsService.removeDelegate(self)
         regionChangeRequestTimer?.invalidate()
+        stopHideTimer?.invalidate()
 
         // Cancel all ongoing geocoding operations
         for geocoder in activeGeocoders.values {
@@ -415,7 +417,7 @@ public class MapRegionManager: NSObject,
         }
     }
 
-    private func displayUniqueStopAnnotations() {
+    private func displayUniqueStopAnnotations(notifyDelegates: Bool = true) {
         var bookmarksHash = [StopID: Bookmark]()
         // When multiple bookmarks exist for the same stop, the last one in the bookmarks array takes precedence
         for bm in bookmarks {
@@ -484,7 +486,9 @@ public class MapRegionManager: NSObject,
         }
         mapView.addAnnotations(stopsToAdd)
         refreshAnnotationViews(for: Array(affectedStopIDs))
-        notifyDelegatesStopsChanged()
+        if notifyDelegates {
+            notifyDelegatesStopsChanged()
+        }
     }
 
     private func refreshAnnotationViews(for affectedStopIDs: [StopID]) {
@@ -503,6 +507,7 @@ public class MapRegionManager: NSObject,
                 continue
             }
             view.prepareForReuse()
+            view.clusteringIdentifier = StopAnnotationView.stopClusterIdentifier
             view.annotation = annotation
             view.delegate = self
             mapViewDelegate?.mapRegionManager(self, customize: view)
@@ -511,13 +516,25 @@ public class MapRegionManager: NSObject,
     // MARK: - Zoom In Warning
 
     private static let requiredHeightToShowStops = 40000.0
+    private static let stopHideThreshold = 42000.0
+    private static let stopShowThreshold = 38000.0
+    private static let stopHideDelay: TimeInterval = 0.35
+    private var shouldShowStopAnnotations = true
 
     public var zoomInStatus: Bool {
         mapView.visibleMapRect.height > MapRegionManager.requiredHeightToShowStops
     }
 
-    private func updateZoomWarningOverlay(mapHeight: Double) {
-        notifyDelegatesZoomInStatus(status: zoomInStatus)
+    static func shouldShowStopAnnotations(previouslyShowing: Bool, mapHeight: Double) -> Bool {
+        if previouslyShowing {
+            return mapHeight <= stopHideThreshold
+        } else {
+            return mapHeight <= stopShowThreshold
+        }
+    }
+
+    private func updateZoomWarningOverlay(showZoomWarning: Bool) {
+        notifyDelegatesZoomInStatus(status: showZoomWarning)
     }
 
     // MARK: - Search
@@ -673,12 +690,29 @@ public class MapRegionManager: NSObject,
             return
         }
 
-        updateZoomWarningOverlay(mapHeight: mapView.visibleMapRect.height)
+        let mapHeight = mapView.visibleMapRect.height
+        shouldShowStopAnnotations = Self.shouldShowStopAnnotations(previouslyShowing: shouldShowStopAnnotations, mapHeight: mapHeight)
+        updateZoomWarningOverlay(showZoomWarning: !shouldShowStopAnnotations)
 
-        guard mapView.visibleMapRect.height <= MapRegionManager.requiredHeightToShowStops else {
-            mapView.removeAnnotations(type: Stop.self)
+        guard shouldShowStopAnnotations else {
+            if stopHideTimer == nil {
+                stopHideTimer = Timer.scheduledTimer(
+                    timeInterval: MapRegionManager.stopHideDelay,
+                    target: self,
+                    selector: #selector(hideStopAnnotations),
+                    userInfo: nil,
+                    repeats: false
+                )
+            }
+            regionChangeRequestTimer?.invalidate()
             return
         }
+
+        stopHideTimer?.invalidate()
+        stopHideTimer = nil
+
+        //show existing stops instantly while new data is loading in the background
+        displayUniqueStopAnnotations(notifyDelegates: false)
 
         let visibleStops = mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self)
         for s in visibleStops {
@@ -690,6 +724,17 @@ public class MapRegionManager: NSObject,
         regionChangeRequestTimer?.invalidate()
 
         regionChangeRequestTimer = Timer.scheduledTimer(timeInterval: 0.25, target: self, selector: #selector(requestDataForMapRegion(_:)), userInfo: nil, repeats: false)
+    }
+
+    @objc private func hideStopAnnotations() {
+        stopHideTimer?.invalidate()
+        stopHideTimer = nil
+
+        guard !shouldShowStopAnnotations else {
+            return
+        }
+
+        mapView.removeAnnotations(type: Stop.self)
     }
 
     private var isHidingRegions: Bool? {
@@ -793,6 +838,7 @@ public class MapRegionManager: NSObject,
         }
 
         if let stopAnnotation = annotationView as? StopAnnotationView {
+            stopAnnotation.clusteringIdentifier = StopAnnotationView.stopClusterIdentifier
             stopAnnotation.delegate = self
             mapViewDelegate?.mapRegionManager(self, customize: stopAnnotation)
         }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -27,6 +27,7 @@ class MapViewController: UIViewController,
     MapRegionMapViewDelegate,
     ModalDelegate,
     MapPanelDelegate,
+    ClusterStopPickerViewControllerDelegate,
     UIContextMenuInteractionDelegate,
     UILargeContentViewerInteractionDelegate,
     UIGestureRecognizerDelegate {
@@ -638,44 +639,39 @@ class MapViewController: UIViewController,
     struct ClusterStopMember: Hashable {
         let stopID: Stop.ID
         let title: String
+        let directionText: String?
         let subtitle: String?
         let isBookmarked: Bool
     }
 
-    private func presentClusterStopPicker(
-        members: [ClusterStopMember],
-        sourceView: UIView,
-        sourceRect: CGRect
-    ) {
+    private func displayClusterStopPicker(members: [ClusterStopMember]) {
         guard !members.isEmpty else { return }
 
         let title = String(
             format: OBALoc(
                 "map_controller.grouped_stop_picker.title_fmt",
                 value: "Select a Stop (%d)",
-                comment: "Title for the action sheet used to select one of many co-located stops."
+                comment: "Title for the grouped stop picker used to select one of many co-located stops."
             ),
             members.count
         )
 
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         let sortedMembers = Self.sortedClusterStopMembers(members)
-
-        for member in sortedMembers {
-            alert.addAction(UIAlertAction(title: Self.clusterStopActionTitle(for: member), style: .default, handler: { _ in
-                self.application.analytics?.reportEvent(pageURL: "app://localhost/map", label: AnalyticsLabels.mapStopAnnotationTapped, value: nil)
-                self.application.viewRouter.navigateTo(stopID: member.stopID, from: self)
-            }))
+        let items = sortedMembers.map { member in
+            ClusterStopPickerViewController.Item(
+                stopID: member.stopID,
+                title: member.title,
+                secondaryText: Self.clusterStopPickerSecondaryText(for: member),
+                isBookmarked: member.isBookmarked
+            )
         }
 
-        alert.addAction(UIAlertAction(title: OBALoc("map_controller.grouped_stop_picker.cancel", value: "Cancel", comment: "Cancel button for grouped stop picker on map."), style: .cancel))
+        dismissExistingClusterStopPicker()
 
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = sourceView
-            popover.sourceRect = sourceRect
-        }
-
-        present(alert, animated: true)
+        let controller = ClusterStopPickerViewController(title: title, items: items, delegate: self)
+        let panel = createSemiModalPanel(childController: controller)
+        panel.addPanel(toParent: self)
+        semiModalClusterStopPickerController = panel
     }
 
     static func clusterStopMembers(from memberAnnotations: [MKAnnotation]) -> [ClusterStopMember] {
@@ -688,6 +684,7 @@ class MapViewController: UIViewController,
                 member = ClusterStopMember(
                     stopID: stop.id,
                     title: stop.nameWithLocalizedDirectionAbbreviation,
+                    directionText: Formatters.adjectiveFormOfCardinalDirection(stop.direction),
                     subtitle: stop.subtitle,
                     isBookmarked: false
                 )
@@ -695,6 +692,7 @@ class MapViewController: UIViewController,
                 member = ClusterStopMember(
                     stopID: bookmark.stop.id,
                     title: bookmark.stop.nameWithLocalizedDirectionAbbreviation,
+                    directionText: Formatters.adjectiveFormOfCardinalDirection(bookmark.stop.direction),
                     subtitle: bookmark.stop.subtitle,
                     isBookmarked: true
                 )
@@ -727,11 +725,30 @@ class MapViewController: UIViewController,
         }
     }
 
-    static func clusterStopActionTitle(for member: ClusterStopMember) -> String {
-        guard let subtitle = String.nilifyBlankValue(member.subtitle) else {
-            return member.title
+    static func clusterStopPickerSecondaryText(for member: ClusterStopMember) -> String? {
+        let directionText = String.nilifyBlankValue(member.directionText)
+        let subtitleText = String.nilifyBlankValue(member.subtitle)
+
+        switch (directionText, subtitleText) {
+        case let (direction?, subtitle?):
+            let directionAndSubtitleFormat = OBALoc(
+                "map_controller.grouped_stop_picker.direction_subtitle_fmt",
+                value: "%1$@ · %2$@",
+                comment: "Secondary text for grouped stop picker rows when both direction and location details are available."
+            )
+            return String(format: directionAndSubtitleFormat, direction, subtitle)
+        case let (direction?, nil):
+            let directionFormat = OBALoc(
+                "map_controller.grouped_stop_picker.direction_fmt",
+                value: "Direction: %@",
+                comment: "Secondary text for grouped stop picker rows when only direction is available."
+            )
+            return String(format: directionFormat, direction)
+        case let (nil, subtitle?):
+            return subtitle
+        case (nil, nil):
+            return nil
         }
-        return "\(member.title) (\(subtitle))"
     }
 
     // MARK: - Overlays
@@ -878,6 +895,11 @@ class MapViewController: UIViewController,
             mapRegionManager.cancelSearch()
             semiModalPanel?.removePanelFromParent(animated: true)
         }
+        else if controller == semiModalClusterStopPickerController?.contentViewController,
+                let panel = semiModalClusterStopPickerController {
+            removeSemiModalPanel(panel, animated: true)
+            semiModalClusterStopPickerController = nil
+        }
         else {
             controller.dismiss(animated: true, completion: nil)
         }
@@ -886,6 +908,7 @@ class MapViewController: UIViewController,
     // MARK: - Map Item Controller
 
     private var semiModalMapItemController: FloatingPanelController?
+    private var semiModalClusterStopPickerController: FloatingPanelController?
 
     /// Dismisses the currently displayed map item controller panel, if one exists.
     /// Ensures proper cleanup before displaying a new map item or when the associated pin is removed.
@@ -898,11 +921,19 @@ class MapViewController: UIViewController,
         }
     }
 
+    private func dismissExistingClusterStopPicker(animated: Bool = false) {
+        if let existingController = semiModalClusterStopPickerController {
+            removeSemiModalPanel(existingController, animated: animated)
+            semiModalClusterStopPickerController = nil
+        }
+    }
+
     /// Presents a `MapItemController` with the provided `MKMapItem` as a semi-modal panel.
     /// - Parameters:
     ///   - mapItem: The map item to display
     ///   - userPin: Optional user-dropped pin associated with this map item (for removal functionality)
     private func displayMapItemController(_ mapItem: MKMapItem, userPin: UserDroppedPin? = nil) {
+        dismissExistingClusterStopPicker()
         dismissExistingMapItemController()
         // Create remove pin handler if this is a user-dropped pin
         let removePinHandler: (() -> Void)?
@@ -974,9 +1005,25 @@ class MapViewController: UIViewController,
         floatingPanel.move(to: state, animated: animated)
     }
 
+    // MARK: - Cluster Stop Picker Delegate
+
+    func clusterStopPicker(_ controller: ClusterStopPickerViewController, didSelectStopID stopID: Stop.ID) {
+        dismissExistingClusterStopPicker(animated: true)
+        application.analytics?.reportEvent(pageURL: "app://localhost/map", label: AnalyticsLabels.mapStopAnnotationTapped, value: nil)
+        application.viewRouter.navigateTo(stopID: stopID, from: self)
+    }
+
+    func clusterStopPickerDidRequestClose(_ controller: ClusterStopPickerViewController) {
+        dismissExistingClusterStopPicker(animated: true)
+    }
+
     // MARK: - MapRegionDelegate
 
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        if !(view.annotation is MKClusterAnnotation) {
+            dismissExistingClusterStopPicker(animated: true)
+        }
+
         if let region = view.annotation as? Region {
             let title = OBALoc("map_controller.change_region_alert.title", value: "Change Region?", comment: "Title of the alert that appears when the user is updating their current region manually.")
             let messageFmt = OBALoc("map_controller.change_region_alert.message_fmt", value: "Would you like to change your region to %@?", comment: "Body of the alert that appears when the user is updating their current region manually.")
@@ -998,7 +1045,7 @@ class MapViewController: UIViewController,
             show(stop: stop)
         } else if let cluster = view.annotation as? MKClusterAnnotation {
             let members = Self.clusterStopMembers(from: cluster.memberAnnotations)
-            presentClusterStopPicker(members: members, sourceView: view, sourceRect: view.bounds)
+            displayClusterStopPicker(members: members)
             mapView.deselectAnnotation(cluster, animated: false)
         } else if let annotation = view.annotation as? UserDroppedPin {
             // Sheet presentation for user-dropped pins is handled via
@@ -1237,6 +1284,237 @@ class MapViewController: UIViewController,
         }
     }
 
+}
+
+protocol ClusterStopPickerViewControllerDelegate: AnyObject {
+    func clusterStopPicker(_ controller: ClusterStopPickerViewController, didSelectStopID stopID: Stop.ID)
+    func clusterStopPickerDidRequestClose(_ controller: ClusterStopPickerViewController)
+}
+
+final class ClusterStopPickerViewController: UIViewController, Scrollable {
+    struct Item: Hashable {
+        let stopID: Stop.ID
+        let title: String
+        let secondaryText: String?
+        let isBookmarked: Bool
+    }
+
+    var scrollView: UIScrollView {
+        resolveHostedScrollView() ?? fallbackScrollView
+    }
+
+    private let titleText: String
+    private let items: [Item]
+    private weak var delegate: ClusterStopPickerViewControllerDelegate?
+
+    private var hostingController: UIHostingController<ClusterStopPickerSheetView>?
+    private let fallbackScrollView = UIScrollView()
+    private weak var hostedScrollView: UIScrollView?
+
+#if DEBUG
+    private var hasLoggedMissingHostedScrollView = false
+#endif
+
+    init(title: String, items: [Item], delegate: ClusterStopPickerViewControllerDelegate?) {
+        self.titleText = title
+        self.items = items
+        self.delegate = delegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+        let sheetItems = items.map {
+            ClusterStopPickerSheetView.Item(
+                id: $0.stopID,
+                title: $0.title,
+                secondaryText: $0.secondaryText,
+                isBookmarked: $0.isBookmarked
+            )
+        }
+
+        let sheetView = ClusterStopPickerSheetView(
+            title: titleText,
+            items: sheetItems,
+            onSelectStopID: { [weak self] stopID in
+                guard let self else { return }
+                self.delegate?.clusterStopPicker(self, didSelectStopID: stopID)
+            },
+            onClose: { [weak self] in
+                guard let self else { return }
+                self.delegate?.clusterStopPickerDidRequestClose(self)
+            }
+        )
+
+        let hostingController = UIHostingController(rootView: sheetView)
+        hostingController.view.backgroundColor = .clear
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.pinToSuperview(.edges)
+        hostingController.didMove(toParent: self)
+
+        self.hostingController = hostingController
+        _ = resolveHostedScrollView()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        guard
+            let panel = parent as? FloatingPanelController,
+            let scrollView = resolveHostedScrollView()
+        else { return }
+
+        panel.track(scrollView: scrollView)
+    }
+
+    private func resolveHostedScrollView() -> UIScrollView? {
+        if let hostedScrollView { return hostedScrollView }
+
+        loadViewIfNeeded()
+        view.layoutIfNeeded()
+
+        guard let hostingView = hostingController?.view else { return nil }
+        let scrollView = findHostedScrollView(in: hostingView)
+        hostedScrollView = scrollView
+
+#if DEBUG
+        if scrollView == nil && !hasLoggedMissingHostedScrollView {
+            Logger.warn("ClusterStopPickerViewController: Unable to locate hosted UIScrollView for FloatingPanel tracking.")
+            hasLoggedMissingHostedScrollView = true
+        }
+#endif
+
+        return scrollView
+    }
+
+    private func findHostedScrollView(in rootView: UIView) -> UIScrollView? {
+        var stack = [rootView]
+
+        while let candidate = stack.popLast() {
+            if let scrollView = candidate as? UIScrollView {
+                return scrollView
+            }
+            stack.append(contentsOf: candidate.subviews)
+        }
+
+        return nil
+    }
+}
+
+private struct ClusterStopPickerSheetView: View {
+    struct Item: Hashable, Identifiable {
+        let id: Stop.ID
+        let title: String
+        let secondaryText: String?
+        let isBookmarked: Bool
+    }
+
+    let title: String
+    let items: [Item]
+    let onSelectStopID: (Stop.ID) -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                header
+                stopList
+            }
+        }
+    }
+
+    private var header: some View {
+        ZStack {
+            Text(title)
+                .font(.headline.weight(.bold))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+
+            HStack {
+                Spacer()
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(Color(uiColor: .secondaryLabel))
+                        .frame(width: 32, height: 32)
+                        .background(
+                            Circle()
+                                .fill(Color(uiColor: .tertiarySystemFill))
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text(Strings.close))
+            }
+        }
+        .padding(.top, 16)
+        .padding(.horizontal, ThemeMetrics.padding)
+    }
+
+    private var stopList: some View {
+        List {
+            ForEach(items) { item in
+                ClusterStopPickerSheetRow(item: item)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onSelectStopID(item.id)
+                    }
+                    .listRowBackground(Color(uiColor: .secondarySystemBackground))
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(Color.clear)
+    }
+}
+
+private struct ClusterStopPickerSheetRow: View {
+    let item: ClusterStopPickerSheetView.Item
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            if item.isBookmarked {
+                Image(systemName: "bookmark.fill")
+                    .foregroundStyle(Color(uiColor: .secondaryLabel))
+                    .padding(.top, 2)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .foregroundStyle(Color(uiColor: .label))
+                    .font(.body)
+
+                if let secondaryText = item.secondaryText {
+                    Text(secondaryText)
+                        .foregroundStyle(Color(uiColor: .secondaryLabel))
+                        .font(.body)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 6)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: Text {
+        if let secondaryText = item.secondaryText {
+            Text("\(item.title), \(secondaryText)")
+        } else {
+            Text(item.title)
+        }
+    }
 }
 
 // swiftlint:enable file_length

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -635,6 +635,105 @@ class MapViewController: UIViewController,
         application.viewRouter.navigateTo(stop: stop, from: self)
     }
 
+    struct ClusterStopMember: Hashable {
+        let stopID: Stop.ID
+        let title: String
+        let subtitle: String?
+        let isBookmarked: Bool
+    }
+
+    private func presentClusterStopPicker(
+        members: [ClusterStopMember],
+        sourceView: UIView,
+        sourceRect: CGRect
+    ) {
+        guard !members.isEmpty else { return }
+
+        let title = String(
+            format: OBALoc(
+                "map_controller.grouped_stop_picker.title_fmt",
+                value: "Select a Stop (%d)",
+                comment: "Title for the action sheet used to select one of many co-located stops."
+            ),
+            members.count
+        )
+
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+        let sortedMembers = Self.sortedClusterStopMembers(members)
+
+        for member in sortedMembers {
+            alert.addAction(UIAlertAction(title: Self.clusterStopActionTitle(for: member), style: .default, handler: { _ in
+                self.application.analytics?.reportEvent(pageURL: "app://localhost/map", label: AnalyticsLabels.mapStopAnnotationTapped, value: nil)
+                self.application.viewRouter.navigateTo(stopID: member.stopID, from: self)
+            }))
+        }
+
+        alert.addAction(UIAlertAction(title: OBALoc("map_controller.grouped_stop_picker.cancel", value: "Cancel", comment: "Cancel button for grouped stop picker on map."), style: .cancel))
+
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = sourceView
+            popover.sourceRect = sourceRect
+        }
+
+        present(alert, animated: true)
+    }
+
+    static func clusterStopMembers(from memberAnnotations: [MKAnnotation]) -> [ClusterStopMember] {
+        var deduped: [Stop.ID: ClusterStopMember] = [:]
+
+        for annotation in memberAnnotations {
+            let member: ClusterStopMember?
+
+            if let stop = annotation as? Stop {
+                member = ClusterStopMember(
+                    stopID: stop.id,
+                    title: stop.nameWithLocalizedDirectionAbbreviation,
+                    subtitle: stop.subtitle,
+                    isBookmarked: false
+                )
+            } else if let bookmark = annotation as? Bookmark {
+                member = ClusterStopMember(
+                    stopID: bookmark.stop.id,
+                    title: bookmark.stop.nameWithLocalizedDirectionAbbreviation,
+                    subtitle: bookmark.stop.subtitle,
+                    isBookmarked: true
+                )
+            } else {
+                member = nil
+            }
+
+            guard let member else { continue }
+
+            if let existing = deduped[member.stopID], existing.isBookmarked && !member.isBookmarked {
+                continue
+            }
+            deduped[member.stopID] = member
+        }
+
+        return sortedClusterStopMembers(Array(deduped.values))
+    }
+
+    static func sortedClusterStopMembers(_ members: [ClusterStopMember]) -> [ClusterStopMember] {
+        members.sorted {
+            if $0.isBookmarked != $1.isBookmarked {
+                return $0.isBookmarked && !$1.isBookmarked
+            }
+
+            let titleCompare = $0.title.localizedCaseInsensitiveCompare($1.title)
+            if titleCompare == .orderedSame {
+                return $0.stopID < $1.stopID
+            }
+            return titleCompare == .orderedAscending
+        }
+    }
+
+    static func clusterStopActionTitle(for member: ClusterStopMember) -> String {
+        guard let subtitle = String.nilifyBlankValue(member.subtitle) else {
+            return member.title
+        }
+        return "\(member.title) (\(subtitle))"
+    }
+
     // MARK: - Overlays
 
     private let mapStatusView = MapStatusView.autolayoutNew()
@@ -897,6 +996,10 @@ class MapViewController: UIViewController,
             // and just go directly to pushing the stop onto the navigation stack.
             application.analytics?.reportEvent(pageURL: "app://localhost/map", label: AnalyticsLabels.mapStopAnnotationTapped, value: nil)
             show(stop: stop)
+        } else if let cluster = view.annotation as? MKClusterAnnotation {
+            let members = Self.clusterStopMembers(from: cluster.memberAnnotations)
+            presentClusterStopPicker(members: members, sourceView: view, sourceRect: view.bounds)
+            mapView.deselectAnnotation(cluster, animated: false)
         } else if let annotation = view.annotation as? UserDroppedPin {
             // Sheet presentation for user-dropped pins is handled via
             // mapRegionManager(_:didSelectUserAnnotation:) delegate callback.

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -18,6 +18,7 @@ protocol StopAnnotationDelegate: NSObjectProtocol {
 }
 
 class StopAnnotationView: MKAnnotationView {
+    static let stopClusterIdentifier = "oba-stop"
 
     // MARK: - Delegate
     public weak var delegate: StopAnnotationDelegate?
@@ -70,6 +71,7 @@ class StopAnnotationView: MKAnnotationView {
         }
 
         rightCalloutAccessoryView = UIButton.chevronButton
+        applyClusteringIdentifier()
 
         annotationSize = ThemeMetrics.defaultMapAnnotationSize
         updateAccessibility()
@@ -93,6 +95,7 @@ class StopAnnotationView: MKAnnotationView {
 
     public override func prepareForReuse() {
         super.prepareForReuse()
+        applyClusteringIdentifier()
 
         labelStack.isHidden = true
 
@@ -101,6 +104,7 @@ class StopAnnotationView: MKAnnotationView {
 
     public override func prepareForDisplay() {
         super.prepareForDisplay()
+        applyClusteringIdentifier()
 
         guard let delegate = delegate else {
             return
@@ -200,5 +204,9 @@ class StopAnnotationView: MKAnnotationView {
         else { return }
 
         image = delegate.iconFactory.buildIcon(for: stop, isBookmarked: delegate.isStopBookmarked(stop), traits: traitCollection)
+    }
+
+    private func applyClusteringIdentifier() {
+        clusteringIdentifier = Self.stopClusterIdentifier
     }
 }

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -340,6 +340,12 @@
 /* Title for the action sheet used to select one of many co-located stops. */
 "map_controller.grouped_stop_picker.title_fmt" = "Select a Stop (%d)";
 
+/* Secondary text for grouped stop picker rows when only direction is available. */
+"map_controller.grouped_stop_picker.direction_fmt" = "Direction: %@";
+
+/* Secondary text for grouped stop picker rows when both direction and location details are available. */
+"map_controller.grouped_stop_picker.direction_subtitle_fmt" = "%1$@ · %2$@";
+
 /* Accessibility label for the My Trip button on the map toolbar. */
 "map_controller.my_trip_button" = "My Trip";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -334,6 +334,12 @@
 /* Voiceover text indicating the current map type as the standard base map. */
 "map_controller.map_type.standard.accessibility_value" = "standard";
 
+/* Cancel button for grouped stop picker on map. */
+"map_controller.grouped_stop_picker.cancel" = "Cancel";
+
+/* Title for the action sheet used to select one of many co-located stops. */
+"map_controller.grouped_stop_picker.title_fmt" = "Select a Stop (%d)";
+
 /* Accessibility label for the My Trip button on the map toolbar. */
 "map_controller.my_trip_button" = "My Trip";
 
@@ -967,4 +973,3 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: arriving at %3$@";
-

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -86,4 +86,104 @@ class MapRegionManagerTests: OBATestCase {
         expect(application.currentRegion).to(beNil())
         expect(mgr.lastVisibleMapRect).to(beNil())
     }
+
+    func test_stopVisibility_hysteresis_staysVisibleWithinBand() {
+        let staysVisible = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: true,
+            mapHeight: 41000
+        )
+
+        expect(staysVisible).to(beTrue())
+    }
+
+    func test_stopVisibility_hysteresis_staysHiddenWithinBand() {
+        let staysHidden = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: false,
+            mapHeight: 39000
+        )
+
+        expect(staysHidden).to(beFalse())
+    }
+
+    func test_stopVisibility_hysteresis_transitionsAtThresholds() {
+        let hides = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: true,
+            mapHeight: 42500
+        )
+        let shows = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: false,
+            mapHeight: 37500
+        )
+
+        expect(hides).to(beFalse())
+        expect(shows).to(beTrue())
+    }
+
+    func test_zoomWarning_matchesVisibilityState() {
+        let showPins = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: true,
+            mapHeight: 37000
+        )
+        let hidePins = MapRegionManager.shouldShowStopAnnotations(
+            previouslyShowing: true,
+            mapHeight: 43000
+        )
+
+        expect(!showPins).to(beFalse())
+        expect(!hidePins).to(beTrue())
+    }
+
+    func test_mapView_viewForStop_resetsClusteringIdentifierOnReuse() {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        dataLoader.mock(data: Fixtures.loadData(file: "puget_sound_alerts.pb")) { request in
+            request.url!.absoluteString.contains("api/gtfs_realtime/alerts-for-agency")
+        }
+
+        let locManager = AuthorizableLocationManagerMock(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: UserDefaults(), locationManager: locManager)
+        let config = makeConfig(locationService: locationService, bundledRegionsPath: regionsFilePath, dataLoader: dataLoader)
+        let application = Application(config: config)
+        let manager = MapRegionManager(application: application)
+
+        let stop = makeStop(id: "test-stop", name: "Pine")
+
+        guard let firstView = manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView else {
+            XCTFail("Expected StopAnnotationView")
+            return
+        }
+        expect(firstView.clusteringIdentifier).to(equal(StopAnnotationView.stopClusterIdentifier))
+
+        firstView.clusteringIdentifier = nil
+
+        guard let reusedView = manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView else {
+            XCTFail("Expected StopAnnotationView on reuse")
+            return
+        }
+        expect(reusedView.clusteringIdentifier).to(equal(StopAnnotationView.stopClusterIdentifier))
+    }
+
+    private func makeStop(id: String, name: String) -> Stop {
+        let dict: [String: Any] = [
+            "id": id,
+            "code": id,
+            "name": name,
+            "lat": 47.6,
+            "lon": -122.3,
+            "direction": "N",
+            "locationType": 0,
+            "routeIds": [],
+            "wheelchairBoarding": "unknown"
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: dict) // swiftlint:disable:this force_try
+        let stop = try! JSONDecoder().decode(Stop.self, from: data) // swiftlint:disable:this force_try
+        stop.routes = []
+        return stop
+    }
+
 }

--- a/OBAKitTests/Application/Mapping/MapViewControllerGroupedStopPickerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapViewControllerGroupedStopPickerTests.swift
@@ -1,0 +1,75 @@
+//
+//  MapViewControllerGroupedStopPickerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import MapKit
+@testable import OBAKit
+@testable import OBAKitCore
+
+final class MapViewControllerGroupedStopPickerTests: XCTestCase {
+    func test_clusterStopMembers_dedupesAndPrioritizesBookmarkedStop() {
+        let stopA = makeStop(id: "A", name: "Pine")
+        let stopB = makeStop(id: "B", name: "Broadway")
+        let bookmarkA = Bookmark(name: "Pinned", regionIdentifier: 1, stop: stopA)
+
+        let members = MapViewController.clusterStopMembers(from: [stopA, stopB, bookmarkA])
+
+        XCTAssertEqual(members.count, 2)
+        XCTAssertEqual(members.first?.stopID, "A")
+        XCTAssertEqual(members.first?.isBookmarked, true)
+    }
+
+    func test_clusterStopMembers_ignoresNonStopAnnotations() {
+        let point = MKPointAnnotation()
+        point.coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+
+        let members = MapViewController.clusterStopMembers(from: [point])
+
+        XCTAssertTrue(members.isEmpty)
+    }
+
+    func test_sortedClusterStopMembers_prioritizesBookmarkedThenTitleThenStopID() {
+        let input = [
+            MapViewController.ClusterStopMember(stopID: "3", title: "Pine", subtitle: nil, isBookmarked: false),
+            MapViewController.ClusterStopMember(stopID: "2", title: "Pine", subtitle: nil, isBookmarked: true),
+            MapViewController.ClusterStopMember(stopID: "1", title: "Broadway", subtitle: nil, isBookmarked: false)
+        ]
+
+        let sorted = MapViewController.sortedClusterStopMembers(input)
+
+        XCTAssertEqual(sorted.map(\.stopID), ["2", "1", "3"])
+    }
+
+    func test_clusterStopActionTitle_includesSubtitleWhenPresent() {
+        let withSubtitle = MapViewController.ClusterStopMember(stopID: "1", title: "Pine & 3rd", subtitle: "NW", isBookmarked: false)
+        let withoutSubtitle = MapViewController.ClusterStopMember(stopID: "2", title: "Pine & 4th", subtitle: nil, isBookmarked: false)
+
+        XCTAssertEqual(MapViewController.clusterStopActionTitle(for: withSubtitle), "Pine & 3rd (NW)")
+        XCTAssertEqual(MapViewController.clusterStopActionTitle(for: withoutSubtitle), "Pine & 4th")
+    }
+
+    private func makeStop(id: String, name: String) -> Stop {
+        let dict: [String: Any] = [
+            "id": id,
+            "code": id,
+            "name": name,
+            "lat": 47.6,
+            "lon": -122.3,
+            "direction": "N",
+            "locationType": 0,
+            "routeIds": [],
+            "wheelchairBoarding": "unknown"
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: dict) // swiftlint:disable:this force_try
+        let stop = try! JSONDecoder().decode(Stop.self, from: data) // swiftlint:disable:this force_try
+        stop.routes = []
+        return stop
+    }
+}

--- a/OBAKitTests/Application/Mapping/StopAnnotationViewTests.swift
+++ b/OBAKitTests/Application/Mapping/StopAnnotationViewTests.swift
@@ -1,0 +1,86 @@
+//
+//  StopAnnotationViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+
+final class StopAnnotationViewTests: XCTestCase {
+    func test_init_setsClusteringIdentifier() {
+        let view = StopAnnotationView(annotation: nil, reuseIdentifier: "stop")
+
+        XCTAssertEqual(view.clusteringIdentifier, StopAnnotationView.stopClusterIdentifier)
+    }
+
+    func test_prepareForReuse_keepsClusteringIdentifier() {
+        let view = StopAnnotationView(annotation: nil, reuseIdentifier: "stop")
+        view.clusteringIdentifier = nil
+
+        view.prepareForReuse()
+
+        XCTAssertEqual(view.clusteringIdentifier, StopAnnotationView.stopClusterIdentifier)
+    }
+
+    func test_prepareForDisplay_stop_keepsClusteringIdentifier() {
+        let stop = makeStop(id: "1", name: "Pine")
+        let view = StopAnnotationView(annotation: stop, reuseIdentifier: "stop")
+        view.delegate = MockStopAnnotationDelegate()
+        view.clusteringIdentifier = nil
+
+        view.prepareForDisplay()
+
+        XCTAssertEqual(view.clusteringIdentifier, StopAnnotationView.stopClusterIdentifier)
+    }
+
+    func test_prepareForDisplay_bookmark_keepsClusteringIdentifier() {
+        let stop = makeStop(id: "2", name: "Broadway")
+        let bookmark = Bookmark(name: "Pinned Stop", regionIdentifier: 1, stop: stop)
+        let view = StopAnnotationView(annotation: bookmark, reuseIdentifier: "stop")
+        view.delegate = MockStopAnnotationDelegate()
+        view.clusteringIdentifier = nil
+
+        view.prepareForDisplay()
+
+        XCTAssertEqual(view.clusteringIdentifier, StopAnnotationView.stopClusterIdentifier)
+    }
+
+    private func makeStop(id: String, name: String) -> Stop {
+        let dict: [String: Any] = [
+            "id": id,
+            "code": id,
+            "name": name,
+            "lat": 47.6,
+            "lon": -122.3,
+            "direction": "N",
+            "locationType": 0,
+            "routeIds": [],
+            "wheelchairBoarding": "unknown"
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: dict) // swiftlint:disable:this force_try
+        let stop = try! JSONDecoder().decode(Stop.self, from: data) // swiftlint:disable:this force_try
+        stop.routes = []
+        return stop
+    }
+}
+
+private final class MockStopAnnotationDelegate: StopAnnotationDelegate {
+    let iconFactory = StopIconFactory(
+        iconSize: ThemeMetrics.defaultMapAnnotationSize,
+        themeColors: ThemeColors.shared
+    )
+
+    func isStopBookmarked(_ stop: Stop) -> Bool {
+        false
+    }
+
+    var shouldHideExtraStopAnnotationData: Bool {
+        true
+    }
+}


### PR DESCRIPTION
Problems Addressed #515 
This update makes stop pins on the map feel much more reliable and easier to use.
Instead of custom grouping, it now uses native MapKit clustering, so pins stay consistent even when you zoom or move around. Tapping a cluster shows a simple list of stops, letting you quickly pick one and navigate to it.

Pins no longer flicker during zoom, and they reappear instantly when you zoom back in, so the map feels smooth and responsive. Clusters also stay stable instead of breaking into messy overlapping pins.

Overall, the map behaves more predictably, and selecting the right stop is faster and clearer

RESULTS: 
1. Clusters remain stable after map interactions, 
2. Dense areas no longer degrade into overlapping unclustered pins.


| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/9810205b-92d0-4725-993e-fa0ee4a49eda" width="330"/> | <img src="https://github.com/user-attachments/assets/c94e6aee-b67f-4f06-9214-da40fd78020e" width="330"/> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cluster stop picker interface that appears when tapping grouped stops on the map, allowing easier selection from co-located stops.
  * Improved stop annotation visibility behavior with hysteresis thresholds and delayed hiding for smoother map interactions.

* **Tests**
  * Added comprehensive test coverage for cluster stop picker deduplication, sorting, and UI formatting logic.
  * Added tests for stop annotation view clustering behavior and visibility hysteresis logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->