### PR TITLE
Speed up and instrument the OBAKitTests CI workflow

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -10,14 +10,26 @@ on:
 # https://github.com/actions/runner-images?tab=readme-ov-file
 # Installed versions of Xcode on macOS 15 are documented at:
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-  
+#
+# Performance note (figures observed 2026-06 — a dated snapshot, not an invariant;
+# they will drift as the suite, runner images, and Xcode change): the OBAKitTests
+# suite itself executes in ~5s locally / ~2-3 min in CI. Everything beyond that is
+# CI infrastructure, not the tests:
+#   - iOS Simulator runtime prep / first boot (can silently download a multi-GB
+#     runtime if the image lags the targeted Xcode point release)
+#   - build-for-testing (~5 min)
+#   - the test-results upload step (~9 min; see the gated upload step below)
+# The steps below make each of those visible and time-boxed so a slow run is
+# obvious rather than a mystery 20-minute gap. If you're investigating "slow
+# tests", check the step timings first — it is almost never the tests.
+
 jobs:
   build:
     runs-on: macos-15
     permissions:
       checks: write
       contents: read
-      
+
     steps:
     - uses: actions/checkout@v4
 
@@ -28,16 +40,23 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-spm-
 
+    # DerivedData cache. The key is intentionally narrow: it busts only when the
+    # resolved dependency graph, the XcodeGen project specs, or this workflow
+    # change. The previous `**/*.yml` glob also matched vendored yml under
+    # .build/checkouts and caused needless cache misses (→ full rebuilds).
     - uses: actions/cache@v4
       with:
         path: DerivedData
-        key: ${{ runner.os }}-deriveddata-${{ hashFiles('**/Package.resolved', '**/*.yml') }}
+        key: ${{ runner.os }}-deriveddata-${{ hashFiles('**/Package.resolved', 'project.yml', 'Apps/**/project.yml', '.github/workflows/obakittests.yml') }}
         restore-keys: |
           ${{ runner.os }}-deriveddata-
 
-    - name: Switch Xcode
-      # FIX: Updated from 26.0 to 26.2 because 26.0 was removed in the Jan 27 update
-      run: sudo xcode-select -switch /Applications/Xcode_26.2.app
+    # Pin Xcode deterministically so the set of bundled simulator runtimes is
+    # known, instead of relying on `xcode-select` against whatever the image ships.
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '26.2'
 
     - name: Install xcodegen
       env:
@@ -45,37 +64,94 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: brew install xcodegen
 
-    - name: Boot iOS Simulator
+    # Make iOS runtime acquisition explicit and time-boxed. If the runtime is
+    # already on the image this is a no-op (seconds). If it is NOT, xcodebuild
+    # would otherwise download it *silently* during the test step — appearing as
+    # a ~20 min hang with no log output. Surfacing it here means it is visible,
+    # attributable, and fails fast on a real stall.
+    - name: Download iOS platform (if needed)
+      timeout-minutes: 30
+      run: xcodebuild -downloadPlatform iOS
+
+    # Diagnostic preflight: logs whether the iOS runtime is actually installed.
+    # If `simctl runtime list` doesn't show the targeted iOS version as Ready,
+    # the slow runs are paying for a runtime download (see header note).
+    - name: Simulator diagnostics
       run: |
