### PR TITLE
Current Trip View Model

### DIFF
--- a/OBAKit/Trip/CurrentTripViewController.swift
+++ b/OBAKit/Trip/CurrentTripViewController.swift
@@ -8,13 +8,13 @@
 //
 
 import UIKit
+import Combine
 import OBAKitCore
-import CoreLocation
 
 /// Finds and displays the user's current trip on a selected route.
 ///
 /// After the user picks a route in `RoutePickerViewController`, this controller:
-/// 1. Queries `NearbyTripMatcher` for nearby active vehicles on that route.
+/// 1. Asks `CurrentTripViewModel` to query nearby active vehicles on that route.
 /// 2. If one match → navigates directly to `TripViewController`.
 /// 3. If multiple → shows a disambiguation list.
 /// 4. If none → shows an appropriate error state.
@@ -25,24 +25,10 @@ class CurrentTripViewController: UIViewController,
 
     let application: Application
 
-    private let route: Route
+    private let viewModel: CurrentTripViewModel
     private let listView = OBAListView()
     private lazy var dataLoadFeedbackGenerator = DataLoadFeedbackGenerator(application: application)
-
-    /// Matching results found near the user.
-    private var matchResults = [NearbyTripMatcher.MatchResult]()
-
-    /// Current loading/error state.
-    private enum State {
-        case loading
-        case noLocation
-        case noResults
-        case noRealtime
-        case multipleResults
-        case error(Error)
-    }
-
-    private var state: State = .loading
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Timer
 
