### PR TITLE
Restore persistent location authorization in onboarding

### DIFF
--- a/OBAKit/Onboarding/RegionPicker/RegionPickerLocationAuthorizationView.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionPickerLocationAuthorizationView.swift
@@ -7,11 +7,14 @@
 
 import SwiftUI
 import OBAKitCore
-import CoreLocationUI
 
-/// Asks the user for one-time location authorization.
+/// Asks the user for "while in use" location authorization so the app can
+/// automatically select their region. Unlike a one-time authorization, this
+/// grant persists across launches.
 public struct RegionPickerLocationAuthorizationView<Provider: RegionProvider>: View, OnboardingView {
     @ObservedObject var regionProvider: Provider
+
+    @Environment(\.coreApplication) var application
 
     public var dismissBlock: VoidBlock?
     @Environment(\.dismiss) public var dismissAction
@@ -33,17 +36,26 @@ public struct RegionPickerLocationAuthorizationView<Provider: RegionProvider>: V
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 16) {
-                // LocationButton API is picky, so this button won't stretch across the width of the screen.
-                LocationButton {
+                Button {
                     regionProvider.automaticallySelectRegion = true
+                    application.locationService.requestInUseAuthorization()
                     dismiss()
+                } label: {
+                    Label(OBALoc("location_permission_bulletin.use_location_button_text", value: "Use My Location", comment: "Button the user taps to grant access to their location."), systemImage: "location.fill")
+                        .frame(maxWidth: .infinity)
                 }
-                .cornerRadius(8)
-                .labelStyle(.titleAndIcon)
-                .foregroundColor(.white)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button {
+                    regionProvider.automaticallySelectRegion = false
+                    dismiss()
+                } label: {
+                    Label(OBALoc("location_permission_bulletin.do_not_use_location_button_text", value: "Not Now", comment: "Button the user can tap on to decline access to their location."), systemImage: "location.slash")
+                }
             }
             .symbolVariant(.fill)
-            .tint(.blue) // .accentColor might fail LocationButton's contrast test, so we'll just use the standard blue.
+            .tint(.blue)
         }
         .navigationBarHidden(true)
         .padding()

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -259,8 +259,14 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Please allow the app to access your location to make it easier to find your transit stops.";
 
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Not Now";
+
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Welcome!";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Use My Location";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Turn On in Settings";


### PR DESCRIPTION
## Problem

On first/second launch after a fresh install, location services break on the **second** launch:

1. **First launch:** the Welcome screen's "Current Location" button (Apple's CoreLocationUI `LocationButton`) grants location, the region auto-selects, and the map centers on the user. Everything looks fine.
2. **Second launch:** the map opens zoomed out to the whole continent, a persistent **"Location services unavailable"** banner appears, and the app re-prompts for location permission from scratch.

### Root cause

`LocationButton` grants **one-time** location authorization by design — it does *not* establish a persistent `CLAuthorizationStatus`. So once the app is killed and relaunched, the authorization has lapsed back to `notDetermined`. The first launch only *looked* fully working because one-time access is enough for a single session, which masked that nothing durable was ever granted.

This one-time approach was introduced in **#639** (`ba6ca1eb`, "Move Onboarding to app-level"), which intentionally switched onboarding to `LocationButton` for "one-time location usage."

## Fix

- Replace `LocationButton` with a standard button that requests the formal **"While Using App"** authorization via `LocationService.requestInUseAuthorization()`, reached through the existing `coreApplication` environment value (same pattern `DataMigrationView` already uses — no new plumbing in either app's `OnboardingNavigationController`).
- Restore the **"Not Now"** opt-out button (removed in `f0c50391`), which turns off automatic region selection and drops the user to the manual region picker.

The downstream flow is unchanged: granting authorization populates `LocationService.currentLocation`, which `RegionsService` already uses to auto-select the region. The later `requestWhenInUseAuthorization()` call on the map harmlessly no-ops once authorization is determined.

## Testing

- `xcodebuild test-without-building -only-testing:OBAKitTests` → **982 tests, 0 failures.**
- Existing `RegionsServiceAutoSelectTests` / `LocationServiceTests` cover the downstream auto-select + authorization logic.

## Note for reviewers

This re-introduces a formal location prompt during onboarding, which is roughly the area Apple's 24.3 rejection touched (`f0c50391`, "placate Apple"). The original rejection reason wasn't recorded. The purpose string is clear and the opt-out is prominent, so the flow reads as user-initiated — but worth being aware this could draw App Review attention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Location permission request during onboarding now features standard interface buttons with clearer language options ("Use My Location" and "Not Now"), making it significantly more intuitive for users to share their location. This improvement enhances the onboarding experience and enables better location-based regional recommendations and service personalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->