### PR TITLE
Translate missing strings and remove orphaned keys

### DIFF
--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@، %2$@: الوصول عند %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "ليس الآن";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "استخدام موقعي";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Title of the Bookmarks tab */
 "bookmarks_controller.title" = "Marcadores";
 
-/* An error message displayed on the bookmarks tab when the user has Sort By Distance enabled and their location isn't available. */
-"bookmarks_controller.unable_to_sort_by_distance_error" = "No podemos ordernar sus marcadores por distancia porque su ubicación no está disponible.";
-
 /* The title for the bookmarks controller section that shows bookmarks that aren't in a group. */
 "bookmarks_controller.ungrouped_bookmarks_section.title" = "Marcadores";
 
@@ -121,7 +118,6 @@
 /* This comment is displayed after the user's data is upgraded in the DataMigrationBulletinPage. */
 "data_migration_bulletin.finished_loading" = "Data Upgrade Complete!";
 
-
 /* Title for the Summary section of a data migration report */
 "data_migration_bulletin.report_summary_title" = "Summary";
 
@@ -186,7 +182,7 @@
 "location_permission_bulletin.description_text" = "Por favor permitir a la aplicación acceder a su ubicación para hacer más fácil encontrar su parada.";
 
 /* Button the user can tap on to disallow access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Don't use my location";
+"location_permission_bulletin.do_not_use_location_button_text" = "Ahora no";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "¡Bien venido!";
@@ -269,15 +265,6 @@
 /* about section header */
 "map_item_controller.about_header" = "Acerca de";
 
-/* More options header */
-"map_item_controller.more_header" = "Más";
-
-/* A table row that shows stops nearby. */
-"map_item_controller.nearby_stops_row" = "Paradas Cercanas";
-
-/* Map region manager message to the user when they need to zoom in more to view stops */
-"map_region_manager.status_overlay.zoom_to_see_stops" = "Acérquese para ver las paradas.";
-
 /* Displayed in the map status view at the top of the map when the user has declined to give the app access to their location */
 "map_status_view.location_services_unavailable" = "Los servicios de ubicación no están disponibles";
 
@@ -307,9 +294,6 @@
 
 /* Title for a button that will crash the app. */
 "more_controller.debug_section.crash_row" = "Error en la aplicación";
-
-/* Section title for debugging helpers */
-"more_controller.debug_section.header" = "Depuración";
 
 /* This is displayed instead of the user's push ID if the value is not available. */
 "more_controller.debug_section.push_id.not_available" = "No disponible";
@@ -346,12 +330,6 @@
 
 /* Updates and Alerts header text */
 "more_controller.updates_and_alerts.header" = "Actualizaciones y Alertas";
-
-/* Title of the alert that tells the user they've disabled debug mode. */
-"more_header.debug_disabled.title" = "Modo de Depuración Desactivado";
-
-/* Title of the alert that tells the user they've enabled debug mode. */
-"more_header.debug_enabled.title" = "Modo de Depuración Activado";
 
 /* Explanation about how this app is built and maintained by volunteers. */
 "more_header.support_us_label_text" = "Esta aplicación está hecha y apoyada por voluntarios.";
@@ -773,7 +751,6 @@
 /* Error message of Custom Region URL if it's invalid or does not point to a functional OBA server */
 "region_url.error_messsage" = "La URL de la región proporcionada no es válida o no apunta a un servidor OBA funcional.";
 
-
 /* Morning time period label */
 "schedule_view.am_period" = "AM";
 
@@ -1026,3 +1003,6 @@
 
 /* Settings > Walking Speed section title */
 "settings_controller.walking_speed_section.title" = "Velocidad al Caminar";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Usar mi ubicación";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: darating sa %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Hindi Ngayon";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Gamitin ang Aking Lokasyon";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@ : arrivée à %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Plus tard";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Utiliser ma position";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Title of the Bookmarks tab */
 "bookmarks_controller.title" = "Segnalibri";
 
-/* An error message displayed on the bookmarks tab when the user has Sort By Distance enabled and their location isn't available. */
-"bookmarks_controller.unable_to_sort_by_distance_error" = "Impossibile ordinare segnalibri in base alla distanza: la tua posizione non è disponibile.";
-
 /* The title for the bookmarks controller section that shows bookmarks that aren't in a group. */
 "bookmarks_controller.ungrouped_bookmarks_section.title" = "Segnalibri";
 
@@ -121,7 +118,6 @@
 /* This comment is displayed after the user's data is upgraded in the DataMigrationBulletinPage. */
 "data_migration_bulletin.finished_loading" = "Data Upgrade Complete!";
 
-
 /* Title for the Summary section of a data migration report */
 "data_migration_bulletin.report_summary_title" = "Summary";
 
@@ -186,7 +182,7 @@
 "location_permission_bulletin.description_text" = "Consenti all'applicazione di accedere alla tua posizione per facilitare l'individuazione di fermate nei tuoi dintorni. ";
 
 /* Button the user can tap on to disallow access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Don't use my location";
+"location_permission_bulletin.do_not_use_location_button_text" = "Non adesso";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Ti diamo il benvenuto!";
@@ -269,15 +265,6 @@
 /* about section header */
 "map_item_controller.about_header" = "Info";
 
-/* More options header */
-"map_item_controller.more_header" = "Altro";
-
-/* A table row that shows stops nearby. */
-"map_item_controller.nearby_stops_row" = "Fermate vicine";
-
-/* Map region manager message to the user when they need to zoom in more to view stops */
-"map_region_manager.status_overlay.zoom_to_see_stops" = "Ingrandisci per cercare le fermate";
-
 /* Displayed in the map status view at the top of the map when the user has declined to give the app access to their location */
 "map_status_view.location_services_unavailable" = "Servizi di posizione non disponibili";
 
@@ -307,9 +294,6 @@
 
 /* Title for a button that will crash the app. */
 "more_controller.debug_section.crash_row" = "Arresta applicazione";
-
-/* Section title for debugging helpers */
-"more_controller.debug_section.header" = "Debug";
 
 /* This is displayed instead of the user's push ID if the value is not available. */
 "more_controller.debug_section.push_id.not_available" = "Non disponibile";
@@ -346,12 +330,6 @@
 
 /* Updates and Alerts header text */
 "more_controller.updates_and_alerts.header" = "Aggiornamenti e avvisi";
-
-/* Title of the alert that tells the user they've disabled debug mode. */
-"more_header.debug_disabled.title" = "Modalità debug disabilitata";
-
-/* Title of the alert that tells the user they've enabled debug mode. */
-"more_header.debug_enabled.title" = "Modalità debug abilitata";
 
 /* Explanation about how this app is built and maintained by volunteers. */
 "more_header.support_us_label_text" = "Questa applicazione è fatta e mantenuta da volontari.";
