### PR TITLE
Fix region-wide alerts never showing as modal bulletins

### DIFF
--- a/OBAKit/Alerts/AgencyAlertBulletin.swift
+++ b/OBAKit/Alerts/AgencyAlertBulletin.swift
@@ -50,10 +50,6 @@ class AgencyAlertBulletin: NSObject {
     }
 
     func show(in application: UIApplication) {
-        guard !bulletinManager.isShowingBulletin else {
-            return
-        }
-
-        bulletinManager.showBulletin(in: application)
+        bulletinManager.show(in: application)
     }
 }

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -23,3 +23,21 @@ class ThemedBulletinPage: BLTNPageItem {
         appearance.imageViewTintColor = ThemeColors.shared.brand
     }
 }
+
+extension BLTNItemManager {
+    /// Presents the bulletin above the topmost view controller of the application's key window.
+    ///
+    /// Use this instead of `showBulletin(in:)`: that method presents inside a `UIWindow`
+    /// it creates without a `windowScene`, and iOS never displays such a window in a
+    /// scene-based app, so the bulletin silently fails to appear.
+    func show(in application: UIApplication) {
+        guard
+            !isShowingBulletin,
+            let topViewController = application.keyWindowFromScene?.topViewController
+        else {
+            return
+        }
+
+        showBulletin(above: topViewController)
+    }
+}