-        DEVICE_ID=$(xcrun simctl list devices available -j | python3 -c "import sys,json; devs=[d for dv in json.load(sys.stdin)['devices'].values() for d in dv if d['name']=='iPhone 16']; print(devs[0]['udid'])")
-        xcrun simctl boot "$DEVICE_ID" || true
+        echo "=== Installed simulator runtimes ==="
+        xcrun simctl runtime list || true
+        echo "=== Available SDKs ==="
+        xcodebuild -showsdks || true
+
+    # Pick an available iPhone simulator and capture its UDID. Using `id=` in the
+    # destination (rather than `name=iPhone 16`) avoids the "multiple matching
+    # destinations" ambiguity and guarantees we target a device on an installed
+    # runtime. Booting it here isolates first-boot cost from the test step.
+    - name: Prepare iOS Simulator
+      run: |
+        set -euo pipefail
+        UDID=$(xcrun simctl list devices available -j | python3 -c "import sys, json; devices = [d for runtime in json.load(sys.stdin)['devices'].values() for d in runtime if d['name'].startswith('iPhone')]; print(devices[0]['udid'])")
+        [ -n "$UDID" ] || { echo "::error::No available iPhone simulator found"; exit 1; }
+        echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
+        echo "Using simulator UDID: $UDID"
+        xcrun simctl boot "$UDID" || true
+        xcrun simctl bootstatus "$UDID" || true
 
     - name: Generate xcodeproj for OneBusAway
       run: scripts/generate_project OneBusAway
 
     # Build
     - name: Build OneBusAway
+      timeout-minutes: 20
       run: xcodebuild build-for-testing
         -scheme 'App'
-        -destination 'platform=iOS Simulator,name=iPhone 16'
+        -destination "platform=iOS Simulator,id=${SIMULATOR_UDID}"
         -derivedDataPath DerivedData
         -quiet
 
-    # Unit Test
+    # Unit Test. Output is teed to a log so the "Report slowest tests" step can
+    # surface per-test timing. `set -o pipefail` keeps xcodebuild's exit code
+    # through the pipe so a test failure still fails the step.
     - name: OBAKit Unit Test
-      run: xcodebuild test-without-building
-        -only-testing:OBAKitTests
-        -project 'OBAKit.xcodeproj'
-        -scheme 'App'
-        -destination 'platform=iOS Simulator,name=iPhone 16'
-        -derivedDataPath DerivedData
-        -enableCodeCoverage NO
-        -resultBundlePath OBAKitTests.xcresult
+      timeout-minutes: 15
+      run: |
+        set -o pipefail
+        xcodebuild test-without-building \
+          -only-testing:OBAKitTests \
+          -project 'OBAKit.xcodeproj' \
+          -scheme 'App' \
+          -destination "platform=iOS Simulator,id=${SIMULATOR_UDID}" \
+          -derivedDataPath DerivedData \
+          -enableCodeCoverage NO \
+          -resultBundlePath OBAKitTests.xcresult \
+          | tee xcodebuild-test.log
 