@@ -773,3 +751,259 @@
 /* Error message of Custom Region URL if it's invalid or does not point to a functional OBA server */
 "region_url.error_messsage" = "L'URL della regione fornita non è valida o non punta a un server OBA funzionante.";
 ⼊‪潍湲湩⁧楴敭瀠牥潩⁤慬敢⁬⼪∊捳敨畤敬癟敩⹷浡灟牥潩≤㴠∠䵁㬢ਊ⨯䰠扡汥映牯搠瑡⁥楰正牥椠⁮捳敨畤敬瘠敩⁷⼪∊捳敨畤敬癟敩⹷慤整•‽䐢瑡≡਻⼊‪慌敢⁬潦⁲楤敲瑣潩⁮楰正牥椠⁮捳敨畤敬瘠敩⁷⼪∊捳敨畤敬癟敩⹷楤敲瑣潩≮㴠∠楄敲楺湯≥਻⼊‪敄慦汵⁴楤敲瑣潩⁮慬敢⁬桷湥渠⁯敨摡楳湧椠⁳癡楡慬汢⹥┠⁤獩愠渠浵敢⁲汰捡桥汯敤⹲⨠ਯ猢档摥汵彥楶睥搮物捥楴湯湟浵敢彲浦≴㴠∠楄敲楺湯⁥搥㬢ਊ⨯䄠捣獥楳楢楬祴琠硥⁴桷湥琠敨敲椠⁳潮搠灥牡畴敲琠浩⁥⼪∊捳敨畤敬癟敩⹷潮摟灥牡畴敲•‽丢獥畳慮瀠牡整穮≡਻⼊‪敍獳条⁥桳睯⁮桷湥猠档摥汵⁥慤慴椠⁳潮⁴癡楡慬汢⁥⼪∊捳敨畤敬癟敩⹷潮獟档摥汵彥慤慴•‽丢獥畳⁮慤潴漠慲楲⁯楤灳湯扩汩≥਻⼊‪敍獳条⁥桷湥渠⁯瑳灯⁳牡⁥癡楡慬汢⁥潦⁲桴⁥敳敬瑣摥搠物捥楴湯⨠ਯ猢档摥汵彥楶睥渮彯瑳灯彳潦湵≤㴠∠敎獳湵⁡敦浲瑡⁡牴癯瑡⁡数⁲畱獥慴搠物穥潩敮㬢ਊ⨯䄠瑦牥潮湯支敶楮杮琠浩⁥数楲摯氠扡汥⨠ਯ猢档摥汵彥楶睥瀮彭数楲摯•‽倢≍਻⼊‪效摡楳湧氠扡汥猠潨楷杮搠獥楴慮楴湯‮䀥椠⁳⁡瑳楲杮瀠慬散潨摬牥映牯琠敨搠獥楴慮楴湯渠浡⹥⨠ਯ猢档摥汵彥楶睥琮彯敨摡楳湧晟瑭•‽嘢牥潳›䀥㬢ਊ⨯䔠牲牯洠獥慳敧眠敨⁮捳敨畤敬映楡獬琠⁯潬摡⨠ਯ猢档摥汵彥楶睥甮慮汢彥潴江慯≤㴠∠浉潰獳扩汩⁥慣楲慣敲氠漧慲楲≯਻⼊‪慌敢⁬潦⁲慤整瀠捩敫⁲湩猠档摥汵⁥楶睥⨠ਯ猢潴彰捳敨畤敬癟敩⹷慤整•‽䐢瑡≡਻⼊‪敍獳条⁥桷湥渠⁯敤慰瑲牵獥愠敲猠档摥汵摥⨠ਯ猢潴彰捳敨畤敬癟敩⹷潮摟灥牡畴敲≳㴠∠敎獳湵⁡慰瑲湥慺瀠潲牧浡慭慴瀠牥焠敵瑳⁡慤慴㬢ਊ⨯䴠獥慳敧猠潨湷眠敨⁮捳敨畤敬搠瑡⁡獩渠瑯愠慶汩扡敬⨠ਯ猢潴彰捳敨畤敬癟敩⹷潮獟档摥汵彥慤慴•‽丢獥畳⁮慤潴漠慲楲⁯楤灳湯扩汩≥਻⼊‪慌敢⁬潦⁲潲瑵⁥楰正牥椠⁮捳敨畤敬瘠敩⁷⼪∊瑳灯獟档摥汵彥楶睥爮畯整•‽䰢湩慥㬢ਊ⨯䔠牲牯洠獥慳敧眠敨⁮捳敨畤敬映楡獬琠⁯潬摡⨠ਯ猢潴彰捳敨畤敬癟敩⹷湵扡敬瑟彯潬摡•‽䤢灭獯楳楢敬挠牡捩牡⁥❬牯牡潩㬢ਊ
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Usa la mia posizione";
+
+/* Explanatory text shown when route bookmarking is unavailable due to no upcoming departures. */
+"add_bookmark_controller.trip_bookmark_unavailable" = "I segnalibri delle linee sono disponibili solo quando ci sono partenze imminenti per questa fermata.";
+
+/* Action to call agency */
+"agencies_controller.call_agency" = "Chiama l'ente";
+
+/* Error dialog title */
+"agencies_controller.error_title" = "Errore";
+
+/* Error message for invalid phone */
+"agencies_controller.invalid_phone" = "Numero di telefono non valido.";
+
+/* Action to open agency website */
+"agencies_controller.open_website" = "Apri il sito web";
+
+/* Loading message while searching for the user's vehicle. */
+"current_trip_controller.detecting" = "Ricerca del tuo veicolo…";
+
+/* Distance from user to vehicle. e.g. '0.2 mi away' */
+"current_trip_controller.distance_fmt" = "%@ di distanza";
+
+/* Error when the API service is unavailable. */
+"current_trip_controller.error_no_service" = "Impossibile connettersi al servizio di trasporto.";
+
+/* Error message when the user's location is not available. */
+"current_trip_controller.location_unavailable" = "Posizione non disponibile. Abilita i servizi di localizzazione.";
+
+/* Section header when multiple vehicles are found on the selected route. */
+"current_trip_controller.multiple_vehicles" = "Trovati più veicoli";
+
+/* Title for the current trip screen. */
+"current_trip_controller.my_trip" = "Il mio viaggio";
+
+/* Message when the route has no real-time tracking data. */
+"current_trip_controller.no_realtime" = "Nessun tracciamento in tempo reale disponibile per questa linea";
+
+/* Message when no active vehicle is found near the user on the selected route. */
+"current_trip_controller.no_results" = "Nessun veicolo attivo trovato su questa linea vicino a te";
+
+/* Button to retry finding the user's vehicle. */
+"current_trip_controller.retry" = "Riprova";
+
+/* Data migration report label for showing the number of failed migration tasks. */
+"data_migration_bulletin.report_summary_number_of_failures" = "%d non riusciti";
+
+/* Data migration report label for showing the number of successful migration tasks. */
+"data_migration_bulletin.report_summary_number_of_successes" = "%d riusciti";
+
+/* Body of the donation widget that appears on the stop view controller */
+"donation_cell.body" = "Questa app è attualmente realizzata con il 100% di lavoro volontario e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.";
+
+/* Title of the button that shows the donation UI. */
+"donation_cell.donate_button_title" = "Dona ora";
+
+/* Title of the button that shows the donation explanation UI. */
+"donation_cell.learn_more_button_title" = "Scopri di più";
+
+/* Title of the donation widget that appears on the stop view controller. */
+"donation_cell.title" = "🚨 OneBusAway ha bisogno del tuo aiuto";
+
+/* Dismiss button on the alert */
+"donations.donations_dismiss_alert.button_dismiss" = "Non voglio aiutare in questo momento";
+
+/* A button that prompts the system to remind them to donate later. */
+"donations.donations_dismiss_alert.button_remind_later" = "Ricordamelo più tardi";
+
+/* Body of the alert that appears when the user chooses to dismiss the donations request UI on a stop page */
+"donations.donations_dismiss_alert.message" = "OneBusAway è un'organizzazione gestita da volontari e con pochissimi fondi. Abbiamo bisogno del tuo aiuto per mantenere attiva questa app.";
+
+/* Title of the alert that appears when the user chooses to dismiss the donations request UI on a stop page */
+"donations.donations_dismiss_alert.title" = "Per favore non ignorare questa richiesta";
+
+/* Body of an alert shown when a bookmark cannot be saved because the current region is unavailable. */
+"edit_bookmark_controller.region_error.body" = "La regione attuale non è disponibile. Riprova.";
+
+/* Title of an alert shown when a bookmark cannot be saved because the current region is unavailable. */
+"edit_bookmark_controller.region_error.title" = "Impossibile salvare";
+
+/* Message shown when there are no logs to display */
+"log_viewer_controller.no_logs" = "Nessun log disponibile.";
+
+/* Message for alert when there are no logs to share */
+"log_viewer_controller.no_logs_to_share.message" = "Non ci sono file di log da condividere.";
+
+/* Title for alert when there are no logs to share */
+"log_viewer_controller.no_logs_to_share.title" = "Nessun log";
+
+/* Title of the Logs viewer controller */
+"log_viewer_controller.title" = "Log";
+
+/* Accessibility label for the My Trip button on the map toolbar. */
+"map_controller.my_trip_button" = "Il mio viaggio";
+
+/* Search bar placeholder on the map floating panel when the trip planner is enabled. */
+"map_floating_panel.where_are_you_going" = "Dove vuoi andare?";
+
+/* Call button */
+"map_item_controller.call" = "Chiama";
+
+/* Accessibility label for call button */
+"map_item_controller.call_accessibility" = "Chiama il numero di telefono";
+
+/* Accessibility label for close button */
+"map_item_controller.close_button" = "Chiudi";
+
+/* Accessibility label for Look Around preview */
+"map_item_controller.look_around" = "Anteprima Look Around. Tocca per aprire il visualizzatore a schermo intero";
+
+/* Button to view nearby stops
+   Nearby stops button */
+"map_item_controller.nearby_stops" = "Fermate vicine";
+
+/* Accessibility label for nearby stops button */
+"map_item_controller.nearby_stops_accessibility" = "Visualizza le fermate vicine";
+
+/* Plan trip button */
+"map_item_controller.plan_trip" = "Pianifica viaggio";
+
+/* Accessibility label for plan trip button */
+"map_item_controller.plan_trip_accessibility" = "Pianifica un viaggio verso questa posizione";
+
+/* Button to remove a dropped pin from the map */
+"map_item_controller.remove_pin" = "Rimuovi segnaposto";
+
+/* Accessibility label for remove pin button */
+"map_item_controller.remove_pin_accessibility" = "Rimuovi questo segnaposto dalla mappa";
+
+/* Accessibility label for share button */
+"map_item_controller.share_button" = "Condividi posizione";
+
+/* Website button */
+"map_item_controller.website" = "Sito web";
+
+/* Accessibility label for website button */
+"map_item_controller.website_accessibility" = "Apri il sito web";
+
+/* Displayed in the map status view at the top of the map when the user must zoom in to see stops on the map */
+"map_status_view.zoom_in_for_stops" = "Ingrandisci per le fermate";
+
+/* Header for the donate section. */
+"more_controller.donate" = "Sostienici";
+
+/* The call to action for the More controller's donate buton */
+"more_controller.donate_description" = "Fai una donazione a OneBusAway";
+
+/* A button that will open a web based donation portal. */
+"more_controller.manage_donations" = "Gestisci donazioni";
+
+/* A link to view application logs */
+"more_controller.view_logs_row_title" = "Visualizza log";
+
+/* Error shown on the Nearby Stops screen when no API service is configured (e.g. no region selected). */
+"nearby_stops_controller.no_api_service_error" = "Nessun servizio dati di trasporto disponibile. Scegli una regione nelle Impostazioni.";
+
+/* Error when location is unavailable in the route picker. */
+"route_picker.error_no_location" = "Posizione non disponibile. Abilita i servizi di localizzazione per trovare le linee vicine.";
+
+/* Error when API service is unavailable in the route picker. */
+"route_picker.error_no_service" = "Impossibile connettersi al servizio di trasporto.";
+
+/* Loading message while fetching nearby routes. */
+"route_picker.loading" = "Caricamento delle linee…";
+
+/* Message when no routes are found near the user's location. */
+"route_picker.no_routes" = "Nessuna linea trovata nelle vicinanze.";
+
+/* Placeholder text in the route search field. */
+"route_picker.search_placeholder" = "Cerca linee…";
+
+/* Title for the route picker screen where the user selects their transit route. */
+"route_picker.title" = "Seleziona la tua linea";
+
+/* Morning time period label */
+"schedule_view.am_period" = "AM";
+
+/* Label for date picker in schedule view */
+"schedule_view.date" = "Data";
+
+/* Label for direction picker in schedule view */
+"schedule_view.direction" = "Direzione";
+
+/* Default direction label when no headsign is available */
+"schedule_view.direction_number_fmt" = "Direzione %d";
+
+/* Accessibility text when there is no departure time */
+"schedule_view.no_departure" = "Nessuna partenza";
+
+/* Message shown when schedule data is not available */
+"schedule_view.no_schedule_data" = "Nessun dato sull'orario disponibile";
+
+/* Message when no stops are available for the selected direction */
+"schedule_view.no_stops_found" = "Nessuna fermata trovata per questa direzione";
+
+/* Afternoon/evening time period label */
+"schedule_view.pm_period" = "PM";
+
+/* Headsign label showing destination */
+"schedule_view.to_headsign_fmt" = "Per: %@";
+
+/* Error message when schedule fails to load */
+"schedule_view.unable_to_load" = "Impossibile caricare l'orario";
+
+/* Subtitle on search error row prompting the user to retry. */
+"search_controller.placemarks.error_retry" = "Tocca per riprovare";
+
+/* Placemark search header */
+"search_controller.placemarks.header" = "Risultati";
+
+/* Loading message for placemark search */
+"search_controller.placemarks.loading" = "Ricerca di luoghi...";
+
+/* No results message for placemark search */
+"search_controller.placemarks.no_results" = "Nessun risultato trovato";
+
+/* Error shown when vehicle search is attempted with no API service configured (e.g. no region selected). */
+"search_results_controller.no_api_service_error" = "Nessun servizio dati di trasporto disponibile. Scegli una regione nelle Impostazioni.";
+
+/* Settings > Walking Speed > Average preset label */
+"settings_controller.walking_speed.avg" = "Media (~3 mph)";
+
+/* Settings > Walking Speed > Fast preset label */
+"settings_controller.walking_speed.fast" = "Veloce (~4 mph)";
+
+/* Settings > Walking Speed > HealthKit denial or no-data toast */
+"settings_controller.walking_speed.healthkit_unavailable" = "Impossibile sincronizzare la velocità di camminata da Salute. Vai su Impostazioni > Privacy e sicurezza > Salute per consentire l'accesso.";
+
+/* Settings > Walking Speed > Slow preset label */
+"settings_controller.walking_speed.slow" = "Lenta (~2 mph)";
+
+/* Settings > Walking Speed section > Speed picker */
+"settings_controller.walking_speed.title" = "Velocità di camminata";
+
+/* Settings > Walking Speed section > HealthKit toggle */
+"settings_controller.walking_speed.use_healthkit" = "Usa i dati dell'app Salute";
+
+/* Settings > Walking Speed section title */
+"settings_controller.walking_speed_section.title" = "Velocità di camminata";
+
+/* Label for date picker in schedule view */
+"stop_schedule_view.date" = "Data";
+
+/* Message when no departures are scheduled */
+"stop_schedule_view.no_departures" = "Nessuna partenza programmata per questa data";
+
+/* Message shown when schedule data is not available */
+"stop_schedule_view.no_schedule_data" = "Nessun dato sull'orario disponibile";
+
+/* Label for route picker in schedule view */
+"stop_schedule_view.route" = "Linea";
+
+/* Error message when schedule fails to load */
+"stop_schedule_view.unable_to_load" = "Impossibile caricare l'orario";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1001,3 +1001,9 @@
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: %3$@ 도착";
 
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "나중에";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "내 위치 사용";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Title of the Bookmarks tab */
 "bookmarks_controller.title" = "Zakładki";
 
