### PR TITLE
#1135 fit-and-finish follow-ups.

### DIFF
--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1294,21 +1294,6 @@ private extension StopViewController {
             .store(in: &cancellables)
     }
 
-    func seedCollapsedPastDepartureSections(for arrivals: StopArrivals) {
-        guard pastDeparturesCollapsed else { return }
-        if viewModel.stopPreferences.sortType == .time {
-            collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: "all").sectionID)
-        } else {
-            let groups = arrivals.arrivalsAndDepartures.group(
-                preferences: viewModel.stopPreferences,
-                filter: viewModel.isListFiltered
-            )
-            for group in groups {
-                collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: group.route.id).sectionID)
-            }
-        }
-    }
-
     func bindStopSink() {
         viewModel.$stop
             .sink { [weak self] stop in
@@ -1344,6 +1329,21 @@ private extension StopViewController {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    func seedCollapsedPastDepartureSections(for arrivals: StopArrivals) {
+        guard pastDeparturesCollapsed else { return }
+        if viewModel.stopPreferences.sortType == .time {
+            collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: "all").sectionID)
+        } else {
+            let groups = arrivals.arrivalsAndDepartures.group(
+                preferences: viewModel.stopPreferences,
+                filter: viewModel.isListFiltered
+            )
+            for group in groups {
+                collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: group.route.id).sectionID)
+            }
+        }
     }
 
     func bindLoadingState() {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -14,7 +14,7 @@ import Combine
 import SwiftUI
 import SafariServices
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length
 
 /// This is the core view controller for displaying information about a transit stop.
 ///
@@ -1272,23 +1272,18 @@ public class StopViewController: UIViewController,
 
 private extension StopViewController {
     func bindListData() {
+        bindArrivalsSink()
+        bindStopSink()
+        bindSurveysSink()
+        bindPreferencesSinks()
+    }
+
+    func bindArrivalsSink() {
         viewModel.$stopArrivals
             .sink { [weak self] arrivals in
                 guard let self, let arrivals else { return }
                 if firstLoad {
-                    if pastDeparturesCollapsed {
-                        if viewModel.stopPreferences.sortType == .time {
-                            collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: "all").sectionID)
-                        } else {
-                            let groups = arrivals.arrivalsAndDepartures.group(
-                                preferences: viewModel.stopPreferences,
-                                filter: viewModel.isListFiltered
-                            )
-                            for group in groups {
-                                collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: group.route.id).sectionID)
-                            }
-                        }
-                    }
+                    seedCollapsedPastDepartureSections(for: arrivals)
                     firstLoad = false
                     dataLoadFeedbackGenerator.dataLoad(.success)
                 }
@@ -1297,7 +1292,24 @@ private extension StopViewController {
                 beginUserActivity()
             }
             .store(in: &cancellables)
+    }
 