-    # Upload results
+    # Surface the slowest tests in the job summary so a regression in *test*
+    # time (vs. infra time) is easy to spot without re-running the investigation.
+    # Parses the classic XCTest "passed (N seconds)" log format; if the suite ever
+    # moves to swift-testing/xcbeautify output the list just comes up empty.
+    - name: Report slowest tests
+      if: success() || failure()
+      run: |
+        {
+          echo "### Slowest 20 tests"
+          echo '```'
+          grep -oE "'-\[OBAKitTests\.[^]]+\]' passed \([0-9.]+ seconds\)" xcodebuild-test.log \
+            | sed -E "s/'-\[OBAKitTests\.(.+)\]' passed \(([0-9.]+) seconds\)/\2  \1/" \
+            | sort -rn | head -20
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY" || true
+
+    # Upload results only when the run fails — parsing/uploading the xcresult
+    # bundle takes ~9 min and is wasted effort on green runs. Trade-off: this is
+    # the only consumer of the `checks: write` permission, so green runs no longer
+    # publish the per-test GitHub Checks summary; the "Report slowest tests" step
+    # writes a lighter summary to $GITHUB_STEP_SUMMARY instead. If test-retry flags
+    # are ever added, broaden this to `always()` so flaky-but-passing runs still
+    # surface which tests retried.
     - uses: slidoapp/xcresulttool@v3.1.1
       continue-on-error: true
-      if: success() || failure()
+      if: failure()
       with:
          path: OBAKitTests.xcresult
          show-passed-tests: false

--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -64,14 +64,24 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: brew install xcodegen
 
-    # Make iOS runtime acquisition explicit and time-boxed. If the runtime is
-    # already on the image this is a no-op (seconds). If it is NOT, xcodebuild
-    # would otherwise download it *silently* during the test step — appearing as
-    # a ~20 min hang with no log output. Surfacing it here means it is visible,
-    # attributable, and fails fast on a real stall.
+    # Make iOS runtime acquisition explicit and time-boxed. The macOS runner image
+    # ships several iOS simulator runtimes preinstalled, so this is normally a skip.
+    # Only download when none is present: `xcodebuild -downloadPlatform iOS` insists
+    # on fetching the *newest* runtime (e.g. 26.3.1) even when an older one Xcode can
+    # use is already installed — which wastes ~2-3 min and is flaky on CI ("Unable to
+    # connect to simulator", exit 70, which failed an earlier run here). If a download
+    # genuinely IS needed it stays visible and time-boxed rather than stalling
+    # silently inside the test step.
     - name: Download iOS platform (if needed)
       timeout-minutes: 30
-      run: xcodebuild -downloadPlatform iOS
+      run: |
+        if xcrun simctl runtime list 2>/dev/null | grep -qE "iOS [0-9].*\(Ready\)"; then
+          echo "An iOS simulator runtime is already installed; skipping download:"
+          xcrun simctl runtime list | grep -E "iOS [0-9]" || true
+        else
+          echo "No iOS simulator runtime found; downloading…"
+          xcodebuild -downloadPlatform iOS
+        fi
 
     # Diagnostic preflight: logs whether the iOS runtime is actually installed.
     # If `simctl runtime list` doesn't show the targeted iOS version as Ready,

--- a/OBAKitCore/Network/APIService/APIService+GetData.swift
+++ b/OBAKitCore/Network/APIService/APIService+GetData.swift
@@ -11,9 +11,13 @@ extension APIService {
     nonisolated func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let (data, response): (Data, URLResponse)
         do {
-            logger.info("Begin network request for \(request.description, privacy: .public)")
+            // Per-request begin/finish is high-volume trace detail (the unit-test
+            // suite alone fires ~1,600 mocked requests), so log it at `.debug` to
+            // keep it out of the default os_log / CI capture. Failures below stay
+            // at `.error`.
+            logger.debug("Begin network request for \(request.description, privacy: .public)")
             (data, response) = try await dataLoader.data(for: request)
-            logger.info("Finish network request for \(request.description, privacy: .public)")
+            logger.debug("Finish network request for \(request.description, privacy: .public)")
         } catch let error as NSError {
             logger.error("Failed network request for \(request.description, privacy: .public): \(error, privacy: .public)")
             if errorLooksLikeCaptivePortal(error) {

--- a/OBAKitTests/Controls/DataLoadFeedbackGeneratorTests.swift
+++ b/OBAKitTests/Controls/DataLoadFeedbackGeneratorTests.swift
@@ -29,10 +29,28 @@ class DataLoadFeedbackGeneratorTests: OBATestCase {
     }
     
     func test_init_withApplication() {
-        let config = AppConfig(appBundle: Bundle.main, userDefaults: userDefaults, analytics: nil)
+        // Inject a MockDataLoader instead of the `AppConfig(appBundle:userDefaults:analytics:)`
+        // convenience init, which defaults to `URLSession.shared`. `Application.init` calls
+        // `regionsService.updateRegionsList()`, so that init would hit the live regions server.
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: LocationManagerMock())
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: nil,
+            queue: OperationQueue(),
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader
+        )
         let application = Application(config: config)
         let generator = DataLoadFeedbackGenerator(application: application)
-        
+
         expect(generator).toNot(beNil())
     }
     


### PR DESCRIPTION
## Summary

The `OBAKitTests` workflow routinely ran **20–55 min** (one main run hit 55m). Investigation (local repro + parsing two real CI job logs) showed the **suite itself runs in ~5s locally / ~2–3 min in CI** — the wall-clock was almost entirely CI infrastructure:

- **Simulator runtime prep** — a silent dead gap between destination resolution and the app launching in the sim. In run `26969522096` this was **~19 min** (17:59:56 → 18:19:15) with zero log output; in another run only ~4 min. Classic on-demand iOS runtime download when the image lags the targeted Xcode point release. **Highly variable → the main cause of the run-to-run spread.**
- **`xcresulttool` upload** — a consistent **~9 min**, even on green runs.
- **`build-for-testing`** — ~5 min.

This PR attacks each and makes the rest visible/time-boxed so a slow run is obvious instead of a mystery gap.

### Workflow (`.github/workflows/obakittests.yml`)
- Pin Xcode via `maxim-lobanov/setup-xcode`; add an explicit, **time-boxed** `xcodebuild -downloadPlatform iOS` step so a runtime download is visible and isolated rather than a silent hang inside the test step.
- Add a simulator-diagnostics preflight (`simctl runtime list` / `-showsdks`).
- Select the simulator by **UDID (`id=`)** instead of `name=iPhone 16` (avoids the "multiple matching destinations" ambiguity; the old hardcoded name isn't a default device on the 26.2 image), and pre-boot it to isolate first-boot cost.
- **Gate the `slidoapp/xcresulttool` upload to `if: failure()`** — saves ~9 min on every green run.
- Add `timeout-minutes` to build (20) and test (15) so a hang fails fast.
- Surface the **slowest 20 tests** in the job summary so a future *test*-time regression (vs. infra time) is easy to spot.
- Narrow the over-broad DerivedData cache key (the old `**/*.yml` glob matched vendored yml under `.build/checkouts`).

### Test fix
- `DataLoadFeedbackGeneratorTests.test_init_withApplication` used `AppConfig(appBundle:userDefaults:analytics:)`, whose convenience init defaults `dataLoader: URLSession.shared`. `Application.init` fires `regionsService.updateRegionsList()`, so the test made a **live request to the production regions server**. It now injects a `MockDataLoader` with stubbed regions — fully offline. (Audited the whole suite: this was the only live-network test.)

## Test plan

- [x] Generated project, built, ran full suite locally: **904 tests, 0 failures in 4.8s**.
- [x] Verified `test_init_withApplication` passes and is offline (`MockDataLoader`, no `URLSession.shared`).
- [x] Exercised the new workflow shell logic locally: UDID picker, `simctl runtime list`, `-showsdks`, and the slowest-tests grep/sed/sort parser against a real test log.
- [x] Ran `xcodebuild` with the new `id=<UDID>` destination form — works.
- [x] `python -c yaml.safe_load` validates the workflow (13 steps).
- [ ] **CI itself** — can only be verified by this PR's own run. Watch whether the `Download iOS platform` step is a fast no-op (runtime preinstalled) or a long download (runtime missing); the diagnostics step's `simctl runtime list` answers that.

## Review notes (non-blocking decisions for the reviewer)

- **Green-run GitHub Checks annotations:** gating the upload to `if: failure()` means green runs no longer publish the per-test Checks summary (that step was the only consumer of the `checks: write` permission). The new "Report slowest tests" step writes a lighter summary to `$GITHUB_STEP_SUMMARY` instead. If you'd rather keep full green-run annotations, say so and I'll revisit the gate. Documented inline.
- **Future test retries:** if `-retry-tests-on-failure` is ever added, broaden the upload gate to `always()` so flaky-but-passing runs still report which tests retried (noted in a comment).
- **Follow-ups (not in this PR):** a shared `createTestApplication()` factory in `OBATestCase` would prevent the live-network footgun class from recurring; and `test_init_withApplication`'s `toNot(beNil())` assertion is tautological (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS CI for more deterministic test runs, caching accuracy, and safer Xcode/runtime setup.
  * Restrained artifact uploads to failures and added simulator/SDK diagnostics.

* **Tests**
  * Added timeouts, structured test logging, and job-summary reporting of slowest tests.
  * Improved test isolation to avoid external network calls during initialization.

* **Style**
  * Reduced noise from per-request network logs by lowering verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->