-/* An error message displayed on the bookmarks tab when the user has Sort By Distance enabled and their location isn't available. */
-"bookmarks_controller.unable_to_sort_by_distance_error" = "Nie możemy posortować zakładek według odległości, ponieważ Twoja lokalizacja jest niedostępna.";
-
 /* The title for the bookmarks controller section that shows bookmarks that aren't in a group. */
 "bookmarks_controller.ungrouped_bookmarks_section.title" = "Zakładki";
 
@@ -121,7 +118,6 @@
 /* This comment is displayed after the user's data is upgraded in the DataMigrationBulletinPage. */
 "data_migration_bulletin.finished_loading" = "Aktualizacja danych zakończona!";
 
-
 /* Title for the Summary section of a data migration report */
 "data_migration_bulletin.report_summary_title" = "Podsumowanie";
 
@@ -186,7 +182,7 @@
 "location_permission_bulletin.description_text" = "Zezwól aplikacji na dostęp do Twojej lokalizacji, aby ułatwić wyszukiwanie Twoich najbliższych przystanków.";
 
 /* Button the user can tap on to disallow access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Nie używaj mojej lokalizacji";
+"location_permission_bulletin.do_not_use_location_button_text" = "Nie teraz";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Witaj!";
@@ -269,15 +265,6 @@
 /* about section header */
 "map_item_controller.about_header" = "O nas";
 
