### PR TITLE
Add NSHealthUpdateUsageDescription to fix App Store upload rejection

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -51,6 +51,7 @@ targets:
           - comgooglemaps
         NSLocationWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
         NSHealthShareUsageDescription: OneBusAway uses your walking speed from the Health app to give you more accurate arrival time estimates.
+        NSHealthUpdateUsageDescription: OneBusAway uses your walking speed from the Health app to give you more accurate arrival time estimates.
         NSLocationTemporaryUsageDescriptionDictionary:
           MapStatusView: See where you are in relation to transit, and help you navigate more easily.
         UILaunchStoryboardName: LaunchScreen


### PR DESCRIPTION
## Summary

App Store Connect rejects uploads with error 90683 (Missing purpose string in Info.plist) because the `App.app` bundle is missing `NSHealthUpdateUsageDescription`.

The walking speed feature links the HealthKit framework, and Apple's static analysis requires **both** Health purpose strings to be present when HealthKit is linked — `NSHealthShareUsageDescription` (read) **and** `NSHealthUpdateUsageDescription` (write) — even though OneBusAway only reads walking speed data.

## Changes

- Add `NSHealthUpdateUsageDescription` to `Apps/Shared/app_shared.yml`, next to the existing `NSHealthShareUsageDescription`. Because every app's `project.yml` inherits from this shared config, the key applies to all app targets with no per-app edits.

## Testing

Run `scripts/generate_project` to regenerate the Xcode project; the new key lands in the built Info.plist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS app privacy settings to include proper permissions declaration for health data updates, ensuring transparency with users and compliance with App Store requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->