--- a/OBAKit/Errors/ErrorBulletin.swift
+++ b/OBAKit/Errors/ErrorBulletin.swift
@@ -81,10 +81,6 @@ class ErrorBulletin: NSObject {
     }
 
     func show(in app: UIApplication) {
-        guard !bulletinManager.isShowingBulletin else {
-            return
-        }
-
-        bulletinManager.showBulletin(in: app)
+        bulletinManager.show(in: app)
     }
 }

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -337,6 +337,15 @@ public class Application: CoreApplication, PushServiceDelegate {
     private var alertBulletin: AgencyAlertBulletin?
 
     public func agencyAlertsUpdated() {
+        #if DEBUG
+        // UI tests run against the live network, so a real high-severity alert can
+        // pop a modal bulletin over the UI mid-test. Tests that aren't about the
+        // bulletin set this to keep their runs deterministic.
+        if ProcessInfo.processInfo.environment["TEST_SUPPRESS_ALERT_BULLETINS"] == "1" {
+            return
+        }
+        #endif
+
         guard
             let alert = alertsStore.recentUnreadHighSeverityAlerts.first,
             let app = self.delegate?.uiApplication
@@ -395,6 +404,15 @@ public class Application: CoreApplication, PushServiceDelegate {
         }
 
         configureConnectivity()
+
+        #if DEBUG
+        // Lets UI tests exercise the modal alert bulletin deterministically,
+        // without depending on a high-severity alert being live in the region.
+        if ProcessInfo.processInfo.environment["TEST_INJECT_REGION_WIDE_ALERT"] == "1" {
+            alertsStore.seedRegionWideAlertForTesting()
+        }
+        #endif
+
         alertsStore.checkForUpdates()
 
         if presentDonationUIOnActive, let topViewController {

--- a/OBAKit/Reachability/Reachability.swift
+++ b/OBAKit/Reachability/Reachability.swift
@@ -82,7 +82,7 @@ class ReachabilityBulletin: NSObject {
 
         dismiss()
 
-        bulletinManager.showBulletin(in: application)
+        bulletinManager.show(in: application)
     }
 
     func dismiss() {

--- a/OBAKit/Regions/RegionMismatchBulletin.swift
+++ b/OBAKit/Regions/RegionMismatchBulletin.swift
@@ -56,9 +56,6 @@ class RegionMismatchBulletin: NSObject {
     }
 
     func show(in app: UIApplication) {
-        guard !bulletinManager.isShowingBulletin else {
-            return
-        }
-        bulletinManager.showBulletin(in: app)
+        bulletinManager.show(in: app)
     }
 }

--- a/OBAKitCore/Models/AgencyAlertsStore.swift
+++ b/OBAKitCore/Models/AgencyAlertsStore.swift
@@ -105,6 +105,15 @@ public class AgencyAlertsStore: NSObject, RegionsServiceDelegate {
 
     /// Convenience wrapper for ``update()``. Errors are reported via ``AgencyAlertsDelegate``.
     public func checkForUpdates() {
+        #if DEBUG
+        // Once a UI test has injected a synthetic alert (`seedRegionWideAlertForTesting()`),
+        // skip live fetches entirely so the seeded alert is the only bulletin the
+        // test can encounter.
+        guard !suppressLiveFetchesForTesting else {
+            return
+        }
+        #endif
+
         Task {
             do {
                 try await update()
@@ -203,6 +212,63 @@ public class AgencyAlertsStore: NSObject, RegionsServiceDelegate {
             }
         }
     }
+
+    #if DEBUG
+    /// Set once a synthetic alert has been seeded, so ``checkForUpdates()`` stops
+    /// issuing live network fetches that could surface a competing bulletin.
+    private var suppressLiveFetchesForTesting = false
+
+    /// Seeds a synthetic, unread, high-severity region-wide alert and notifies delegates,
+    /// exactly as a live alerts fetch would. Lets UI tests exercise the modal
+    /// `AgencyAlertBulletin` presentation without depending on live alert data.
+    /// The entity ID is unique per call so the read-state persisted in UserDefaults
+    /// by earlier runs never suppresses the bulletin.
+    public func seedRegionWideAlertForTesting() {
+        suppressLiveFetchesForTesting = true
+
+        var period = TransitRealtime_TimeRange()
+        period.start = UInt64(Date().timeIntervalSince1970)
+
+        var entitySelector = TransitRealtime_EntitySelector()
+        entitySelector.agencyID = ""
+
+        var title = TransitRealtime_TranslatedString.Translation()
+        title.text = "Test Region-Wide Alert"
+        title.language = "en"
+
+        var body = TransitRealtime_TranslatedString.Translation()
+        body.text = "This synthetic alert exists to test bulletin presentation."
+        body.language = "en"
+
+        var transitAlert = TransitRealtime_Alert()
+        transitAlert.severityLevel = .warning
+        transitAlert.activePeriod = [period]
+        transitAlert.informedEntity = [entitySelector]
+        transitAlert.headerText.translation = [title]
+        transitAlert.descriptionText.translation = [body]
+
+        var feedEntity = TransitRealtime_FeedEntity()
+        feedEntity.id = "ui-test-region-wide-alert-\(UUID().uuidString)"
+        feedEntity.alert = transitAlert
+
+        let agencyAlert: AgencyAlert
+        do {
+            agencyAlert = try AgencyAlert(feedEntity: feedEntity, agency: nil)
+        } catch {
+            // This entity is constructed right here to satisfy AgencyAlert's invariants,
+            // so a failure means the model changed out from under the test hook. Fail
+            // loudly rather than letting the UI test time out waiting for a bulletin
+            // that was never seeded.
+            assertionFailure("seedRegionWideAlertForTesting failed to construct an AgencyAlert: \(error)")
+            return
+        }
+
+        stateLock.withLock {
+            _ = alerts.insert(agencyAlert)
+        }
+        notifyDelegatesAlertsUpdated()
+    }
+    #endif
 
     /// Deletes all local data. Useful in preparation for changing the region.
     private func deleteAgencyAlerts() {

--- a/OBAKitCore/Models/REST/AgencyAlert.swift
+++ b/OBAKitCore/Models/REST/AgencyAlert.swift
@@ -34,7 +34,11 @@ public class AgencyAlert: NSObject, Identifiable {
         return nil
     }
 
+    /// The agency this alert applies to, or `nil` for a region-wide alert.
     public let agency: AgencyWithCoverage?
+
+    /// `true` when this alert applies to the whole region rather than a single agency.
+    public var isRegionWide: Bool { agency == nil }
 
     // MARK: - Localized Content Accessors
 
@@ -86,20 +90,26 @@ public class AgencyAlert: NSObject, Identifiable {
             throw AlertError.invalidAlert
         }
 
-        guard let selectedAgency = agencies.filter({ $0.agencyID == gtfsAgency.agencyID }).first else {
+        let selectedAgency = agencies.first { $0.agencyID == gtfsAgency.agencyID }
+
+        // Obaco marks region-wide alerts — ones that apply to every agency in the
+        // region rather than to one in particular — with an empty agency ID.
+        guard selectedAgency != nil || gtfsAgency.agencyID.isEmpty else {
             throw AlertError.unknownAgency
         }
 
         try self.init(feedEntity: feedEntity, agency: selectedAgency)
     }
 
-    public init(feedEntity: TransitRealtime_FeedEntity, agency: AgencyWithCoverage) throws {
+    public init(feedEntity: TransitRealtime_FeedEntity, agency: AgencyWithCoverage?) throws {
         guard
             feedEntity.hasAlert,
             AgencyAlert.isAgencyWideAlert(alert: feedEntity.alert),
             let gtfsAgency = AgencyAlert.findAgencyInList(list: feedEntity.alert.informedEntity),
             gtfsAgency.hasAgencyID,
-            gtfsAgency.agencyID == agency.agencyID
+            // A region-wide alert (no agency) must carry the empty agency ID Obaco
+            // uses to mark it; an agency-specific alert's ID must match its agency.
+            agency == nil ? gtfsAgency.agencyID.isEmpty : gtfsAgency.agencyID == agency?.agencyID
         else {
             throw AlertError.invalidAlert
         }

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -176,7 +176,12 @@ public actor ObacoAPIService: @preconcurrency APIService {
         }
 
         return qualifiedEntities.compactMap { (entity: TransitRealtime_FeedEntity) -> AgencyAlert? in
-            return try? AgencyAlert(feedEntity: entity, agencies: agencies)
+            do {
+                return try AgencyAlert(feedEntity: entity, agencies: agencies)
+            } catch {
+                logger.error("Dropped alert \(entity.id, privacy: .public) from regional alerts feed: \(error, privacy: .public)")
+                return nil
+            }
         }
     }
 }

--- a/OBAKitCore/Network/RESTAPIService/RESTAPIService+GetAgencyAlerts.swift
+++ b/OBAKitCore/Network/RESTAPIService/RESTAPIService+GetAgencyAlerts.swift
@@ -31,9 +31,13 @@ extension RESTAPIService {
             let message = try TransitRealtime_FeedMessage(serializedBytes: data)
             return message.entity
                 .filter(isQualifiedAlert)
-                .compactMap {
-                    // TODO: Don't swallow error
-                    try? AgencyAlert(feedEntity: $0, agencies: [agency])
+                .compactMap { entity in
+                    do {
+                        return try AgencyAlert(feedEntity: entity, agencies: [agency])
+                    } catch {
+                        logger.error("Dropped alert \(entity.id, privacy: .public) from \(agency.agency.name, privacy: .public) feed: \(error, privacy: .public)")
+                        return nil
+                    }
                 }
         } catch {
             logger.error("getAlerts() failed for \(agency.agency.name, privacy: .public): \(error, privacy: .public)")

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/RegionWideAgencyAlertTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/RegionWideAgencyAlertTests.swift
@@ -1,0 +1,226 @@
+//
+//  RegionWideAgencyAlertTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Regression coverage for region-wide agency alerts.
+///
+/// Obaco (sidecar.onebusaway.org) marks alerts that apply to the whole region —
+/// rather than to one specific agency — with an *empty* `agency_id` in the GTFS-RT
+/// `informed_entity`. `AgencyAlert` used to reject those alerts with
+/// `AlertError.unknownAgency` because no agency in the region has an empty ID, and
+/// `ObacoAPIService.getAlerts` silently dropped them via `try?`. The result was that
+/// high-severity region-wide alerts never reached `AgencyAlertsStore`, so the modal
+/// `AgencyAlertBulletin` never appeared.
+class RegionWideAgencyAlertTests: OBATestCase {
+    var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    private let enUSLocale = Locale(identifier: "en_US")
+
+    // MARK: - Helpers
+
+    private func loadAgencies() throws -> [AgencyWithCoverage] {
+        try Fixtures.loadRESTAPIPayload(type: [AgencyWithCoverage].self, fileName: "agencies_with_coverage.json")
+    }
+
+    private func translatedString(_ text: String) -> TransitRealtime_TranslatedString {
+        var translation = TransitRealtime_TranslatedString.Translation()
+        translation.text = text
+        translation.language = "en"
+
+        var translated = TransitRealtime_TranslatedString()
+        translated.translation = [translation]
+        return translated
+    }
+
+    /// Builds a feed entity mirroring the live Obaco regional alerts payload:
+    /// a WARNING-severity alert whose `informed_entity` carries an empty `agency_id`.
+    private func makeRegionWideFeedEntity(startDate: Date = Date()) -> TransitRealtime_FeedEntity {
+        var period = TransitRealtime_TimeRange()
+        period.start = UInt64(startDate.timeIntervalSince1970)
+        period.end = UInt64(startDate.timeIntervalSince1970 + 28_800)
+
+        var entitySelector = TransitRealtime_EntitySelector()
+        entitySelector.agencyID = ""
+
+        var alert = TransitRealtime_Alert()
+        alert.severityLevel = .warning
+        alert.activePeriod = [period]
+        alert.informedEntity = [entitySelector]
+        alert.headerText = translatedString("Get Ready for World Cup")
+        alert.descriptionText = translatedString("Transit agencies are preparing for record ridership.")
+        alert.url = translatedString("https://www.example.com/worldcup")
+
+        var feedEntity = TransitRealtime_FeedEntity()
+        feedEntity.id = "Alert_1"
+        feedEntity.alert = alert
+        return feedEntity
+    }
+
+    private func makeFeedData(entities: [TransitRealtime_FeedEntity]) throws -> Data {
+        var message = TransitRealtime_FeedMessage()
+        message.header.gtfsRealtimeVersion = "1.0"
+        message.entity = entities
+        return try message.serializedData()
+    }
+
+    // MARK: - Model Parsing
+
+    func test_emptyAgencyID_parsesAsRegionWideAlert() throws {
+        let agencies = try loadAgencies()
+        let feedEntity = makeRegionWideFeedEntity()
+
+        let alert = try AgencyAlert(feedEntity: feedEntity, agencies: agencies)
+
+        XCTAssertNil(alert.agency, "A region-wide alert is not affiliated with any single agency")
+        XCTAssertEqual(alert.agencyID, "")
+        XCTAssertTrue(alert.isHighSeverity)
+        XCTAssertEqual(alert.title(forLocale: enUSLocale), "Get Ready for World Cup")
+        XCTAssertEqual(alert.url(forLocale: enUSLocale)?.absoluteString, "https://www.example.com/worldcup")
+    }
+
+    func test_unknownNonEmptyAgencyID_stillThrows() throws {
+        let agencies = try loadAgencies()
+
+        var feedEntity = makeRegionWideFeedEntity()
+        var entitySelector = TransitRealtime_EntitySelector()
+        entitySelector.agencyID = "not-a-real-agency"
+        feedEntity.alert.informedEntity = [entitySelector]
+
+        XCTAssertThrowsError(try AgencyAlert(feedEntity: feedEntity, agencies: agencies)) { error in
+            XCTAssertEqual(error as? AgencyAlert.AlertError, .unknownAgency)
+        }
+    }
+
+    func test_missingAgencyID_throwsInvalidAlert() throws {
+        let agencies = try loadAgencies()
+
+        // An `informed_entity` whose `agency_id` was never set (presence bit false),
+        // as distinct from one explicitly set to the empty string. This is not a
+        // region-wide alert; it's malformed and must be rejected.
+        var feedEntity = makeRegionWideFeedEntity()
+        feedEntity.alert.informedEntity = [TransitRealtime_EntitySelector()]
+
+        XCTAssertThrowsError(try AgencyAlert(feedEntity: feedEntity, agencies: agencies)) { error in
+            XCTAssertEqual(error as? AgencyAlert.AlertError, .invalidAlert)
+        }
+    }
+
+    // MARK: - Obaco Service
+
+    func test_obacoGetAlerts_includesRegionWideAlerts() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader) // swiftlint:disable:this force_cast
+        let feedData = try makeFeedData(entities: [makeRegionWideFeedEntity()])
+        dataLoader.mock(data: feedData) { request in
+            request.url!.absoluteString.contains("alerts.pb")
+        }
+
+        let agencies = try loadAgencies()
+        let alerts = try await obacoService.getAlerts(agencies: agencies)
+
+        XCTAssertEqual(alerts.count, 1, "The region-wide alert must not be dropped during parsing")
+
+        let alert = try XCTUnwrap(alerts.first)
+        XCTAssertNil(alert.agency)
+        XCTAssertTrue(alert.isHighSeverity)
+        XCTAssertEqual(alert.title(forLocale: enUSLocale), "Get Ready for World Cup")
+    }
+
+    func test_obacoGetAlerts_oneBadEntityDoesNotDropTheRest() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader) // swiftlint:disable:this force_cast
+
+        // A feed carrying one valid region-wide alert and one malformed entity (an
+        // unknown, non-empty agency ID). The bad entity must be dropped without
+        // taking the valid alert down with it — the resilience the per-entity
+        // `do/catch` in `getAlerts` exists to provide.
+        var badEntity = makeRegionWideFeedEntity()
+        badEntity.id = "Alert_Bad"
+        var badSelector = TransitRealtime_EntitySelector()
+        badSelector.agencyID = "not-a-real-agency"
+        badEntity.alert.informedEntity = [badSelector]
+
+        let feedData = try makeFeedData(entities: [makeRegionWideFeedEntity(), badEntity])
+        dataLoader.mock(data: feedData) { request in
+            request.url!.absoluteString.contains("alerts.pb")
+        }
+
+        let agencies = try loadAgencies()
+        let alerts = try await obacoService.getAlerts(agencies: agencies)
+
+        XCTAssertEqual(alerts.count, 1, "The valid alert must survive even when a sibling entity fails to parse")
+        XCTAssertEqual(try XCTUnwrap(alerts.first).title(forLocale: enUSLocale), "Get Ready for World Cup")
+    }
+
+    // MARK: - Bulletin Presentation Pipeline
+
+    /// Drives the real pipeline used at app launch — `AgencyAlertsStore.update()` through
+    /// the API services — and asserts that a fresh region-wide WARNING alert lands in
+    /// `recentUnreadHighSeverityAlerts`, the exact predicate `Application.agencyAlertsUpdated()`
+    /// uses to decide whether to present the modal `AgencyAlertBulletin`.
+    @MainActor
+    func test_regionWideAlert_isSurfacedForBulletinPresentation() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let feedData = try makeFeedData(entities: [makeRegionWideFeedEntity()])
+        dataLoader.mock(data: feedData) { request in
+            let url = request.url!.absoluteString
+            return url.contains("/api/gtfs_realtime/alerts-for-agency") || url.contains("alerts.pb")
+        }
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+        let app = Application(config: config)
+        let store = app.alertsStore
+
+        try await store.update()
+
+        let alert = try XCTUnwrap(
+            store.recentUnreadHighSeverityAlerts.first,
+            "A fresh region-wide WARNING alert must qualify for bulletin presentation"
+        )
+        XCTAssertNil(alert.agency)
+
+        let bulletin = AgencyAlertBulletin(agencyAlert: alert, locale: enUSLocale)
+        XCTAssertNotNil(bulletin, "The bulletin must be constructible from a region-wide alert")
+    }
+}

--- a/OBAKitUITests/MainFlowUITests.swift
+++ b/OBAKitUITests/MainFlowUITests.swift
@@ -28,6 +28,11 @@ final class MainFlowUITests: XCTestCase {
             "-OBACurrentRegionIdentifierUserDefaultsKey", "<integer>1</integer>"
         ]
 
+        // These tests run against the live network: a real high-severity alert in
+        // the region would otherwise pop a modal bulletin over the UI mid-test.
+        // The bulletin itself is covered by test_regionWideAlertBulletin_appears_andIsDismissible.
+        app.launchEnvironment["TEST_SUPPRESS_ALERT_BULLETINS"] = "1"
+
         // The map requests location authorization on first appearance; dismiss the
         // system alert so it can't block tab interactions.
         addUIInterruptionMonitor(withDescription: "Location permission") { alert in
@@ -66,6 +71,59 @@ final class MainFlowUITests: XCTestCase {
             // center-screen tap could hit a row and navigate away.
             tab.tap()
             XCTAssertTrue(tabBar.exists, "App should still be running after opening '\(tabName)'")
+        }
+    }
+
+    /// Regression test: a high-severity region-wide alert must surface as a modal
+    /// bulletin above all other content. Region-wide alerts (empty GTFS-RT `agency_id`,
+    /// as served by sidecar.onebusaway.org) used to be silently dropped during parsing,
+    /// so the bulletin never appeared.
+    func test_regionWideAlertBulletin_appears_andIsDismissible() throws {
+        // Relaunch with the bulletin suppression removed and a synthetic
+        // region-wide alert injected (DEBUG-only hook), so this test does not
+        // depend on a real alert being live in the region.
+        app.launchEnvironment.removeValue(forKey: "TEST_SUPPRESS_ALERT_BULLETINS")
+        app.launchEnvironment["TEST_INJECT_REGION_WIDE_ALERT"] = "1"
+        app.launch()
+
+        // The alert is seeded in `applicationDidBecomeActive`, which the system
+        // withholds while a permission dialog is up. Clear the notification and
+        // location prompts first so the scene can become active and seed the alert.
+        dismissSystemPermissionDialogs()
+
+        let title = app.staticTexts["Test Region-Wide Alert"]
+        XCTAssertTrue(
+            title.waitForExistence(timeout: 30),
+            "The region-wide alert bulletin should appear above the main UI")
+
+        let dismissButton = app.buttons["Dismiss"]
+        XCTAssertTrue(dismissButton.waitForExistence(timeout: 5))
+        dismissButton.tap()
+
+        XCTAssertTrue(
+            title.waitForNonExistence(timeout: 10),
+            "The bulletin should disappear after tapping Dismiss")
+        XCTAssertTrue(app.tabBars.firstMatch.exists, "Main UI should still be present after dismissal")
+    }
+
+    /// Dismisses the notification and location permission dialogs that the OS presents
+    /// on first launch. These are SpringBoard alerts, so they're tapped through the
+    /// SpringBoard proxy rather than `app` — and directly, rather than via an
+    /// interruption monitor, since a withheld scene never delivers the interaction
+    /// an interruption monitor depends on.
+    private func dismissSystemPermissionDialogs() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let buttonLabels = ["Allow", "Allow Once", "Allow While Using App", "Allow While Using the App", "OK", "Don't Allow"]
+
+        // Two passes: one for the notification prompt, one for the location prompt.
+        for _ in 0..<2 {
+            guard let button = buttonLabels
+                .map({ springboard.buttons[$0] })
+                .first(where: { $0.waitForExistence(timeout: 5) })
+            else {
+                break
+            }
+            button.tap()
         }
     }
 


### PR DESCRIPTION
## Summary

Region-wide transit alerts — high-severity alerts that apply to the whole region rather than a single agency, served by `sidecar.onebusaway.org` with an **empty** GTFS-RT `agency_id` — were being fetched successfully but never appeared as the modal BulletinBoard alert they're meant to trigger. There were two independent root causes:

- **Parsing silently dropped them.** `AgencyAlert`'s initializer rejected any alert whose `informed_entity` `agency_id` didn't match a known agency. An empty `agency_id` matches nothing, so every region-wide alert threw `AlertError.unknownAgency` and was swallowed by `try?` in both the REST and Obaco fetch paths. An empty `agency_id` is now a first-class **region-wide** alert (`agency == nil`, new `isRegionWide`); a *non-empty* unknown `agency_id` still throws. Both parse sites now **log** dropped entities instead of swallowing them, resolving a pre-existing `// TODO: Don't swallow error`.
- **The bulletin window was never displayed.** BulletinBoard's `showBulletin(in:)` creates a `UIWindow` with no `windowScene`, which iOS does not display in a scene-based app — so even when an alert *was* present, nothing showed. A new `BLTNItemManager.show(in:)` extension presents above the key window's top view controller, and all four bulletin call sites (agency alert, error, reachability, region mismatch) now route through it.

## Test plan

- [x] Unit: region-wide (empty `agency_id`) parses with `agency == nil`; non-empty unknown agency still throws `.unknownAgency`; missing `agency_id` (presence bit unset) throws `.invalidAlert`.
- [x] Unit: `ObacoAPIService.getAlerts` includes region-wide alerts, and one malformed entity in a feed doesn't drop the valid siblings (guards the new per-entity `do/catch`).
- [x] Unit: full `AgencyAlertsStore.update()` pipeline surfaces a region-wide alert into `recentUnreadHighSeverityAlerts` (the exact predicate the app uses to present the bulletin).
- [x] UI: `test_regionWideAlertBulletin_appears_andIsDismissible` drives launch -> bulletin appears above the main UI -> Dismiss -> bulletin gone, via a DEBUG-only alert-injection hook (mirrors the existing `TEST_SHOW_ALL_TIPS` pattern).
- [x] Full `OBAKitTests` unit suite green; `MainFlowUITests` green in isolation (the two pre-existing live-network tests are flaky only under simulator contention, not from this change).
- [x] SwiftLint clean on changed files.

## Notes for the reviewer

- **Base is `release-ready`, not `main`**, because this work builds on the `OBAKitUITests` target added earlier on that branch. It's a focused diff of just the alert fix.
- **DEBUG test scaffolding** (`seedRegionWideAlertForTesting`, `TEST_INJECT_REGION_WIDE_ALERT`, `TEST_SUPPRESS_ALERT_BULLETINS`, `suppressLiveFetchesForTesting`) is all `#if DEBUG`-gated and follows the existing `TEST_SHOW_ALL_TIPS` convention.
- **Non-blocking judgment call from review:** the two `getAlerts` parse sites use a catch-all `catch` (log + drop one entity) rather than `catch let error as AgencyAlert.AlertError`. Catch-all keeps the two paths consistent (the REST one is non-throwing) and the initializer's only throw surface today is `AlertError`. Happy to narrow it to a typed catch if you'd prefer unexpected errors to propagate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for region-wide alerts that apply to the entire transit system, not just specific agencies.

* **Improvements**
  * Enhanced alert bulletin presentation for improved reliability and consistency.
  * Strengthened error handling and logging when processing alerts to prevent silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->