-/* More options header */
-"map_item_controller.more_header" = "Więcej";
-
-/* A table row that shows stops nearby. */
-"map_item_controller.nearby_stops_row" = "Przystanki w pobliżu";
-
-/* Map region manager message to the user when they need to zoom in more to view stops */
-"map_region_manager.status_overlay.zoom_to_see_stops" = "Przybliż, aby zobaczyć przystanki";
-
 /* Displayed in the map status view at the top of the map when the user has declined to give the app access to their location */
 "map_status_view.location_services_unavailable" = "Usługi lokalizacyjne niedostępne";
 
@@ -307,9 +294,6 @@
 
 /* Title for a button that will crash the app. */
 "more_controller.debug_section.crash_row" = "Crash the App";
-
-/* Section title for debugging helpers */
-"more_controller.debug_section.header" = "Debugowanie";
 
 /* This is displayed instead of the user's push ID if the value is not available. */
 "more_controller.debug_section.push_id.not_available" = "Niedostępne";
@@ -346,12 +330,6 @@
 
 /* Updates and Alerts header text */
 "more_controller.updates_and_alerts.header" = "Komunikaty i alerty";
-
-/* Title of the alert that tells the user they've disabled debug mode. */
-"more_header.debug_disabled.title" = "Tryb debugowania wyłączony";
-
-/* Title of the alert that tells the user they've enabled debug mode. */
-"more_header.debug_enabled.title" = "Tryb debugowania włączony";
 
 /* Explanation about how this app is built and maintained by volunteers. */
 "more_header.support_us_label_text" = "Ta aplikacja jest stworzona i utrzymywania przez woluntariuszy.";
@@ -773,5 +751,260 @@
 /* Error message of Custom Region URL if it's invalid or does not point to a functional OBA server */
 "region_url.error_messsage" = "Podany adres URL regionu jest nieprawidłowy lub nie wskazuje na funkcjonujący serwer OBA.";
 