@@ -53,7 +39,7 @@ class CurrentTripViewController: UIViewController,
 
     init(application: Application, route: Route) {
         self.application = application
-        self.route = route
+        self.viewModel = CurrentTripViewModel(application: application, route: route)
         super.init(nibName: nil, bundle: nil)
 
         title = OBALoc(
@@ -67,7 +53,6 @@ class CurrentTripViewController: UIViewController,
 
     deinit {
         refreshTimer?.invalidate()
-        findVehicleTask?.cancel()
     }
 
     // MARK: - UIViewController Lifecycle
@@ -81,7 +66,8 @@ class CurrentTripViewController: UIViewController,
         view.addSubview(listView)
         listView.pinToSuperview(.edges)
 
-        findVehicle()
+        bindViewModel()
+        viewModel.findVehicle()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -101,6 +87,45 @@ class CurrentTripViewController: UIViewController,
 
     public var idleTimerFailsafe: Timer?
 
+    // MARK: - View Model Binding
+
+    private func bindViewModel() {
+        viewModel.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                self.listView.applyData()
+                switch state {
+                case .loading, .noLocation:
+                    break
+                case .noResults, .multipleResults:
+                    // Matcher returned (possibly empty) — treat as a successful fetch.
+                    self.dataLoadFeedbackGenerator.dataLoad(.success)
+                case .noRealtime, .error:
+                    self.dataLoadFeedbackGenerator.dataLoad(.failed)
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$pendingNavigation
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] arrival in
+                guard let self else { return }
+                guard let nav = self.navigationController else {
+                    self.viewModel.pendingNavigationUnavailable()
+                    return
+                }
+                self.dataLoadFeedbackGenerator.dataLoad(.success)
+                let tripController = TripViewController(application: self.application, arrivalDeparture: arrival)
+                var stack = nav.viewControllers
+                stack[stack.count - 1] = tripController
+                nav.setViewControllers(stack, animated: true)
+                self.viewModel.pendingNavigation = nil
+            }
+            .store(in: &cancellables)
+    }
+
     // MARK: - Refresh Timer
 
     private func startRefreshTimer() {
@@ -112,114 +137,15 @@ class CurrentTripViewController: UIViewController,
             guard let self else { return }
             // Skip refresh when VoiceOver is active to avoid disrupting screen reader users.
             guard !UIAccessibility.isVoiceOverRunning else { return }
-            self.findVehicle()
-        }
-    }
-
-    // MARK: - Vehicle Finding
-
-    private var findVehicleTask: Task<Void, Never>?
-
-    private func findVehicle() {
-        findVehicleTask?.cancel()
-
-        findVehicleTask = Task { [weak self] in
-            guard let self else { return }
-
-            guard let userLocation = self.application.locationService.currentLocation else {
-                await MainActor.run {
-                    self.state = .noLocation
-                    self.listView.applyData()
-                }
-                return
-            }
-
-            guard let apiService = self.application.apiService else {
-                let error = NSError(
-                    domain: "CurrentTripViewController",
-                    code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: OBALoc(
-                        "current_trip_controller.error_no_service",
-                        value: "Unable to connect to the transit service.",
-                        comment: "Error when the API service is unavailable."
-                    )]
-                )
-                await MainActor.run {
-                    self.state = .error(error)
-                    self.listView.applyData()
-                }
-                return
-            }
-
-            let cachedStops = self.application.mapRegionManager.stops
-
-            do {
-                let results = try await NearbyTripMatcher.findTrips(
-                    for: self.route,
-                    near: userLocation,
-                    using: apiService,
-                    stops: cachedStops
-                )
-
-                if Task.isCancelled { return }
-
-                await MainActor.run {
-                    self.handleMatchResults(results)
-                    self.dataLoadFeedbackGenerator.dataLoad(.success)
-                }
-            } catch is CancellationError {
-                return
-            } catch let error as NearbyTripMatcher.MatchError where error == .noRealtimeData {
-                await MainActor.run {
-                    self.state = .noRealtime
-                    self.listView.applyData()
-                    self.dataLoadFeedbackGenerator.dataLoad(.failed)
-                }
-            } catch {
-                Logger.error("Failed to find trips: \(error)")
-                await MainActor.run {
-                    self.state = .error(error)
-                    self.listView.applyData()
-                    self.dataLoadFeedbackGenerator.dataLoad(.failed)
-                }
-            }
-        }
-    }
-
-    private func handleMatchResults(_ results: [NearbyTripMatcher.MatchResult]) {
-        matchResults = results
-
-        switch results.count {
-        case 0:
-            state = .noResults
-            listView.applyData()
-
-        case 1:
-            // Single match — navigate directly to TripViewController.
-            let arrival = results[0].arrivalDeparture
-            let tripController = TripViewController(application: application, arrivalDeparture: arrival)
-            // Replace self in the navigation stack so back goes to the map, not this loading screen.
-            if var viewControllers = navigationController?.viewControllers {
-                viewControllers[viewControllers.count - 1] = tripController
-                navigationController?.setViewControllers(viewControllers, animated: true)
-            } else {
-                // Fallback: show as disambiguation list so the user can still tap through.
-                state = .multipleResults
-                listView.applyData()
-            }
-
-        default:
-            state = .multipleResults
-            listView.applyData()
+            self.viewModel.findVehicle()
         }
     }
 
     // MARK: - OBAListViewDataSource
 
     func items(for listView: OBAListView) -> [OBAListViewSection] {
-        switch state {
+        switch viewModel.state {
         case .loading, .noLocation, .noResults, .noRealtime, .error:
-            // Return empty — the empty state view is provided by emptyData(for:).
             return []
 
         case .multipleResults:
@@ -228,7 +154,7 @@ class CurrentTripViewController: UIViewController,
     }
 
     func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        switch state {
+        switch viewModel.state {
         case .loading:
             return .standard(.init(
                 alignment: .center,
@@ -272,7 +198,7 @@ class CurrentTripViewController: UIViewController,
     }
 
     private func multipleResultsSections() -> [OBAListViewSection] {
-        let rows: [AnyOBAListViewItem] = matchResults.map { result in
+        let rows: [AnyOBAListViewItem] = viewModel.matchResults.map { result in
             let arrival = result.arrivalDeparture
             let formattedDistance = application.formatters.distanceFormatter.string(fromDistance: result.distanceFromUser)
             let headsign = arrival.routeAndHeadsign
@@ -323,7 +249,7 @@ class CurrentTripViewController: UIViewController,
         largeContentImage: Icons.refresh,
         showsActivityIndicatorOnTap: true
     ) { [weak self] in
-        self?.findVehicle()
+        self?.viewModel.findVehicle()
     }
 
     // MARK: - Localized Strings

--- a/OBAKit/Trip/CurrentTripViewController.swift
+++ b/OBAKit/Trip/CurrentTripViewController.swift
@@ -30,11 +30,6 @@ class CurrentTripViewController: UIViewController,
     private lazy var dataLoadFeedbackGenerator = DataLoadFeedbackGenerator(application: application)
     private var cancellables = Set<AnyCancellable>()
 
-    // MARK: - Timer
-
-    private static let refreshInterval: TimeInterval = 20.0
-    private var refreshTimer: Timer?
-
     // MARK: - Init
 
     init(application: Application, route: Route) {
@@ -51,10 +46,6 @@ class CurrentTripViewController: UIViewController,
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    deinit {
-        refreshTimer?.invalidate()
-    }
-
     // MARK: - UIViewController Lifecycle
 
     override func viewDidLoad() {
@@ -66,21 +57,20 @@ class CurrentTripViewController: UIViewController,
         view.addSubview(listView)
         listView.pinToSuperview(.edges)
 
+        viewModel.shouldSkipProgrammaticRefresh = { UIAccessibility.isVoiceOverRunning }
         bindViewModel()
-        viewModel.findVehicle()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         disableIdleTimer()
-        startRefreshTimer()
+        viewModel.start()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         enableIdleTimer()
-        refreshTimer?.invalidate()
-        refreshTimer = nil
+        viewModel.deactivate()
     }
 
     // MARK: - Idle Timer
@@ -124,21 +114,6 @@ class CurrentTripViewController: UIViewController,
                 self.viewModel.pendingNavigation = nil
             }
             .store(in: &cancellables)
-    }
-
-    // MARK: - Refresh Timer
-
-    private func startRefreshTimer() {
-        refreshTimer?.invalidate()
-        refreshTimer = Timer.scheduledTimer(
-            withTimeInterval: Self.refreshInterval,
-            repeats: true
-        ) { [weak self] _ in
-            guard let self else { return }
-            // Skip refresh when VoiceOver is active to avoid disrupting screen reader users.
-            guard !UIAccessibility.isVoiceOverRunning else { return }
-            self.viewModel.findVehicle()
-        }
     }
 
     // MARK: - OBAListViewDataSource

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -22,11 +22,18 @@ class CurrentTripViewModel: ObservableObject {
 
     /// Loading / error / result state for the screen.
     enum State {
+        /// Initial state, and while a find is in flight.
         case loading
+        /// No user location is available — the location service returned `nil`.
         case noLocation
+        /// The matcher returned an empty array — no active vehicle is currently
+        /// on the selected route near the user.
         case noResults
+        /// The selected route has no real-time tracking data.
         case noRealtime
+        /// Two or more vehicles matched; the UI shows a disambiguation list.
         case multipleResults
+        /// A network or service error surfaced from the matcher.
         case error(Error)
     }
 
@@ -124,8 +131,8 @@ class CurrentTripViewModel: ObservableObject {
         }
     }
 
-    /// Applies a fresh set of matches. Internal so tests can drive the result branches
-    /// directly without staging a full `NearbyTripMatcher` round trip.
+    /// Routes a fresh set of matches into the appropriate state transition:
+    /// empty → `.noResults`, one → `pendingNavigation`, more → `.multipleResults`.
     func handle(results: [NearbyTripMatcher.MatchResult]) {
         matchResults = results
 
@@ -139,7 +146,8 @@ class CurrentTripViewModel: ObservableObject {
         }
     }
 
-    /// Maps a matcher error onto VM state. Internal so tests can drive both branches.
+    /// Maps a matcher error onto VM state. `MatchError.noRealtimeData` gets its own
+    /// `.noRealtime` state; everything else surfaces as `.error(error)`.
     func handle(error: Error) {
         if let matchError = error as? NearbyTripMatcher.MatchError, matchError == .noRealtimeData {
             state = .noRealtime
@@ -175,6 +183,8 @@ class CurrentTripViewModel: ObservableObject {
 
     // MARK: - Helpers
 
+    /// Builds the localized "transit service unavailable" error used when no
+    /// `apiService` is resolved (e.g. the user has no region selected).
     private static func noServiceError() -> NSError {
         NSError(
             domain: "CurrentTripViewModel",

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -1,0 +1,149 @@
+//
+//  CurrentTripViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Combine
+import CoreLocation
+import OBAKitCore
+
+/// Shared ViewModel for the "find my current trip on a selected route" screen.
+///
+/// Consumed by `CurrentTripViewController` (UIKit, via Combine `sink`) and by
+/// future SwiftUI consumers (via `@StateObject`).
+/// Contains no UIKit imports.
+@MainActor
+class CurrentTripViewModel: ObservableObject {
+
+    /// Loading / error / result state for the screen.
+    enum State {
+        case loading
+        case noLocation
+        case noResults
+        case noRealtime
+        case multipleResults
+        case error(Error)
+    }
+
+    // MARK: - Published State
+
+    @Published private(set) var state: State = .loading
+
+    /// Matches found near the user. Empty unless `state == .multipleResults` or a
+    /// single match has just produced a `pendingNavigation` event.
+    @Published private(set) var matchResults: [NearbyTripMatcher.MatchResult] = []
+
+    /// Set when exactly one match is found. UIKit consumers sink this and perform
+    /// the navigation push; SwiftUI consumers bind it to `.navigationDestination(item:)`.
+    /// Settable so consumers can clear it after acting (and so SwiftUI bindings can
+    /// drive it to `nil` on pop).
+    @Published var pendingNavigation: ArrivalDeparture?
+
+    // MARK: - Private
+
+    private let application: Application
+    private let route: Route
+    private var findVehicleTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(application: Application, route: Route) {
+        self.application = application
+        self.route = route
+    }
+
+    deinit {
+        findVehicleTask?.cancel()
+    }
+
+    // MARK: - Intent
+
+    /// Cancels any in-flight find, then starts a new search.
+    func findVehicle() {
+        findVehicleTask?.cancel()
+
+        findVehicleTask = Task { [weak self] in
+            guard let self else { return }
+
+            guard let userLocation = self.application.locationService.currentLocation else {
+                self.state = .noLocation
+                return
+            }
+
+            guard let apiService = self.application.apiService else {
+                self.state = .error(Self.noServiceError())
+                return
+            }
+
+            let cachedStops = self.application.mapRegionManager.stops
+
+            do {
+                let results = try await NearbyTripMatcher.findTrips(
+                    for: self.route,
+                    near: userLocation,
+                    using: apiService,
+                    stops: cachedStops
+                )
+                if Task.isCancelled { return }
+                self.handle(results: results)
+            } catch is CancellationError {
+                return
+            } catch {
+                self.handle(error: error)
+            }
+        }
+    }
+
+    /// Applies a fresh set of matches. Internal so tests can drive the result branches
+    /// directly without staging a full `NearbyTripMatcher` round trip.
+    func handle(results: [NearbyTripMatcher.MatchResult]) {
+        matchResults = results
+
+        switch results.count {
+        case 0:
+            state = .noResults
+        case 1:
+            pendingNavigation = results[0].arrivalDeparture
+        default:
+            state = .multipleResults
+        }
+    }
+
+    /// Maps a matcher error onto VM state. Internal so tests can drive both branches.
+    func handle(error: Error) {
+        if let matchError = error as? NearbyTripMatcher.MatchError, matchError == .noRealtimeData {
+            state = .noRealtime
+        } else {
+            Logger.error("Failed to find trips: \(error)")
+            state = .error(error)
+        }
+    }
+
+    /// Called by a UIKit consumer that cannot perform the single-match navigation
+    /// (e.g. the VC isn't embedded in a `UINavigationController`). Falls back to
+    /// the disambiguation list so the user can still act on the match. `matchResults`
+    /// already holds the single result from `handle(results:)`.
+    func pendingNavigationUnavailable() {
+        state = .multipleResults
+        pendingNavigation = nil
+    }
+
+    // MARK: - Helpers
+
+    private static func noServiceError() -> NSError {
+        NSError(
+            domain: "CurrentTripViewModel",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: OBALoc(
+                "current_trip_controller.error_no_service",
+                value: "Unable to connect to the transit service.",
+                comment: "Error when the API service is unavailable."
+            )]
+        )
+    }
+}

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -101,6 +101,9 @@ class CurrentTripViewModel: ObservableObject {
 
         findVehicleTask = Task { [weak self] in
             guard let self else { return }
+            // `deactivate()` cancels the task. Bail out before the synchronous early-return
+            // paths so a cancelled task can't still publish a final `.noLocation` / `.error`.
+            if Task.isCancelled { return }
 
             guard let userLocation = self.application.locationService.currentLocation else {
                 self.state = .noLocation

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -44,10 +44,18 @@ class CurrentTripViewModel: ObservableObject {
     /// drive it to `nil` on pop).
     @Published var pendingNavigation: ArrivalDeparture?
 
+    // MARK: - Configuration
+
+    /// Set by the UI layer to gate programmatic auto-refreshes.
+    /// e.g. `viewModel.shouldSkipProgrammaticRefresh = { UIAccessibility.isVoiceOverRunning }`
+    var shouldSkipProgrammaticRefresh: (() -> Bool)?
+
     // MARK: - Private
 
     private let application: Application
     private let route: Route
+    private static let refreshInterval: TimeInterval = 20.0
+    private var refreshTimer: Timer?
     private var findVehicleTask: Task<Void, Never>?
 
     // MARK: - Init
@@ -58,7 +66,24 @@ class CurrentTripViewModel: ObservableObject {
     }
 
     deinit {
+        refreshTimer?.invalidate()
         findVehicleTask?.cancel()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Call from `viewWillAppear`. Starts the refresh timer and kicks off an initial find.
+    func start() {
+        startRefreshTimer()
+        findVehicle()
+    }
+
+    /// Call from `viewWillDisappear`. Stops the timer and cancels any in-flight find.
+    func deactivate() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        findVehicleTask?.cancel()
+        findVehicleTask = nil
     }
 
     // MARK: - Intent
@@ -131,6 +156,21 @@ class CurrentTripViewModel: ObservableObject {
     func pendingNavigationUnavailable() {
         state = .multipleResults
         pendingNavigation = nil
+    }
+
+    // MARK: - Refresh Timer
+
+    private func startRefreshTimer() {
+        refreshTimer?.invalidate()
+        refreshTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.refreshInterval,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !(self.shouldSkipProgrammaticRefresh?() ?? false) else { return }
+                self.findVehicle()
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -243,6 +243,27 @@ class CurrentTripViewModelTests: OBATestCase {
         expect(viewModel.matchResults.count) == 1
     }
 
+    // MARK: - Lifecycle
+
+    /// `start()` must kick off `findVehicle()` — guards against a future refactor
+    /// accidentally turning it into a no-op (e.g. only starting the timer).
+    @MainActor
+    func test_start_invokesFindVehicle() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, withLocation: false)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.start()
+        for _ in 0..<5 { await Task.yield() }
+
+        guard case .noLocation = viewModel.state else {
+            XCTFail("Expected start() to kick findVehicle() into the no-location branch, got \(viewModel.state)")
+            return
+        }
+
+        viewModel.deactivate()
+    }
+
     // MARK: - findVehicle()
 
     @MainActor

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -1,0 +1,263 @@
+//
+//  CurrentTripViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+import CoreLocation
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_cast force_try
+
+/// Tests for `CurrentTripViewModel`.
+class CurrentTripViewModelTests: OBATestCase {
+    /// Near stop 1_10020 in the fixture (NE 55th & 37th Ave NE).
+    private let userLocation = CLLocation(latitude: 47.6685, longitude: -122.2883)
+
+    private var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Application Builder
+
+    /// Builds an `Application` whose REST API service routes through the supplied `MockDataLoader`.
+    /// When `withLocation` is false, the location service has no current location — useful for
+    /// driving the `.noLocation` branch.
+    private func createApplication(dataLoader: MockDataLoader, withLocation: Bool = true) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        let locationService: LocationService
+        if withLocation {
+            let locManager = MockAuthorizedLocationManager(
+                updateLocation: userLocation,
+                updateHeading: TestData.mockHeading
+            )
+            locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+            locationService.startUpdates()
+        } else {
+            // Plain mock — `startUpdatingLocation` flips a bool but never assigns a location,
+            // so `currentLocation` stays `nil`.
+            let locManager = LocationManagerMock()
+            locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        }
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return Application(config: config)
+    }
+
+    // MARK: - Fixtures
+
+    private let arrivalsFixture = "arrivals_and_departures_for_stop_1_10020.json"
+
+    private func stopsFromArrivalsFixture() -> [Stop] {
+        let response = try! Fixtures.loadRESTAPIPayload(type: StopArrivals.self, fileName: arrivalsFixture)
+        return [response.stop]
+    }
+
+    private func route30() -> Route {
+        let stops = stopsFromArrivalsFixture()
+        return stops.flatMap(\.routes).first { $0.id == "1_30" }!
+    }
+
+    private func makeMatchResult() -> NearbyTripMatcher.MatchResult {
+        let arrivals = try! Fixtures.loadRESTAPIPayload(type: StopArrivals.self, fileName: arrivalsFixture)
+        return NearbyTripMatcher.MatchResult(
+            arrivalDeparture: arrivals.arrivalsAndDepartures[0],
+            distanceFromUser: 50
+        )
+    }
+
+    // MARK: - Initial State
+
+    @MainActor
+    func test_initialState_isLoading() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        guard case .loading = viewModel.state else {
+            XCTFail("Expected initial state .loading, got \(viewModel.state)")
+            return
+        }
+        expect(viewModel.matchResults).to(beEmpty())
+        expect(viewModel.pendingNavigation).to(beNil())
+    }
+
+    // MARK: - handle(results:)
+
+    @MainActor
+    func test_handleResults_empty_setsNoResults() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.handle(results: [])
+
+        guard case .noResults = viewModel.state else {
+            XCTFail("Expected .noResults, got \(viewModel.state)")
+            return
+        }
+        expect(viewModel.matchResults).to(beEmpty())
+        expect(viewModel.pendingNavigation).to(beNil())
+    }
+
+    @MainActor
+    func test_handleResults_single_setsPendingNavigation() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let result = makeMatchResult()
+        viewModel.handle(results: [result])
+
+        expect(viewModel.pendingNavigation).toNot(beNil())
+        expect(viewModel.pendingNavigation?.tripID) == result.arrivalDeparture.tripID
+        expect(viewModel.matchResults.count) == 1
+        // State remains `.loading` — the consumer is expected to navigate away.
+        guard case .loading = viewModel.state else {
+            XCTFail("State should stay .loading for single match, got \(viewModel.state)")
+            return
+        }
+    }
+
+    @MainActor
+    func test_handleResults_multiple_setsMultipleResults() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let first = makeMatchResult()
+        let second = makeMatchResult()
+        viewModel.handle(results: [first, second])
+
+        guard case .multipleResults = viewModel.state else {
+            XCTFail("Expected .multipleResults, got \(viewModel.state)")
+            return
+        }
+        expect(viewModel.matchResults.count) == 2
+        expect(viewModel.pendingNavigation).to(beNil())
+    }
+
+    // MARK: - handle(error:)
+
+    @MainActor
+    func test_handleError_noRealtimeData_setsNoRealtime() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.handle(error: NearbyTripMatcher.MatchError.noRealtimeData)
+
+        guard case .noRealtime = viewModel.state else {
+            XCTFail("Expected .noRealtime, got \(viewModel.state)")
+            return
+        }
+    }
+
+    @MainActor
+    func test_handleError_genericError_setsErrorState() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let underlying = NSError(domain: "Test", code: 42, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        viewModel.handle(error: underlying)
+
+        guard case .error(let surfaced) = viewModel.state else {
+            XCTFail("Expected .error, got \(viewModel.state)")
+            return
+        }
+        expect((surfaced as NSError).code) == 42
+    }
+
+    /// `noStopsNearby` is a `MatchError` but not `noRealtimeData` — it must fall through
+    /// to the generic `.error` branch, not be silently mapped to `.noRealtime`.
+    @MainActor
+    func test_handleError_noStopsNearby_fallsThroughToError() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.handle(error: NearbyTripMatcher.MatchError.noStopsNearby)
+
+        guard case .error = viewModel.state else {
+            XCTFail("Expected .error for .noStopsNearby, got \(viewModel.state)")
+            return
+        }
+    }
+
+    // MARK: - pendingNavigationUnavailable()
+
+    /// When the UIKit consumer cannot perform single-match navigation (no embedded
+    /// `UINavigationController`), the VM falls back to the disambiguation list so
+    /// the user can still tap through. `matchResults` is preserved from `handle(results:)`.
+    @MainActor
+    func test_pendingNavigationUnavailable_fallsBackToMultipleResults() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let result = makeMatchResult()
+        viewModel.handle(results: [result])
+        expect(viewModel.pendingNavigation).toNot(beNil())
+        expect(viewModel.matchResults.count) == 1
+
+        viewModel.pendingNavigationUnavailable()
+
+        guard case .multipleResults = viewModel.state else {
+            XCTFail("Expected .multipleResults, got \(viewModel.state)")
+            return
+        }
+        expect(viewModel.pendingNavigation).to(beNil())
+        // The single match must still be available so the user can tap through.
+        expect(viewModel.matchResults.count) == 1
+    }
+
+    // MARK: - findVehicle()
+
+    @MainActor
+    func test_findVehicle_noLocation_setsNoLocationState() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, withLocation: false)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.findVehicle()
+        for _ in 0..<5 { await Task.yield() }
+
+        guard case .noLocation = viewModel.state else {
+            XCTFail("Expected .noLocation, got \(viewModel.state)")
+            return
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Moves state ownership for the **"My Trip"** screen out of the view controller and into a new `@MainActor ObservableObject` under `OBAKit/ViewModels/`.

The view model now owns:

- `State` enum
- `matchResults`
- `findVehicle()` task
- Settable `pendingNavigation: ArrivalDeparture?` output
- Refresh and idle timers

The view controller retains UIKit-specific responsibilities:
- `OBAListView` management
- Navigation push behavior
- A small Combine binding layer

---

## What Changed

### New: `OBAKit/ViewModels/CurrentTripViewModel.swift`

The new view model owns:

- `State`
- `matchResults`
- `pendingNavigation`
- `findVehicle()`

Additional internal seams were introduced to improve testability:

- `handle(results:)`
- `handle(error:)`
- `pendingNavigationUnavailable()`

These allow tests to cover every state transition without requiring the full matcher round-trip.

### Refactored: `OBAKit/Trip/CurrentTripViewController.swift`
- `$state` sink now drives:
  - `listView.applyData()`
  - Haptic feedback
- `$pendingNavigation` sink now:
  - Performs the navigation stack swap
  - Falls back through `pendingNavigationUnavailable()` when no navigation controller is available

### New Tests: `OBAKitTests/ViewModels/CurrentTripViewModelTests.swift`

Added **10 tests** covering:

- Initial state
- All `handle(results:)` result-count branches
- Both `handle(error:)` branches
- `noStopsNearby` fall-through
- No-location flow
- Missing navigation controller fallback

---

## SwiftUI Readiness

`pendingNavigation` is implemented as:

```swift
@Published var pendingNavigation: ArrivalDeparture?
```

This matches the shape expected by:

- `.navigationDestination(item:)`
- `.sheet(item:)`

A future SwiftUI consumer can bind directly to this property without requiring any view model changes.

---

## Behavior Preserved

- `noResults` continues to trigger a **success** haptic, since an empty match array represents a successful fetch.
- **Failed** haptics remain reserved for thrown errors.
- The single-match navigation-controller fallback introduced in `51a917db` is preserved through the new `pendingNavigationUnavailable()` intent.
- `MatchError.noRealtimeData` continues to map to `.noRealtime`.
- All other errors continue to map to `.error(error)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the current trip-finding experience with improved state transitions and clearer error feedback across scenarios including no location, no results, no real-time data, and multiple matches.
  * Added periodic refresh capability for trip availability monitoring.

* **Tests**
  * Added comprehensive test coverage for trip-finding state transitions and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->