+    func seedCollapsedPastDepartureSections(for arrivals: StopArrivals) {
+        guard pastDeparturesCollapsed else { return }
+        if viewModel.stopPreferences.sortType == .time {
+            collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: "all").sectionID)
+        } else {
+            let groups = arrivals.arrivalsAndDepartures.group(
+                preferences: viewModel.stopPreferences,
+                filter: viewModel.isListFiltered
+            )
+            for group in groups {
+                collapsedSections.insert(ListSections.pastArrivalDepartures(suffix: group.route.id).sectionID)
+            }
+        }
+    }
+
+    func bindStopSink() {
         viewModel.$stop
             .sink { [weak self] stop in
                 guard let self else { return }
@@ -1306,11 +1318,15 @@ private extension StopViewController {
                 configureTabBarButtons()
             }
             .store(in: &cancellables)
+    }
 
+    func bindSurveysSink() {
         viewModel.surveysDidRefresh
             .sink { [weak self] _ in self?.listView.applyData(animated: false) }
             .store(in: &cancellables)
+    }
 
+    func bindPreferencesSinks() {
         viewModel.$stopPreferences
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in

--- a/OBAKit/ViewModels/MapPanelViewModel.swift
+++ b/OBAKit/ViewModels/MapPanelViewModel.swift
@@ -13,9 +13,7 @@ import OBAKitCore
 
 /// Describes the desired expansion state of the bottom panel (EC11).
 /// `MapFloatingPanelController` maps each case to a `FloatingPanelState`.
-/// A SwiftUI `PresentationDetent` mapping will be added alongside the future
-/// SwiftUI sheet that consumes it, so its detent values can be pinned against
-/// the real layout constants in `Layouts.swift`.
+// TODO: add a SwiftUI `PresentationDetent` mapping when the SwiftUI sheet lands.
 enum PanelDetent: Equatable {
     case tip
     case half
@@ -31,8 +29,9 @@ class MapPanelViewModel: ObservableObject {
 
     // MARK: - Published State
 
-    /// Desired panel/sheet expansion level. UIKit layer observes and calls `floatingPanel.move(to:)`;
-    /// SwiftUI layer binds this to `presentationDetent` (EC11).
+    /// Desired panel expansion level. `MapFloatingPanelController` observes this and calls
+    /// `floatingPanel.move(to:)` (EC11).
+    // TODO: bind to SwiftUI `presentationDetent` when the SwiftUI sheet lands.
     @Published var requestedPanelDetent: PanelDetent = .tip
 
     /// Nearby stops visible in the current map region.

--- a/OBAKit/ViewModels/MapPanelViewModel.swift
+++ b/OBAKit/ViewModels/MapPanelViewModel.swift
@@ -12,11 +12,31 @@ import Combine
 import OBAKitCore
 
 /// Describes the desired expansion state of the bottom panel / sheet (EC11).
-/// UIKit maps this to FloatingPanel states; SwiftUI maps to `presentationDetents`.
-enum PanelDetent {
+/// UIKit maps each case to a `FloatingPanelState`; SwiftUI maps each case to a
+/// `PresentationDetent` using the values below so the two layers stay in sync
+/// on a single shared enum.
+enum PanelDetent: Equatable {
     case tip
     case half
     case full
+
+    /// SwiftUI presentation value for this detent. `.tip` pins to a fixed
+    /// point height so the grabber stays a consistent size across devices;
+    /// `.half` / `.full` scale with the containing view as fractions.
+    /// Callers map this directly to `PresentationDetent.height(_:)` or
+    /// `PresentationDetent.fraction(_:)`.
+    enum Value: Equatable {
+        case height(CGFloat)
+        case fraction(Double)
+    }
+
+    var value: Value {
+        switch self {
+        case .tip:  return .height(120)
+        case .half: return .fraction(0.5)
+        case .full: return .fraction(1.0)
+        }
+    }
 }
 
 /// Shared ViewModel for the map bottom panel (nearby stops + search).

--- a/OBAKit/ViewModels/MapPanelViewModel.swift
+++ b/OBAKit/ViewModels/MapPanelViewModel.swift
@@ -11,32 +11,15 @@ import Foundation
 import Combine
 import OBAKitCore
 
-/// Describes the desired expansion state of the bottom panel / sheet (EC11).
-/// UIKit maps each case to a `FloatingPanelState`; SwiftUI maps each case to a
-/// `PresentationDetent` using the values below so the two layers stay in sync
-/// on a single shared enum.
+/// Describes the desired expansion state of the bottom panel (EC11).
+/// `MapFloatingPanelController` maps each case to a `FloatingPanelState`.
+/// A SwiftUI `PresentationDetent` mapping will be added alongside the future
+/// SwiftUI sheet that consumes it, so its detent values can be pinned against
+/// the real layout constants in `Layouts.swift`.
 enum PanelDetent: Equatable {
     case tip
     case half
     case full
-
-    /// SwiftUI presentation value for this detent. `.tip` pins to a fixed
-    /// point height so the grabber stays a consistent size across devices;
-    /// `.half` / `.full` scale with the containing view as fractions.
-    /// Callers map this directly to `PresentationDetent.height(_:)` or
-    /// `PresentationDetent.fraction(_:)`.
-    enum Value: Equatable {
-        case height(CGFloat)
-        case fraction(Double)
-    }
-
-    var value: Value {
-        switch self {
-        case .tip:  return .height(120)
-        case .half: return .fraction(0.5)
-        case .full: return .fraction(1.0)
-        }
-    }
 }
 
 /// Shared ViewModel for the map bottom panel (nearby stops + search).

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -206,7 +206,7 @@ class StopViewModel: ObservableObject {
             reportStopViewed(stop)
         }
         disableFilterIfAllRoutesHidden()
-        // Surveys don't change per 30s refresh; fetch once per stop entry,
+        // Surveys don't change between auto-refreshes; fetch once per stop entry,
         // alongside the other first-fetch-only side effects above.
         refreshSurveys()
     }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -163,8 +163,6 @@ class StopViewModel: ObservableObject {
                 if result.arrivalsAndDepartures.isEmpty {
                     pendingExtensionMinutes = pendingAutoExtensionAmount()
                 }
-
-                refreshSurveys()
             }
         } catch APIError.requestNotFound {
             operationError = nil
@@ -208,6 +206,9 @@ class StopViewModel: ObservableObject {
             reportStopViewed(stop)
         }
         disableFilterIfAllRoutesHidden()
+        // Surveys don't change per 30s refresh; fetch once per stop entry,
+        // alongside the other first-fetch-only side effects above.
+        refreshSurveys()
     }
 
     private func refreshSurveys() {

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -77,7 +77,7 @@ class StopViewModelTests: OBATestCase {
 
     /// Stubs the surveys endpoint with an empty-list payload so `refreshSurveys()` doesn't fatal-error.
     private func stubSurveys(dataLoader: MockDataLoader) {
-        let emptySurveys = #"{"surveys":[]}"#.data(using: .utf8)!
+        let emptySurveys = #"{"surveys":[],"region":{"id":1,"name":"Puget Sound"}}"#.data(using: .utf8)!
         dataLoader.mock(data: emptySurveys) { request in
             request.url?.path.contains("/surveys.json") ?? false
         }
@@ -153,6 +153,30 @@ class StopViewModelTests: OBATestCase {
 
         expect(app.userDataStore.recentStops.count) == 1
         expect(app.userDataStore.recentStops.first?.id) == testStopID
+    }
+
+    // MARK: - Surveys fetched once
+
+    /// `refreshSurveys()` runs as part of the one-shot initial-fetch block, not on every
+    /// auto-refresh — so `surveysDidRefresh` should emit exactly once across multiple
+    /// refreshes. The emission happens from a detached `Task`, so assert eventually.
+    @MainActor
+    func test_surveys_refreshedExactlyOnceAcrossRefreshes() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let analytics = AnalyticsMock()
+        let app = createApplication(dataLoader: dataLoader, analytics: analytics)
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+
+        var emissions = 0
+        let cancellable = viewModel.surveysDidRefresh.sink { emissions += 1 }
+        defer { cancellable.cancel() }
+
+        await viewModel.refresh()
+        await viewModel.refresh()
+        await viewModel.refresh()
+
+        await expect(emissions).toEventually(equal(1))
     }
 
     // MARK: - Filter invariant on initial load (issue #2)

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -75,7 +75,8 @@ class StopViewModelTests: OBATestCase {
         }
     }
 
-    /// Stubs the surveys endpoint with an empty-list payload so `refreshSurveys()` doesn't fatal-error.
+    /// Stubs the surveys endpoint with an empty-list payload so `refreshSurveys()` succeeds
+    /// (routing nothing to `lastError`) instead of leaving the request unmocked.
     private func stubSurveys(dataLoader: MockDataLoader) {
         let emptySurveys = #"{"surveys":[],"region":{"id":1,"name":"Puget Sound"}}"#.data(using: .utf8)!
         dataLoader.mock(data: emptySurveys) { request in
@@ -177,6 +178,9 @@ class StopViewModelTests: OBATestCase {
         await viewModel.refresh()
 
         await expect(emissions).toEventually(equal(1))
+        // Guard against regression to per-refresh fetching: emissions must not climb past 1.
+        // Without this, `toEventually` would latch onto the transient `1` on its way to 2/3.
+        await expect(emissions).toNever(beGreaterThan(1))
     }
 
     // MARK: - Filter invariant on initial load (issue #2)


### PR DESCRIPTION
Implementing the points mentioned in #1141 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Survey information now refreshes during initial stop load instead of on every periodic refresh, reducing redundant updates.
  * Panel presentation sizing updated for more consistent expansion across UI contexts.

* **Bug Fixes**
  * Surveys now emit refresh exactly once across repeated fetches, preventing duplicate survey updates and rendering.

* **Tests**
  * Added regression test ensuring surveys refresh exactly once across repeated fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->