-
 ⼊‪潍湲湩⁧楴敭瀠牥潩⁤慬敢⁬⼪∊捳敨畤敬癟敩⹷浡灟牥潩≤㴠∠䵁㬢ਊ⨯䰠扡汥映牯搠瑡⁥楰正牥椠⁮捳敨畤敬瘠敩⁷⼪∊捳敨畤敬癟敩⹷慤整•‽䐢瑡≡਻⼊‪慌敢⁬潦⁲楤敲瑣潩⁮楰正牥椠⁮捳敨畤敬瘠敩⁷⼪∊捳敨畤敬癟敩⹷楤敲瑣潩≮㴠∠楋牥湵步㬢ਊ⨯䐠晥畡瑬搠物捥楴湯氠扡汥眠敨⁮潮栠慥獤杩⁮獩愠慶汩扡敬‮搥椠⁳⁡畮扭牥瀠慬散潨摬牥‮⼪∊捳敨畤敬癟敩⹷楤敲瑣潩彮畮扭牥晟瑭•‽䬢敩畲敮⁫搥㬢ਊ⨯䄠捣獥楳楢楬祴琠硥⁴桷湥琠敨敲椠⁳潮搠灥牡畴敲琠浩⁥⼪∊捳敨畤敬癟敩⹷潮摟灥牡畴敲•‽䈢慲⁫摯慪摺≵਻⼊‪敍獳条⁥桳睯⁮桷湥猠档摥汵⁥慤慴椠⁳潮⁴癡楡慬汢⁥⼪∊捳敨畤敬癟敩⹷潮獟档摥汵彥慤慴•‽䈢慲⁫慤祮档漠爠穯앫憂穤敩樠穡祤㬢ਊ⨯䴠獥慳敧眠敨⁮潮猠潴獰愠敲愠慶汩扡敬映牯琠敨猠汥捥整⁤楤敲瑣潩⁮⼪∊捳敨畤敬癟敩⹷潮獟潴獰晟畯摮•‽丢敩稠慮敬楺湯⁯牰祺瑳湡썫瞳搠慬琠来⁯楫牥湵畫㬢ਊ⨯䄠瑦牥潮湯支敶楮杮琠浩⁥数楲摯氠扡汥⨠ਯ猢档摥汵彥楶睥瀮彭数楲摯•‽倢≍਻⼊‪效摡楳湧氠扡汥猠潨楷杮搠獥楴慮楴湯‮䀥椠⁳⁡瑳楲杮瀠慬散潨摬牥映牯琠敨搠獥楴慮楴湯渠浡⹥⨠ਯ猢档摥汵彥楶睥琮彯敨摡楳湧晟瑭•‽䐢㩯┠≀਻⼊‪牅潲⁲敭獳条⁥桷湥猠档摥汵⁥慦汩⁳潴氠慯⁤⼪∊捳敨畤敬癟敩⹷湵扡敬瑟彯潬摡•‽丢敩洠앯溼⁡慺苅摡睯쑡₇潲歺苅摡⁵慪摺≹਻⼊‪慌敢⁬潦⁲慤整瀠捩敫⁲湩猠档摥汵⁥楶睥⨠ਯ猢潴彰捳敨畤敬癟敩⹷慤整•‽䐢瑡≡਻⼊‪敍獳条⁥桷湥渠⁯敤慰瑲牵獥愠敲猠档摥汵摥⨠ਯ猢潴彰捳敨畤敬癟敩⹷潮摟灥牡畴敲≳㴠∠牂歡稠灡慬潮慷祮档漠橤穡썤瞳渠⁡整⁮穤敩蓅㬢ਊ⨯䴠獥慳敧猠潨湷眠敨⁮捳敨畤敬搠瑡⁡獩渠瑯愠慶汩扡敬⨠ਯ猢潴彰捳敨畤敬癟敩⹷潮獟档摥汵彥慤慴•‽䈢慲⁫慤祮档漠爠穯앫憂穤敩樠穡祤㬢ਊ⨯䰠扡汥映牯爠畯整瀠捩敫⁲湩猠档摥汵⁥楶睥⨠ਯ猢潴彰捳敨畤敬癟敩⹷潲瑵≥㴠∠楌楮≡਻⼊‪牅潲⁲敭獳条⁥桷湥猠档摥汵⁥慦汩⁳潴氠慯⁤⼪∊瑳灯獟档摥汵彥楶睥甮慮汢彥潴江慯≤㴠∠楎⁥潭볅慮稠액憂潤慷蟄爠穯앫憂畤樠穡祤㬢ਊ
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Użyj mojej lokalizacji";
+
+/* Explanatory text shown when route bookmarking is unavailable due to no upcoming departures. */
+"add_bookmark_controller.trip_bookmark_unavailable" = "Zakładki linii są dostępne tylko wtedy, gdy dla tego przystanku są zaplanowane najbliższe odjazdy.";
+
+/* Action to call agency */
+"agencies_controller.call_agency" = "Zadzwoń do przewoźnika";
+
+/* Error dialog title */
+"agencies_controller.error_title" = "Błąd";
+
+/* Error message for invalid phone */
+"agencies_controller.invalid_phone" = "Nieprawidłowy numer telefonu.";
+
+/* Action to open agency website */
+"agencies_controller.open_website" = "Otwórz stronę internetową";
+
+/* Loading message while searching for the user's vehicle. */
+"current_trip_controller.detecting" = "Wyszukiwanie Twojego pojazdu…";
+
+/* Distance from user to vehicle. e.g. '0.2 mi away' */
+"current_trip_controller.distance_fmt" = "%@ stąd";
+
+/* Error when the API service is unavailable. */
+"current_trip_controller.error_no_service" = "Nie można połączyć się z usługą transportową.";
+
+/* Error message when the user's location is not available. */
+"current_trip_controller.location_unavailable" = "Lokalizacja niedostępna. Włącz usługi lokalizacji.";
+
+/* Section header when multiple vehicles are found on the selected route. */
+"current_trip_controller.multiple_vehicles" = "Znaleziono wiele pojazdów";
+
+/* Title for the current trip screen. */
+"current_trip_controller.my_trip" = "Moja podróż";
+
+/* Message when the route has no real-time tracking data. */
+"current_trip_controller.no_realtime" = "Brak śledzenia na żywo dla tej linii";
+
+/* Message when no active vehicle is found near the user on the selected route. */
+"current_trip_controller.no_results" = "Nie znaleziono aktywnego pojazdu na tej linii w pobliżu";
+
+/* Button to retry finding the user's vehicle. */
+"current_trip_controller.retry" = "Spróbuj ponownie";
+
+/* Data migration report label for showing the number of failed migration tasks. */
+"data_migration_bulletin.report_summary_number_of_failures" = "Nieudane: %d";
+
+/* Data migration report label for showing the number of successful migration tasks. */
+"data_migration_bulletin.report_summary_number_of_successes" = "Udane: %d";
+
+/* Body of the donation widget that appears on the stop view controller */
+"donation_cell.body" = "Ta aplikacja jest obecnie tworzona w 100% przez wolontariuszy i potrzebujemy Twojej pomocy w finansowaniu dalszego rozwoju.";
+
+/* Title of the button that shows the donation UI. */
+"donation_cell.donate_button_title" = "Przekaż darowiznę";
+
+/* Title of the button that shows the donation explanation UI. */
+"donation_cell.learn_more_button_title" = "Dowiedz się więcej";
+
+/* Title of the donation widget that appears on the stop view controller. */
+"donation_cell.title" = "🚨 OneBusAway potrzebuje Twojej pomocy";
+
+/* Dismiss button on the alert */
+"donations.donations_dismiss_alert.button_dismiss" = "Nie chcę teraz pomagać";
+
+/* A button that prompts the system to remind them to donate later. */
+"donations.donations_dismiss_alert.button_remind_later" = "Przypomnij mi później";
+
+/* Body of the alert that appears when the user chooses to dismiss the donations request UI on a stop page */
+"donations.donations_dismiss_alert.message" = "OneBusAway to organizacja prowadzona przez wolontariuszy, niemal bez żadnych funduszy. Potrzebujemy Twojej pomocy, aby utrzymać działanie tej aplikacji.";
+
+/* Title of the alert that appears when the user chooses to dismiss the donations request UI on a stop page */
+"donations.donations_dismiss_alert.title" = "Prosimy, nie odrzucaj tej prośby";
+
+/* Body of an alert shown when a bookmark cannot be saved because the current region is unavailable. */
+"edit_bookmark_controller.region_error.body" = "Bieżący region jest niedostępny. Spróbuj ponownie.";
+
+/* Title of an alert shown when a bookmark cannot be saved because the current region is unavailable. */
+"edit_bookmark_controller.region_error.title" = "Nie można zapisać";
+
+/* Message shown when there are no logs to display */
+"log_viewer_controller.no_logs" = "Brak dostępnych dzienników.";
+
+/* Message for alert when there are no logs to share */
+"log_viewer_controller.no_logs_to_share.message" = "Brak plików dziennika do udostępnienia.";
+
+/* Title for alert when there are no logs to share */
+"log_viewer_controller.no_logs_to_share.title" = "Brak dzienników";
+
+/* Title of the Logs viewer controller */
+"log_viewer_controller.title" = "Dzienniki";
+
+/* Accessibility label for the My Trip button on the map toolbar. */
+"map_controller.my_trip_button" = "Moja podróż";
+
+/* Search bar placeholder on the map floating panel when the trip planner is enabled. */
+"map_floating_panel.where_are_you_going" = "Dokąd jedziesz?";
+
+/* Call button */
+"map_item_controller.call" = "Zadzwoń";
+
+/* Accessibility label for call button */
+"map_item_controller.call_accessibility" = "Zadzwoń pod numer telefonu";
+
+/* Accessibility label for close button */
+"map_item_controller.close_button" = "Zamknij";
+
+/* Accessibility label for Look Around preview */
+"map_item_controller.look_around" = "Podgląd Look Around. Dotknij, aby otworzyć przeglądarkę pełnoekranową";
+
+/* Button to view nearby stops
+   Nearby stops button */
+"map_item_controller.nearby_stops" = "Pobliskie przystanki";
+
+/* Accessibility label for nearby stops button */
+"map_item_controller.nearby_stops_accessibility" = "Wyświetl pobliskie przystanki";
+
+/* Plan trip button */
+"map_item_controller.plan_trip" = "Zaplanuj podróż";
+
+/* Accessibility label for plan trip button */
+"map_item_controller.plan_trip_accessibility" = "Zaplanuj podróż do tego miejsca";
+
+/* Button to remove a dropped pin from the map */
+"map_item_controller.remove_pin" = "Usuń pinezkę";
+
+/* Accessibility label for remove pin button */
+"map_item_controller.remove_pin_accessibility" = "Usuń tę pinezkę z mapy";
+
+/* Accessibility label for share button */
+"map_item_controller.share_button" = "Udostępnij lokalizację";
+
+/* Website button */
+"map_item_controller.website" = "Strona internetowa";
+
+/* Accessibility label for website button */
+"map_item_controller.website_accessibility" = "Otwórz stronę internetową";
+
+/* Displayed in the map status view at the top of the map when the user must zoom in to see stops on the map */
+"map_status_view.zoom_in_for_stops" = "Przybliż, aby zobaczyć przystanki";
+
+/* Header for the donate section. */
+"more_controller.donate" = "Zostań darczyńcą";
+
+/* The call to action for the More controller's donate buton */
+"more_controller.donate_description" = "Przekaż darowiznę dla OneBusAway";
+
+/* A button that will open a web based donation portal. */
+"more_controller.manage_donations" = "Zarządzaj darowiznami";
+
+/* A link to view application logs */
+"more_controller.view_logs_row_title" = "Wyświetl dzienniki";
+
+/* Error shown on the Nearby Stops screen when no API service is configured (e.g. no region selected). */
+"nearby_stops_controller.no_api_service_error" = "Brak dostępnej usługi danych transportowych. Wybierz region w Ustawieniach.";
+
+/* Error when location is unavailable in the route picker. */
+"route_picker.error_no_location" = "Lokalizacja niedostępna. Włącz usługi lokalizacji, aby znaleźć pobliskie linie.";
+
+/* Error when API service is unavailable in the route picker. */
+"route_picker.error_no_service" = "Nie można połączyć się z usługą transportową.";
+
+/* Loading message while fetching nearby routes. */
+"route_picker.loading" = "Wczytywanie linii…";
+
+/* Message when no routes are found near the user's location. */
+"route_picker.no_routes" = "Nie znaleziono linii w pobliżu.";
+
+/* Placeholder text in the route search field. */
+"route_picker.search_placeholder" = "Szukaj linii…";
+
+/* Title for the route picker screen where the user selects their transit route. */
+"route_picker.title" = "Wybierz swoją linię";
+
+/* Morning time period label */
+"schedule_view.am_period" = "AM";
+
+/* Label for date picker in schedule view */
+"schedule_view.date" = "Data";
+
+/* Label for direction picker in schedule view */
+"schedule_view.direction" = "Kierunek";
+
+/* Default direction label when no headsign is available */
+"schedule_view.direction_number_fmt" = "Kierunek %d";
+
+/* Accessibility text when there is no departure time */
+"schedule_view.no_departure" = "Brak odjazdu";
+
+/* Message shown when schedule data is not available */
+"schedule_view.no_schedule_data" = "Brak dostępnych danych rozkładu";
+
+/* Message when no stops are available for the selected direction */
+"schedule_view.no_stops_found" = "Nie znaleziono przystanków dla tego kierunku";
+
+/* Afternoon/evening time period label */
+"schedule_view.pm_period" = "PM";
+
+/* Headsign label showing destination */
+"schedule_view.to_headsign_fmt" = "Do: %@";
+
+/* Error message when schedule fails to load */
+"schedule_view.unable_to_load" = "Nie można wczytać rozkładu";
+
+/* Subtitle on search error row prompting the user to retry. */
+"search_controller.placemarks.error_retry" = "Dotknij, aby spróbować ponownie";
+
+/* Placemark search header */
+"search_controller.placemarks.header" = "Wyniki";
+
+/* Loading message for placemark search */
+"search_controller.placemarks.loading" = "Wyszukiwanie miejsc...";
+
+/* No results message for placemark search */
+"search_controller.placemarks.no_results" = "Nie znaleziono wyników";
+
+/* Error shown when vehicle search is attempted with no API service configured (e.g. no region selected). */
+"search_results_controller.no_api_service_error" = "Brak dostępnej usługi danych transportowych. Wybierz region w Ustawieniach.";
+
+/* Settings > Walking Speed > Average preset label */
+"settings_controller.walking_speed.avg" = "Średnia (~3 mph)";
+
+/* Settings > Walking Speed > Fast preset label */
+"settings_controller.walking_speed.fast" = "Szybka (~4 mph)";
+
+/* Settings > Walking Speed > HealthKit denial or no-data toast */
+"settings_controller.walking_speed.healthkit_unavailable" = "Nie udało się zsynchronizować prędkości chodzenia z aplikacją Zdrowie. Przejdź do Ustawienia > Prywatność i bezpieczeństwo > Zdrowie, aby zezwolić na dostęp.";
+
+/* Settings > Walking Speed > Slow preset label */
+"settings_controller.walking_speed.slow" = "Wolna (~2 mph)";
+
+/* Settings > Walking Speed section > Speed picker */
+"settings_controller.walking_speed.title" = "Prędkość chodzenia";
+
+/* Settings > Walking Speed section > HealthKit toggle */
+"settings_controller.walking_speed.use_healthkit" = "Użyj danych z aplikacji Zdrowie";
+
+/* Settings > Walking Speed section title */
+"settings_controller.walking_speed_section.title" = "Prędkość chodzenia";
+
+/* Label for date picker in schedule view */
+"stop_schedule_view.date" = "Data";
+
+/* Message when no departures are scheduled */
+"stop_schedule_view.no_departures" = "Brak zaplanowanych odjazdów na ten dzień";
+
+/* Message shown when schedule data is not available */
+"stop_schedule_view.no_schedule_data" = "Brak dostępnych danych rozkładu";
+
+/* Label for route picker in schedule view */
+"stop_schedule_view.route" = "Linia";
+
+/* Error message when schedule fails to load */
+"stop_schedule_view.unable_to_load" = "Nie można wczytać rozkładu";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: chegando às %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Agora não";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Usar minha localização";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: прибытие в %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Не сейчас";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Использовать мою геопозицию";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: đến nơi lúc %3$@";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "Để sau";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "Dùng vị trí của tôi";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Title of the Bookmarks tab */
 "bookmarks_controller.title" = "书签";
 
