### PR TITLE
Fix survey appearance bugs (stop/route targeting + deferral) and add appearance tests

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -6,7 +6,7 @@ name: OBAKit
 
 settings:
   base:
-    MARKETING_VERSION: 26.2.0
+    MARKETING_VERSION: 26.2.1
 
 options:
   minimumXcodeGenVersion: 2.42

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -646,7 +646,7 @@ public class StopViewController: UIViewController,
         if survey.isExternalSurvey {
             let launcher = SurveyLauncherListItem(
                 survey: survey,
-                title: OBALoc("survey_launcher.title", value: "Help improve transit", comment: "Title of the survey launcher card on the stop screen."),
+                title: survey.heroQuestion?.content.labelText ?? OBALoc("survey_launcher.title", value: "Help improve transit", comment: "Title of the survey launcher card on the stop screen."),
                 onTakeSurvey: { [weak self] in self?.handleOpenExternalSurvey(survey: survey) },
                 onDismiss: { [weak self] in self?.handleSurveyDismiss(survey: survey) }
             )

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -646,7 +646,7 @@ public class StopViewController: UIViewController,
         if survey.isExternalSurvey {
             let launcher = SurveyLauncherListItem(
                 survey: survey,
-                title: survey.heroQuestion?.content.labelText ?? OBALoc("survey_launcher.title", value: "Help improve transit", comment: "Title of the survey launcher card on the stop screen."),
+                title: survey.heroQuestionTitle ?? OBALoc("survey_launcher.title", value: "Help improve transit", comment: "Title of the survey launcher card on the stop screen."),
                 onTakeSurvey: { [weak self] in self?.handleOpenExternalSurvey(survey: survey) },
                 onDismiss: { [weak self] in self?.handleSurveyDismiss(survey: survey) }
             )

--- a/OBAKitCore/Models/REST/Surveys/StudyResponse.swift
+++ b/OBAKitCore/Models/REST/Surveys/StudyResponse.swift
@@ -132,6 +132,18 @@ extension Survey {
         return questions.first { $0.position == 1 }
     }
 
+    /// The hero question's display text, trimmed of surrounding whitespace, or
+    /// `nil` when there is no hero question or its text is blank. Callers supply
+    /// their own (localized) fallback — e.g. a survey launcher title — since the
+    /// model layer has no access to UI localization.
+    public var heroQuestionTitle: String? {
+        guard let title = heroQuestion?.content.labelText.trimmingCharacters(in: .whitespacesAndNewlines),
+              !title.isEmpty else {
+            return nil
+        }
+        return title
+    }
+
     /// Returns all questions except the hero question
     public var remainingQuestions: [SurveyQuestion] {
         guard let hero = heroQuestion else { return questions }

--- a/OBAKitCore/Models/REST/Surveys/StudyResponse.swift
+++ b/OBAKitCore/Models/REST/Surveys/StudyResponse.swift
@@ -148,17 +148,19 @@ extension Survey {
 
     /// Returns true if the survey should be shown on the specified stop.
     /// Checks `showOnStops` and `isActive` before matching the stop list.
+    /// A `nil` or empty `visibleStopsList` means "no stop restriction" (all stops).
     public func shouldShowOnStop(_ stopID: String) -> Bool {
         guard showOnStops, isActive else { return false }
-        guard let visibleStops = visibleStopsList else { return true }
+        guard let visibleStops = visibleStopsList, !visibleStops.isEmpty else { return true }
         return visibleStops.contains(stopID)
     }
 
     /// Returns true if the survey should be shown for the specified route.
     /// Checks `showOnStops` and `isActive` before matching the route list.
+    /// A `nil` or empty `visibleRoutesList` means "no route restriction" (all routes).
     public func shouldShowOnRoute(_ routeID: String) -> Bool {
         guard showOnStops, isActive else { return false }
-        guard let visibleRoutes = visibleRoutesList else { return true }
+        guard let visibleRoutes = visibleRoutesList, !visibleRoutes.isEmpty else { return true }
         return visibleRoutes.contains(routeID)
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -208,7 +208,14 @@ public protocol UserDataStore: NSObjectProtocol {
     /// - Parameter userIdentifier: The user's UUID
     func markSurveyForLater(surveyId: Int, userIdentifier: String)
 
-    /// Checks if a survey should be shown again based on app launch count
+    /// Checks whether a survey has been deferred via "show later".
+    /// - Parameter surveyId: The ID of the survey to check
+    /// - Parameter userIdentifier: The user's UUID
+    /// - Returns: True if the survey is currently marked for later.
+    func isSurveyMarkedForLater(surveyId: Int, userIdentifier: String) -> Bool
+
+    /// Checks if a deferred ("show later") survey is due to be shown again,
+    /// based on the number of app launches since it was deferred.
     /// - Parameter surveyId: The ID of the survey to check
     /// - Parameter userIdentifier: The user's UUID
     /// - Returns: True if the survey should be shown again
@@ -298,26 +305,24 @@ public protocol UserDataStore: NSObjectProtocol {
 public struct CompletedSurvey: Codable, Hashable {
     public let surveyId: Int
     public let userIdentifier: String
-    public let completedAt: Date
 
-    public init(surveyId: Int, userIdentifier: String, completedAt: Date = Date()) {
+    public init(surveyId: Int, userIdentifier: String) {
         self.surveyId = surveyId
         self.userIdentifier = userIdentifier
-        self.completedAt = completedAt
     }
 }
 
-/// Represents a survey marked for later viewing
+/// Represents a survey marked for later viewing. `appLaunchCountWhenMarked`
+/// records the launch count at deferral so the survey can be re-shown a fixed
+/// number of launches later (see `shouldShowSurveyLater`).
 public struct SurveyForLater: Codable, Hashable {
     public let surveyId: Int
     public let userIdentifier: String
-    public let markedAt: Date
     public let appLaunchCountWhenMarked: Int
 
-    public init(surveyId: Int, userIdentifier: String, markedAt: Date = Date(), appLaunchCountWhenMarked: Int) {
+    public init(surveyId: Int, userIdentifier: String, appLaunchCountWhenMarked: Int) {
         self.surveyId = surveyId
         self.userIdentifier = userIdentifier
-        self.markedAt = markedAt
         self.appLaunchCountWhenMarked = appLaunchCountWhenMarked
     }
 }
@@ -819,6 +824,10 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         surveysForLater.append(surveyForLater)
 
         self.surveysForLater = surveysForLater
+    }
+
+    public func isSurveyMarkedForLater(surveyId: Int, userIdentifier: String) -> Bool {
+        return surveysForLater.contains { $0.surveyId == surveyId && $0.userIdentifier == userIdentifier }
     }
 
     public func shouldShowSurveyLater(surveyId: Int, userIdentifier: String) -> Bool {

--- a/OBAKitCore/Surveys/Service/SurveyService.swift
+++ b/OBAKitCore/Surveys/Service/SurveyService.swift
@@ -312,16 +312,29 @@ public final class SurveyService: ObservableObject {
     }
 
     private func checkStopVisibility(survey: Survey, stopID: String?, routeIDs: [String]) -> Bool {
-        guard survey.showOnStops else { return false }
+        guard survey.showOnStops, survey.isActive else { return false }
         guard let stopID = stopID else { return true }
 
-        if survey.shouldShowOnStop(stopID) {
+        let hasStopTargeting = !(survey.visibleStopsList?.isEmpty ?? true)
+        let hasRouteTargeting = !(survey.visibleRoutesList?.isEmpty ?? true)
+
+        // No stop or route targeting at all → show on every (active) stop.
+        if !hasStopTargeting && !hasRouteTargeting {
             return true
         }
 
-        return routeIDs.contains { routeID in
-            survey.shouldShowOnRoute(routeID)
+        // Each present dimension contributes to an OR; an absent (nil/empty)
+        // dimension contributes nothing rather than matching everything, so a
+        // stop-scoped survey doesn't leak onto unlisted stops via nil routes.
+        if hasStopTargeting, survey.shouldShowOnStop(stopID) {
+            return true
         }
+
+        if hasRouteTargeting {
+            return routeIDs.contains { survey.shouldShowOnRoute($0) }
+        }
+
+        return false
     }
 
     private func applySurveyPriorityLogic(survey: Survey, userID: String, index: Int) -> SurveyPriorityResult {
@@ -334,13 +347,15 @@ public final class SurveyService: ObservableObject {
                 return isSurveyCompleted ? .continue : .returnImmediately(survey)
             }
         } else {
-            if !isSurveyCompleted {
-                return .setOneTime(index)
-            } else if userDataStore.shouldShowSurveyLater(surveyId: survey.id, userIdentifier: userID) {
-                return .setOneTime(index)
-            } else {
-                return .continue
+            // A survey deferred via "show later" stays hidden until it is due to
+            // reappear (regardless of completion state); this is self-contained
+            // and does not rely on the global reminder gate. Otherwise show it
+            // unless it has already been completed.
+            if userDataStore.isSurveyMarkedForLater(surveyId: survey.id, userIdentifier: userID) {
+                return userDataStore.shouldShowSurveyLater(surveyId: survey.id, userIdentifier: userID)
+                    ? .setOneTime(index) : .continue
             }
+            return isSurveyCompleted ? .continue : .setOneTime(index)
         }
     }
 }

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceAppearanceTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceAppearanceTests.swift
@@ -1,0 +1,376 @@
+//
+//  SurveyServiceAppearanceTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKitCore
+
+@MainActor
+final class SurveyServiceAppearanceTests: OBATestCase {
+
+    nonisolated(unsafe) private var testUserDefaults: UserDefaults!
+    nonisolated(unsafe) private var store: UserDefaultsStore!
+
+    override func setUp() {
+        super.setUp()
+        testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).appearance")
+        testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).appearance")
+        store = UserDefaultsStore(userDefaults: testUserDefaults)
+    }
+
+    override func tearDown() {
+        testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).appearance")
+        super.tearDown()
+    }
+
+    // MARK: - visibleSurveys filtering (date activity) ----------------------
+
+    func test_fetch_mixedActiveAndExpired_visibleSurveysExcludesExpired() async {
+        let service = await fetchService([
+            makeSurvey(id: 1),                                   // active
+            makeSurvey(id: 2, startDate: hoursAgo(2), endDate: hoursAgo(1)), // expired
+            makeSurvey(id: 3, startDate: hoursFromNow(1), endDate: hoursFromNow(2)) // future
+        ])
+
+        expect(service.allSurveys.count).to(equal(3))
+        expect(service.visibleSurveys.map(\.id)).to(equal([1]))
+    }
+
+    func test_fetch_allInactive_visibleEmpty_andFindReturnsNil() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, startDate: hoursAgo(2), endDate: hoursAgo(1)),
+            makeSurvey(id: 2, showOnStops: true, startDate: hoursFromNow(1), endDate: hoursFromNow(2))
+        ])
+
+        expect(service.allSurveys.count).to(equal(2))
+        expect(service.visibleSurveys).to(beEmpty())
+        expect(service.findSurveyForMap()).to(beNil())
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"])).to(beNil())
+    }
+
+    func test_fetch_surveyWithOpenEndedDates_isActive() async {
+        // nil start + nil end => always within range.
+        let service = await fetchService([makeSurvey(id: 1, startDate: nil, endDate: nil)])
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+    }
+
+    // MARK: - Stop targeting matrix ----------------------------------------
+
+    func test_findSurveyForStop_nilStopList_nilRouteList_showsAtAnyStop() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: nil, routesList: nil)
+        ])
+        expect(service.findSurveyForStop(stopID: "ANY_STOP", routeIDs: []).map(\.id)).to(equal(1))
+    }
+
+    func test_findSurveyForStop_stopInList_shows() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A", "STOP_B"])
+        ])
+        expect(service.findSurveyForStop(stopID: "STOP_B", routeIDs: []).map(\.id)).to(equal(1))
+    }
+
+    func test_findSurveyForStop_stopNotInList_routeMatches_shows() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: ["R9"])
+        ])
+        // The stop is not listed, but one of its routes is.
+        expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: ["R9"]).map(\.id)).to(equal(1))
+    }
+
+    func test_findSurveyForStop_stopNotInList_routeNotInList_returnsNil() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: ["R9"])
+        ])
+        expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: ["R1"])).to(beNil())
+    }
+
+    func test_findSurveyForStop_showOnStopsFalse_returnsNil() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnMap: true, showOnStops: false)
+        ])
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"])).to(beNil())
+    }
+
+    // An empty stop/route list means "no restriction" — identical to nil — so a
+    // stops-enabled survey with both lists empty appears on every stop,
+    // regardless of the stop's routes.
+    func test_findSurveyForStop_emptyStopAndRouteLists_showsAtAnyStop() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: [], routesList: [])
+        ])
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"]).map(\.id)).to(equal(1))
+        expect(service.findSurveyForStop(stopID: "STOP_OTHER", routeIDs: []).map(\.id)).to(equal(1))
+    }
+
+    // A survey scoped to a specific stop list with no route targeting (nil/empty
+    // route list) must NOT leak onto stops outside its list. A nil/empty route
+    // list means "no route-based targeting" — it contributes nothing — not
+    // "every route".
+    func test_findSurveyForStop_stopScoped_nilRouteList_doesNotLeakToUnlistedStop() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: nil)
+        ])
+        // Listed stop: shows.
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"]).map(\.id)).to(equal(1))
+        // Unlisted stop must not match, regardless of the stop's routes.
+        expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: ["R1"])).to(beNil())
+        expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: [])).to(beNil())
+    }
+
+    func test_findSurveyForStop_routeScoped_nilStopList_showsOnlyOnServedStops() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnStops: true, stopList: nil, routesList: ["R9"])
+        ])
+        // Any stop served by R9 shows it...
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R9"]).map(\.id)).to(equal(1))
+        expect(service.findSurveyForStop(stopID: "STOP_B", routeIDs: ["R9", "R1"]).map(\.id)).to(equal(1))
+        // ...stops not served by R9 do not.
+        expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"])).to(beNil())
+    }
+
+    // MARK: - Map targeting -------------------------------------------------
+
+    func test_findSurveyForMap_showOnMapFalse_returnsNil() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnMap: false, showOnStops: true)
+        ])
+        expect(service.findSurveyForMap()).to(beNil())
+    }
+
+    func test_findSurveyForMap_skipsStopOnlySurvey_returnsMapSurvey() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, showOnMap: false, showOnStops: true),
+            makeSurvey(id: 2, showOnMap: true, showOnStops: false)
+        ])
+        expect(service.findSurveyForMap()?.id).to(equal(2))
+    }
+
+    // MARK: - Empty-question gating ----------------------------------------
+
+    func test_findSurvey_skipsSurveyWithNoQuestions_returnsNextValidSurvey() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, questions: []),                  // no questions -> skipped
+            makeSurvey(id: 2, questions: makeQuestions())      // valid
+        ])
+        expect(service.findSurveyForMap()?.id).to(equal(2))
+    }
+
+    func test_findSurvey_onlySurveyHasNoQuestions_returnsNil() async {
+        let service = await fetchService([makeSurvey(id: 1, questions: [])])
+        expect(service.findSurveyForMap()).to(beNil())
+    }
+
+    // MARK: - Priority ordering --------------------------------------------
+
+    // Always-visible single-response surveys are documented as the highest
+    // priority and are returned immediately — even when an incomplete one-time
+    // survey appears earlier in the list. This pins that ordering contract.
+    func test_priority_alwaysVisibleSingle_beatsEarlierOneTime() async {
+        let service = await fetchService([
+            makeSurvey(id: 1),                          // one-time, incomplete (earlier)
+            makeSurvey(id: 2, alwaysVisible: true)      // always-visible single (later)
+        ])
+        expect(service.findSurveyForMap()?.id).to(equal(2))
+    }
+
+    func test_priority_completedAlwaysVisibleSingle_fallsThroughToOneTime() async {
+        let userID = store.surveyUserIdentifier
+        store.markSurveyCompleted(surveyId: 2, userIdentifier: userID)
+
+        let service = await fetchService([
+            makeSurvey(id: 1),                          // one-time, incomplete
+            makeSurvey(id: 2, alwaysVisible: true)      // always-visible single, completed
+        ])
+        // The always-visible single is exhausted, so the one-time wins.
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+    }
+
+    func test_priority_oneTimeIncomplete_beatsAlwaysVisibleMulti() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, multipleResponses: true, alwaysVisible: true), // lowest priority
+            makeSurvey(id: 2)                                                 // one-time incomplete
+        ])
+        expect(service.findSurveyForMap()?.id).to(equal(2))
+    }
+
+    // MARK: - Completion / dismissal ---------------------------------------
+
+    func test_dismissSurvey_hidesOneTimeSurvey() async {
+        let service = await fetchService([makeSurvey(id: 1)])
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+
+        service.dismissSurvey(service.allSurveys[0])
+        expect(service.findSurveyForMap()).to(beNil())
+    }
+
+    func test_markCompleted_hidesOneTime_butMultiResponseStillShows() async {
+        let service = await fetchService([
+            makeSurvey(id: 1, multipleResponses: true, alwaysVisible: true)
+        ])
+        service.markSurveyCompleted(service.allSurveys[0])
+        // Multiple-response always-visible surveys re-appear after completion.
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+    }
+
+    // `markSurveyForLater` is self-contained: it defers the survey at the
+    // `findSurvey` level (no dependency on the global reminder gate). The
+    // deferred survey is hidden until it is due to reappear.
+    func test_markSurveyForLater_hidesSurveyUntilDue() async {
+        let service = await fetchService([makeSurvey(id: 1)])
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+
+        service.markSurveyForLater(service.allSurveys[0])
+        expect(service.findSurveyForMap()).to(beNil())
+
+        // Still deferred on the next launch...
+        store.incrementAppLaunchCount()
+        expect(service.findSurveyForMap()).to(beNil())
+    }
+
+    func test_markSurveyForLater_reappearsAfterThreeLaunches() async {
+        let service = await fetchService([makeSurvey(id: 1)])
+        service.markSurveyForLater(service.allSurveys[0])
+        expect(service.findSurveyForMap()).to(beNil())
+
+        store.incrementAppLaunchCount()
+        store.incrementAppLaunchCount()
+        store.incrementAppLaunchCount()
+        expect(service.findSurveyForMap()?.id).to(equal(1))
+    }
+
+    // MARK: - Fetch state ---------------------------------------------------
+
+    func test_fetchSurveys_successAfterFailure_clearsLastError() async {
+        let userID = store.surveyUserIdentifier
+        let mockLoader = MockDataLoader(testName: name)
+
+        // First fetch fails.
+        let url = URL(string: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=\(userID)")!
+        let failResponse = MockDataResponse(
+            data: Data(),
+            urlResponse: mockLoader.buildURLResponse(URL: url, statusCode: 500),
+            error: nil
+        ) { $0.url?.host == url.host && $0.url?.path == url.path }
+        mockLoader.mock(response: failResponse)
+
+        let service = SurveyService(apiService: buildREST(mockLoader), userDataStore: store)
+        await service.fetchSurveys()
+        expect(service.lastError).toNot(beNil())
+
+        // Then a forced fetch succeeds and the error is cleared.
+        mockLoader.removeMappedResponses()
+        mockLoader.mock(URLString: url.absoluteString, with: encode([makeSurvey(id: 1)]))
+        await service.fetchSurveys(force: true)
+
+        expect(service.lastError).to(beNil())
+        expect(service.allSurveys.map(\.id)).to(equal([1]))
+        expect(service.isLoading).to(beFalse())
+    }
+
+    // SUSPECTED INEFFICIENCY: an empty (but successful) response leaves
+    // `allSurveys` empty, which makes the staleness cooldown a no-op — every
+    // subsequent `fetchSurveys()` hits the network again. Pinned as behavior:
+    // a non-forced re-fetch after an empty response *does* run and can pick up
+    // newly-published surveys immediately (no 5-minute wait).
+    func test_fetchSurveys_emptyResponse_doesNotEngageCooldown_characterization() async {
+        let userID = store.surveyUserIdentifier
+        let mockLoader = MockDataLoader(testName: name)
+        let urlString = "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=\(userID)"
+
+        mockLoader.mock(URLString: urlString, with: encode([]))
+        let service = SurveyService(apiService: buildREST(mockLoader), userDataStore: store)
+        await service.fetchSurveys()
+        expect(service.allSurveys).to(beEmpty())
+
+        // Without force, a second fetch still runs because allSurveys is empty.
+        mockLoader.removeMappedResponses()
+        mockLoader.mock(URLString: urlString, with: encode([makeSurvey(id: 1)]))
+        await service.fetchSurveys()
+
+        expect(service.allSurveys.map(\.id)).to(equal([1]))
+    }
+
+    // MARK: - Helpers -------------------------------------------------------
+
+    private func hoursAgo(_ h: Double) -> Date { Date().addingTimeInterval(-3600 * h) }
+    private func hoursFromNow(_ h: Double) -> Date { Date().addingTimeInterval(3600 * h) }
+
+    private func buildREST(_ loader: MockDataLoader) -> RESTAPIService {
+        let config = APIServiceConfiguration(
+            baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion,
+            regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL
+        )
+        return RESTAPIService(config, dataLoader: loader)
+    }
+
+    private func encode(_ surveys: [Survey]) -> Data {
+        let response = StudyResponse(surveys: surveys, region: SurveyRegion(id: 1, name: "Test"))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try! encoder.encode(response) // swiftlint:disable:this force_try
+    }
+
+    /// Builds a `SurveyService`, mocks the surveys endpoint with `surveys`,
+    /// fetches, and returns the populated service.
+    private func fetchService(_ surveys: [Survey]) async -> SurveyService {
+        let mockLoader = MockDataLoader(testName: name)
+        let userID = store.surveyUserIdentifier
+        mockLoader.mock(
+            URLString: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=\(userID)",
+            with: encode(surveys)
+        )
+        let service = SurveyService(apiService: buildREST(mockLoader), userDataStore: store)
+        await service.fetchSurveys()
+        return service
+    }
+
+    // Defaults are concrete (active) dates rather than `nil`, so callers can
+    // pass an explicit `nil` to mean "open-ended" without it being overwritten.
+    private func makeSurvey(
+        id: Int = 1,
+        showOnMap: Bool = true,
+        showOnStops: Bool = true,
+        startDate: Date? = Date().addingTimeInterval(-3600),
+        endDate: Date? = Date().addingTimeInterval(3600),
+        stopList: [String]? = nil,
+        routesList: [String]? = nil,
+        multipleResponses: Bool = false,
+        alwaysVisible: Bool = false,
+        questions: [SurveyQuestion]? = nil
+    ) -> Survey {
+        Survey(
+            id: id,
+            name: "Survey \(id)",
+            createdAt: Date(),
+            updatedAt: Date(),
+            showOnMap: showOnMap,
+            showOnStops: showOnStops,
+            startDate: startDate,
+            endDate: endDate,
+            visibleStopsList: stopList,
+            visibleRoutesList: routesList,
+            allowsMultipleResponses: multipleResponses,
+            alwaysVisible: alwaysVisible,
+            study: Study(id: 1, name: "Study", description: nil),
+            questions: questions ?? makeQuestions()
+        )
+    }
+
+    private func makeQuestions(count: Int = 2) -> [SurveyQuestion] {
+        (0..<count).map { index in
+            SurveyQuestion(
+                id: index + 1,
+                position: index + 1,
+                required: false,
+                content: QuestionContent(labelText: "Q\(index + 1)", type: .text)
+            )
+        }
+    }
+}

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceTests.swift
@@ -541,6 +541,43 @@ final class SurveyServiceTests: OBATestCase {
         expect(survey.remainingQuestions.map(\.id)).to(equal([20, 30]))
     }
 
