### PR TITLE
(Recent - Nearby) Stops - Search ViewModels 

### DIFF
--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 import OBAKitCore
 
 /// Provides an interface to browse recently-viewed information, mostly `Stop`s.
@@ -16,12 +17,15 @@ public class RecentStopsViewController: UIViewController,
 
     let application: Application
 
-    let listView = OBAListView()
+    private let viewModel: RecentStopsViewModel
+    private let listView = OBAListView()
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 
     public init(application: Application) {
         self.application = application
+        self.viewModel = RecentStopsViewModel(application: application)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -47,13 +51,28 @@ public class RecentStopsViewController: UIViewController,
         view.addSubview(listView)
         listView.contextMenuDelegate = self
         listView.pinToSuperview(.edges)
+
+        bindViewModel()
+    }
+
+    private func bindViewModel() {
+        Publishers.CombineLatest(viewModel.$alarms, viewModel.$recentStops)
+            .sink { [weak self] _ in self?.listView.applyData(animated: true) }
+            .store(in: &cancellables)
+
+        viewModel.$deletionError
+            .compactMap { $0 }
+            .sink { [weak self] error in
+                guard let self else { return }
+                Task { await self.application.displayError(error) }
+            }
+            .store(in: &cancellables)
     }
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        application.userDataStore.deleteExpiredAlarms()
-        listView.applyData()
+        viewModel.loadData()
     }
 
     // MARK: - Actions
@@ -62,9 +81,7 @@ public class RecentStopsViewController: UIViewController,
         let title = OBALoc("recent_stops.confirmation_alert.title", value: "Are you sure you want to delete all of your recent stops?", comment: "Title for a confirmation alert displayed before the user deletes all of their recent stops.")
 
         let alertController = UIAlertController.deletionAlert(title: title) { [weak self] _ in
-            guard let self = self else { return }
-            self.application.userDataStore.deleteAllRecentStops()
-            self.listView.applyData(animated: true)
+            self?.viewModel.deleteAllRecentStops()
         }
 
         present(alertController, animated: true, completion: nil)
@@ -104,21 +121,15 @@ public class RecentStopsViewController: UIViewController,
         }
     }
 