-/* An error message displayed on the bookmarks tab when the user has Sort By Distance enabled and their location isn't available. */
-"bookmarks_controller.unable_to_sort_by_distance_error" = "无法按距离排序，因为未能获取您的位置。";
-
 /* The title for the bookmarks controller section that shows bookmarks that aren't in a group. */
 "bookmarks_controller.ungrouped_bookmarks_section.title" = "未分类书签";
 
@@ -121,7 +118,6 @@
 /* This comment is displayed after the user's data is upgraded in the DataMigrationBulletinPage. */
 "data_migration_bulletin.finished_loading" = "Data Upgrade Complete!";
 
-
 /* Title for the Summary section of a data migration report */
 "data_migration_bulletin.report_summary_title" = "Summary";
 
@@ -186,7 +182,7 @@
 "location_permission_bulletin.description_text" = "请允许本App使用您的定位信息，以便更好地帮您找到附近的公交车站。";
 
 /* Button the user can tap on to disallow access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Don't use my location";
+"location_permission_bulletin.do_not_use_location_button_text" = "暂不";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "您好！";
@@ -269,15 +265,6 @@
 /* about section header */
 "map_item_controller.about_header" = "关于";
 
-/* More options header */
-"map_item_controller.more_header" = "更多";
-
-/* A table row that shows stops nearby. */
-"map_item_controller.nearby_stops_row" = "附近的车站";
-
-/* Map region manager message to the user when they need to zoom in more to view stops */
-"map_region_manager.status_overlay.zoom_to_see_stops" = "请将放大地图后寻找车站";
-
 /* Displayed in the map status view at the top of the map when the user has declined to give the app access to their location */
 "map_status_view.location_services_unavailable" = "无法获取位置";
 