+    // MARK: - heroQuestionTitle
+
+    func test_heroQuestionTitle_returnsTrimmedHeroText() {
+        let survey = makeSurveyWithHero(labelText: "  Help us improve transit  ")
+        expect(survey.heroQuestionTitle).to(equal("Help us improve transit"))
+    }
+
+    func test_heroQuestionTitle_nilWhenHeroTextIsEmpty() {
+        let survey = makeSurveyWithHero(labelText: "")
+        expect(survey.heroQuestionTitle).to(beNil())
+    }
+
+    func test_heroQuestionTitle_nilWhenHeroTextIsWhitespaceOnly() {
+        let survey = makeSurveyWithHero(labelText: "   \n\t ")
+        expect(survey.heroQuestionTitle).to(beNil())
+    }
+
+    func test_heroQuestionTitle_nilWhenNoHeroQuestion() {
+        // Only a non-hero (position != 1) question exists.
+        let survey = makeSurveyWithHero(labelText: "Question", position: 2)
+        expect(survey.heroQuestionTitle).to(beNil())
+    }
+
+    private func makeSurveyWithHero(labelText: String, position: Int = 1) -> Survey {
+        Survey(
+            id: 1, name: "Test", createdAt: Date(), updatedAt: Date(),
+            showOnMap: true, showOnStops: true, startDate: nil, endDate: nil,
+            visibleStopsList: nil, visibleRoutesList: nil,
+            allowsMultipleResponses: false, alwaysVisible: false,
+            study: Study(id: 1, name: "S", description: nil),
+            questions: [
+                SurveyQuestion(id: 1, position: position, required: false,
+                               content: QuestionContent(labelText: labelText, type: .text))
+            ]
+        )
+    }
+
     private func makeResponseFailureMock(_ data: Data, url: URL, statusCode: Int, error: Error? = nil) {
         let urlResponse = mockDataLoader.buildURLResponse(URL: url, statusCode: statusCode)
         let response = MockDataResponse(data: data, urlResponse: urlResponse, error: error) { request in


### PR DESCRIPTION
## Summary

Audited `SurveyService`'s "should this survey appear?" logic from a bug-hunting lens and fixed three subtle defects that affected when surveys show, each landed test-first (TDD).

## Survey fixes (`e051b1ff`)

1. **Empty targeting lists hid surveys.** An empty `visible_stop_list` / `visible_route_list` (`[]`) matched *nothing*, so a stops-enabled survey configured with empty lists never appeared on any stop. Empty now means "no restriction," identical to `nil` → shows on all stops.
2. **Stop-scoped surveys leaked onto unlisted stops.** A survey scoped to `["STOP_A"]` with a `nil` route list showed at *any* stop carrying a route, because a nil route list was treated as "every route." Targeting now ORs only the dimensions that are actually present, so an absent dimension contributes nothing.
3. **`markSurveyForLater` wasn't self-contained.** A deferred one-time survey was still returned by `findSurvey` (it wasn't marked completed), and was only hidden because callers separately set a global 3-day reminder. `findSurvey` now honors per-survey deferral directly — a "remind me later" survey is hidden until it's due to reappear (`isSurveyMarkedForLater` + `shouldShowSurveyLater`). This also makes the previously-dead launch-count reappearance logic live.

**Cleanup:** removed the never-read `CompletedSurvey.completedAt` and `SurveyForLater.markedAt` fields (backward-compatible — Codable ignores the now-unknown persisted keys).

**Left intact:** the global `nextSurveyReminderDate` anti-pester throttle — it's a real product feature distinct from per-survey deferral.

## Also included

- `390c8c5b` — use the survey hero question's text as the external-survey launcher title on the stop screen.
- `450bf3e7` — bump marketing version to 26.2.1.

## Tests

New `SurveyServiceAppearanceTests` (24 tests) covering the full appearance matrix: date activity, stop/route targeting (incl. empty-list and no-leak cases), map targeting, empty-question gating, priority ordering, completion/dismissal, and per-survey deferral (hidden-until-due + reappears-after-three-launches).

Full survey suite green: **132 tests, 0 failures** on iPhone 17 Pro.

## Test plan

- [x] `xcodebuild test` for all survey test classes — 132/0
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Survey launcher cards now display custom titles when available instead of generic text.

* **Bug Fixes**
  * Improved survey visibility logic for targeted stop and route surveys.
  * Enhanced tracking of surveys marked to appear later.

* **Tests**
  * Added comprehensive test suite for survey appearance and behavior validation.

* **Chores**
  * Version bumped to 26.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->