-    func onDeleteAlarm(_ viewModel: AlarmViewModel) {
-        Task {
-            try? await self.application.obacoService?.deleteAlarm(url: viewModel.alarm.url)
-        }
-        self.application.userDataStore.delete(alarm: viewModel.alarm)
-        self.listView.applyData(animated: true)
+    func onDeleteAlarm(_ alarmViewModel: AlarmViewModel) {
+        viewModel.delete(alarm: alarmViewModel.alarm)
     }
 
     // MARK: - Sections
 
-    private var alarms: OBAListViewSection? {
-        let alarms = application.userDataStore.alarms
-        guard alarms.count > 0 else {
-            return nil
-        }
+    private var alarmSection: OBAListViewSection? {
+        let alarms = viewModel.alarms
+        guard alarms.count > 0 else { return nil }
 
         let rows = alarms.compactMap { alarm in
             return AlarmViewModel(withAlarm: alarm, onSelect: onSelectAlarm, onDelete: onDeleteAlarm)
@@ -128,15 +139,9 @@ public class RecentStopsViewController: UIViewController,
         return OBAListViewSection(id: "alarms", title: title, contents: rows)
     }
 
-    private var stops: OBAListViewSection? {
-        guard let currentRegion = application.currentRegion else {
-            return nil
-        }
-
-        let stops = application.userDataStore.recentStops.filter { $0.regionIdentifier == currentRegion.regionIdentifier }
-        guard stops.count > 0 else {
-            return nil
-        }
+    private var stopsSection: OBAListViewSection? {
+        let stops = viewModel.recentStops
+        guard stops.count > 0 else { return nil }
 
         let rows = stops.map { stop -> StopRowItem in
             let onSelect: OBAListViewAction<StopRowItem> = { [unowned self] viewModel in
@@ -144,21 +149,20 @@ public class RecentStopsViewController: UIViewController,
             }
 
             let onDelete: OBAListViewAction<StopRowItem> = { [unowned self] _ in
-                self.application.userDataStore.delete(recentStop: stop)
-                self.listView.applyData(animated: true)
+                self.viewModel.delete(recentStop: stop)
             }
 
             return StopRowItem(withStop: stop, onSelect: onSelect, onDelete: onDelete)
         }
 
-        let title = application.userDataStore.alarms.count > 0 ? Strings.recentStops : nil
+        let title = viewModel.alarms.count > 0 ? Strings.recentStops : nil
         return OBAListViewSection(id: "recent_stops", title: title, contents: rows)
     }
 
     // MARK: - OBAListView
 
     public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        return [alarms, stops].compactMap { $0 }
+        return [alarmSection, stopsSection].compactMap { $0 }
     }
 
     public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -56,16 +56,12 @@ public class RecentStopsViewController: UIViewController,
     }
 
     private func bindViewModel() {
+        // Deliver on the main queue so the sink runs *after* @Published commits its new
+        // value (it publishes in willSet). Otherwise items(for:) would read stale
+        // alarms / recentStops and the list would render one update behind.
         Publishers.CombineLatest(viewModel.$alarms, viewModel.$recentStops)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.listView.applyData(animated: true) }
-            .store(in: &cancellables)
-
-        viewModel.$deletionError
-            .compactMap { $0 }
-            .sink { [weak self] error in
-                guard let self else { return }
-                Task { await self.application.displayError(error) }
-            }
             .store(in: &cancellables)
     }
 

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -56,9 +56,9 @@ public class RecentStopsViewController: UIViewController,
     }
 
     private func bindViewModel() {
-        // Deliver on the main queue so the sink runs *after* @Published commits its new
-        // value (it publishes in willSet). Otherwise items(for:) would read stale
-        // alarms / recentStops and the list would render one update behind.
+        // `@Published` fires from `willSet`, so a synchronous sink would read the *old*
+        // stored values via `items(for:)` (alarms / recentStops). The main-queue hop
+        // defers the closure until after the property writes complete.
         Publishers.CombineLatest(viewModel.$alarms, viewModel.$recentStops)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.listView.applyData(animated: true) }

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  RecentStopsViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+@MainActor
+final class RecentStopsViewModel: ObservableObject {
+
+    @Published private(set) var alarms: [Alarm] = []
+    @Published private(set) var recentStops: [Stop] = []
+    @Published private(set) var deletionError: Error?
+
+    private let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    func loadData() {
+        application.userDataStore.deleteExpiredAlarms()
+        alarms = application.userDataStore.alarms
+        let currentRegion = application.currentRegion
+        recentStops = application.userDataStore.recentStops.filter {
+            $0.regionIdentifier == currentRegion?.regionIdentifier
+        }
+    }
+
+    func deleteAllRecentStops() {
+        application.userDataStore.deleteAllRecentStops()
+        recentStops = []
+    }
+
+    func delete(recentStop: Stop) {
+        application.userDataStore.delete(recentStop: recentStop)
+        loadData()
+    }
+
+    func delete(alarm: Alarm) {
+        application.userDataStore.delete(alarm: alarm)
+        loadData()
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await application.obacoService?.deleteAlarm(url: alarm.url)
+            } catch {
+                deletionError = error
+            }
+        }
+    }
+}

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -26,9 +26,12 @@ final class RecentStopsViewModel: ObservableObject {
     func loadData() {
         application.userDataStore.deleteExpiredAlarms()
         alarms = application.userDataStore.alarms
-        let currentRegion = application.currentRegion
+        guard let currentRegion = application.currentRegion else {
+            recentStops = []
+            return
+        }
         recentStops = application.userDataStore.recentStops.filter {
-            $0.regionIdentifier == currentRegion?.regionIdentifier
+            $0.regionIdentifier == currentRegion.regionIdentifier
         }
     }
 
@@ -43,6 +46,7 @@ final class RecentStopsViewModel: ObservableObject {
     }
 
     func delete(alarm: Alarm) {
+        deletionError = nil
         application.userDataStore.delete(alarm: alarm)
         loadData()
         Task { [weak self] in

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -17,6 +17,9 @@ final class RecentStopsViewModel: ObservableObject {
     @Published private(set) var recentStops: [Stop] = []
 
     private let application: Application
+    // `viewWillAppear` calls `loadData()` every time the Recent tab is shown; without
+    // this flag a user with no current region would flood the log on every tab switch.
+    private var didWarnNilRegion = false
 
     init(application: Application) {
         self.application = application
@@ -27,11 +30,17 @@ final class RecentStopsViewModel: ObservableObject {
         alarms = application.userDataStore.alarms
         guard let currentRegion = application.currentRegion else {
             // No current region (mid-region-change, first launch race, denied location).
-            // The user sees a generic empty state — log so the condition is observable.
-            Logger.warn("RecentStopsViewModel.loadData: currentRegion is nil; returning empty recent stops.")
+            // The user sees a generic empty state — log once per VM so the condition is
+            // observable without spamming on every viewWillAppear.
+            if !didWarnNilRegion {
+                Logger.warn("RecentStopsViewModel.loadData: currentRegion is nil; returning empty recent stops.")
+                didWarnNilRegion = true
+            }
             recentStops = []
             return
         }
+        // Region resolved — re-arm the warn so a *later* region loss is still observable.
+        didWarnNilRegion = false
         recentStops = application.userDataStore.recentStops.filter {
             $0.regionIdentifier == currentRegion.regionIdentifier
         }

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -15,7 +15,6 @@ final class RecentStopsViewModel: ObservableObject {
 
     @Published private(set) var alarms: [Alarm] = []
     @Published private(set) var recentStops: [Stop] = []
-    @Published private(set) var deletionError: Error?
 
     private let application: Application
 
@@ -46,15 +45,16 @@ final class RecentStopsViewModel: ObservableObject {
     }
 
     func delete(alarm: Alarm) {
-        deletionError = nil
         application.userDataStore.delete(alarm: alarm)
         loadData()
+        // The alarm is already gone locally; a remote-delete failure isn't actionable by
+        // the user, so log it rather than surfacing a modal error for a background op.
         Task { [weak self] in
             guard let self else { return }
             do {
                 try await application.obacoService?.deleteAlarm(url: alarm.url)
             } catch {
-                deletionError = error
+                Logger.error("Failed to delete alarm remotely: \(error.localizedDescription)")
             }
         }
     }

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -26,6 +26,9 @@ final class RecentStopsViewModel: ObservableObject {
         application.userDataStore.deleteExpiredAlarms()
         alarms = application.userDataStore.alarms
         guard let currentRegion = application.currentRegion else {
+            // No current region (mid-region-change, first launch race, denied location).
+            // The user sees a generic empty state — log so the condition is observable.
+            Logger.warn("RecentStopsViewModel.loadData: currentRegion is nil; returning empty recent stops.")
             recentStops = []
             return
         }
@@ -44,15 +47,20 @@ final class RecentStopsViewModel: ObservableObject {
         loadData()
     }
 
-    func delete(alarm: Alarm) {
+    @discardableResult
+    func delete(alarm: Alarm) -> Task<Void, Never> {
         application.userDataStore.delete(alarm: alarm)
         loadData()
-        // The alarm is already gone locally; a remote-delete failure isn't actionable by
-        // the user, so log it rather than surfacing a modal error for a background op.
-        Task { [weak self] in
-            guard let self else { return }
+        // Capture the service directly: if the VM is deallocated mid-delete (common when
+        // the user pops the view right after tapping delete), [weak self] would abort
+        // the DELETE before it ran, leaving the alarm live on the Obaco server.
+        // The returned Task is `@discardableResult` for the call site, but tests can
+        // await it to assert on remote-side behaviour.
+        let service = application.obacoService
+        let url = alarm.url
+        return Task {
             do {
-                try await application.obacoService?.deleteAlarm(url: alarm.url)
+                try await service?.deleteAlarm(url: url)
             } catch {
                 Logger.error("Failed to delete alarm remotely: \(error.localizedDescription)")
             }

--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -14,7 +14,7 @@ import OBAKitCore
 // MARK: - SearchError
 
 /// Defines errors that can occur during search operations in the app.
-public enum SearchError: Error, LocalizedError {
+public enum SearchError: Error, LocalizedError, Equatable {
     case noTripsAvailable
 
     public var errorDescription: String? {

--- a/OBAKit/Search/SearchResultsController.swift
+++ b/OBAKit/Search/SearchResultsController.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import Combine
 import OBAKitCore
 import MapKit
 
@@ -18,20 +19,21 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
 
     let application: Application
 
-    private let searchResponse: SearchResponse
+    private let viewModel: SearchViewModel
 
     private let listView = OBAListView()
     private let titleView = StackedTitleView.autolayoutNew()
+    private var cancellables = Set<AnyCancellable>()
 
     public init(searchResponse: SearchResponse, application: Application, delegate: ModalDelegate?) {
-        self.searchResponse = searchResponse
+        self.viewModel = SearchViewModel(searchResponse: searchResponse, application: application)
         self.application = application
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
 
         title = OBALoc("search_results_controller.title", value: "Search Results", comment: "The title of the Search Results controller.")
         titleView.titleLabel.text = title
-        titleView.subtitleLabel.text = subtitleText(from: searchResponse)
+        titleView.subtitleLabel.text = viewModel.subtitle
 
         listView.obaDataSource = self
         view.addSubview(listView)
@@ -49,6 +51,27 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.close, style: .plain, target: self, action: #selector(close))
 
         view.backgroundColor = ThemeColors.shared.systemBackground
+
+        bindViewModel()
+    }
+
+    private func bindViewModel() {
+        viewModel.$vehicleSearchResponse
+            .compactMap { $0 }
+            .sink { [weak self] response in
+                guard let self else { return }
+                self.application.mapRegionManager.searchResponse = response
+                self.delegate?.dismissModalController(self)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$vehicleError
+            .compactMap { $0 }
+            .sink { [weak self] error in
+                guard let self else { return }
+                Task { await self.application.displayError(error) }
+            }
+            .store(in: &cancellables)
     }
 
     override public func viewWillAppear(_ animated: Bool) {
@@ -60,23 +83,6 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
 
     @objc private func close() {
         delegate?.dismissModalController(self)
-    }
-
-    // MARK: - Private
-
-    private func subtitleText(from response: SearchResponse) -> String {
-        let subtitleFormat: String
-        switch searchResponse.request.searchType {
-        case .address:
-            subtitleFormat = OBALoc("search_results_controller.subtitle.address_fmt", value: "%@", comment: "A format string for address searches. In English, this is just the address itself without any adornment.")
-        case .route:
-            subtitleFormat = OBALoc("search_results_controller.subtitle.route_fmt", value: "Route %@", comment: "A format string for route searches. e.g. in english: Route \"{SEARCH TEXT}\"")
-        case .stopNumber:
-            subtitleFormat = OBALoc("search_results_controller.subtitle.stop_number_fmt", value: "Stop number %@", comment: "A format string for stop number searches. e.g. in english: Stop number \"{SEARCH TEXT}\"")
-        case .vehicleID:
-            subtitleFormat = OBALoc("search_results_controller.subtitle.vehicle_id_fmt", value: "Vehicle ID %@", comment: "A format string for vehicle ID searches. e.g. in english: Vehicle ID \"{SEARCH TEXT}\"")
-        }
-        return String(format: subtitleFormat, searchResponse.request.query)
     }
 
     // MARK: - Rows
@@ -102,35 +108,16 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
 
     private func row(for agencyVehicle: AgencyVehicle) -> AnyOBAListViewItem? {
         guard let vehicleID = agencyVehicle.vehicleID, application.apiService != nil else { return nil }
-        return OBAListRowView.SubtitleViewModel(title: vehicleID, subtitle: agencyVehicle.agencyName, accessoryType: .none) { _ in
-            self.didSelectAgencyVehicle(vehicleID: vehicleID)
+        return OBAListRowView.SubtitleViewModel(title: vehicleID, subtitle: agencyVehicle.agencyName, accessoryType: .none) { [weak self] _ in
+            guard let self else { return }
+            Task(priority: .userInitiated) { await self.viewModel.selectVehicle(vehicleID: vehicleID) }
         }.typeErased
     }
 
-    private func didSelectAgencyVehicle(vehicleID: String) {
-        guard let apiService = application.apiService else { return }
-
-        Task(priority: .userInitiated) {
-            do {
-                let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
-                await MainActor.run {
-                    let response = SearchResponse(response: self.searchResponse, substituteResult: vehicle)
-                    self.application.mapRegionManager.searchResponse = response
-                    self.delegate?.dismissModalController(self)
-                }
-            } catch DecodingError.keyNotFound {
-                let error = SearchError.noTripsAvailable
-                await self.application.displayError(error)
-            } catch {
-                await self.application.displayError(error)
-            }
-        }
-    }
-
     private func listViewItem(for item: Any) -> AnyOBAListViewItem? {
-        let tapHandler: VoidBlock = {
-            let mgr = self.application.mapRegionManager
-            mgr.searchResponse = SearchResponse(response: self.searchResponse, substituteResult: item)
+        let tapHandler: VoidBlock = { [weak self] in
+            guard let self else { return }
+            self.application.mapRegionManager.searchResponse = self.viewModel.response(substituting: item)
             self.delegate?.dismissModalController(self)
         }
 
@@ -150,7 +137,7 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
 
     // MARK: - OBAListView
     public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        let rows = searchResponse.results.compactMap { listViewItem(for: $0) }
+        let rows = viewModel.results.compactMap { listViewItem(for: $0) }
         return [OBAListViewSection(id: "results", contents: rows)]
     }
 }

--- a/OBAKit/Search/SearchResultsController.swift
+++ b/OBAKit/Search/SearchResultsController.swift
@@ -65,10 +65,12 @@ public class SearchResultsController: UIViewController, AppContext, OBAListViewD
             }
             .store(in: &cancellables)
 
+        // Sink on the full optional (not `.compactMap`): an explicit reset to nil at the
+        // start of `selectVehicle(...)` is a valid signal that the previous error is no
+        // longer current. Filtering nils leaves a retry's alert state stale.
         viewModel.$vehicleError
-            .compactMap { $0 }
             .sink { [weak self] error in
-                guard let self else { return }
+                guard let self, let error else { return }
                 Task { await self.application.displayError(error) }
             }
             .store(in: &cancellables)

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  SearchViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+@MainActor
+final class SearchViewModel: ObservableObject {
+
+    @Published private(set) var vehicleSearchResponse: SearchResponse?
+    @Published private(set) var vehicleError: Error?
+
+    let subtitle: String
+    let results: [Any]
+
+    private let searchResponse: SearchResponse
+    private let apiService: RESTAPIService?
+    private var isLoading = false
+
+    init(searchResponse: SearchResponse, application: Application) {
+        self.searchResponse = searchResponse
+        self.apiService = application.apiService
+        self.subtitle = SearchViewModel.subtitleText(from: searchResponse)
+        self.results = searchResponse.results
+    }
+
+    init(searchResponse: SearchResponse, apiService: RESTAPIService?) {
+        self.searchResponse = searchResponse
+        self.apiService = apiService
+        self.subtitle = SearchViewModel.subtitleText(from: searchResponse)
+        self.results = searchResponse.results
+    }
+
+    func response(substituting item: Any) -> SearchResponse {
+        SearchResponse(response: searchResponse, substituteResult: item)
+    }
+
+    func selectVehicle(vehicleID: String) async {
+        guard let apiService, !isLoading else { return }
+        isLoading = true
+        vehicleError = nil
+        vehicleSearchResponse = nil
+        defer { isLoading = false }
+        do {
+            let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
+            vehicleSearchResponse = SearchResponse(response: searchResponse, substituteResult: vehicle)
+        } catch DecodingError.keyNotFound {
+            vehicleError = SearchError.noTripsAvailable
+        } catch {
+            vehicleError = error
+        }
+    }
+
+    private static func subtitleText(from response: SearchResponse) -> String {
+        let subtitleFormat: String
+        switch response.request.searchType {
+        case .address:
+            subtitleFormat = OBALoc("search_results_controller.subtitle.address_fmt", value: "%@", comment: "A format string for address searches. In English, this is just the address itself without any adornment.")
+        case .route:
+            subtitleFormat = OBALoc("search_results_controller.subtitle.route_fmt", value: "Route %@", comment: "A format string for route searches. e.g. in english: Route \"{SEARCH TEXT}\"")
+        case .stopNumber:
+            subtitleFormat = OBALoc("search_results_controller.subtitle.stop_number_fmt", value: "Stop number %@", comment: "A format string for stop number searches. e.g. in english: Stop number \"{SEARCH TEXT}\"")
+        case .vehicleID:
+            subtitleFormat = OBALoc("search_results_controller.subtitle.vehicle_id_fmt", value: "Vehicle ID %@", comment: "A format string for vehicle ID searches. e.g. in english: Vehicle ID \"{SEARCH TEXT}\"")
+        }
+        return String(format: subtitleFormat, response.request.query)
+    }
+}

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -23,11 +23,8 @@ final class SearchViewModel: ObservableObject {
     private let apiService: RESTAPIService?
     private var isLoading = false
 
-    init(searchResponse: SearchResponse, application: Application) {
-        self.searchResponse = searchResponse
-        self.apiService = application.apiService
-        self.subtitle = SearchViewModel.subtitleText(from: searchResponse)
-        self.results = searchResponse.results
+    convenience init(searchResponse: SearchResponse, application: Application) {
+        self.init(searchResponse: searchResponse, apiService: application.apiService)
     }
 
     init(searchResponse: SearchResponse, apiService: RESTAPIService?) {

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -39,7 +39,13 @@ final class SearchViewModel: ObservableObject {
     }
 
     func selectVehicle(vehicleID: String) async {
-        guard let apiService, !isLoading else { return }
+        guard !isLoading else { return }
+        guard let apiService else {
+            // Misconfiguration (no API service available). Surface it through the same
+            // error channel as a request failure so the screen doesn't silently no-op.
+            vehicleError = UnstructuredError("No API service available for vehicle search.")
+            return
+        }
         isLoading = true
         vehicleError = nil
         vehicleSearchResponse = nil
@@ -47,9 +53,13 @@ final class SearchViewModel: ObservableObject {
         do {
             let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
             vehicleSearchResponse = SearchResponse(response: searchResponse, substituteResult: vehicle)
-        } catch DecodingError.keyNotFound {
+        } catch let DecodingError.keyNotFound(key, _) where key.stringValue == "tripId" {
+            // VehicleStatus requires `tripId`; its absence means the vehicle isn't on
+            // any trip right now. Any *other* missing key signals a real decode failure
+            // (renamed field, malformed payload) and should surface as-is.
             vehicleError = SearchError.noTripsAvailable
         } catch {
+            Logger.error("selectVehicle decode failure: \(error)")
             vehicleError = error
         }
     }

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -43,7 +43,11 @@ final class SearchViewModel: ObservableObject {
         guard let apiService else {
             // Misconfiguration (no API service available). Surface it through the same
             // error channel as a request failure so the screen doesn't silently no-op.
-            vehicleError = UnstructuredError("No API service available for vehicle search.")
+            vehicleError = UnstructuredError(OBALoc(
+                "search_results_controller.no_api_service_error",
+                value: "No transit data service is available. Please choose a region in Settings.",
+                comment: "Error shown when vehicle search is attempted with no API service configured (e.g. no region selected)."
+            ))
             return
         }
         isLoading = true

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import Combine
 import CoreLocation
 import OBAKitCore
 
@@ -17,7 +18,7 @@ class NearbyStopsViewController: UIViewController,
     UISearchResultsUpdating {
 
     let application: Application
-    private let coordinate: CLLocationCoordinate2D
+    private let viewModel: NearbyStopsViewModel
 
     private var searchFilter: String? {
         didSet {
@@ -28,13 +29,13 @@ class NearbyStopsViewController: UIViewController,
     }
 
     private let listView = OBAListView()
-    private var stops: [Stop] = []
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 
     public init(coordinate: CLLocationCoordinate2D, application: Application) {
-        self.coordinate = coordinate
         self.application = application
+        self.viewModel = NearbyStopsViewModel(coordinate: coordinate, application: application)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -54,10 +55,37 @@ class NearbyStopsViewController: UIViewController,
         listView.obaDataSource = self
 
         configureSearchController()
+        bindViewModel()
 
         Task(priority: .userInitiated) {
-            await loadStops()
+            await viewModel.loadStops()
         }
+    }
+
+    private func bindViewModel() {
+        viewModel.$isLoading
+            .sink { [weak self] isLoading in
+                if isLoading {
+                    self?.startLoading()
+                } else {
+                    self?.finishLoading()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$stops
+            .sink { [weak self] _ in
+                self?.searchFilter = nil
+            }
+            .store(in: &cancellables)
+
+        viewModel.$operationError
+            .compactMap { $0 }
+            .sink { [weak self] error in
+                guard let self else { return }
+                Task { await self.application.displayError(error) }
+            }
+            .store(in: &cancellables)
     }
 
     func startLoading() {
@@ -66,35 +94,6 @@ class NearbyStopsViewController: UIViewController,
 
     func finishLoading() {
         navigationItem.rightBarButtonItem = nil
-    }
-
-    func loadStops() async {
-        guard let apiService = application.apiService else {
-            return
-        }
-
-        await MainActor.run {
-            self.startLoading()
-        }
-
-        defer {
-            Task { @MainActor in
-                self.finishLoading()
-            }
-        }
-
-        try? await Task.sleep(nanoseconds: 3_000_000_000)
-        do {
-            let stops = try await apiService.getStops(coordinate: coordinate).list
-            await MainActor.run {
-                self.stops = stops
-                self.searchFilter = nil
-                self.listView.applyData()
-            }
-        } catch {
-            // TODO: (ualch9) Show error inline instead of presenting an ugly error.
-            await self.application.displayError(error)
-        }
     }
 
     // MARK: - Search
@@ -113,6 +112,7 @@ class NearbyStopsViewController: UIViewController,
 
     // MARK: - Data and Collection Controller
     func items(for listView: OBAListView) -> [OBAListViewSection] {
+        let stops = viewModel.stops
         guard !stops.isEmpty else { return [] }
 
         let filter = String.nilifyBlankValue(searchFilter?.localizedLowercase.trimmingCharacters(in: .whitespacesAndNewlines)) ?? nil

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -73,10 +73,11 @@ class NearbyStopsViewController: UIViewController,
             }
             .store(in: &cancellables)
 
-        // Deliver on the main queue so the sink runs *after* @Published commits the new
-        // value (it publishes in willSet). Otherwise items(for:) would read the old `stops`.
-        // Apply directly rather than routing through `searchFilter`, whose nil != nil guard
-        // would swallow the refresh on first load.
+        // `@Published` fires from `willSet`, so a synchronous sink would read the *old*
+        // stored value via `items(for:)`. The main-queue hop defers the closure until
+        // after the property write completes. Apply directly rather than routing through
+        // `searchFilter`, whose `oldValue != searchFilter` guard would swallow the
+        // refresh on first load when both are nil.
         viewModel.$stops
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -84,10 +85,12 @@ class NearbyStopsViewController: UIViewController,
             }
             .store(in: &cancellables)
 
+        // Sink on the full optional (not `.compactMap`): an explicit reset to nil at the
+        // start of `loadStops()` is a valid signal that the previous error is no longer
+        // current. Filtering nils means a retry leaves the prior alert state stale.
         viewModel.$operationError
-            .compactMap { $0 }
             .sink { [weak self] error in
-                guard let self else { return }
+                guard let self, let error else { return }
                 Task { await self.application.displayError(error) }
             }
             .store(in: &cancellables)

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -73,9 +73,14 @@ class NearbyStopsViewController: UIViewController,
             }
             .store(in: &cancellables)
 
+        // Deliver on the main queue so the sink runs *after* @Published commits the new
+        // value (it publishes in willSet). Otherwise items(for:) would read the old `stops`.
+        // Apply directly rather than routing through `searchFilter`, whose nil != nil guard
+        // would swallow the refresh on first load.
         viewModel.$stops
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.searchFilter = nil
+                self?.listView.applyData(animated: false)
             }
             .store(in: &cancellables)
 

--- a/OBAKit/Stops/NearbyStopsViewModel.swift
+++ b/OBAKit/Stops/NearbyStopsViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  NearbyStopsViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+import OBAKitCore
+
+@MainActor
+final class NearbyStopsViewModel: ObservableObject {
+
+    @Published private(set) var stops: [Stop] = []
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var operationError: Error?
+
+    private let coordinate: CLLocationCoordinate2D
+    private let apiService: RESTAPIService?
+
+    init(coordinate: CLLocationCoordinate2D, application: Application) {
+        self.coordinate = coordinate
+        self.apiService = application.apiService
+    }
+
+    init(coordinate: CLLocationCoordinate2D, apiService: RESTAPIService?) {
+        self.coordinate = coordinate
+        self.apiService = apiService
+    }
+
+    func loadStops() async {
+        guard !isLoading, let apiService else { return }
+
+        isLoading = true
+        operationError = nil
+
+        defer { isLoading = false }
+
+        do {
+            stops = try await apiService.getStops(coordinate: coordinate).list
+        } catch {
+            operationError = error
+        }
+    }
+}

--- a/OBAKit/Stops/NearbyStopsViewModel.swift
+++ b/OBAKit/Stops/NearbyStopsViewModel.swift
@@ -21,9 +21,8 @@ final class NearbyStopsViewModel: ObservableObject {
     private let coordinate: CLLocationCoordinate2D
     private let apiService: RESTAPIService?
 
-    init(coordinate: CLLocationCoordinate2D, application: Application) {
-        self.coordinate = coordinate
-        self.apiService = application.apiService
+    convenience init(coordinate: CLLocationCoordinate2D, application: Application) {
+        self.init(coordinate: coordinate, apiService: application.apiService)
     }
 
     init(coordinate: CLLocationCoordinate2D, apiService: RESTAPIService?) {

--- a/OBAKit/Stops/NearbyStopsViewModel.swift
+++ b/OBAKit/Stops/NearbyStopsViewModel.swift
@@ -36,7 +36,11 @@ final class NearbyStopsViewModel: ObservableObject {
             // Misconfiguration (no API service available, e.g. region not selected). Surface
             // it through the same error channel as a load failure so the screen doesn't
             // sit silently empty with no signal to the user or in the logs.
-            operationError = UnstructuredError("No API service available for nearby stops.")
+            operationError = UnstructuredError(OBALoc(
+                "nearby_stops_controller.no_api_service_error",
+                value: "No transit data service is available. Please choose a region in Settings.",
+                comment: "Error shown on the Nearby Stops screen when no API service is configured (e.g. no region selected)."
+            ))
             return
         }
 

--- a/OBAKit/Stops/NearbyStopsViewModel.swift
+++ b/OBAKit/Stops/NearbyStopsViewModel.swift
@@ -31,7 +31,14 @@ final class NearbyStopsViewModel: ObservableObject {
     }
 
     func loadStops() async {
-        guard !isLoading, let apiService else { return }
+        guard !isLoading else { return }
+        guard let apiService else {
+            // Misconfiguration (no API service available, e.g. region not selected). Surface
+            // it through the same error channel as a load failure so the screen doesn't
+            // sit silently empty with no signal to the user or in the logs.
+            operationError = UnstructuredError("No API service available for nearby stops.")
+            return
+        }
 
         isLoading = true
         operationError = nil

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -482,6 +482,9 @@
 /* Title for the empty set indicator on the Nearby controller */
 "nearby_controller.empty_set.title" = "No Nearby Stops";
 
+/* Error shown on the Nearby Stops screen when no API service is configured (e.g. no region selected). */
+"nearby_stops_controller.no_api_service_error" = "No transit data service is available. Please choose a region in Settings.";
+
 /* Body for the empty set indicator on the Nearby Stops controller. */
 "nearby_stops_controller.empty_set.body" = "There are no other stops in the vicinity.";
 
@@ -682,6 +685,9 @@
 
 /* Quick search prefix for Vehicle. */
 "search_interactor.quick_search.vehicle_prefix" = "Vehicle:";
+
+/* Error shown when vehicle search is attempted with no API service configured (e.g. no region selected). */
+"search_results_controller.no_api_service_error" = "No transit data service is available. Please choose a region in Settings.";
 
 /* Error message shown when a vehicle has no trips available. */
 "search_results_controller.no_trips_available" = "This vehicle is not currently on any trips.";

--- a/OBAKitCore/Models/Obaco/Alarm.swift
+++ b/OBAKitCore/Models/Obaco/Alarm.swift
@@ -62,6 +62,10 @@ public class Alarm: NSObject, Codable {
     }
 
     private static func datesEqual(_ lhs: Date?, _ rhs: Date?) -> Bool {
+        // TODO: If `ArrivalDepartureDeepLink` (combined into isEqual above) ever grows
+        // its own Date fields that round-trip through TimeInterval, apply the same
+        // normalization there — otherwise the precision-drift bug returns silently
+        // through `deepLink ==`.
         switch (lhs, rhs) {
         case (nil, nil): return true
         case let (l?, r?): return l.timeIntervalSince1970 == r.timeIntervalSince1970

--- a/OBAKitCore/Models/Obaco/Alarm.swift
+++ b/OBAKitCore/Models/Obaco/Alarm.swift
@@ -50,19 +50,31 @@ public class Alarm: NSObject, Codable {
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Alarm else { return false }
+        // Compare dates via timeIntervalSince1970 so an in-memory alarm equals the same
+        // alarm after a UserDefaults round-trip — `Date` carries sub-microsecond precision
+        // that is lost on encode/decode (see init(from:) / encode(to:) above), so a raw
+        // `==` would falsely report inequality for an alarm that was just persisted.
         return
             url == rhs.url &&
             deepLink == rhs.deepLink &&
-            tripDate == rhs.tripDate &&
-            alarmDate == rhs.alarmDate
+            Alarm.datesEqual(tripDate, rhs.tripDate) &&
+            Alarm.datesEqual(alarmDate, rhs.alarmDate)
+    }
+
+    private static func datesEqual(_ lhs: Date?, _ rhs: Date?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): return true
+        case let (l?, r?): return l.timeIntervalSince1970 == r.timeIntervalSince1970
+        default: return false
+        }
     }
 
     override public var hash: Int {
         var hasher = Hasher()
         hasher.combine(url)
         hasher.combine(deepLink)
-        hasher.combine(tripDate)
-        hasher.combine(alarmDate)
+        hasher.combine(tripDate?.timeIntervalSince1970)
+        hasher.combine(alarmDate?.timeIntervalSince1970)
         return hasher.finalize()
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -720,7 +720,11 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     }
 
     public func delete(alarm: Alarm) {
-        alarms.removeAll { $0 == alarm }
+        // Match on `url` (the stable server identifier), not full equality: Alarm.isEqual
+        // compares tripDate/alarmDate, which lose sub-microsecond precision on the
+        // timeIntervalSince1970 round-trip through UserDefaults, so a stored alarm would
+        // never equal its in-memory counterpart and nothing would be removed.
+        alarms.removeAll { $0.url == alarm.url }
     }
 
     // MARK: - Proximity Alerts

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -720,10 +720,14 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     }
 
     public func delete(alarm: Alarm) {
-        // Match on `url` (the stable server identifier), not full equality: Alarm.isEqual
-        // compares tripDate/alarmDate, which lose sub-microsecond precision on the
-        // timeIntervalSince1970 round-trip through UserDefaults, so a stored alarm would
-        // never equal its in-memory counterpart and nothing would be removed.
+        // Match on `url` — the stable server-side identifier for the alarm. Full
+        // `Alarm` equality is now date-precision-safe (see Alarm.isEqual), but `url`
+        // is still the right notion of identity here: two alarms with the same URL
+        // are the same alarm regardless of any other field drift.
+        let matches = alarms.filter { $0.url == alarm.url }
+        if matches.count > 1 {
+            Logger.warn("delete(alarm:) found \(matches.count) alarms sharing url \(alarm.url) — removing all.")
+        }
         alarms.removeAll { $0.url == alarm.url }
     }
 

--- a/OBAKitTests/Helpers/Mocks/CountingDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/CountingDataLoader.swift
@@ -1,0 +1,33 @@
+//
+//  CountingDataLoader.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Wraps a `MockDataLoader`, counts how many times `data(for:)` is called, and inserts a
+/// `Task.yield()` before forwarding so that concurrent tasks genuinely interleave on `@MainActor`.
+///
+/// Used by ViewModel tests to assert that an in-flight-load guard collapses concurrent calls
+/// into a single network request.
+class CountingDataLoader: NSObject, URLDataLoader {
+    let inner: MockDataLoader
+    private(set) var callCount = 0
+
+    init(_ inner: MockDataLoader) { self.inner = inner }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        inner.dataTask(with: request, completionHandler: completionHandler)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        callCount += 1
+        await Task.yield()
+        return try await inner.data(for: request)
+    }
+}

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -148,6 +148,29 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(IDs2) == ["2"]
     }
 
+    /// Regression test for the `tripDate`/`alarmDate` precision-loss bug in `Alarm.isEqual`.
+    /// Before the fix, encoding to UserDefaults stripped sub-microsecond precision from
+    /// the `Date` fields (via the `TimeInterval` round-trip in `Alarm.{init(from:),encode(to:)}`),
+    /// so the reloaded Alarm would no longer compare equal to its in-memory original — and
+    /// any equality-based delete would silently no-op. This test persists, reloads, then
+    /// deletes by the round-tripped instance to anchor the fix path to a named test.
+    func test_alarms_delete_afterUserDefaultsRoundTrip() {
+        let alarm = try! Fixtures.loadAlarm(id: "round-trip")
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+
+        userDefaultsStore.add(alarm: alarm)
+
+        // Force the encode → decode round-trip by going through the `alarms` getter,
+        // which reads back from UserDefaults rather than returning the in-memory instance.
+        let reloaded = userDefaultsStore.alarms.first { $0.url == alarm.url }
+        expect(reloaded).toNot(beNil())
+        expect(reloaded) == alarm
+
+        userDefaultsStore.delete(alarm: reloaded!)
+
+        expect(self.userDefaultsStore.alarms.map(\.url)).toNot(contain(alarm.url))
+    }
+
     // MARK: - Selected Tab Index
 
     func test_selectedTabIndex_mapSelectedByDefault() {

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -8,6 +8,7 @@
 //
 
 import XCTest
+import CoreLocation
 import Nimble
 @testable import OBAKit
 @testable import OBAKitCore
@@ -207,5 +208,77 @@ class RecentStopsViewModelTests: OBATestCase {
         // The remote delete runs in a fire-and-forget Task on @MainActor.
         // Poll until the Task has had a chance to run and set deletionError.
         await expect(viewModel.deletionError).toEventually(beAKindOf(NSError.self))
+    }
+
+    @MainActor
+    func test_delete_alarm_remoteSuccessPath_doesNotSetDeletionError() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+
+        let alarm = try! Fixtures.loadAlarm()
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+
+        let successURLResponse = HTTPURLResponse(
+            url: alarm.url, statusCode: 200, httpVersion: "2",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        dataLoader.mock(response: MockDataResponse(data: Data(), urlResponse: successURLResponse, error: nil) { request in
+            request.url?.absoluteString.contains("alarms") == true && request.httpMethod == "DELETE"
+        })
+
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+
+        viewModel.delete(alarm: alarm)
+
+        // Drain pending tasks — the mock is synchronous, so a few yields are enough.
+        for _ in 0..<10 { await Task.yield() }
+        expect(viewModel.deletionError).to(beNil())
+    }
+
+    // MARK: - loadData / nil currentRegion
+
+    @MainActor
+    func test_loadData_nilCurrentRegion_recentStopsIsEmpty() {
+        // Use "Null Island" (0, 0) which is in the Gulf of Guinea — not covered by any
+        // transit region — so application.currentRegion is nil when loadData() runs.
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        let nullIslandLocation = CLLocation(latitude: 0, longitude: 0)
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: nullIslandLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader
+        )
+        let app = Application(config: config)
+
+        let stop = try! Fixtures.loadSomeStops().first!
+        stop.regionIdentifier = nil
+        app.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        let viewModel = RecentStopsViewModel(application: app)
+
+        viewModel.loadData()
+
+        // When currentRegion is nil, loadData() exits early and returns an empty list —
+        // no accidental nil == nil matches.
+        expect(viewModel.recentStops).to(beEmpty())
     }
 }

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -78,14 +78,6 @@ class RecentStopsViewModelTests: OBATestCase {
         expect(viewModel.recentStops).to(beEmpty())
     }
 
-    @MainActor
-    func test_init_deletionErrorIsNil() {
-        let app = createApplication(dataLoader: MockDataLoader(testName: name))
-        let viewModel = RecentStopsViewModel(application: app)
-
-        expect(viewModel.deletionError).to(beNil())
-    }
-
     // MARK: - loadData
 
     @MainActor
@@ -182,59 +174,6 @@ class RecentStopsViewModelTests: OBATestCase {
         viewModel.delete(alarm: alarm)
 
         expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
-    }
-
-    @MainActor
-    func test_delete_alarm_setsErrorWhenRemoteDeleteFails() async {
-        let dataLoader = MockDataLoader(testName: name)
-        let app = createApplication(dataLoader: dataLoader)
-
-        let alarm = try! Fixtures.loadAlarm()
-        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
-        app.userDataStore.add(alarm: alarm)
-
-        // Mock the remote deleteAlarm endpoint to fail.
-        let remoteError = NSError(domain: "RemoteDeleteError", code: 503, userInfo: nil)
-        let failResponse = MockDataResponse(data: nil, urlResponse: nil, error: remoteError) { request in
-            request.url?.absoluteString.contains("alarms") == true && request.httpMethod == "DELETE"
-        }
-        dataLoader.mock(response: failResponse)
-
-        let viewModel = RecentStopsViewModel(application: app)
-        viewModel.loadData()
-
-        viewModel.delete(alarm: alarm)
-
-        // The remote delete runs in a fire-and-forget Task on @MainActor.
-        // Poll until the Task has had a chance to run and set deletionError.
-        await expect(viewModel.deletionError).toEventually(beAKindOf(NSError.self))
-    }
-
-    @MainActor
-    func test_delete_alarm_remoteSuccessPath_doesNotSetDeletionError() async {
-        let dataLoader = MockDataLoader(testName: name)
-        let app = createApplication(dataLoader: dataLoader)
-
-        let alarm = try! Fixtures.loadAlarm()
-        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
-        app.userDataStore.add(alarm: alarm)
-
-        let successURLResponse = HTTPURLResponse(
-            url: alarm.url, statusCode: 200, httpVersion: "2",
-            headerFields: ["Content-Type": "application/json"]
-        )!
-        dataLoader.mock(response: MockDataResponse(data: Data(), urlResponse: successURLResponse, error: nil) { request in
-            request.url?.absoluteString.contains("alarms") == true && request.httpMethod == "DELETE"
-        })
-
-        let viewModel = RecentStopsViewModel(application: app)
-        viewModel.loadData()
-
-        viewModel.delete(alarm: alarm)
-
-        // Drain pending tasks — the mock is synchronous, so a few yields are enough.
-        for _ in 0..<10 { await Task.yield() }
-        expect(viewModel.deletionError).to(beNil())
     }
 
     // MARK: - loadData / nil currentRegion

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -1,0 +1,211 @@
+//
+//  RecentStopsViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_try
+
+class RecentStopsViewModelTests: OBATestCase {
+    var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader
+        )
+
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        return Application(config: config)
+    }
+
+    // MARK: - Initial State
+
+    @MainActor
+    func test_init_alarmsIsEmpty() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let viewModel = RecentStopsViewModel(application: app)
+
+        expect(viewModel.alarms).to(beEmpty())
+    }
+
+    @MainActor
+    func test_init_recentStopsIsEmpty() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let viewModel = RecentStopsViewModel(application: app)
+
+        expect(viewModel.recentStops).to(beEmpty())
+    }
+
+    @MainActor
+    func test_init_deletionErrorIsNil() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let viewModel = RecentStopsViewModel(application: app)
+
+        expect(viewModel.deletionError).to(beNil())
+    }
+
+    // MARK: - loadData
+
+    @MainActor
+    func test_loadData_populatesRecentStopsForCurrentRegion() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let stop = try! Fixtures.loadSomeStops().first!
+        stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        app.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        let viewModel = RecentStopsViewModel(application: app)
+
+        viewModel.loadData()
+
+        expect(viewModel.recentStops).to(contain(stop))
+    }
+
+    @MainActor
+    func test_loadData_excludesStopsFromOtherRegions() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let stop = try! Fixtures.loadSomeStops().first!
+        stop.regionIdentifier = Fixtures.tampaRegion.regionIdentifier
+        app.userDataStore.addRecentStop(stop, region: Fixtures.tampaRegion)
+        let viewModel = RecentStopsViewModel(application: app)
+
+        viewModel.loadData()
+
+        expect(viewModel.recentStops).to(beEmpty())
+    }
+
+    @MainActor
+    func test_loadData_populatesAlarms() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let alarm = try! Fixtures.loadAlarm()
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+        let viewModel = RecentStopsViewModel(application: app)
+
+        viewModel.loadData()
+
+        expect(viewModel.alarms.map(\.url)).to(contain(alarm.url))
+    }
+
+    // MARK: - deleteAllRecentStops
+
+    @MainActor
+    func test_deleteAllRecentStops_emptiesRecentStops() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let stops = try! Fixtures.loadSomeStops()
+        stops.prefix(3).forEach {
+            $0.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+            app.userDataStore.addRecentStop($0, region: Fixtures.pugetSoundRegion)
+        }
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+        expect(viewModel.recentStops).toNot(beEmpty())
+
+        viewModel.deleteAllRecentStops()
+
+        expect(viewModel.recentStops).to(beEmpty())
+    }
+
+    // MARK: - delete(recentStop:)
+
+    @MainActor
+    func test_delete_recentStop_removesItAndKeepsOthers() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let stops = try! Fixtures.loadSomeStops()
+        let stopA = stops[0]
+        let stopB = stops[1]
+        stopA.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        stopB.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        app.userDataStore.addRecentStop(stopA, region: Fixtures.pugetSoundRegion)
+        app.userDataStore.addRecentStop(stopB, region: Fixtures.pugetSoundRegion)
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+
+        viewModel.delete(recentStop: stopA)
+
+        expect(viewModel.recentStops).toNot(contain(stopA))
+        expect(viewModel.recentStops).to(contain(stopB))
+    }
+
+    // MARK: - delete(alarm:)
+
+    @MainActor
+    func test_delete_alarm_removesItLocally() {
+        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+        let alarm = try! Fixtures.loadAlarm()
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+        expect(viewModel.alarms.map(\.url)).to(contain(alarm.url))
+
+        viewModel.delete(alarm: alarm)
+
+        expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
+    }
+
+    @MainActor
+    func test_delete_alarm_setsErrorWhenRemoteDeleteFails() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+
+        let alarm = try! Fixtures.loadAlarm()
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+
+        // Mock the remote deleteAlarm endpoint to fail.
+        let remoteError = NSError(domain: "RemoteDeleteError", code: 503, userInfo: nil)
+        let failResponse = MockDataResponse(data: nil, urlResponse: nil, error: remoteError) { request in
+            request.url?.absoluteString.contains("alarms") == true && request.httpMethod == "DELETE"
+        }
+        dataLoader.mock(response: failResponse)
+
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+
+        viewModel.delete(alarm: alarm)
+
+        // The remote delete runs in a fire-and-forget Task on @MainActor.
+        // Poll until the Task has had a chance to run and set deletionError.
+        await expect(viewModel.deletionError).toEventually(beAKindOf(NSError.self))
+    }
+}

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -186,6 +186,60 @@ class RecentStopsViewModelTests: OBATestCase {
         expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
     }
 
+    @MainActor
+    func test_delete_alarm_remoteSuccess_keepsLocalRemoval() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let alarm = try! Fixtures.loadAlarm()
+
+        // Track whether the remote DELETE actually hit the stub. The catch-all matcher
+        // pattern from the local-only test would silently disable obaco; we want this
+        // test to *fail* if the remote call is short-circuited.
+        var didHitRemote = false
+        dataLoader.mock(data: Data(), matcher: { req in
+            if req.url?.path.contains("/alarms/") == true {
+                didHitRemote = true
+                return true
+            }
+            return false
+        })
+
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+
+        await viewModel.delete(alarm: alarm).value
+
+        expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
+        expect(didHitRemote).to(beTrue())
+    }
+
+    @MainActor
+    func test_delete_alarm_remoteFailure_keepsLocalRemoval() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let alarm = try! Fixtures.loadAlarm()
+
+        // Stub the obaco DELETE to fail. Local removal should still hold and the Task
+        // should swallow the error via Logger.error (so awaiting it doesn't throw).
+        let remoteError = NSError(domain: "RecentStopsViewModelTests", code: 503, userInfo: nil)
+        dataLoader.mock(response: MockDataResponse(
+            data: nil, urlResponse: nil, error: remoteError,
+            matcher: { $0.url?.path.contains("/alarms/") ?? false }
+        ))
+
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
+        app.userDataStore.add(alarm: alarm)
+        let viewModel = RecentStopsViewModel(application: app)
+        viewModel.loadData()
+
+        await viewModel.delete(alarm: alarm).value
+
+        // Remote failure does not undo the local removal — that's the contract.
+        expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
+    }
+
     // MARK: - loadData / nil currentRegion
 
     @MainActor

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -164,12 +164,15 @@ class RecentStopsViewModelTests: OBATestCase {
     @MainActor
     func test_delete_alarm_removesItLocally() async {
         let dataLoader = MockDataLoader(testName: name)
-        // Stub anything the obaco service might hit — the remote DELETE is now a real
-        // fire-and-forget detached Task (no `[weak self]` early-out), and without a
-        // catch-all the MockDataLoader fatals if/when the Task lands.
-        dataLoader.mock(data: Data()) { _ in true }
         let app = createApplication(dataLoader: dataLoader)
         let alarm = try! Fixtures.loadAlarm()
+        // Stub the obaco DELETE *after* createApplication so we don't shadow the
+        // regions-v3.json stub it registers (mockResponses is iterated in registration
+        // order, and a catch-all here would blank the regions load and silently
+        // disable obacoService construction).
+        dataLoader.mock(data: Data()) { req in
+            req.url?.path.contains("/alarms/") ?? false
+        }
         alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
         app.userDataStore.add(alarm: alarm)
         let viewModel = RecentStopsViewModel(application: app)

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -162,8 +162,13 @@ class RecentStopsViewModelTests: OBATestCase {
     // MARK: - delete(alarm:)
 
     @MainActor
-    func test_delete_alarm_removesItLocally() {
-        let app = createApplication(dataLoader: MockDataLoader(testName: name))
+    func test_delete_alarm_removesItLocally() async {
+        let dataLoader = MockDataLoader(testName: name)
+        // Stub anything the obaco service might hit — the remote DELETE is now a real
+        // fire-and-forget detached Task (no `[weak self]` early-out), and without a
+        // catch-all the MockDataLoader fatals if/when the Task lands.
+        dataLoader.mock(data: Data()) { _ in true }
+        let app = createApplication(dataLoader: dataLoader)
         let alarm = try! Fixtures.loadAlarm()
         alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
         app.userDataStore.add(alarm: alarm)
@@ -171,7 +176,9 @@ class RecentStopsViewModelTests: OBATestCase {
         viewModel.loadData()
         expect(viewModel.alarms.map(\.url)).to(contain(alarm.url))
 
-        viewModel.delete(alarm: alarm)
+        // Await the returned Task so the remote DELETE completes inside the test
+        // boundary — otherwise it races past tearDown.
+        await viewModel.delete(alarm: alarm).value
 
         expect(viewModel.alarms.map(\.url)).toNot(contain(alarm.url))
     }
@@ -213,6 +220,11 @@ class RecentStopsViewModelTests: OBATestCase {
         stop.regionIdentifier = nil
         app.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
         let viewModel = RecentStopsViewModel(application: app)
+
+        // Pin the precondition the test relies on: if a future stub region ever covers
+        // (0,0) (e.g. a worldwide bounding box), `currentRegion` would become non-nil
+        // and the assertion below would pass for the wrong reason.
+        expect(app.currentRegion).to(beNil())
 
         viewModel.loadData()
 

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -15,27 +15,6 @@ import Nimble
 
 // swiftlint:disable force_try
 
-// MARK: - CountingDataLoader
-
-private class CountingDataLoader: NSObject, URLDataLoader {
-    let inner: MockDataLoader
-    private(set) var callCount = 0
-
-    init(_ inner: MockDataLoader) { self.inner = inner }
-
-    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        inner.dataTask(with: request, completionHandler: completionHandler)
-    }
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        callCount += 1
-        await Task.yield()
-        return try await inner.data(for: request)
-    }
-}
-
-// MARK: -
-
 class SearchViewModelTests: OBATestCase {
 
     // MARK: - Helpers

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -44,10 +44,14 @@ class SearchViewModelTests: OBATestCase {
     }
 
     func makeKeyNotFoundLoader() -> MockDataLoader {
-        // Returns a valid OBA API envelope but with "entry" missing from "data",
-        // which causes DecodingError.keyNotFound when the vehicle model is decoded.
+        // Returns a valid VehicleStatus envelope but with `tripId` omitted from `entry`,
+        // mirroring the real "vehicle isn't on any trip" payload — this is the specific
+        // keyNotFound case SearchViewModel maps to `noTripsAvailable`. Other missing
+        // keys (envelope, tripStatus, etc.) deliberately do *not* map to that error.
         let loader = MockDataLoader(testName: name)
-        let json = #"{"code":200,"currentTime":1588888802143,"data":{},"text":"OK","version":2}"#
+        let json = #"""
+        {"code":200,"currentTime":1588888802143,"data":{"entry":{"lastUpdateTime":1588888744000,"lastLocationUpdateTime":1588888744000,"phase":"in_progress","status":"SCHEDULED","tripStatus":{"activeTripId":"","blockTripSequence":0,"closestStop":"","closestStopTimeOffset":0,"distanceAlongTrip":0,"lastKnownDistanceAlongTrip":0,"lastLocationUpdateTime":0,"lastUpdateTime":0,"nextStop":"","nextStopTimeOffset":0,"orientation":0,"phase":"","position":{"lat":0,"lon":0},"predicted":false,"scheduleDeviation":0,"scheduledDistanceAlongTrip":0,"serviceDate":0,"situationIds":[],"status":"","totalDistanceAlongTrip":0,"vehicleId":""},"vehicleId":"1_4351"},"references":{"agencies":[],"routes":[],"situations":[],"stops":[],"trips":[]}},"text":"OK","version":2}
+        """#
         loader.mock(URLString: vehicleURLString, with: Data(json.utf8))
         return loader
     }
@@ -159,10 +163,12 @@ class SearchViewModelTests: OBATestCase {
     }
 
     @MainActor
-    func test_selectVehicle_nilApiService_vehicleErrorRemainsNil() async {
+    func test_selectVehicle_nilApiService_setsVehicleError() async {
+        // Without an API service, the call would otherwise silently no-op. Surface the
+        // misconfiguration through `vehicleError` so the existing error sink can present it.
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
         await vm.selectVehicle(vehicleID: vehicleID)
-        expect(vm.vehicleError).to(beNil())
+        expect(vm.vehicleError).toNot(beNil())
     }
 
     // MARK: - selectVehicle / success

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -1,0 +1,303 @@
+//
+//  SearchViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import MapKit
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_try
+
+// MARK: - CountingDataLoader
+
+private class CountingDataLoader: NSObject, URLDataLoader {
+    let inner: MockDataLoader
+    private(set) var callCount = 0
+
+    init(_ inner: MockDataLoader) { self.inner = inner }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        inner.dataTask(with: request, completionHandler: completionHandler)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        callCount += 1
+        await Task.yield()
+        return try await inner.data(for: request)
+    }
+}
+
+// MARK: -
+
+class SearchViewModelTests: OBATestCase {
+
+    // MARK: - Helpers
+
+    let vehicleID = "1_4351"
+    lazy var vehicleURLString = "https://www.example.com/api/where/vehicle/\(vehicleID).json"
+
+    func makeSearchResponse(
+        searchType: SearchType,
+        query: String = "test",
+        results: [Any] = []
+    ) -> SearchResponse {
+        SearchResponse(request: SearchRequest(query: query, type: searchType), results: results, boundingRegion: nil, error: nil)
+    }
+
+    func makeSuccessLoader() -> MockDataLoader {
+        let loader = MockDataLoader(testName: name)
+        loader.mock(URLString: vehicleURLString, with: Fixtures.loadData(file: "api_where_vehicle_1_4351.json"))
+        return loader
+    }
+
+    func makeNetworkErrorLoader() -> MockDataLoader {
+        let loader = MockDataLoader(testName: name)
+        let error = NSError(domain: "SearchViewModelTests", code: 500, userInfo: nil)
+        loader.mock(response: MockDataResponse(data: nil, urlResponse: nil, error: error) { _ in true })
+        return loader
+    }
+
+    func makeKeyNotFoundLoader() -> MockDataLoader {
+        // Returns a valid OBA API envelope but with "entry" missing from "data",
+        // which causes DecodingError.keyNotFound when the vehicle model is decoded.
+        let loader = MockDataLoader(testName: name)
+        let json = #"{"code":200,"currentTime":1588888802143,"data":{},"text":"OK","version":2}"#
+        loader.mock(URLString: vehicleURLString, with: Data(json.utf8))
+        return loader
+    }
+
+    // MARK: - Subtitle
+
+    @MainActor
+    func test_subtitle_address_isQueryVerbatim() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address, query: "Seattle, WA"), apiService: nil)
+        expect(vm.subtitle) == "Seattle, WA"
+    }
+
+    @MainActor
+    func test_subtitle_route_prefixedWithRoute() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .route, query: "44"), apiService: nil)
+        expect(vm.subtitle) == "Route 44"
+    }
+
+    @MainActor
+    func test_subtitle_stopNumber_prefixedWithStopNumber() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, query: "1234"), apiService: nil)
+        expect(vm.subtitle) == "Stop number 1234"
+    }
+
+    @MainActor
+    func test_subtitle_vehicleID_prefixedWithVehicleID() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID, query: "XYZ"), apiService: nil)
+        expect(vm.subtitle) == "Vehicle ID XYZ"
+    }
+
+    // MARK: - results
+
+    @MainActor
+    func test_results_matchesSearchResponseResults() throws {
+        let stop = try Fixtures.loadSomeStops().first!
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, results: [stop]), apiService: nil)
+        expect(vm.results.count) == 1
+        expect(vm.results.first as? Stop) === stop
+    }
+
+    // MARK: - response(substituting:)
+
+    @MainActor
+    func test_responseSubstituting_singleResultIsSubstitute() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, results: [stops[0]]), apiService: nil)
+
+        let substituted = vm.response(substituting: stops[1])
+
+        expect(substituted.results.count) == 1
+        expect(substituted.results.first as? Stop) === stops[1]
+    }
+
+    @MainActor
+    func test_responseSubstituting_preservesOriginalRequest() throws {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .route, query: "44"), apiService: nil)
+        let substituted = vm.response(substituting: "anything")
+        expect(substituted.request.query) == "44"
+        expect(substituted.request.searchType) == .route
+    }
+
+    @MainActor
+    func test_responseSubstituting_preservesBoundingRegion() {
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
+        let searchResponse = SearchResponse(request: SearchRequest(query: "test", type: .address), results: [], boundingRegion: region, error: nil)
+        let vm = SearchViewModel(searchResponse: searchResponse, apiService: nil)
+
+        let substituted = vm.response(substituting: "anything")
+
+        expect(substituted.boundingRegion).toNot(beNil())
+        expect(substituted.boundingRegion?.center.latitude) == 47.6
+        expect(substituted.boundingRegion?.center.longitude) == -122.3
+    }
+
+    @MainActor
+    func test_responseSubstituting_preservesError() {
+        let searchResponse = SearchResponse(request: SearchRequest(query: "test", type: .address), results: [], boundingRegion: nil, error: SearchError.noTripsAvailable)
+        let vm = SearchViewModel(searchResponse: searchResponse, apiService: nil)
+
+        let substituted = vm.response(substituting: "anything")
+
+        expect(substituted.error as? SearchError) == .noTripsAvailable
+    }
+
+    // MARK: - Initial State
+
+    @MainActor
+    func test_init_vehicleSearchResponseIsNil() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address), apiService: nil)
+        expect(vm.vehicleSearchResponse).to(beNil())
+    }
+
+    @MainActor
+    func test_init_vehicleErrorIsNil() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address), apiService: nil)
+        expect(vm.vehicleError).to(beNil())
+    }
+
+    // MARK: - selectVehicle / nil apiService
+
+    @MainActor
+    func test_selectVehicle_nilApiService_vehicleSearchResponseRemainsNil() async {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        await vm.selectVehicle(vehicleID: vehicleID)
+        expect(vm.vehicleSearchResponse).to(beNil())
+    }
+
+    @MainActor
+    func test_selectVehicle_nilApiService_vehicleErrorRemainsNil() async {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        await vm.selectVehicle(vehicleID: vehicleID)
+        expect(vm.vehicleError).to(beNil())
+    }
+
+    // MARK: - selectVehicle / success
+
+    @MainActor
+    func test_selectVehicle_success_vehicleSearchResponseIsSet() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeSuccessLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleSearchResponse).toNot(beNil())
+        expect(vm.vehicleError).to(beNil())
+    }
+
+    @MainActor
+    func test_selectVehicle_success_responseContainsSingleVehicleStatusResult() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeSuccessLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleSearchResponse?.results.count) == 1
+        expect(vm.vehicleSearchResponse?.results.first as? VehicleStatus).toNot(beNil())
+    }
+
+    @MainActor
+    func test_selectVehicle_success_preservesOriginalRequest() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeSuccessLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleSearchResponse?.request.query) == vehicleID
+        expect(vm.vehicleSearchResponse?.request.searchType) == .vehicleID
+    }
+
+    // MARK: - selectVehicle / network error
+
+    @MainActor
+    func test_selectVehicle_networkError_setsVehicleError() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID),
+            apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleError).toNot(beNil())
+        expect(vm.vehicleSearchResponse).to(beNil())
+    }
+
+    // MARK: - selectVehicle / keyNotFound → noTripsAvailable
+
+    @MainActor
+    func test_selectVehicle_keyNotFoundDecoding_setsNoTripsAvailableError() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID),
+            apiService: buildRESTService(dataLoader: makeKeyNotFoundLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleError as? SearchError) == .noTripsAvailable
+        expect(vm.vehicleSearchResponse).to(beNil())
+    }
+
+    // MARK: - selectVehicle / concurrent-call guard
+
+    @MainActor
+    func test_selectVehicle_guard_preventsConcurrentCalls() async {
+        let mockLoader = makeSuccessLoader()
+        let countingLoader = CountingDataLoader(mockLoader)
+        let config = APIServiceConfiguration(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL)
+        let service = RESTAPIService(config, dataLoader: countingLoader)
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: service
+        )
+
+        async let first: Void = vm.selectVehicle(vehicleID: vehicleID)
+        async let second: Void = vm.selectVehicle(vehicleID: vehicleID)
+        await first
+        await second
+
+        expect(countingLoader.callCount) == 1
+        expect(vm.vehicleSearchResponse).toNot(beNil())
+    }
+
+    // MARK: - selectVehicle / state transitions
+
+    @MainActor
+    func test_selectVehicle_errorThenSuccess_vehicleErrorIsCleared() async {
+        let loader = makeNetworkErrorLoader()
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: loader)
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+        expect(vm.vehicleError).toNot(beNil())
+
+        loader.removeMappedResponses()
+        loader.mock(URLString: vehicleURLString, with: Fixtures.loadData(file: "api_where_vehicle_1_4351.json"))
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        expect(vm.vehicleError).to(beNil())
+        expect(vm.vehicleSearchResponse).toNot(beNil())
+    }
+}

--- a/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
+++ b/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
@@ -73,10 +73,13 @@ class NearbyStopsViewModelTests: OBATestCase {
     }
 
     @MainActor
-    func test_loadStops_nilApiService_operationErrorRemainsNil() async {
+    func test_loadStops_nilApiService_setsOperationError() async {
+        // Without an API service, the screen would otherwise sit empty with no signal.
+        // Surface the misconfiguration through `operationError` so the existing error
+        // sink can present it.
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         await viewModel.loadStops()
-        expect(viewModel.operationError).to(beNil())
+        expect(viewModel.operationError).toNot(beNil())
     }
 
     // MARK: - Successful load

--- a/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
+++ b/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
@@ -1,0 +1,183 @@
+//
+//  NearbyStopsViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+import CoreLocation
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_cast
+
+// MARK: - CountingDataLoader
+
+/// Wraps a MockDataLoader, counts how many times data(for:) is called, and inserts a
+/// Task.yield() before forwarding so that concurrent tasks genuinely interleave on @MainActor.
+private class CountingDataLoader: NSObject, URLDataLoader {
+    let inner: MockDataLoader
+    private(set) var callCount = 0
+
+    init(_ inner: MockDataLoader) { self.inner = inner }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        inner.dataTask(with: request, completionHandler: completionHandler)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        callCount += 1
+        await Task.yield()
+        return try await inner.data(for: request)
+    }
+}
+
+// MARK: -
+
+class NearbyStopsViewModelTests: OBATestCase {
+
+    let coordinate = TestData.seattleCoordinate
+    let stopsURLString = "https://www.example.com/api/where/stops-for-location.json"
+
+    // MARK: - Helpers
+
+    func makeDataLoader(stubStops: Bool = false) -> MockDataLoader {
+        let loader = MockDataLoader(testName: name)
+        if stubStops {
+            loader.mock(URLString: stopsURLString, with: Fixtures.loadData(file: "stops_for_location_seattle.json"))
+        }
+        return loader
+    }
+
+    func makeErrorLoader() -> MockDataLoader {
+        let loader = MockDataLoader(testName: name)
+        let error = NSError(domain: "NearbyStopsViewModelTests", code: 500, userInfo: nil)
+        let response = MockDataResponse(data: nil, urlResponse: nil, error: error) { _ in true }
+        loader.mock(response: response)
+        return loader
+    }
+
+    // MARK: - Initial State
+
+    @MainActor
+    func test_init_stopsIsEmpty() {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        expect(viewModel.stops).to(beEmpty())
+    }
+
+    @MainActor
+    func test_init_isLoadingIsFalse() {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        expect(viewModel.isLoading).to(beFalse())
+    }
+
+    @MainActor
+    func test_init_operationErrorIsNil() {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        expect(viewModel.operationError).to(beNil())
+    }
+
+    // MARK: - Guard: nil apiService
+
+    @MainActor
+    func test_loadStops_nilApiService_stopsRemainsEmpty() async {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        await viewModel.loadStops()
+        expect(viewModel.stops).to(beEmpty())
+    }
+
+    @MainActor
+    func test_loadStops_nilApiService_isLoadingReturnsFalse() async {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        await viewModel.loadStops()
+        expect(viewModel.isLoading).to(beFalse())
+    }
+
+    @MainActor
+    func test_loadStops_nilApiService_operationErrorRemainsNil() async {
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
+        await viewModel.loadStops()
+        expect(viewModel.operationError).to(beNil())
+    }
+
+    // MARK: - Successful load
+
+    @MainActor
+    func test_loadStops_success_populatesStops() async {
+        let service = buildRESTService(dataLoader: makeDataLoader(stubStops: true))
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        await viewModel.loadStops()
+
+        expect(viewModel.stops).toNot(beEmpty())
+        expect(viewModel.operationError).to(beNil())
+    }
+
+    @MainActor
+    func test_loadStops_success_isLoadingIsFalseAfterCompletion() async {
+        let service = buildRESTService(dataLoader: makeDataLoader(stubStops: true))
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        await viewModel.loadStops()
+
+        expect(viewModel.isLoading).to(beFalse())
+    }
+
+    // MARK: - Failed load
+
+    @MainActor
+    func test_loadStops_failure_setsOperationError() async {
+        let service = buildRESTService(dataLoader: makeErrorLoader())
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        await viewModel.loadStops()
+
+        expect(viewModel.operationError).toNot(beNil())
+    }
+
+    @MainActor
+    func test_loadStops_failure_stopsRemainsEmpty() async {
+        let service = buildRESTService(dataLoader: makeErrorLoader())
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        await viewModel.loadStops()
+
+        expect(viewModel.stops).to(beEmpty())
+    }
+
+    @MainActor
+    func test_loadStops_failure_isLoadingIsFalseAfterCompletion() async {
+        let service = buildRESTService(dataLoader: makeErrorLoader())
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        await viewModel.loadStops()
+
+        expect(viewModel.isLoading).to(beFalse())
+    }
+
+    // MARK: - Guard: prevents concurrent double-load
+
+    @MainActor
+    func test_loadStops_guard_preventsDoubleLoad() async {
+        // CountingDataLoader yields before forwarding, giving the second concurrent
+        // loadStops() a chance to run and see isLoading == true, so it returns early.
+        let mockLoader = makeDataLoader(stubStops: true)
+        let countingLoader = CountingDataLoader(mockLoader)
+        let config = APIServiceConfiguration(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL)
+        let service = RESTAPIService(config, dataLoader: countingLoader)
+        let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
+
+        async let first: Void = viewModel.loadStops()
+        async let second: Void = viewModel.loadStops()
+        await first
+        await second
+
+        expect(countingLoader.callCount) == 1
+        expect(viewModel.stops).toNot(beEmpty())
+        expect(viewModel.isLoading).to(beFalse())
+    }
+}

--- a/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
+++ b/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
@@ -13,31 +13,6 @@ import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
-// swiftlint:disable force_cast
-
-// MARK: - CountingDataLoader
-
-/// Wraps a MockDataLoader, counts how many times data(for:) is called, and inserts a
-/// Task.yield() before forwarding so that concurrent tasks genuinely interleave on @MainActor.
-private class CountingDataLoader: NSObject, URLDataLoader {
-    let inner: MockDataLoader
-    private(set) var callCount = 0
-
-    init(_ inner: MockDataLoader) { self.inner = inner }
-
-    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        inner.dataTask(with: request, completionHandler: completionHandler)
-    }
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        callCount += 1
-        await Task.yield()
-        return try await inner.data(for: request)
-    }
-}
-
-// MARK: -
-
 class NearbyStopsViewModelTests: OBATestCase {
 
     let coordinate = TestData.seattleCoordinate

--- a/OBAKitTests/ViewModels/MapViewModelTests.swift
+++ b/OBAKitTests/ViewModels/MapViewModelTests.swift
@@ -113,9 +113,14 @@ class MapViewModelTests: OBATestCase {
         await viewModel.loadWeather()
         expect(viewModel.weather).toNot(beNil())
 
-        // Swap the weather mock for an error. getWeather() only hits the weather URL, so
-        // dropping the other mocks is safe for this second load.
+        // Swap the weather mock for an error. removeMappedResponses() wipes *every*
+        // stub — including the regions / agencies-with-coverage / agency-alerts ones
+        // that the Application's async region resolver may still be hitting — so we
+        // have to re-register them or in-flight requests will fatal on MockDataLoader.
         dataLoader.removeMappedResponses()
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
         stubWeatherError(dataLoader: dataLoader)
 
         await viewModel.loadWeather()


### PR DESCRIPTION
 ### Summary 

Extracts three ViewModels from their ViewControllers as part of the Tier 2 ViewModel layer plan (PR T2-4). Each VC becomes a thin Combine-binding shell; all business logic moves into a testable `@MainActor ObservableObject`.

  | New File |
  |----------|
  | `RecentStopsViewModel` | 
  | `NearbyStopsViewModel` 
  | `SearchViewModel` | 

### Notable fixes included

- **`RecentStopsViewModel.loadData()`** — guards against nil `currentRegion` with an early return to `recentStops = []`, preventing unintended `nil == nil` filter matches
- **`RecentStopsViewModel.delete(alarm:)`** — a failed background remote delete is logged via `Logger.error` rather than surfaced as a modal: the alarm is already gone locally and the server failure isn't user-actionable
- **`UserDataStore.delete(alarm:)`** — matches on the stable `url` instead of full equality. `Alarm.isEqual` compares `tripDate`/`alarmDate`, which lose sub-microsecond precision on the `timeIntervalSince1970` round-trip through `UserDefaults`, so a stored alarm never equalled its in-memory counterpart and delete was a no-op (in production as well as tests)
- **`SearchViewModel.selectVehicle()`** — resets both `vehicleError` and `vehicleSearchResponse` at the start of each call; adds an `isLoading` guard against concurrent taps
- **`SearchError`** — adds `Equatable` conformance solely for the `vehicleError as? SearchError == .noTripsAvailable` test assertion (`SearchViewModelTests.swift:235`); no production consumer.
- **`NearbyStopsViewController`** — removes a 3-second debug sleep that had been left in.

 ### Test coverage


 - `RecentStopsViewModelTests` — initial state, `loadData` region filtering (including nil-region edge case), deleteAll, delete stop, delete alarm (local + remote success + remote failure
  paths)
  - `NearbyStopsViewModelTests` — initial state, nil API service guard, success/failure load, concurrent double-load guard via `CountingDataLoader`
  - `SearchViewModelTests` — subtitle formatting, `results`, `response(substituting:)` (including `boundingRegion`/`error` preservation), `selectVehicle` (nil service, success, network
  error, keyNotFound, concurrent guard, error-then-success state transition)
  
  
  ### What's deferred

  `NearbyStopsListViewController` rewire (replace `MapRegionManager` delegate with `MapPanelViewModel.$nearbyStops` sink) is blocked on `feature/viewModel-layer` merging first, since
  `MapPanelViewModel` lives there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alarm equality/hashing to prevent mismatches after saving/loading.

* **Improvements**
  * Recent Stops, Search, and Nearby Stops screens are now more responsive and consistent (better loading indicators, refreshes, and delete flows).
  * Vehicle selection and search subtitles/results behave more reliably, with fewer duplicate network calls and clearer error handling.

* **Localization**
  * Added user-facing messages prompting selection of a region in Settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/onebusaway-ios/pull/1139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