@@ -307,9 +294,6 @@
 
 /* Title for a button that will crash the app. */
 "more_controller.debug_section.crash_row" = "使App崩溃";
-
-/* Section title for debugging helpers */
-"more_controller.debug_section.header" = "排错";
 
 /* This is displayed instead of the user's push ID if the value is not available. */
 "more_controller.debug_section.push_id.not_available" = "无";
@@ -346,12 +330,6 @@
 
 /* Updates and Alerts header text */
 "more_controller.updates_and_alerts.header" = "更新与通知";
-
-/* Title of the alert that tells the user they've disabled debug mode. */
-"more_header.debug_disabled.title" = "关闭排错模式";
-
-/* Title of the alert that tells the user they've enabled debug mode. */
-"more_header.debug_enabled.title" = "启动排错模式";
 
 /* Explanation about how this app is built and maintained by volunteers. */
 "more_header.support_us_label_text" = "本App由志愿者开发并提供支持";
@@ -1025,3 +1003,6 @@
 
 /* Settings > Walking Speed section title */
 "settings_controller.walking_speed_section.title" = "步行速度";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "使用我的位置";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1000,3 +1000,9 @@
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@，%2$@：%3$@ 抵達";
+
+/* Button the user can tap on to decline access to their location. */
+"location_permission_bulletin.do_not_use_location_button_text" = "暫時不要";
+
+/* Button the user taps to grant access to their location. */
+"location_permission_bulletin.use_location_button_text" = "使用我的位置";

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -395,3 +395,90 @@
 /* Plural form of schedule, referring to bus/train schedules or timetables. */
 "common.schedules" = "Orari";
 
+
+/* An error that is produced in response to HTTP status code 404 */
+"api_error.request_not_found" = "404 Non trovato (%@)";
+
+/* Button to clear recent search results */
+"common.clear_recent_searches" = "Cancella ricerche recenti";
+
+/* Confirmation message before clearing recent search results */
+"common.clear_recent_searches.confirmation" = "Vuoi davvero cancellare le tue ricerche recenti?";
+
+/* The verb 'to donate', as in to give money to a charitable cause. */
+"common.donate" = "Dona";
+
+/* The body of the message to display to the user after they donate to OTSF */
+"common.donation_thank_you.body" = "Il tuo sostegno ci aiuterà a continuare a migliorare OneBusAway.";
+
+/* Title of an alert to display to the user after they donate to OTSF */
+"common.donation_thank_you.title" = "Grazie per il tuo sostegno!";
+
+/* Description of the privacy policy for sharing data with the external survey service. */
+"common.external_survey_privacy_info.description" = "Questo sondaggio condividerà la tua fermata, linea, regione e posizione attuale.";
+
+"common.go" = "Vai";
+
+"common.next" = "Avanti";
+
+/* i.e. recently selected search results for map locations from the trip planner. */
+"common.recent_searches" = "Ricerche recenti";
+
+"common.submit" = "Invia";
+
+/* The title of the Vehicles tab showing real-time vehicle positions on a map. */
+"common.vehicles" = "Veicoli";
+
+/* Error when a route has no real-time vehicle tracking data. */
+"nearby_trip_matcher.error.no_realtime" = "Nessun dato di tracciamento in tempo reale disponibile per questa linea.";
+
+/* Error when no transit stops are found near the user's location. */
+"nearby_trip_matcher.error.no_stops" = "Nessuna fermata trovata nelle vicinanze.";
+
+/* The body of the schedule/timetable feature tip */
+"schedule_tip.message" = "Tocca qui e poi tocca \"Orari\" per visualizzare l'orario dei tuoi autobus e treni.";
+
+/* Title for the schedule/timetable feature tip */
+"schedule_tip.title" = "Visualizza l'orario della tua linea";
+
+"survey.external.url.missing" = "Non è stato possibile aprire il sondaggio in questo momento. Riprova più tardi.";
+
+"survey_alert.dismissal.body" = "Il tuo feedback aiuta a migliorare i servizi di trasporto e l'esperienza dell'app.";
+
+"survey_alert.dismissal.title" = "Ignora sondaggio";
+
+"survey_alert.do.not.show.again" = "Non mostrare più";
+
+"survey_alert.remind.later" = "Ricordamelo più tardi";
+
+"survey_alert.skip.survey" = "Salta questo sondaggio";
+
+"survey_error.hero_question_answer.error" = "Inserisci una risposta valida";
+
+"survey_error.required_remaining_questions.error" = "Rispondi a tutte le domande obbligatorie";
+
+"survey_service.not.available" = "Il servizio sondaggi non è disponibile.";
+
+"survey_service.update.path.missing" = "Si è verificato un errore durante l'invio delle tue risposte. Riprova più tardi.";
+
+"survey_success.submitted" = "Risposta al sondaggio inviata! Rispondi alle restanti domande per un feedback migliore.";
+
+"surveys.accessibility.hint_answer.input" = "Inserisci la tua risposta alla domanda del sondaggio";
+
+"surveys.accessibility_answer.input" = "Campo risposta";
+
+"surveys.accessibility_not_selected_value" = "Non selezionato";
+
+"surveys.accessibility_selected_value" = "Selezionato";
+
+"surveys.accessibility_survey_label" = "Etichetta sondaggio";
+
+"surveys.accessibility_tap_to_select" = "Tocca per selezionare";
+
+"surveys.accessibility_tap_toggle_selection" = "Tocca per attivare/disattivare la selezione";
+
+/* Message for the trip planner tip */
+"trip_planner_tip.message" = "Tocca qui per cercare luoghi e pianificare il tuo viaggio con le indicazioni del trasporto pubblico.";
+
+/* Title for the trip planner tip */
+"trip_planner_tip.title" = "Pianifica il tuo viaggio";

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -398,3 +398,87 @@
 /* Plural form of schedule, referring to bus/train schedules or timetables. */
 "common.schedules" = "Rozkłady jazdy";
 
