### PR TITLE
Make CI test failures diagnosable

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -11,6 +11,10 @@ on:
 # Installed versions of Xcode on macOS 15 are documented at:
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
 
+permissions:
+  checks: write
+  contents: read
+  
 jobs:
   build:
     runs-on: macos-15

--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -10,15 +10,14 @@ on:
 # https://github.com/actions/runner-images?tab=readme-ov-file
 # Installed versions of Xcode on macOS 15 are documented at:
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-
-permissions:
-  checks: write
-  contents: read
   
 jobs:
   build:
     runs-on: macos-15
-
+    permissions:
+      checks: write
+      contents: read
+      
     steps:
     - uses: actions/checkout@v4
 
@@ -76,8 +75,8 @@ jobs:
     # Upload results
     - uses: slidoapp/xcresulttool@v3.1.1
       continue-on-error: true
-      with:
-        show-passed-tests: false    # Avoid truncation of annotations by GitHub by omitting succeeding tests.
-        path: |
-          OBAKitTests.xcresult
       if: success() || failure()
+      with:
+         path: OBAKitTests.xcresult
+         show-passed-tests: false
+         show-code-coverage: false

--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -68,10 +68,9 @@ jobs:
         -derivedDataPath DerivedData
         -enableCodeCoverage NO
         -resultBundlePath OBAKitTests.xcresult
-        -quiet
 
     # Upload results
-    - uses: kishikawakatsumi/xcresulttool@v1.7.0
+    - uses: slidoapp/xcresulttool@v3.1.1
       continue-on-error: true
       with:
         show-passed-tests: false    # Avoid truncation of annotations by GitHub by omitting succeeding tests.


### PR DESCRIPTION
  ## Summary

  Two small changes to `.github/workflows/obakittests.yml` so failing CI runs surface the failing test name + assertion message instead of just `exit code 65`.
  
  - Replace kishikawakatsumi/xcresulttool@v1.7.0 with slidoapp/xcresulttool@v3.1.1.
  The upstream action is unmaintained and fails on Xcode 16+ runners (exit code 64) due to missing --legacy support for xcresulttool. The Slido fork includes the fix, maintains compatibility with the existing inputs (path, show-passed-tests), and adds support for Node 24 ahead of GitHub’s Node 20 deprecation on June 16, 2026.
  - **Remove `-quiet` from the test step.** 
  When the xcresulttool action also breaks, the raw workflow log is the only fallback — and `-quiet` was suppressing every `Test Case … failed`  line and assertion message. `-quiet` stays on the build step where it isn't a diagnostic pain point.

  ## Motivation

  Current state when CI fails:
  **TEST EXECUTE FAILED**
`[error]Process completed with exit code 65`
    
  No test name, no file: line, no assertion message. Multiple PRs this week have spent debugging cycles just figuring out *what* failed before being able to start fixing it.

  After this change:
  - Workflow log contains lines like `Test Case '-[OBAKitTests.X testY]' failed (0.012s) — XCTAssertEqual failed: …`.
  - `slidoapp/xcresulttool` posts inline PR annotations on the failing assertion line, restoring the`kishikawakatsumi/xcresulttool` used to provide before it broke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to declare explicit job-level permissions for clearer, safer runs.
  * Test-result upload step improved: uploader replaced with a more reliable tool and its placement refined for consistent test reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->