+
+/* Button to clear recent search results */
+"common.clear_recent_searches" = "Wyczyść ostatnie wyszukiwania";
+
+/* Confirmation message before clearing recent search results */
+"common.clear_recent_searches.confirmation" = "Czy na pewno chcesz wyczyścić ostatnie wyszukiwania?";
+
+/* The verb 'to donate', as in to give money to a charitable cause. */
+"common.donate" = "Przekaż darowiznę";
+
+/* The body of the message to display to the user after they donate to OTSF */
+"common.donation_thank_you.body" = "Twoje wsparcie pomoże nam dalej ulepszać OneBusAway.";
+
+/* Title of an alert to display to the user after they donate to OTSF */
+"common.donation_thank_you.title" = "Dziękujemy za Twoje wsparcie!";
+
+/* Description of the privacy policy for sharing data with the external survey service. */
+"common.external_survey_privacy_info.description" = "Ta ankieta udostępni Twój przystanek, linię, region i bieżącą lokalizację.";
+
+"common.go" = "Przejdź";
+
+"common.next" = "Dalej";
+
+/* i.e. recently selected search results for map locations from the trip planner. */
+"common.recent_searches" = "Ostatnie wyszukiwania";
+
+"common.submit" = "Wyślij";
+
+/* The title of the Vehicles tab showing real-time vehicle positions on a map. */
+"common.vehicles" = "Pojazdy";
+
+/* Error when a route has no real-time vehicle tracking data. */
+"nearby_trip_matcher.error.no_realtime" = "Brak danych śledzenia na żywo dla tej linii.";
+
+/* Error when no transit stops are found near the user's location. */
+"nearby_trip_matcher.error.no_stops" = "Nie znaleziono przystanków w pobliżu.";
+
+/* The body of the schedule/timetable feature tip */
+"schedule_tip.message" = "Dotknij tutaj, a następnie dotknij „Rozkłady”, aby zobaczyć rozkład jazdy autobusów i pociągów.";
+
+/* Title for the schedule/timetable feature tip */
+"schedule_tip.title" = "Zobacz rozkład swojej linii";
+
+"survey.external.url.missing" = "Nie udało się teraz otworzyć ankiety. Spróbuj ponownie później.";
+
+"survey_alert.dismissal.body" = "Twoja opinia pomaga ulepszać usługi transportowe i działanie aplikacji.";
+
+"survey_alert.dismissal.title" = "Odrzuć ankietę";
+
+"survey_alert.do.not.show.again" = "Nie pokazuj ponownie";
+
+"survey_alert.remind.later" = "Przypomnij mi później";
+
+"survey_alert.skip.survey" = "Pomiń tę ankietę";
+
+"survey_error.hero_question_answer.error" = "Wprowadź prawidłową odpowiedź";
+
+"survey_error.required_remaining_questions.error" = "Odpowiedz na wszystkie wymagane pytania";
+
+"survey_service.not.available" = "Usługa ankiet jest niedostępna.";
+
+"survey_service.update.path.missing" = "Coś poszło nie tak podczas przesyłania Twoich odpowiedzi. Spróbuj ponownie później.";
+
+"survey_success.submitted" = "Odpowiedź w ankiecie została wysłana! Odpowiedz na pozostałe pytania, aby przekazać lepszą opinię.";
+
+"surveys.accessibility.hint_answer.input" = "Wprowadź odpowiedź na pytanie ankiety";
+
+"surveys.accessibility_answer.input" = "Pole odpowiedzi";
+
+"surveys.accessibility_not_selected_value" = "Nie wybrano";
+
+"surveys.accessibility_selected_value" = "Wybrano";
+
+"surveys.accessibility_survey_label" = "Etykieta ankiety";
+
+"surveys.accessibility_tap_to_select" = "Dotknij, aby wybrać";
+
+"surveys.accessibility_tap_toggle_selection" = "Dotknij, aby przełączyć wybór";
+
+/* Message for the trip planner tip */
+"trip_planner_tip.message" = "Dotknij tutaj, aby wyszukać miejsca i zaplanować podróż ze wskazówkami dojazdu komunikacją.";
+
+/* Title for the trip planner tip */
+"trip_planner_tip.title" = "Zaplanuj swoją podróż";


### PR DESCRIPTION
## Summary

Brings every locale's `Localizable.strings` into full alignment with the English source.

### Added translations
- **`it` and `pl`** were substantially behind — added ~120 keys each, covering current-trip tracking, the route picker, schedule views, donations, surveys, walking-speed settings, and map item actions. Terminology was grounded in each file's existing vocabulary for consistency.
- **`use_location_button_text`** ("Use My Location") was never translated in any locale — added across all 12.
- **`do_not_use_location_button_text`** changed in English to "Not Now"; corrected the stale values in `es`, `it`, `pl`, and `zh-Hans`.

### Removed orphaned keys
Deleted 7 keys from `es`, `it`, `pl`, and `zh-Hans` that no longer exist in the English source (e.g. `map_item_controller.more_header`, `more_header.debug_enabled.title`).

## Verification
- ✅ Every locale now matches the English key set exactly — no missing, no orphaned keys
- ✅ All 14 changed files pass `plutil -lint`
- ✅ Placeholders (`%@`, `%d`, `%1$s`), emoji, ellipses, and escaped quotes preserved
- ✅ New keys carry their English source comments; no existing translations reordered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multilingual support for location permission prompts across 12+ languages.
  * Introduced new UI strings for donations, surveys, trip planning tips, and recent search functionality.
  * Enhanced accessibility support for survey interactions.

* **Improvements**
  * Expanded internationalization with location permission and feature-specific translations.
  * Refined nearby trip matching error messaging and schedule tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->