### PR TITLE
Floating sheet system — foundation

### DIFF
--- a/Apps/KiedyBus/AppDelegate.m
+++ b/Apps/KiedyBus/AppDelegate.m
@@ -13,7 +13,7 @@
 
 @interface AppDelegate ()<OBAApplicationDelegate>
 @property(nonatomic,strong) NSUserDefaults *userDefaults;
-@property(nonatomic,strong) OBAClassicApplicationRootController *rootController;
+@property(nonatomic,strong) UIViewController *rootController;
 @end
 
 @implementation AppDelegate
@@ -73,7 +73,7 @@
 }
 
 - (void)applicationReloadRootInterface:(OBAApplication*)application {
-    self.rootController = [[OBAClassicApplicationRootController alloc] initWithApplication:application];
+    self.rootController = [OBAApplicationRootControllerFactory makeWithApplication:application];
     self.window.rootViewController = self.rootController;
 }
 

--- a/Apps/OneBusAway/AppDelegate.m
+++ b/Apps/OneBusAway/AppDelegate.m
@@ -15,7 +15,7 @@
 
 @interface AppDelegate ()<OBAApplicationDelegate>
 @property(nonatomic,strong) NSUserDefaults *userDefaults;
-@property(nonatomic,strong) OBAClassicApplicationRootController *rootController;
+@property(nonatomic,strong) UIViewController *rootController;
 @property(nonatomic,strong) OBAAnalyticsOrchestrator *analyticsClient;
 @property(nonatomic,strong) OBACloudPushService *pushService;
 @end
@@ -99,7 +99,7 @@
 
 - (void)applicationReloadRootInterface:(OBAApplication*)application {
     void(^showRootController)(void) = ^{
-        self.rootController = [[OBAClassicApplicationRootController alloc] initWithApplication:application];
+        self.rootController = [OBAApplicationRootControllerFactory makeWithApplication:application];
         self.window.rootViewController = self.rootController;
     };
 

--- a/OBAKit/Alerts/AgencyAlertBulletin.swift
+++ b/OBAKit/Alerts/AgencyAlertBulletin.swift
@@ -49,6 +49,7 @@ class AgencyAlertBulletin: NSObject {
         }
     }
 
+    @MainActor
     func show(in application: UIApplication) {
         bulletinManager.show(in: application, rootItem: alertPage)
     }

--- a/OBAKit/Alerts/AgencyAlertBulletin.swift
+++ b/OBAKit/Alerts/AgencyAlertBulletin.swift
@@ -50,6 +50,6 @@ class AgencyAlertBulletin: NSObject {
     }
 
     func show(in application: UIApplication) {
-        bulletinManager.show(in: application)
+        bulletinManager.show(in: application, rootItem: alertPage)
     }
 }

--- a/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
+++ b/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
@@ -26,6 +26,7 @@ import BLTNBoard
 /// Single-page bulletins only: BLTN fires the dismissal handler on the
 /// `currentItem`, which equals `rootItem` until something is pushed. OBA's
 /// bulletins are all single-page today; revisit if that changes.
+@MainActor
 final class BulletinOverlayWindow {
 
     static let shared = BulletinOverlayWindow()

--- a/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
+++ b/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
@@ -1,0 +1,83 @@
+//
+//  BulletinOverlayWindow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import BLTNBoard
+
+/// Owns a dedicated `UIWindow` for hosting `BLTNItemManager` presentations.
+///
+/// Bulletins originally rode `keyWindowFromScene?.topViewController`. That walk
+/// lands inside the SwiftUI map-panel home sheet's hosting controller, which is
+/// constrained by `UISheetPresentationController` to its current detent (~80pt
+/// when collapsed) — so a `present(_:animated:)` from there squeezes the bulletin
+/// into the sheet's height and wedges the floating sheet.
+///
+/// A dedicated window at `.alert` level dodges the sheet hierarchy entirely.
+/// Teardown is wired into BLTN's per-item `dismissalHandler` (its official
+/// dismissal hook), so the window retires exactly when the bulletin finishes
+/// animating out — no timers, no `dismiss(_:animated:)` overrides.
+///
+/// Single-page bulletins only: BLTN fires the dismissal handler on the
+/// `currentItem`, which equals `rootItem` until something is pushed. OBA's
+/// bulletins are all single-page today; revisit if that changes.
+final class BulletinOverlayWindow {
+
+    static let shared = BulletinOverlayWindow()
+
+    private var window: UIWindow?
+
+    private init() {}
+
+    /// Installs the overlay window (if not already up) and returns its host
+    /// controller for `showBulletin(above:)`. Hooks `rootItem.dismissalHandler`
+    /// to tear the window down once the bulletin dismisses, chaining any
+    /// handler the caller already set.
+    func install(in scene: UIWindowScene, rootItem: BLTNItem) -> UIViewController {
+        if let host = window?.rootViewController {
+            return host
+        }
+
+        let window = UIWindow(windowScene: scene)
+        window.windowLevel = .alert
+        window.backgroundColor = .clear
+
+        let host = UIViewController()
+        host.view.backgroundColor = .clear
+        window.rootViewController = host
+        // Non-key intentionally: iOS hit-tests top-down by window level, so the
+        // bulletin's buttons still receive touches without us hijacking key
+        // status from the main app window.
+        window.isHidden = false
+
+        self.window = window
+
+        let originalDismissal = rootItem.dismissalHandler
+        rootItem.dismissalHandler = { [weak self] item in
+            originalDismissal?(item)
+            self?.teardown()
+        }
+
+        return host
+    }
+
+    private func teardown() {
+        let scene = window?.windowScene
+        window?.rootViewController = nil
+        window?.isHidden = true
+        window?.windowScene = nil
+        window = nil
+
+        // iOS doesn't always rebind key status when an alert-level window
+        // hides — force the main app window to reclaim it so the visible UI
+        // resumes receiving touches.
+        scene?.windows
+            .first(where: { !$0.isHidden && $0.windowLevel == .normal })?
+            .makeKey()
+    }
+}

--- a/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
+++ b/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
@@ -35,12 +35,24 @@ final class BulletinOverlayWindow {
 
     private init() {}
 
-    /// Installs the overlay window (if not already up) and returns its host
-    /// controller for `showBulletin(above:)`. Hooks `rootItem.dismissalHandler`
-    /// to tear the window down once the bulletin dismisses, chaining any
-    /// handler the caller already set.
+    /// Installs the overlay window and returns its host controller for
+    /// `showBulletin(above:)`. Hooks `rootItem.dismissalHandler` to tear the
+    /// window down once the bulletin dismisses, chaining any handler the
+    /// caller already set.
+    ///
+    /// One bulletin at a time. Each `BLTNItemManager` already guards on
+    /// `isShowingBulletin`, but those guards are per-manager; this singleton is
+    /// shared across every OBA bulletin manager, so two managers can call
+    /// `install` while a third is mid-presentation. If that ever happens, the
+    /// second caller's `dismissalHandler` chain would never be installed (the
+    /// early-return path used to silently skip it) and teardown would fire on
+    /// the first dismissal, yanking the window out from under the second
+    /// bulletin. The DEBUG assert flags the violation at the point it occurs;
+    /// release builds still return the existing host so the second bulletin at
+    /// worst piggybacks on the first's window rather than crashing.
     func install(in scene: UIWindowScene, rootItem: BLTNItem) -> UIViewController {
         if let host = window?.rootViewController {
+            assertionFailure("BulletinOverlayWindow already in use — concurrent bulletin presentations aren't supported (shared singleton, single-bulletin-at-a-time).")
             return host
         }
 

--- a/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
+++ b/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
@@ -51,6 +51,15 @@ final class BulletinOverlayWindow {
     /// release builds still return the existing host so the second bulletin at
     /// worst piggybacks on the first's window rather than crashing.
     func install(in scene: UIWindowScene, rootItem: BLTNItem) -> UIViewController {
+        // Single-page only: teardown rides `rootItem.dismissalHandler`, but
+        // BLTN fires the dismissal handler on `currentItem` — which only
+        // equals `rootItem` until something gets pushed. A multi-page item
+        // would tear the window down on the first page's dismissal rather
+        // than the flow's final dismissal. Catch the violation at install
+        // time so a future contributor sees the contract instead of debugging
+        // a teardown-mid-flow weirdness in the wild.
+        assert(rootItem.next == nil, "BulletinOverlayWindow only supports single-page bulletins — multi-page flows would tear down on the first page's dismissal. See type docstring.")
+
         if let host = window?.rootViewController {
             assertionFailure("BulletinOverlayWindow already in use — concurrent bulletin presentations aren't supported (shared singleton, single-bulletin-at-a-time).")
             return host

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -25,19 +25,30 @@ class ThemedBulletinPage: BLTNPageItem {
 }
 
 extension BLTNItemManager {
-    /// Presents the bulletin above the topmost view controller of the application's key window.
+    /// Presents the bulletin in a dedicated overlay `UIWindow` attached to the
+    /// active scene.
     ///
-    /// Use this instead of `showBulletin(in:)`: that method presents inside a `UIWindow`
-    /// it creates without a `windowScene`, and iOS never displays such a window in a
-    /// scene-based app, so the bulletin silently fails to appear.
-    func show(in application: UIApplication) {
+    /// Avoid `showBulletin(in:)` (BLTNBoard's built-in): it creates a `UIWindow`
+    /// without a `windowScene`, which iOS won't display in a scene-based app.
+    /// Avoid presenting from `keyWindowFromScene?.topViewController` directly:
+    /// in the SwiftUI map-panel experience that walk lands inside the home
+    /// sheet's hosting controller, and `UISheetPresentationController` clamps
+    /// modal presentations to the sheet's current detent — the bulletin then
+    /// renders inside the collapsed sheet's ~80pt strip.
+    ///
+    /// `rootItem` is the item passed to `BLTNItemManager.init(rootItem:)`; it
+    /// has to be supplied here because the manager keeps its reference private,
+    /// and we hook its `dismissalHandler` to retire the overlay window.
+    func show(in application: UIApplication, rootItem: BLTNItem) {
         guard
             !isShowingBulletin,
-            let topViewController = application.keyWindowFromScene?.topViewController
+            let scene = application.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
         else {
             return
         }
 
-        showBulletin(above: topViewController)
+        let host = BulletinOverlayWindow.shared.install(in: scene, rootItem: rootItem)
+        showBulletin(above: host)
     }
 }

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -41,7 +41,15 @@ extension BLTNItemManager {
     /// and we hook its `dismissalHandler` to retire the overlay window.
     @MainActor
     func show(in application: UIApplication, rootItem: BLTNItem) {
-        guard !isShowingBulletin, let scene = application.bulletinTargetScene else {
+        // Re-entrant call while a bulletin is already up: silent no-op is the
+        // intended behavior — callers (e.g. reachability flapping) lean on this.
+        guard !isShowingBulletin else { return }
+
+        // No usable scene means the bulletin disappears with no UI trace,
+        // including for the error path (`Application.displayError`). Log so
+        // there's at least a diagnostic breadcrumb instead of silent loss.
+        guard let scene = application.bulletinTargetScene else {
+            Logger.error("Bulletin dropped: no foreground-active window scene available to host it.")
             return
         }
 

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -39,16 +39,35 @@ extension BLTNItemManager {
     /// `rootItem` is the item passed to `BLTNItemManager.init(rootItem:)`; it
     /// has to be supplied here because the manager keeps its reference private,
     /// and we hook its `dismissalHandler` to retire the overlay window.
+    @MainActor
     func show(in application: UIApplication, rootItem: BLTNItem) {
-        guard
-            !isShowingBulletin,
-            let scene = application.connectedScenes
-                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        else {
+        guard !isShowingBulletin, let scene = application.bulletinTargetScene else {
             return
         }
 
         let host = BulletinOverlayWindow.shared.install(in: scene, rootItem: rootItem)
         showBulletin(above: host)
+    }
+}
+
+extension UIApplication {
+    /// The `UIWindowScene` a bulletin should target.
+    ///
+    /// Prefers the scene whose key window is actually key — that's where the
+    /// user is interacting on multi-window iPad. Filters out external displays
+    /// (`.windowExternalDisplayNonInteractive`) so bulletins never land on a
+    /// secondary screen no one is touching. Falls back to the first
+    /// foreground-active application scene when no key window can be found.
+    fileprivate var bulletinTargetScene: UIWindowScene? {
+        let activeAppScenes = connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive && $0.session.role == .windowApplication }
+
+        if let interactiveScene = activeAppScenes.first(where: { scene in
+            scene.windows.contains(where: \.isKeyWindow)
+        }) {
+            return interactiveScene
+        }
+        return activeAppScenes.first
     }
 }

--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import SwiftUI
 import UIKit
 import OBAKitCore
 
@@ -20,39 +21,65 @@ public class ClassicApplicationRootController: UITabBarController {
     }
 
     private let application: Application
+    private let useMapPanel: Bool
 
     @objc public init(application: Application) {
         self.application = application
 
-        self.mapController = MapViewController(application: application)
-        self.recentStopsController = RecentStopsViewController(application: application)
-        self.bookmarksController = BookmarksViewController(application: application)
-        self.moreController = MoreViewController(application: application)
+        let useMapPanel = application.userDefaults.bool(
+            forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey
+        )
+        self.useMapPanel = useMapPanel
 
-        super.init(nibName: nil, bundle: nil)
+        if useMapPanel {
+            // Map panel experience — the tab bar is discarded and the SwiftUI
+            // map (with the floating sheet) occupies the whole screen.
+            self.mapController = nil
+            self.recentStopsController = nil
+            self.bookmarksController = nil
+            self.moreController = nil
 
-        if #available(iOS 26.0, *) {
-            self.tabBar.isTranslucent = true
+            super.init(nibName: nil, bundle: nil)
+
+            self.tabBar.isHidden = true
+
+            self.application.viewRouter.rootController = self
+
+            let host = UIHostingController(rootView: MapPanelRootView(application: application))
+            viewControllers = [host]
         } else {
-            self.tabBar.isTranslucent = false
+            self.mapController = MapViewController(application: application)
+            self.recentStopsController = RecentStopsViewController(application: application)
+            self.bookmarksController = BookmarksViewController(application: application)
+            self.moreController = MoreViewController(application: application)
+
+            super.init(nibName: nil, bundle: nil)
+
+            if #available(iOS 26.0, *) {
+                self.tabBar.isTranslucent = true
+            } else {
+                self.tabBar.isTranslucent = false
+            }
+
+            self.application.viewRouter.rootController = self
+
+            let mapNav = application.viewRouter.buildNavigation(controller: self.mapController!, prefersLargeTitles: false)
+            let recentStopsNav = application.viewRouter.buildNavigation(controller: self.recentStopsController!)
+            let bookmarksNav = application.viewRouter.buildNavigation(controller: self.bookmarksController!)
+            let moreNav = application.viewRouter.buildNavigation(controller: self.moreController!)
+
+            viewControllers = [mapNav, recentStopsNav, bookmarksNav, moreNav]
+
+            selectedIndex = application.userDataStore.lastSelectedView.rawValue
         }
-
-        self.application.viewRouter.rootController = self
-
-        let mapNav = application.viewRouter.buildNavigation(controller: self.mapController, prefersLargeTitles: false)
-        let recentStopsNav = application.viewRouter.buildNavigation(controller: self.recentStopsController)
-        let bookmarksNav = application.viewRouter.buildNavigation(controller: self.bookmarksController)
-        let moreNav = application.viewRouter.buildNavigation(controller: self.moreController)
-
-        viewControllers = [mapNav, recentStopsNav, bookmarksNav, moreNav]
-
-        selectedIndex = application.userDataStore.lastSelectedView.rawValue
     }
 
-    let mapController: MapViewController
-    let recentStopsController: RecentStopsViewController
-    let bookmarksController: BookmarksViewController
-    let moreController: MoreViewController
+    /// Non-nil only when the classic UIKit experience is active.
+    /// In map panel mode, the tab bar and these tab VCs are not constructed.
+    let mapController: MapViewController?
+    let recentStopsController: RecentStopsViewController?
+    let bookmarksController: BookmarksViewController?
+    let moreController: MoreViewController?
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -67,7 +94,10 @@ public class ClassicApplicationRootController: UITabBarController {
         }
 
         // If the user is already on the map tab and they tap on the map tab item again, then zoom to their location.
-        if let root = (selectedViewController as? UINavigationController)?.viewControllers.first, root == mapController, selectedTab == .map {
+        // Only available with the classic UIKit map.
+        if let mapController, let root = (selectedViewController as? UINavigationController)?.viewControllers.first,
+            root === mapController,
+            selectedTab == .map {
             mapController.centerMapOnUserLocation()
         }
 
@@ -75,6 +105,8 @@ public class ClassicApplicationRootController: UITabBarController {
     }
 
     func navigate(to destination: Page) {
+        // In map panel mode there are no per-page tabs to switch to.
+        guard !useMapPanel else { return }
         navigationController?.popToViewController(self, animated: true)
         selectedIndex = destination.rawValue
     }

--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -7,18 +7,9 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import SwiftUI
 import UIKit
 import OBAKitCore
 
-// TODO: Transitional shape — in map-panel mode this class hides the tab bar
-// and hosts a single `UIHostingController(MapPanelRootView)`, leaving the
-// tab-VC properties as `Optional`. Once the map-panel experience graduates
-// from experimental, split into a dedicated `MapPanelRootController:
-// UIViewController` and have the AppDelegates (Apps/OneBusAway, Apps/KiedyBus)
-// + `ViewRouter.rootController` pick between the two. That removes the
-// optional properties and the `useMapPanel` guards in `navigate(to:)` and
-// `tabBar(_:didSelect:)`.
 @objc(OBAClassicApplicationRootController)
 public class ClassicApplicationRootController: UITabBarController {
     public enum Page: Int {
@@ -29,68 +20,39 @@ public class ClassicApplicationRootController: UITabBarController {
     }
 
     private let application: Application
-    private let useMapPanel: Bool
 
     @objc public init(application: Application) {
         self.application = application
 
-        let useMapPanel = application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey)
-        self.useMapPanel = useMapPanel
+        self.mapController = MapViewController(application: application)
+        self.recentStopsController = RecentStopsViewController(application: application)
+        self.bookmarksController = BookmarksViewController(application: application)
+        self.moreController = MoreViewController(application: application)
 
-        if useMapPanel {
-            // Map panel experience — the tab bar is discarded and the SwiftUI
-            // map (with the floating sheet) occupies the whole screen.
-            self.mapController = nil
-            self.recentStopsController = nil
-            self.bookmarksController = nil
-            self.moreController = nil
+        super.init(nibName: nil, bundle: nil)
 
-            super.init(nibName: nil, bundle: nil)
-
-            self.tabBar.isHidden = true
-
-            self.application.viewRouter.rootController = self
-
-            let host = UIHostingController(rootView: MapPanelRootView(application: application))
-            viewControllers = [host]
+        if #available(iOS 26.0, *) {
+            self.tabBar.isTranslucent = true
         } else {
-            let mapController = MapViewController(application: application)
-            let recentStopsController = RecentStopsViewController(application: application)
-            let bookmarksController = BookmarksViewController(application: application)
-            let moreController = MoreViewController(application: application)
-
-            self.mapController = mapController
-            self.recentStopsController = recentStopsController
-            self.bookmarksController = bookmarksController
-            self.moreController = moreController
-
-            super.init(nibName: nil, bundle: nil)
-
-            if #available(iOS 26.0, *) {
-                self.tabBar.isTranslucent = true
-            } else {
-                self.tabBar.isTranslucent = false
-            }
-
-            self.application.viewRouter.rootController = self
-
-            let mapNav = application.viewRouter.buildNavigation(controller: mapController, prefersLargeTitles: false)
-            let recentStopsNav = application.viewRouter.buildNavigation(controller: recentStopsController)
-            let bookmarksNav = application.viewRouter.buildNavigation(controller: bookmarksController)
-            let moreNav = application.viewRouter.buildNavigation(controller: moreController)
-
-            viewControllers = [mapNav, recentStopsNav, bookmarksNav, moreNav]
-
-            selectedIndex = application.userDataStore.lastSelectedView.rawValue
+            self.tabBar.isTranslucent = false
         }
+
+        self.application.viewRouter.rootController = self
+
+        let mapNav = application.viewRouter.buildNavigation(controller: self.mapController, prefersLargeTitles: false)
+        let recentStopsNav = application.viewRouter.buildNavigation(controller: self.recentStopsController)
+        let bookmarksNav = application.viewRouter.buildNavigation(controller: self.bookmarksController)
+        let moreNav = application.viewRouter.buildNavigation(controller: self.moreController)
+
+        viewControllers = [mapNav, recentStopsNav, bookmarksNav, moreNav]
+
+        selectedIndex = application.userDataStore.lastSelectedView.rawValue
     }
 
-    /// Non-nil only when the classic UIKit experience is active.
-    /// In map panel mode, the tab bar and these tab VCs are not constructed.
-    let mapController: MapViewController?
-    let recentStopsController: RecentStopsViewController?
-    let bookmarksController: BookmarksViewController?
-    let moreController: MoreViewController?
+    let mapController: MapViewController
+    let recentStopsController: RecentStopsViewController
+    let bookmarksController: BookmarksViewController
+    let moreController: MoreViewController
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -105,10 +67,7 @@ public class ClassicApplicationRootController: UITabBarController {
         }
 
         // If the user is already on the map tab and they tap on the map tab item again, then zoom to their location.
-        // Only available with the classic UIKit map.
-        if let mapController, let root = (selectedViewController as? UINavigationController)?.viewControllers.first,
-            root === mapController,
-            selectedTab == .map {
+        if let root = (selectedViewController as? UINavigationController)?.viewControllers.first, root == mapController, selectedTab == .map {
             mapController.centerMapOnUserLocation()
         }
 
@@ -116,8 +75,6 @@ public class ClassicApplicationRootController: UITabBarController {
     }
 
     func navigate(to destination: Page) {
-        // In map panel mode there are no per-page tabs to switch to.
-        guard !useMapPanel else { return }
         navigationController?.popToViewController(self, animated: true)
         selectedIndex = destination.rawValue
     }

--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -26,9 +26,7 @@ public class ClassicApplicationRootController: UITabBarController {
     @objc public init(application: Application) {
         self.application = application
 
-        let useMapPanel = application.userDefaults.bool(
-            forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey
-        )
+        let useMapPanel = application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey)
         self.useMapPanel = useMapPanel
 
         if useMapPanel {
@@ -48,10 +46,15 @@ public class ClassicApplicationRootController: UITabBarController {
             let host = UIHostingController(rootView: MapPanelRootView(application: application))
             viewControllers = [host]
         } else {
-            self.mapController = MapViewController(application: application)
-            self.recentStopsController = RecentStopsViewController(application: application)
-            self.bookmarksController = BookmarksViewController(application: application)
-            self.moreController = MoreViewController(application: application)
+            let mapController = MapViewController(application: application)
+            let recentStopsController = RecentStopsViewController(application: application)
+            let bookmarksController = BookmarksViewController(application: application)
+            let moreController = MoreViewController(application: application)
+
+            self.mapController = mapController
+            self.recentStopsController = recentStopsController
+            self.bookmarksController = bookmarksController
+            self.moreController = moreController
 
             super.init(nibName: nil, bundle: nil)
 
@@ -63,10 +66,10 @@ public class ClassicApplicationRootController: UITabBarController {
 
             self.application.viewRouter.rootController = self
 
-            let mapNav = application.viewRouter.buildNavigation(controller: self.mapController!, prefersLargeTitles: false)
-            let recentStopsNav = application.viewRouter.buildNavigation(controller: self.recentStopsController!)
-            let bookmarksNav = application.viewRouter.buildNavigation(controller: self.bookmarksController!)
-            let moreNav = application.viewRouter.buildNavigation(controller: self.moreController!)
+            let mapNav = application.viewRouter.buildNavigation(controller: mapController, prefersLargeTitles: false)
+            let recentStopsNav = application.viewRouter.buildNavigation(controller: recentStopsController)
+            let bookmarksNav = application.viewRouter.buildNavigation(controller: bookmarksController)
+            let moreNav = application.viewRouter.buildNavigation(controller: moreController)
 
             viewControllers = [mapNav, recentStopsNav, bookmarksNav, moreNav]
 

--- a/OBAKit/ClassicUI/ClassicApplicationRootController.swift
+++ b/OBAKit/ClassicUI/ClassicApplicationRootController.swift
@@ -11,6 +11,14 @@ import SwiftUI
 import UIKit
 import OBAKitCore
 
+// TODO: Transitional shape — in map-panel mode this class hides the tab bar
+// and hosts a single `UIHostingController(MapPanelRootView)`, leaving the
+// tab-VC properties as `Optional`. Once the map-panel experience graduates
+// from experimental, split into a dedicated `MapPanelRootController:
+// UIViewController` and have the AppDelegates (Apps/OneBusAway, Apps/KiedyBus)
+// + `ViewRouter.rootController` pick between the two. That removes the
+// optional properties and the `useMapPanel` guards in `navigate(to:)` and
+// `tabBar(_:didSelect:)`.
 @objc(OBAClassicApplicationRootController)
 public class ClassicApplicationRootController: UITabBarController {
     public enum Page: Int {

--- a/OBAKit/Errors/ErrorBulletin.swift
+++ b/OBAKit/Errors/ErrorBulletin.swift
@@ -81,6 +81,6 @@ class ErrorBulletin: NSObject {
     }
 
     func show(in app: UIApplication) {
-        bulletinManager.show(in: app)
+        bulletinManager.show(in: app, rootItem: page)
     }
 }

--- a/OBAKit/Errors/ErrorBulletin.swift
+++ b/OBAKit/Errors/ErrorBulletin.swift
@@ -80,6 +80,7 @@ class ErrorBulletin: NSObject {
         )
     }
 
+    @MainActor
     func show(in app: UIApplication) {
         bulletinManager.show(in: app, rootItem: page)
     }

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -256,17 +256,21 @@ public class Application: CoreApplication, PushServiceDelegate {
             .eraseToAnyPublisher()
             .sink(receiveValue: { [weak self] result in
                 guard let self = self else { return }
-                if result.isConnected {
-                    self.reachabilityBulletin?.dismiss()
-                }
-                else {
-                    guard let app = self.delegate?.uiApplication else { return }
-
-                    if self.reachabilityBulletin == nil {
-                        self.reachabilityBulletin = ReachabilityBulletin()
+                // `.receive(on: DispatchQueue.main)` above guarantees main —
+                // bulletin presentation is `@MainActor` and needs that asserted.
+                MainActor.assumeIsolated {
+                    if result.isConnected {
+                        self.reachabilityBulletin?.dismiss()
                     }
+                    else {
+                        guard let app = self.delegate?.uiApplication else { return }
 
-                    self.reachabilityBulletin?.showStatus(result, in: app, isCellularDataRestricted: self.isCellularDataRestricted)
+                        if self.reachabilityBulletin == nil {
+                            self.reachabilityBulletin = ReachabilityBulletin()
+                        }
+
+                        self.reachabilityBulletin?.showStatus(result, in: app, isCellularDataRestricted: self.isCellularDataRestricted)
+                    }
                 }
             })
     }
@@ -336,6 +340,7 @@ public class Application: CoreApplication, PushServiceDelegate {
 
     private var alertBulletin: AgencyAlertBulletin?
 
+    @MainActor
     public func agencyAlertsUpdated() {
         #if DEBUG
         // UI tests run against the live network, so a real high-severity alert can

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -256,21 +256,23 @@ public class Application: CoreApplication, PushServiceDelegate {
             .eraseToAnyPublisher()
             .sink(receiveValue: { [weak self] result in
                 guard let self = self else { return }
-                // `.receive(on: DispatchQueue.main)` above guarantees main —
-                // bulletin presentation is `@MainActor` and needs that asserted.
+                // `.receive(on: DispatchQueue.main)` above is what makes
+                // `assumeIsolated` safe here — bulletin presentation is
+                // `@MainActor`. Don't remove the `.receive(on:)` upstream;
+                // doing so would silently turn this into a crash-on-mismatch.
                 MainActor.assumeIsolated {
                     if result.isConnected {
                         self.reachabilityBulletin?.dismiss()
+                        return
                     }
-                    else {
-                        guard let app = self.delegate?.uiApplication else { return }
 
-                        if self.reachabilityBulletin == nil {
-                            self.reachabilityBulletin = ReachabilityBulletin()
-                        }
+                    guard let app = self.delegate?.uiApplication else { return }
 
-                        self.reachabilityBulletin?.showStatus(result, in: app, isCellularDataRestricted: self.isCellularDataRestricted)
+                    if self.reachabilityBulletin == nil {
+                        self.reachabilityBulletin = ReachabilityBulletin()
                     }
+
+                    self.reachabilityBulletin?.showStatus(result, in: app, isCellularDataRestricted: self.isCellularDataRestricted)
                 }
             })
     }

--- a/OBAKit/Orchestration/ApplicationRootControllerFactory.swift
+++ b/OBAKit/Orchestration/ApplicationRootControllerFactory.swift
@@ -1,0 +1,31 @@
+//
+//  ApplicationRootControllerFactory.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+/// `@objc` seam that the (Objective-C) AppDelegates call to build the
+/// window's root view controller. Reads the map-panel feature flag and
+/// returns either `ClassicApplicationRootController` (the UIKit tab bar) or
+/// `MapPanelRootController` (the SwiftUI map-panel experience).
+///
+/// Centralising the branch here keeps each concrete root controller
+/// single-purpose and removes the need for Obj-C callers to know about the
+/// feature flag.
+@objc(OBAApplicationRootControllerFactory)
+public final class ApplicationRootControllerFactory: NSObject {
+
+    @objc public static func make(application: Application) -> UIViewController {
+        if application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey) {
+            return MapPanelRootController(application: application)
+        } else {
+            return ClassicApplicationRootController(application: application)
+        }
+    }
+}

--- a/OBAKit/Reachability/Reachability.swift
+++ b/OBAKit/Reachability/Reachability.swift
@@ -39,6 +39,7 @@ class ReachabilityBulletin: NSObject {
         bulletinManager.edgeSpacing = .compact
     }
 
+    @MainActor
     func showStatus(_ status: ConnectivityResult, in application: UIApplication, isCellularDataRestricted: Bool = false) {
         guard
             !status.isConnected,

--- a/OBAKit/Reachability/Reachability.swift
+++ b/OBAKit/Reachability/Reachability.swift
@@ -82,7 +82,7 @@ class ReachabilityBulletin: NSObject {
 
         dismiss()
 
-        bulletinManager.show(in: application)
+        bulletinManager.show(in: application, rootItem: connectivityPage)
     }
 
     func dismiss() {

--- a/OBAKit/Regions/RegionMismatchBulletin.swift
+++ b/OBAKit/Regions/RegionMismatchBulletin.swift
@@ -56,6 +56,6 @@ class RegionMismatchBulletin: NSObject {
     }
 
     func show(in app: UIApplication) {
-        bulletinManager.show(in: app)
+        bulletinManager.show(in: app, rootItem: page)
     }
 }

--- a/OBAKit/Regions/RegionMismatchBulletin.swift
+++ b/OBAKit/Regions/RegionMismatchBulletin.swift
@@ -55,6 +55,7 @@ class RegionMismatchBulletin: NSObject {
         }
     }
 
+    @MainActor
     func show(in app: UIApplication) {
         bulletinManager.show(in: app, rootItem: page)
     }

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -55,7 +55,7 @@ class SettingsViewController: FormViewController {
             mapSectionShowsScale: application.mapRegionManager.mapViewShowsScale,
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
             mapSectionShowsHeading: application.mapRegionManager.mapViewShowsHeading,
-            MapPanelRootView.useMapPanelExperienceUserDefaultsKey: application.userDefaults.bool(forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey),
+            FeatureFlags.useMapPanelExperienceKey: application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey),
             privacySectionReportingEnabled: application.analytics?.reportingEnabled() ?? false,
             DataLoadFeedbackGenerator.EnabledUserDefaultsKey: application.userDefaults.bool(forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey),
             AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts: application.userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts),
@@ -99,8 +99,8 @@ class SettingsViewController: FormViewController {
             application.userDefaults.set(mapViewShowsStopAnnotationLabels, forKey: MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey)
         }
 
-        if let useMapPanel = values[MapPanelRootView.useMapPanelExperienceUserDefaultsKey] as? Bool {
-            application.userDefaults.set(useMapPanel, forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey)
+        if let useMapPanel = values[FeatureFlags.useMapPanelExperienceKey] as? Bool {
+            application.userDefaults.set(useMapPanel, forKey: FeatureFlags.useMapPanelExperienceKey)
         }
 
         if let testAlerts = values[AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts] as? Bool {
@@ -176,7 +176,7 @@ class SettingsViewController: FormViewController {
         )
 
         section <<< SwitchRow {
-            $0.tag = MapPanelRootView.useMapPanelExperienceUserDefaultsKey
+            $0.tag = FeatureFlags.useMapPanelExperienceKey
             $0.title = OBALoc("settings_controller.experimental_section.map_panel", value: "Use map panel experience", comment: "Settings > Experimental section > Map panel toggle")
         }
 

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -37,6 +37,7 @@ class SettingsViewController: FormViewController {
 
         form
             +++ mapSection
+            +++ experimentalSection
             +++ alertsSection
             +++ accessibilitySection
             +++ walkingSpeedSection
@@ -54,6 +55,7 @@ class SettingsViewController: FormViewController {
             mapSectionShowsScale: application.mapRegionManager.mapViewShowsScale,
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
             mapSectionShowsHeading: application.mapRegionManager.mapViewShowsHeading,
+            MapPanelRootView.useMapPanelExperienceUserDefaultsKey: application.userDefaults.bool(forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey),
             privacySectionReportingEnabled: application.analytics?.reportingEnabled() ?? false,
             DataLoadFeedbackGenerator.EnabledUserDefaultsKey: application.userDefaults.bool(forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey),
             AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts: application.userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts),
@@ -95,6 +97,10 @@ class SettingsViewController: FormViewController {
 
         if let mapViewShowsStopAnnotationLabels = values[MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey] as? Bool {
             application.userDefaults.set(mapViewShowsStopAnnotationLabels, forKey: MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey)
+        }
+
+        if let useMapPanel = values[MapPanelRootView.useMapPanelExperienceUserDefaultsKey] as? Bool {
+            application.userDefaults.set(useMapPanel, forKey: MapPanelRootView.useMapPanelExperienceUserDefaultsKey)
         }
 
         if let testAlerts = values[AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts] as? Bool {
@@ -156,6 +162,22 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = mapSectionShowsHeading
             $0.title = OBALoc("settings_controller.map_section.shows_heading", value: "Show my current heading", comment: "Settings > Map section > Show my current heading")
+        }
+
+        return section
+    }()
+
+    // MARK: - Experimental Section
+
+    private lazy var experimentalSection: Section = {
+        let section = Section(
+            header: OBALoc("settings_controller.experimental_section.title", value: "Experimental", comment: "Settings > Experimental section title"),
+            footer: OBALoc("settings_controller.experimental_section.map_panel.footer", value: "Restart the app to apply.", comment: "Settings > Experimental section > Footer indicating changes apply on relaunch")
+        )
+
+        section <<< SwitchRow {
+            $0.tag = MapPanelRootView.useMapPanelExperienceUserDefaultsKey
+            $0.title = OBALoc("settings_controller.experimental_section.map_panel", value: "Use map panel experience", comment: "Settings > Experimental section > Map panel toggle")
         }
 
         return section

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -1,0 +1,126 @@
+//
+//  HomeSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+struct HomeSheetView: View {
+    @StateObject private var viewModel: HomeSheetViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+
+    init(viewModel: @autoclosure @escaping () -> HomeSheetViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                searchBarRow
+                    .padding(.top, 16)
+                stackedSheetDebugRow
+            }
+        }
+        .ignoresSafeArea(.container, edges: .bottom)
+    }
+
+    // MARK: - Stacked sheet debug buttons (temporary)
+
+    private var stackedSheetDebugRow: some View {
+        VStack(spacing: 8) {
+            Text("Stacked sheet debug")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("Push 1: recentStopsAll") {
+                coordinator.push(.recentStopsAll)
+            }
+
+            Button("Push 2: stopDetails") {
+                coordinator.push(.stopDetails(stopID: "debug-stop"))
+            }
+
+            Button("Push 3: tripDetails") {
+                coordinator.push(.tripDetails(tripID: "debug-trip"))
+            }
+
+            Button("Push full chain (1 → 2 → 3)") {
+                coordinator.push(.recentStopsAll)
+                coordinator.push(.stopDetails(stopID: "debug-stop"))
+                coordinator.push(.tripDetails(tripID: "debug-trip"))
+            }
+
+            Button("Push 6 sheets deep (staggered)") {
+                Task { @MainActor in
+                    let routes: [AppSheetRoute] = [
+                        .recentStopsAll,
+                        .stopDetails(stopID: "debug-stop-1"),
+                        .tripDetails(tripID: "debug-trip-1"),
+                        .stopDetails(stopID: "debug-stop-2"),
+                        .tripDetails(tripID: "debug-trip-2"),
+                        .transitAlert(alertID: "debug-alert")
+                    ]
+                    for route in routes {
+                        coordinator.push(route)
+                        try? await Task.sleep(for: .milliseconds(450))
+                    }
+                }
+            }
+
+            Button("Pop") {
+                coordinator.pop()
+            }
+        }
+        .buttonStyle(.bordered)
+        .padding(.vertical, 16)
+    }
+
+    // MARK: - Search Bar
+
+    private var searchBarRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            Text("Search stops, routes…")
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background {
+            Capsule()
+                .fill(.gray.opacity(0.3))
+        }
+        .padding(.horizontal, 12)
+        .contentShape(.rect(cornerRadius: 16))
+        .onTapGesture {
+            expandThenPushSearch()
+        }
+    }
+
+    /// Animates the home sheet to its largest detent, then swaps content to
+    /// `.search`. The two-step flow avoids the jarring small→large+swap in one
+    /// frame; the user sees the sheet expand, then the search UI replace home.
+    ///
+    /// If the user collapses the sheet (or the route changes) before the
+    /// expansion finishes, the swap is skipped.
+    private func expandThenPushSearch() {
+        withAnimation(.smooth(duration: 0.3)) {
+            coordinator.currentDetent = AppSheetRoute.largeDetent
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.4))
+            guard coordinator.currentRoute == .home,
+                coordinator.currentDetent == AppSheetRoute.largeDetent
+            else { return }
+            coordinator.push(.search)
+        }
+    }
+
+}

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -51,24 +51,19 @@ struct HomeSheetView: View {
         .padding(.horizontal, 12)
         .contentShape(.rect(cornerRadius: 16))
         .onTapGesture {
-            expandThenPushSearch()
+            expandSheet()
         }
     }
 
-    /// Animates the home sheet to its largest detent, then swaps content to
-    /// `.search`. The two-step flow avoids the jarring small→large+swap in one
-    /// frame; the user sees the sheet expand, then the search UI replace home.
+    /// Animates the home sheet to its largest detent.
     ///
-    /// If the user collapses the sheet (or the route changes) before the
-    /// expansion finishes, the swap is skipped.
-    private func expandThenPushSearch() {
+    /// TODO: Push `.search` once `AppSheetViewFactory` has a real view for it
+    /// — the two-step expand-then-push flow lives in git history. Pushing
+    /// today would land on `unimplementedView(for:)` and trip the debug
+    /// assertion that guards stray routes.
+    private func expandSheet() {
         withAnimation(.smooth(duration: 0.3)) {
             coordinator.currentDetent = AppSheetRoute.largeDetent
-        } completion: {
-            guard coordinator.currentRoute == .home,
-                  coordinator.currentDetent == AppSheetRoute.largeDetent
-            else { return }
-            coordinator.push(.search)
         }
     }
 

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,28 +31,32 @@ struct HomeSheetView: View {
     // MARK: - Search Bar
 
     private var searchBarRow: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            Text(OBALoc(
-                "home_sheet.search_bar.placeholder",
-                value: "Search stops, routes…",
-                comment: "Placeholder text inside the search bar on the home sheet."
-            ))
-                .foregroundStyle(.secondary)
-            Spacer()
+        // `Button` (rather than `.onTapGesture` on a container) so VoiceOver
+        // and Switch Control see action semantics — the row is announced as a
+        // button and reachable via accessibility actions. `.buttonStyle(.plain)`
+        // keeps the search-pill appearance.
+        Button(action: expandSheet) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                Text(OBALoc(
+                    "home_sheet.search_bar.placeholder",
+                    value: "Search stops, routes…",
+                    comment: "Placeholder text inside the search bar on the home sheet."
+                ))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background {
+                Capsule()
+                    .fill(Color(.tertiarySystemFill))
+            }
+            .contentShape(.rect(cornerRadius: 16))
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background {
-            Capsule()
-                .fill(Color(.tertiarySystemFill))
-        }
+        .buttonStyle(.plain)
         .padding(.horizontal, 12)
-        .contentShape(.rect(cornerRadius: 16))
-        .onTapGesture {
-            expandSheet()
-        }
     }
 
     /// Animates the home sheet to its largest detent.

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,18 +31,24 @@ struct HomeSheetView: View {
     // MARK: - Search Bar
 
     private var searchBarRow: some View {
+        // Disabled until the `.search` route has a real view with a back
+        // affordance — `expandSheet()` would otherwise animate to the largest
+        // detent and strand the user there (the route is base-layer with
+        // `isDismissDisabled: true`). Surfaced as "Coming soon" so the only
+        // interactive control on the home sheet doesn't read as a dead tap.
+        //
         // `Button` (rather than `.onTapGesture` on a container) so VoiceOver
         // and Switch Control see action semantics — the row is announced as a
         // button and reachable via accessibility actions. `.buttonStyle(.plain)`
         // keeps the search-pill appearance.
-        Button(action: expandSheet) {
+        Button(action: {}) {
             HStack(spacing: 12) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
                 Text(OBALoc(
-                    "home_sheet.search_bar.placeholder",
-                    value: "Search stops, routes…",
-                    comment: "Placeholder text inside the search bar on the home sheet."
+                    "home_sheet.search_bar.coming_soon",
+                    value: "Search coming soon",
+                    comment: "Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented."
                 ))
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -56,19 +62,8 @@ struct HomeSheetView: View {
             .contentShape(.rect(cornerRadius: 16))
         }
         .buttonStyle(.plain)
+        .disabled(true)
         .padding(.horizontal, 12)
-    }
-
-    /// Animates the home sheet to its largest detent.
-    ///
-    /// TODO: Push `.search` once `AppSheetViewFactory` has a real view for it
-    /// — the two-step expand-then-push flow lives in git history. Pushing
-    /// today would land on `unimplementedView(for:)` and trip the debug
-    /// assertion that guards stray routes.
-    private func expandSheet() {
-        withAnimation(.smooth(duration: 0.3)) {
-            coordinator.currentDetent = AppSheetRoute.largeDetent
-        }
     }
 
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -23,61 +23,9 @@ struct HomeSheetView: View {
             VStack(spacing: 0) {
                 searchBarRow
                     .padding(.top, 16)
-                stackedSheetDebugRow
             }
         }
         .ignoresSafeArea(.container, edges: .bottom)
-    }
-
-    // MARK: - Stacked sheet debug buttons (temporary)
-
-    private var stackedSheetDebugRow: some View {
-        VStack(spacing: 8) {
-            Text("Stacked sheet debug")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Button("Push 1: recentStopsAll") {
-                coordinator.push(.recentStopsAll)
-            }
-
-            Button("Push 2: stopDetails") {
-                coordinator.push(.stopDetails(stopID: "debug-stop"))
-            }
-
-            Button("Push 3: tripDetails") {
-                coordinator.push(.tripDetails(tripID: "debug-trip"))
-            }
-
-            Button("Push full chain (1 → 2 → 3)") {
-                coordinator.push(.recentStopsAll)
-                coordinator.push(.stopDetails(stopID: "debug-stop"))
-                coordinator.push(.tripDetails(tripID: "debug-trip"))
-            }
-
-            Button("Push 6 sheets deep (staggered)") {
-                Task { @MainActor in
-                    let routes: [AppSheetRoute] = [
-                        .recentStopsAll,
-                        .stopDetails(stopID: "debug-stop-1"),
-                        .tripDetails(tripID: "debug-trip-1"),
-                        .stopDetails(stopID: "debug-stop-2"),
-                        .tripDetails(tripID: "debug-trip-2"),
-                        .transitAlert(alertID: "debug-alert")
-                    ]
-                    for route in routes {
-                        coordinator.push(route)
-                        try? await Task.sleep(for: .milliseconds(450))
-                    }
-                }
-            }
-
-            Button("Pop") {
-                coordinator.pop()
-            }
-        }
-        .buttonStyle(.bordered)
-        .padding(.vertical, 16)
     }
 
     // MARK: - Search Bar
@@ -112,12 +60,9 @@ struct HomeSheetView: View {
     private func expandThenPushSearch() {
         withAnimation(.smooth(duration: 0.3)) {
             coordinator.currentDetent = AppSheetRoute.largeDetent
-        }
-
-        Task { @MainActor in
-            try? await Task.sleep(for: .seconds(0.4))
+        } completion: {
             guard coordinator.currentRoute == .home,
-                coordinator.currentDetent == AppSheetRoute.largeDetent
+                  coordinator.currentDetent == AppSheetRoute.largeDetent
             else { return }
             coordinator.push(.search)
         }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -34,7 +34,11 @@ struct HomeSheetView: View {
         HStack(spacing: 12) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.secondary)
-            Text("Search stops, routes…")
+            Text(OBALoc(
+                "home_sheet.search_bar.placeholder",
+                value: "Search stops, routes…",
+                comment: "Placeholder text inside the search bar on the home sheet."
+            ))
                 .foregroundStyle(.secondary)
             Spacer()
         }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -46,7 +46,7 @@ struct HomeSheetView: View {
         .padding(.vertical, 14)
         .background {
             Capsule()
-                .fill(.gray.opacity(0.3))
+                .fill(Color(.tertiarySystemFill))
         }
         .padding(.horizontal, 12)
         .contentShape(.rect(cornerRadius: 16))

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,39 +31,32 @@ struct HomeSheetView: View {
     // MARK: - Search Bar
 
     private var searchBarRow: some View {
-        // Disabled until the `.search` route has a real view with a back
-        // affordance — `expandSheet()` would otherwise animate to the largest
-        // detent and strand the user there (the route is base-layer with
-        // `isDismissDisabled: true`). Surfaced as "Coming soon" so the only
-        // interactive control on the home sheet doesn't read as a dead tap.
-        //
-        // `Button` (rather than `.onTapGesture` on a container) so VoiceOver
-        // and Switch Control see action semantics — the row is announced as a
-        // button and reachable via accessibility actions. `.buttonStyle(.plain)`
-        // keeps the search-pill appearance.
-        Button(action: {}) {
-            HStack(spacing: 12) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                Text(OBALoc(
-                    "home_sheet.search_bar.coming_soon",
-                    value: "Search coming soon",
-                    comment: "Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented."
-                ))
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background {
-                Capsule()
-                    .fill(Color(.tertiarySystemFill))
-            }
-            .contentShape(.rect(cornerRadius: 16))
+        // Non-interactive while the `.search` route lacks a real view with a
+        // back affordance — a tap would otherwise animate to the largest detent
+        // and strand the user there (the route is base-layer with
+        // `isDismissDisabled: true`). Rendered as an `HStack` (not a disabled
+        // `Button`) so the shape communicates "not actionable yet" honestly to
+        // both readers and assistive tech — VoiceOver announces it as static
+        // text rather than a disabled button.
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            Text(OBALoc(
+                "home_sheet.search_bar.coming_soon",
+                value: "Search coming soon",
+                comment: "Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented."
+            ))
+                .foregroundStyle(.secondary)
+            Spacer()
         }
-        .buttonStyle(.plain)
-        .disabled(true)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background {
+            Capsule()
+                .fill(Color(.tertiarySystemFill))
+        }
         .padding(.horizontal, 12)
+        .accessibilityElement(children: .combine)
     }
 
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  HomeSheetViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import MapKit
+import OBAKitCore
+
+// MARK: - HomeSheetViewModel
+
+@MainActor
+class HomeSheetViewModel: ObservableObject {
+
+}

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -13,6 +13,6 @@ import OBAKitCore
 // MARK: - HomeSheetViewModel
 
 @MainActor
-class HomeSheetViewModel: ObservableObject {
+final class HomeSheetViewModel: ObservableObject {
 
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -12,6 +12,9 @@ import OBAKitCore
 
 // MARK: - HomeSheetViewModel
 
+// TODO: Will own nearby-stops snapshot, bookmark groupings, and recent-stops
+// state once the home sheet's content lands. Kept here so `HomeSheetView`'s
+// `@StateObject` + `@autoclosure` plumbing is already in place.
 @MainActor
 final class HomeSheetViewModel: ObservableObject {
 

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -12,10 +12,13 @@ import OBAKitCore
 
 // MARK: - HomeSheetViewModel
 
-// TODO: Will own nearby-stops snapshot, bookmark groupings, and recent-stops
-// state once the home sheet's content lands. Kept here so `HomeSheetView`'s
-// `@StateObject` + `@autoclosure` plumbing is already in place.
+// Owns the home sheet's reactive content state. Empty today beyond a stub
+// for the nearby-stops snapshot — kept here so `HomeSheetView`'s
+// `@StateObject` + `@autoclosure` plumbing is already in place and the
+// next reader sees the intended shape rather than an unexplained empty type.
 @MainActor
 final class HomeSheetViewModel: ObservableObject {
-
+    // TODO: Populate from `RESTAPIService` / `LocationService` once the
+    // home sheet renders nearby stops.
+    @Published private(set) var nearbyStops: [Stop] = []
 }

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -106,7 +106,16 @@ private extension View {
         selection: Binding<PresentationDetent>,
         interactiveDismissDisabled: Bool
     ) -> some View {
-        self
+        // When parked at `fullScreenDetent` (sheet covers the screen — common on iPhone landscape with the full-coverage detent),
+        // background interaction is forced off since nothing remains behind to touch.
+        let effectiveBackgroundInteraction: PresentationBackgroundInteraction = {
+            if let fullScreen = config.fullScreenDetent, selection.wrappedValue == fullScreen {
+                return .disabled
+            }
+            return config.backgroundInteraction
+        }()
+
+        return self
             .presentationDetents(config.detents, selection: selection)
             .presentationDragIndicator(config.showDragIndicator ? .visible : .hidden)
             .interactiveDismissDisabled(interactiveDismissDisabled)

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -58,7 +58,7 @@ private struct StackedSheetLayer<Route: SheetRouteable, SheetContent: View>: Vie
 
     private var routeBinding: Binding<Route?> {
         Binding(
-            get: { coordinator.stackedRoutes.indices.contains(depth) ? coordinator.stackedRoutes[depth] : nil },
+            get: { coordinator.stackedRoute(at: depth) },
             set: { newValue in
                 if newValue == nil {
                     coordinator.truncateStacked(toDepth: depth)
@@ -69,11 +69,7 @@ private struct StackedSheetLayer<Route: SheetRouteable, SheetContent: View>: Vie
 
     private func detentBinding(for route: Route) -> Binding<PresentationDetent> {
         Binding(
-            get: {
-                coordinator.stackedEntries.indices.contains(depth)
-                    ? coordinator.stackedEntries[depth].detent
-                    : route.detentConfiguration.initialDetent
-            },
+            get: { coordinator.stackedDetent(at: depth, fallback: route.detentConfiguration.initialDetent) },
             set: { newValue in
                 coordinator.setStackedDetent(newValue, at: depth)
             }

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -119,7 +119,7 @@ private extension View {
             .presentationDetents(config.detents, selection: selection)
             .presentationDragIndicator(config.showDragIndicator ? .visible : .hidden)
             .interactiveDismissDisabled(interactiveDismissDisabled)
-            .presentationBackgroundInteraction(config.backgroundInteraction)
+            .presentationBackgroundInteraction(effectiveBackgroundInteraction)
             // On iPad / regular size class, force the sheet shape instead of
             // adapting to a popover — the map panel is map-first, and a
             // popover wouldn't preserve the floating-over-the-map model.

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -1,0 +1,147 @@
+//
+//  FloatingSheetContainer.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+// MARK: - FloatingSheetContainer
+
+/// A `ViewModifier` that presents a persistent, never-dismissed bottom sheet
+/// and hosts an optional stacked sheet on top.
+///
+/// Hosting the stacked sheet here (rather than on any one content view) keeps
+/// it alive across base-sheet push/pop — its lifetime is the whole sheet system,
+/// not any single route.
+struct FloatingSheetContainer<Route: SheetRouteable, SheetContent: View>: ViewModifier {
+    @ObservedObject var coordinator: SheetCoordinator<Route>
+    let sheetContent: (Route) -> SheetContent
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: .constant(true)) {
+                sheetContent(coordinator.currentRoute)
+                    .applyDetentConfig(
+                        coordinator.currentRoute.detentConfiguration,
+                        selection: $coordinator.currentDetent,
+                        interactiveDismissDisabled: coordinator.currentRoute.detentConfiguration.isDismissDisabled
+                    )
+                    .environmentObject(coordinator)
+                    .modifier(
+                        StackedSheetLayer(
+                            coordinator: coordinator,
+                            depth: 0,
+                            sheetContent: sheetContent
+                        )
+                    )
+            }
+    }
+}
+
+// MARK: - StackedSheetLayer
+
+/// Recursive layer of the stacked-sheet pile. Layer `depth` attaches a
+/// `.sheet(item:)` whose `item` is `coordinator.stackedRoutes[depth]`. When
+/// presented, that sheet's content carries the next layer (`depth + 1`) — so
+/// each stacked route gets its own physical `UISheetPresentationController`
+/// with the previous sheet peeking beneath.
+///
+/// Implemented as a `ViewModifier` (not a `View`) so the `.sheet` modifier attaches directly to the host content
+private struct StackedSheetLayer<Route: SheetRouteable, SheetContent: View>: ViewModifier {
+    @ObservedObject var coordinator: SheetCoordinator<Route>
+    let depth: Int
+    let sheetContent: (Route) -> SheetContent
+
+    private var routeBinding: Binding<Route?> {
+        Binding(
+            get: { coordinator.stackedRoutes.indices.contains(depth) ? coordinator.stackedRoutes[depth] : nil },
+            set: { newValue in
+                if newValue == nil {
+                    coordinator.truncateStacked(toDepth: depth)
+                }
+            }
+        )
+    }
+
+    private func detentBinding(for route: Route) -> Binding<PresentationDetent> {
+        Binding(
+            get: {
+                coordinator.stackedDetents.indices.contains(depth)
+                    ? coordinator.stackedDetents[depth]
+                    : route.detentConfiguration.initialDetent
+            },
+            set: { newValue in
+                guard coordinator.stackedDetents.indices.contains(depth) else { return }
+                coordinator.stackedDetents[depth] = newValue
+            }
+        )
+    }
+
+    func body(content: Content) -> some View {
+        content.sheet(item: routeBinding) { route in
+            sheetContent(route)
+                .applyDetentConfig(
+                    route.detentConfiguration,
+                    selection: detentBinding(for: route),
+                    interactiveDismissDisabled: false
+                )
+                .environmentObject(coordinator)
+                .modifier(StackedSheetLayer(
+                    coordinator: coordinator,
+                    depth: depth + 1,
+                    sheetContent: sheetContent
+                ))
+        }
+    }
+}
+
+// MARK: - Detent configuration helper
+
+private extension View {
+    func applyDetentConfig(
+        _ config: SheetDetentConfiguration,
+        selection: Binding<PresentationDetent>,
+        interactiveDismissDisabled: Bool
+    ) -> some View {
+        self
+            .presentationDetents(config.detents, selection: selection)
+            .presentationDragIndicator(config.showDragIndicator ? .visible : .hidden)
+            .interactiveDismissDisabled(interactiveDismissDisabled)
+            .presentationBackgroundInteraction(config.backgroundInteraction)
+            .presentationCompactAdaptation(.none)
+            .legacyFloatingCornerRadius()
+    }
+}
+
+// MARK: - Legacy corner radius
+
+private extension View {
+    /// On iOS 26+, sheets render as floating rounded cards natively. On older
+    /// systems they're flush with the screen and corner radius is more conservative,
+    /// so we bump it up to approximate the iOS 26 look (especially noticeable on
+    /// small detents like `.height(80)` where the default radius reads as square).
+    @ViewBuilder
+    func legacyFloatingCornerRadius() -> some View {
+        if #available(iOS 26.0, *) {
+            self
+        } else {
+            self.presentationCornerRadius(24)
+        }
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+    /// Attaches a persistent floating sheet driven by `coordinator`.
+    func floatingSheet<Route: SheetRouteable, Content: View>(
+        coordinator: SheetCoordinator<Route>,
+        @ViewBuilder content: @escaping (Route) -> Content
+    ) -> some View {
+        modifier(FloatingSheetContainer(coordinator: coordinator, sheetContent: content))
+    }
+}

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -70,13 +70,12 @@ private struct StackedSheetLayer<Route: SheetRouteable, SheetContent: View>: Vie
     private func detentBinding(for route: Route) -> Binding<PresentationDetent> {
         Binding(
             get: {
-                coordinator.stackedDetents.indices.contains(depth)
-                    ? coordinator.stackedDetents[depth]
+                coordinator.stackedEntries.indices.contains(depth)
+                    ? coordinator.stackedEntries[depth].detent
                     : route.detentConfiguration.initialDetent
             },
             set: { newValue in
-                guard coordinator.stackedDetents.indices.contains(depth) else { return }
-                coordinator.stackedDetents[depth] = newValue
+                coordinator.setStackedDetent(newValue, at: depth)
             }
         )
     }

--- a/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
+++ b/OBAKit/Sheet/Coordinator/FloatingSheetContainer.swift
@@ -86,7 +86,7 @@ private struct StackedSheetLayer<Route: SheetRouteable, SheetContent: View>: Vie
                 .applyDetentConfig(
                     route.detentConfiguration,
                     selection: detentBinding(for: route),
-                    interactiveDismissDisabled: false
+                    interactiveDismissDisabled: route.detentConfiguration.isDismissDisabled
                 )
                 .environmentObject(coordinator)
                 .modifier(StackedSheetLayer(
@@ -111,6 +111,9 @@ private extension View {
             .presentationDragIndicator(config.showDragIndicator ? .visible : .hidden)
             .interactiveDismissDisabled(interactiveDismissDisabled)
             .presentationBackgroundInteraction(config.backgroundInteraction)
+            // On iPad / regular size class, force the sheet shape instead of
+            // adapting to a popover — the map panel is map-first, and a
+            // popover wouldn't preserve the floating-over-the-map model.
             .presentationCompactAdaptation(.none)
             .legacyFloatingCornerRadius()
     }

--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -18,27 +18,39 @@ class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
 
     // MARK: - Content-swap layer (base sheet)
 
-    @Published private(set) var routeStack: [Route]
+    /// The route always present at the bottom of the content-swap stack.
+    /// Stored separately so `currentRoute` never has to force-unwrap.
+    let root: Route
+
+    /// Routes pushed on top of `root`. Empty when the base sheet is showing root.
+    @Published private(set) var additionalRoutes: [Route] = []
+
     @Published var currentDetent: PresentationDetent
 
-    var currentRoute: Route { routeStack.last! }
+    var currentRoute: Route { additionalRoutes.last ?? root }
+    var routeStack: [Route] { [root] + additionalRoutes }
     var currentDetents: Set<PresentationDetent> { currentRoute.detentConfiguration.detents }
-    var canPop: Bool { routeStack.count > 1 || !stackedRoutes.isEmpty }
+    var canPop: Bool { !additionalRoutes.isEmpty || !stackedEntries.isEmpty }
 
     // MARK: - Stacked layer
 
-    /// One physical sheet per entry; index 0 is the closest to the base sheet,
-    /// `last` is the frontmost. Empty when no stacked sheets are presented.
-    @Published var stackedRoutes: [Route] = []
+    /// A route paired with its currently-selected detent. One entry per
+    /// physical sheet in the stacked pile, index 0 closest to the base sheet.
+    struct StackedEntry: Equatable {
+        let route: Route
+        var detent: PresentationDetent
+    }
 
-    /// Detents parallel to `stackedRoutes`. `stackedDetents[i]` selects the
-    /// current detent of the sheet at depth `i`.
-    @Published var stackedDetents: [PresentationDetent] = []
+    /// Stacked-sheet pile. Empty when no stacked sheets are presented.
+    @Published private(set) var stackedEntries: [StackedEntry] = []
+
+    var stackedRoutes: [Route] { stackedEntries.map(\.route) }
+    var stackedDetents: [PresentationDetent] { stackedEntries.map(\.detent) }
 
     // MARK: - Init
 
     init(root: Route) {
-        routeStack = [root]
+        self.root = root
         currentDetent = root.detentConfiguration.initialDetent
     }
 
@@ -49,10 +61,9 @@ class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
     /// content-swap routes append to the base content stack.
     func push(_ route: Route) {
         if route.prefersStacking {
-            stackedRoutes.append(route)
-            stackedDetents.append(route.detentConfiguration.initialDetent)
+            stackedEntries.append(StackedEntry(route: route, detent: route.detentConfiguration.initialDetent))
         } else {
-            routeStack.append(route)
+            additionalRoutes.append(route)
             currentDetent = route.detentConfiguration.initialDetent
         }
     }
@@ -60,30 +71,33 @@ class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
     /// Pops the top of whichever layer is on top: frontmost stacked sheet if
     /// any, otherwise the content-stack top. No-op at root.
     func pop() {
-        if !stackedRoutes.isEmpty {
-            stackedRoutes.removeLast()
-            stackedDetents.removeLast()
+        if !stackedEntries.isEmpty {
+            stackedEntries.removeLast()
             return
         }
-        guard routeStack.count > 1 else { return }
-        routeStack.removeLast()
+        guard !additionalRoutes.isEmpty else { return }
+        additionalRoutes.removeLast()
         currentDetent = currentRoute.detentConfiguration.initialDetent
     }
 
     /// Removes every stacked sheet at or above the given depth. Called by the
-    /// container when the OS dismisses a sheet (drag-down) so the array stays
-    /// in sync with what's actually on screen.
+    /// container when the OS dismisses a sheet (drag-down) so storage stays in
+    /// sync with what's actually on screen.
     func truncateStacked(toDepth depth: Int) {
-        guard depth >= 0, depth < stackedRoutes.count else { return }
-        stackedRoutes.removeSubrange(depth...)
-        stackedDetents.removeSubrange(depth...)
+        guard depth >= 0, depth < stackedEntries.count else { return }
+        stackedEntries.removeSubrange(depth...)
+    }
+
+    /// Updates the stored detent for the stacked sheet at `depth`.
+    func setStackedDetent(_ detent: PresentationDetent, at depth: Int) {
+        guard stackedEntries.indices.contains(depth) else { return }
+        stackedEntries[depth].detent = detent
     }
 
     /// Clears the stacked layer and unwinds the content stack to its root.
     func popToRoot() {
-        stackedRoutes.removeAll()
-        stackedDetents.removeAll()
-        routeStack = [routeStack[0]]
-        currentDetent = currentRoute.detentConfiguration.initialDetent
+        stackedEntries.removeAll()
+        additionalRoutes.removeAll()
+        currentDetent = root.detentConfiguration.initialDetent
     }
 }

--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// Owns the route stacks for both the base (content-swap) sheet and the
 /// stacked layer (a stack of physical sheets, each peeking behind the next).
 @MainActor
-class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
+final class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
 
     // MARK: - Content-swap layer (base sheet)
 

--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -59,8 +59,17 @@ final class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
     /// Pushes a route on whichever layer it prefers.
     /// Stacked routes append a new physical sheet over the previous one;
     /// content-swap routes append to the base content stack.
+    ///
+    /// Invariant: a stacked route must allow interactive dismissal. The OS
+    /// owns drag-down on the stacked layer, and `truncateStacked` is wired
+    /// to that gesture — locking dismissal would let `stackedEntries` point
+    /// at a sheet that's no longer on screen.
     func push(_ route: Route) {
         if route.prefersStacking {
+            precondition(
+                !route.detentConfiguration.isDismissDisabled,
+                "Stacked routes must have isDismissDisabled == false; \(route) does not."
+            )
             stackedEntries.append(StackedEntry(route: route, detent: route.detentConfiguration.initialDetent))
         } else {
             additionalRoutes.append(route)
@@ -92,6 +101,19 @@ final class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
     func setStackedDetent(_ detent: PresentationDetent, at depth: Int) {
         guard stackedEntries.indices.contains(depth) else { return }
         stackedEntries[depth].detent = detent
+    }
+
+    /// Bounds-checked accessor for the stacked route at `depth`.
+    /// Returns `nil` when `depth` is past the current pile.
+    func stackedRoute(at depth: Int) -> Route? {
+        stackedEntries.indices.contains(depth) ? stackedEntries[depth].route : nil
+    }
+
+    /// Bounds-checked accessor for the detent at `depth`. Returns `fallback`
+    /// when `depth` is past the current pile (used during the brief window
+    /// before SwiftUI installs the new layer).
+    func stackedDetent(at depth: Int, fallback: PresentationDetent) -> PresentationDetent {
+        stackedEntries.indices.contains(depth) ? stackedEntries[depth].detent : fallback
     }
 
     /// Clears the stacked layer and unwinds the content stack to its root.

--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -1,0 +1,89 @@
+//
+//  SheetCoordinator.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+// MARK: - SheetCoordinator
+
+/// Owns the route stacks for both the base (content-swap) sheet and the
+/// stacked layer (a stack of physical sheets, each peeking behind the next).
+@MainActor
+class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
+
+    // MARK: - Content-swap layer (base sheet)
+
+    @Published private(set) var routeStack: [Route]
+    @Published var currentDetent: PresentationDetent
+
+    var currentRoute: Route { routeStack.last! }
+    var currentDetents: Set<PresentationDetent> { currentRoute.detentConfiguration.detents }
+    var canPop: Bool { routeStack.count > 1 || !stackedRoutes.isEmpty }
+
+    // MARK: - Stacked layer
+
+    /// One physical sheet per entry; index 0 is the closest to the base sheet,
+    /// `last` is the frontmost. Empty when no stacked sheets are presented.
+    @Published var stackedRoutes: [Route] = []
+
+    /// Detents parallel to `stackedRoutes`. `stackedDetents[i]` selects the
+    /// current detent of the sheet at depth `i`.
+    @Published var stackedDetents: [PresentationDetent] = []
+
+    // MARK: - Init
+
+    init(root: Route) {
+        routeStack = [root]
+        currentDetent = root.detentConfiguration.initialDetent
+    }
+
+    // MARK: - Unified navigation
+
+    /// Pushes a route on whichever layer it prefers.
+    /// Stacked routes append a new physical sheet over the previous one;
+    /// content-swap routes append to the base content stack.
+    func push(_ route: Route) {
+        if route.prefersStacking {
+            stackedRoutes.append(route)
+            stackedDetents.append(route.detentConfiguration.initialDetent)
+        } else {
+            routeStack.append(route)
+            currentDetent = route.detentConfiguration.initialDetent
+        }
+    }
+
+    /// Pops the top of whichever layer is on top: frontmost stacked sheet if
+    /// any, otherwise the content-stack top. No-op at root.
+    func pop() {
+        if !stackedRoutes.isEmpty {
+            stackedRoutes.removeLast()
+            stackedDetents.removeLast()
+            return
+        }
+        guard routeStack.count > 1 else { return }
+        routeStack.removeLast()
+        currentDetent = currentRoute.detentConfiguration.initialDetent
+    }
+
+    /// Removes every stacked sheet at or above the given depth. Called by the
+    /// container when the OS dismisses a sheet (drag-down) so the array stays
+    /// in sync with what's actually on screen.
+    func truncateStacked(toDepth depth: Int) {
+        guard depth >= 0, depth < stackedRoutes.count else { return }
+        stackedRoutes.removeSubrange(depth...)
+        stackedDetents.removeSubrange(depth...)
+    }
+
+    /// Clears the stacked layer and unwinds the content stack to its root.
+    func popToRoot() {
+        stackedRoutes.removeAll()
+        stackedDetents.removeAll()
+        routeStack = [routeStack[0]]
+        currentDetent = currentRoute.detentConfiguration.initialDetent
+    }
+}

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -124,12 +124,16 @@ extension AppSheetRoute {
         return .fraction(0.99)
     }
 
+    /// Height of the home sheet's smallest detent. Shared by `MapPanelRootView`
+    /// so the map's bottom safe-area padding matches the collapsed sheet.
+    static let homeCollapsedHeight: CGFloat = 80
+
     var detentConfiguration: SheetDetentConfiguration {
         switch self {
         case .home:
             return SheetDetentConfiguration(
-                detents: [.height(80), .medium, AppSheetRoute.largeDetent],
-                initialDetent: .height(80),
+                detents: [.height(AppSheetRoute.homeCollapsedHeight), .medium, AppSheetRoute.largeDetent],
+                initialDetent: .height(AppSheetRoute.homeCollapsedHeight),
                 isDismissDisabled: true
             )
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll:

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -1,0 +1,156 @@
+//
+//  SheetRoute.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - SheetDetentConfiguration
+
+/// Per-route configuration for detent behaviour, drag indicator, dismiss lock, and background interaction.
+struct SheetDetentConfiguration {
+    let detents: Set<PresentationDetent>
+    let initialDetent: PresentationDetent
+    let showDragIndicator: Bool
+    let isDismissDisabled: Bool
+    let backgroundInteraction: PresentationBackgroundInteraction
+
+    init(
+        detents: Set<PresentationDetent>,
+        initialDetent: PresentationDetent,
+        showDragIndicator: Bool = true,
+        isDismissDisabled: Bool,
+        backgroundInteraction: PresentationBackgroundInteraction = .enabled(upThrough: .medium)
+    ) {
+        self.detents = detents
+        self.initialDetent = initialDetent
+        self.showDragIndicator = showDragIndicator
+        self.isDismissDisabled = isDismissDisabled
+        self.backgroundInteraction = backgroundInteraction
+    }
+}
+
+// MARK: - SheetRouteable
+
+/// Protocol that all sheet route enums must conform to.
+/// Each case provides detent configuration and a stacking preference.
+/// ViewModel construction lives in `AppSheetViewFactory`, not on the route itself.
+protocol SheetRouteable: Identifiable, Hashable {
+    var detentConfiguration: SheetDetentConfiguration { get }
+    /// When `true`, `SheetCoordinator.push(_:)` routes this case to the stacked
+    /// layer (a second sheet over the base sheet); otherwise content-swap.
+    var prefersStacking: Bool { get }
+}
+
+// MARK: - AppSheetRoute
+
+/// All navigable destinations within the floating sheet.
+enum AppSheetRoute: SheetRouteable {
+    // Base layer
+    case home
+    case search
+    case nearbyAll
+    case recentStopsAll
+    case bookmarksAll
+
+    // Stacked layer
+    case stopDetails(stopID: Stop.ID)
+    case tripPlanner
+    case tripDetails(tripID: TripIdentifier)
+    case routePicker
+    case currentTrip(routeID: RouteID)
+    case transitAlert(alertID: String)
+
+    case more
+    case settings
+
+}
+
+extension AppSheetRoute {
+    // MARK: Identifiable
+
+    var id: String {
+        switch self {
+        case .home:
+            return "home"
+        case .search:
+            return "search"
+        case .nearbyAll:
+            return "nearbyAll"
+        case .recentStopsAll:
+            return "recentStopsAll"
+        case .bookmarksAll:
+            return "bookmarksAll"
+        case .stopDetails(let stopID):
+            return "stopDetails-\(stopID)"
+        case .tripPlanner:
+            return "tripPlanner"
+        case .tripDetails(let tripID):
+            return "tripDetails-\(tripID)"
+        case .routePicker:
+            return "routePicker"
+        case .currentTrip(let routeID):
+            return "currentTrip-\(routeID)"
+        case .transitAlert(let alertID):
+            return "transitAlert-\(alertID)"
+        case .more:
+            return "more"
+        case .settings:
+            return "settings"
+        }
+    }
+}
+
+extension AppSheetRoute {
+    /// Detail destinations prefer the stacked layer so the base sheet peeks beneath.
+    var prefersStacking: Bool {
+        switch self {
+        case .stopDetails, .tripPlanner, .tripDetails, .currentTrip, .transitAlert, .more, .nearbyAll, .recentStopsAll, .bookmarksAll, .settings:
+            return true
+        case .home, .search, .routePicker:
+            return false
+        }
+    }
+}
+
+extension AppSheetRoute {
+
+    static var `largeDetent`: PresentationDetent {
+        return .fraction(0.99)
+    }
+
+    var detentConfiguration: SheetDetentConfiguration {
+        switch self {
+        case .home:
+            return SheetDetentConfiguration(
+                detents: [.height(80), .medium, AppSheetRoute.largeDetent],
+                initialDetent: .height(80),
+                isDismissDisabled: true
+            )
+        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll:
+            return SheetDetentConfiguration(
+                detents: [.large],
+                initialDetent: .large,
+                isDismissDisabled: true
+            )
+        case .stopDetails:
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .medium,
+                isDismissDisabled: false
+            )
+        case .tripPlanner, .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        }
+    }
+
+}

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -136,11 +136,23 @@ extension AppSheetRoute {
                 initialDetent: .height(AppSheetRoute.homeCollapsedHeight),
                 isDismissDisabled: true
             )
-        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll:
+        case .search:
+            // Base-layer: dismiss is locked so the user pops via the back affordance,
+            // not by dragging the sheet off-screen.
             return SheetDetentConfiguration(
                 detents: [.large],
                 initialDetent: .large,
-                isDismissDisabled: true
+                isDismissDisabled: true,
+                backgroundInteraction: .disabled
+            )
+        case .nearbyAll, .recentStopsAll, .bookmarksAll:
+            // Stacked-layer: the OS owns dismissal so storage stays in sync with
+            // the drag-down gesture via `truncateStacked`.
+            return SheetDetentConfiguration(
+                detents: [.large],
+                initialDetent: .large,
+                isDismissDisabled: false,
+                backgroundInteraction: .disabled
             )
         case .stopDetails:
             return SheetDetentConfiguration(

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -129,7 +129,13 @@ extension AppSheetRoute {
 
 extension AppSheetRoute {
 
-    static var `largeDetent`: PresentationDetent {
+    /// "Almost-full" detent used as the largest stop for the home sheet and
+    /// other content-swap routes. `.fraction(0.99)` rather than `.large`
+    /// preserves the floating-card look (a sliver of map remains visible at
+    /// the top edge) and lets `fullScreenDetent` reliably match — `.large`
+    /// reports through a different detent identity that `==` comparison can't
+    /// catch.
+    static var largeDetent: PresentationDetent {
         return .fraction(0.99)
     }
 

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -35,6 +35,15 @@ struct SheetDetentConfiguration {
         backgroundInteraction: PresentationBackgroundInteraction = .enabled(upThrough: .medium),
         fullScreenDetent: PresentationDetent? = nil
     ) {
+        // `initialDetent` and `fullScreenDetent` must live inside `detents` —
+        // both are matched by `==` against the current selection, so a stray
+        // value would be silently dead config (initialDetent never seeded,
+        // fullScreenDetent never matched). Catch the slip where it happens.
+        precondition(detents.contains(initialDetent), "initialDetent must be a member of detents.")
+        if let fullScreenDetent {
+            precondition(detents.contains(fullScreenDetent), "fullScreenDetent must be a member of detents.")
+        }
+
         self.detents = detents
         self.initialDetent = initialDetent
         self.showDragIndicator = showDragIndicator

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -20,18 +20,27 @@ struct SheetDetentConfiguration {
     let isDismissDisabled: Bool
     let backgroundInteraction: PresentationBackgroundInteraction
 
+    /// When set, background interaction is forced to `.disabled` while the sheet
+    /// is parked at this detent — useful for the iPhone-landscape case where the
+    /// sheet covers the full screen and nothing remains behind it to interact
+    /// with. The `upThrough:` form of `PresentationBackgroundInteraction` isn't
+    /// honored with custom `.height` detents, hence the explicit field.
+    let fullScreenDetent: PresentationDetent?
+
     init(
         detents: Set<PresentationDetent>,
         initialDetent: PresentationDetent,
         showDragIndicator: Bool = true,
         isDismissDisabled: Bool,
-        backgroundInteraction: PresentationBackgroundInteraction = .enabled(upThrough: .medium)
+        backgroundInteraction: PresentationBackgroundInteraction = .enabled(upThrough: .medium),
+        fullScreenDetent: PresentationDetent? = nil
     ) {
         self.detents = detents
         self.initialDetent = initialDetent
         self.showDragIndicator = showDragIndicator
         self.isDismissDisabled = isDismissDisabled
         self.backgroundInteraction = backgroundInteraction
+        self.fullScreenDetent = fullScreenDetent
     }
 }
 
@@ -131,10 +140,17 @@ extension AppSheetRoute {
     var detentConfiguration: SheetDetentConfiguration {
         switch self {
         case .home:
+            // Keep background interaction enabled at small/medium detents so the
+            // map and its overlays remain tappable. `upThrough:` isn't honored
+            // with custom `.height` detents, so `fullScreenDetent` flips
+            // background interaction to `.disabled` only when the sheet is
+            // parked at `largeDetent` (covers ~the full screen).
             return SheetDetentConfiguration(
                 detents: [.height(AppSheetRoute.homeCollapsedHeight), .medium, AppSheetRoute.largeDetent],
                 initialDetent: .height(AppSheetRoute.homeCollapsedHeight),
-                isDismissDisabled: true
+                isDismissDisabled: true,
+                backgroundInteraction: .enabled,
+                fullScreenDetent: AppSheetRoute.largeDetent
             )
         case .search:
             // Base-layer: dismiss is locked so the user pops via the back affordance,

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -35,6 +35,10 @@ final class AppSheetViewFactory {
         switch route {
         case .home:
             homeView()
+        // TODO: `.search` is base-layer and has `isDismissDisabled: true`
+        // — its real view needs to wire up an explicit back affordance
+        // (the home sheet only knows how to push, not pop), otherwise the
+        // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .stopDetails, .tripPlanner, .tripDetails, .routePicker,
              .currentTrip, .transitAlert, .more, .settings:

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -77,13 +77,21 @@ final class AppSheetViewFactory {
         #else
         // swiftlint:disable:next redundant_discardable_let
         let _ = Logger.error("AppSheetRoute.\(route.id) pushed but no view is registered — rendering placeholder.")
-        Text(OBALoc(
-            "app_sheet.unimplemented_route.placeholder",
-            value: "This screen is coming soon.",
-            comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
-        ))
-            .font(.headline)
-            .foregroundStyle(.secondary)
+        // Embed `route.id` in the visible copy so an experimental-flag tester
+        // who hits this in the wild has something concrete to report back —
+        // the `Logger.error` line above is invisible to them.
+        VStack(spacing: 4) {
+            Text(OBALoc(
+                "app_sheet.unimplemented_route.placeholder",
+                value: "This screen is coming soon.",
+                comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
+            ))
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text(route.id)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
             .padding()
         #endif
     }

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -54,6 +54,10 @@ final class AppSheetViewFactory {
     @ViewBuilder
     private func unimplementedView(for route: AppSheetRoute) -> some View {
         #if DEBUG
+        // `let _` (not `_ =`) so SwiftUI's @ViewBuilder treats this as a
+        // declaration rather than an expression statement — the latter fails
+        // to build because `Void` doesn't conform to `View`.
+        // swiftlint:disable:next redundant_discardable_let
         let _ = assertionFailure("AppSheetRoute.\(route.id) has no view registered yet.")
         Text("Unimplemented route: \(route.id)")
             .font(.headline)

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -20,7 +20,7 @@ import OBAKitCore
 /// per-route view builders look eager but are evaluated lazily — SwiftUI
 /// invokes the underlying VM builder exactly once per view identity.
 @MainActor
-final class AppSheetViewFactory: ObservableObject {
+final class AppSheetViewFactory {
 
     let application: Application
 
@@ -38,13 +38,29 @@ final class AppSheetViewFactory: ObservableObject {
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .stopDetails, .tripPlanner, .tripDetails, .routePicker,
              .currentTrip, .transitAlert, .more, .settings:
-            EmptyView()
+            unimplementedView(for: route)
         }
     }
+
     // MARK: - Per-route view builders
 
     func homeView() -> HomeSheetView {
         HomeSheetView(viewModel: HomeSheetViewModel())
     }
 
+    /// Placeholder until each route gets its own real view. In debug builds we
+    /// surface a visible label and fire an assertion so a stray `push(...)`
+    /// during development can't silently render a blank sheet.
+    @ViewBuilder
+    private func unimplementedView(for route: AppSheetRoute) -> some View {
+        #if DEBUG
+        let _ = assertionFailure("AppSheetRoute.\(route.id) has no view registered yet.")
+        Text("Unimplemented route: \(route.id)")
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            .padding()
+        #else
+        EmptyView()
+        #endif
+    }
 }

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -54,7 +54,9 @@ final class AppSheetViewFactory {
 
     /// Placeholder until each route gets its own real view. In debug builds we
     /// surface a visible label and fire an assertion so a stray `push(...)`
-    /// during development can't silently render a blank sheet.
+    /// during development can't silently render a blank sheet. In release we
+    /// log instead of crashing — the user gets a blank sheet, but at least the
+    /// gap leaves a breadcrumb if anyone wires up a push before its view exists.
     @ViewBuilder
     private func unimplementedView(for route: AppSheetRoute) -> some View {
         #if DEBUG
@@ -68,6 +70,8 @@ final class AppSheetViewFactory {
             .foregroundStyle(.secondary)
             .padding()
         #else
+        // swiftlint:disable:next redundant_discardable_let
+        let _ = Logger.error("AppSheetRoute.\(route.id) pushed but no view is registered — rendering EmptyView.")
         EmptyView()
         #endif
     }

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -35,6 +35,10 @@ final class AppSheetViewFactory {
         switch route {
         case .home:
             homeView()
+        // Wiring a push for one of these routes before its view exists will
+        // trip the debug assertion in `unimplementedView(for:)` — register the
+        // view here before reaching for `SheetCoordinator.push(...)`.
+        //
         // TODO: `.search` is base-layer and has `isDismissDisabled: true`
         // — its real view needs to wire up an explicit back affordance
         // (the home sheet only knows how to push, not pop), otherwise the
@@ -55,8 +59,9 @@ final class AppSheetViewFactory {
     /// Placeholder until each route gets its own real view. In debug builds we
     /// surface a visible label and fire an assertion so a stray `push(...)`
     /// during development can't silently render a blank sheet. In release we
-    /// log instead of crashing — the user gets a blank sheet, but at least the
-    /// gap leaves a breadcrumb if anyone wires up a push before its view exists.
+    /// log and render a visible "coming soon" message — preferable to
+    /// `EmptyView()`, which would leave an experimental tester staring at a
+    /// blank sheet with no breadcrumb in the UI.
     @ViewBuilder
     private func unimplementedView(for route: AppSheetRoute) -> some View {
         #if DEBUG
@@ -71,8 +76,15 @@ final class AppSheetViewFactory {
             .padding()
         #else
         // swiftlint:disable:next redundant_discardable_let
-        let _ = Logger.error("AppSheetRoute.\(route.id) pushed but no view is registered — rendering EmptyView.")
-        EmptyView()
+        let _ = Logger.error("AppSheetRoute.\(route.id) pushed but no view is registered — rendering placeholder.")
+        Text(OBALoc(
+            "app_sheet.unimplemented_route.placeholder",
+            value: "This screen is coming soon.",
+            comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
+        ))
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            .padding()
         #endif
     }
 }

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -1,0 +1,50 @@
+//
+//  AppSheetViewFactory.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - AppSheetViewFactory
+
+/// The single DI seam for the SwiftUI sheet system.
+///
+/// The `view(for:)` dispatcher provides compiler-enforced exhaustiveness for routing call sites.
+///
+/// Sheet views own their VM via `@StateObject` + `@autoclosure`, so
+/// per-route view builders look eager but are evaluated lazily — SwiftUI
+/// invokes the underlying VM builder exactly once per view identity.
+@MainActor
+final class AppSheetViewFactory: ObservableObject {
+
+    let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    // MARK: - Dispatcher
+
+    @ViewBuilder
+    func view(for route: AppSheetRoute) -> some View {
+        switch route {
+        case .home:
+            homeView()
+        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+             .stopDetails, .tripPlanner, .tripDetails, .routePicker,
+             .currentTrip, .transitAlert, .more, .settings:
+            EmptyView()
+        }
+    }
+    // MARK: - Per-route view builders
+
+    func homeView() -> HomeSheetView {
+        HomeSheetView(viewModel: HomeSheetViewModel())
+    }
+
+}

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -1,0 +1,50 @@
+//
+//  MapPanelRootController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import OBAKitCore
+
+/// UIKit root for the experimental SwiftUI map-panel experience. Hosts
+/// `MapPanelRootView` as its single child controller and surfaces nothing
+/// else — the SwiftUI tree owns the entire visible UI.
+///
+/// Lives alongside `ClassicApplicationRootController` rather than inside it
+/// so the classic class stays a `UITabBarController` with non-optional tab VCs.
+/// The AppDelegates pick between the two via `ApplicationRootControllerFactory`.
+public final class MapPanelRootController: UIViewController {
+
+    private let application: Application
+    private let host: UIHostingController<MapPanelRootView>
+
+    public init(application: Application) {
+        self.application = application
+        self.host = UIHostingController(rootView: MapPanelRootView(application: application))
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(host)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(host.view)
+        NSLayoutConstraint.activate([
+            host.view.topAnchor.constraint(equalTo: view.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            host.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        host.didMove(toParent: self)
+    }
+}

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -20,11 +20,9 @@ import OBAKitCore
 /// The AppDelegates pick between the two via `ApplicationRootControllerFactory`.
 public final class MapPanelRootController: UIViewController {
 
-    private let application: Application
     private let host: UIHostingController<MapPanelRootView>
 
     public init(application: Application) {
-        self.application = application
         self.host = UIHostingController(rootView: MapPanelRootView(application: application))
         super.init(nibName: nil, bundle: nil)
     }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -36,6 +36,10 @@ struct MapPanelRootView: View {
         Map(position: $cameraPosition) {
             UserAnnotation()
         }
+        // TODO: Detent-aware bottom padding. Pinned to the collapsed sheet
+        // height today, so dragging the sheet up to `.medium` or
+        // `largeDetent` lets the user-location annotation and any future map
+        // overlays slip under the sheet.
         .safeAreaPadding(.bottom, AppSheetRoute.homeCollapsedHeight)
         .floatingSheet(coordinator: coordinator) { route in
             factory.view(for: route)

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -1,0 +1,47 @@
+//
+//  MapPanelRootView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import MapKit
+import SwiftUI
+import OBAKitCore
+
+// MARK: - MapPanelRootView
+
+/// A pure-SwiftUI alternative to `MapViewController`: a full-screen SwiftUI
+/// `Map` with the persistent floating sheet system layered on top.
+///
+/// This is the SwiftUI-native composition root for the sheet system:
+/// `Application` enters the SwiftUI tree here, the factory + coordinator are
+/// owned here as sibling `@StateObject`s, and the sheet content is rendered
+/// over the SwiftUI `Map`.
+struct MapPanelRootView: View {
+
+    /// UserDefaults key that gates the map panel experience.
+    /// Read at tab-construction time; changes apply on next launch.
+    static let useMapPanelExperienceUserDefaultsKey = "OBAUseMapPanelExperience"
+
+    @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
+    @StateObject private var factory: AppSheetViewFactory
+    @State private var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
+
+    init(application: Application) {
+        _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
+        _factory = StateObject(wrappedValue: AppSheetViewFactory(application: application))
+    }
+
+    var body: some View {
+        Map(position: $cameraPosition) {
+            UserAnnotation()
+        }
+        .safeAreaPadding(.bottom, 80)
+        .floatingSheet(coordinator: coordinator) { route in
+            factory.view(for: route)
+        }
+    }
+}

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -17,18 +17,17 @@ import OBAKitCore
 /// `Map` with the persistent floating sheet system layered on top.
 ///
 /// This is the SwiftUI-native composition root for the sheet system:
-/// `Application` enters the SwiftUI tree here, the factory + coordinator are
-/// owned here as sibling `@StateObject`s, and the sheet content is rendered
-/// over the SwiftUI `Map`.
+/// `Application` enters the SwiftUI tree here, the factory + coordinator and the sheet content is rendered  over the SwiftUI `Map`.
 struct MapPanelRootView: View {
 
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
-    @StateObject private var factory: AppSheetViewFactory
     @State private var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
+
+    private let factory: AppSheetViewFactory
 
     init(application: Application) {
         _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
-        _factory = StateObject(wrappedValue: AppSheetViewFactory(application: application))
+        factory = AppSheetViewFactory(application: application)
     }
 
     var body: some View {

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -22,10 +22,6 @@ import OBAKitCore
 /// over the SwiftUI `Map`.
 struct MapPanelRootView: View {
 
-    /// UserDefaults key that gates the map panel experience.
-    /// Read at tab-construction time; changes apply on next launch.
-    static let useMapPanelExperienceUserDefaultsKey = "OBAUseMapPanelExperience"
-
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
     @StateObject private var factory: AppSheetViewFactory
     @State private var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
@@ -39,7 +35,7 @@ struct MapPanelRootView: View {
         Map(position: $cameraPosition) {
             UserAnnotation()
         }
-        .safeAreaPadding(.bottom, 80)
+        .safeAreaPadding(.bottom, AppSheetRoute.homeCollapsedHeight)
         .floatingSheet(coordinator: coordinator) { route in
             factory.view(for: route)
         }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -17,7 +17,9 @@ import OBAKitCore
 /// `Map` with the persistent floating sheet system layered on top.
 ///
 /// This is the SwiftUI-native composition root for the sheet system:
-/// `Application` enters the SwiftUI tree here, the factory + coordinator and the sheet content is rendered  over the SwiftUI `Map`.
+/// `Application` enters the SwiftUI tree here. The coordinator is owned as a
+/// `@StateObject`; the factory is a stateless `let`. Sheet content is rendered
+/// over the SwiftUI `Map`.
 struct MapPanelRootView: View {
 
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -105,7 +105,13 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     }
 
     public func rootNavigateTo(page: ClassicApplicationRootController.Page) {
-        guard let rootController = self.rootController else { return }
+        guard let rootController = self.rootController else {
+            // Map-panel mode bypasses ViewRouter — `SheetCoordinator` owns
+            // navigation. Surface dropped page navigations so deep-link and
+            // recent-stops paths that still call this don't silently degrade.
+            Logger.error("rootNavigateTo(page: \(page)) dropped: no classic root controller (map-panel mode is active)")
+            return
+        }
         rootController.navigate(to: page)
     }
 

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -111,6 +111,14 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
             // call this don't silently degrade. (No `assertionFailure`: test
             // harnesses construct `Application` without a root controller,
             // and tripping there would crash unrelated tests.)
+            //
+            // TODO(mosliem): map-panel deep-link / page-navigation story.
+            // Today deep links and "open in tab" callers go to a log and
+            // nothing visible happens. Either route `.tab` cases through
+            // `SheetCoordinator.push(...)` analogues (e.g. `.recent` →
+            // `.recentStopsAll`, `.bookmarks` → `.bookmarksAll`) or define a
+            // dedicated deep-link surface on the coordinator before the
+            // map-panel experience leaves the experimental flag.
             Logger.error("rootNavigateTo(page: \(page)) dropped: no classic root controller (map-panel mode is active)")
             return
         }

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -28,6 +28,10 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
 
     private let application: Application
 
+    /// Set by `ClassicApplicationRootController.init`. `nil` when the
+    /// experimental SwiftUI map-panel experience is the active root —
+    /// `SheetCoordinator` owns navigation in that mode and bypasses
+    /// `ViewRouter` entirely.
     var rootController: ClassicApplicationRootController?
 
     public init(application: Application) {

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -107,8 +107,10 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     public func rootNavigateTo(page: ClassicApplicationRootController.Page) {
         guard let rootController = self.rootController else {
             // Map-panel mode bypasses ViewRouter — `SheetCoordinator` owns
-            // navigation. Surface dropped page navigations so deep-link and
-            // recent-stops paths that still call this don't silently degrade.
+            // navigation. Log so deep-link / recent-stops paths that still
+            // call this don't silently degrade. (No `assertionFailure`: test
+            // harnesses construct `Application` without a root controller,
+            // and tripping there would crash unrelated tests.)
             Logger.error("rootNavigateTo(page: \(page)) dropped: no classic root controller (map-panel mode is active)")
             return
         }

--- a/OBAKitCore/Orchestration/FeatureFlags.swift
+++ b/OBAKitCore/Orchestration/FeatureFlags.swift
@@ -1,0 +1,18 @@
+//
+//  FeatureFlags.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// UserDefaults keys for experimental, opt-in features. Read at app
+/// construction; changes generally require a relaunch to take effect.
+public enum FeatureFlags {
+    /// Gates the SwiftUI map panel experience (full-screen map + floating
+    /// sheet) over the classic UIKit tab bar.
+    public static let useMapPanelExperienceKey = "OBAUseMapPanelExperience"
+}

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -562,6 +562,7 @@ class ApplicationTests: OBATestCase {
         app.agencyAlertsStore(app.alertsStore, displayError: testError)
     }
 
+    @MainActor
     func test_agency_alerts_updated_without_alerts() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -1,0 +1,119 @@
+//
+//  AppSheetRouteTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Pure-enum tests for `AppSheetRoute`: stable identifiers,
+/// stacking preference, and per-detent configuration.
+final class AppSheetRouteTests: XCTestCase {
+
+    // MARK: - Identifiers
+
+    func test_id_isStableForCaselessRoutes() {
+        expect(AppSheetRoute.home.id) == "home"
+        expect(AppSheetRoute.search.id) == "search"
+        expect(AppSheetRoute.nearbyAll.id) == "nearbyAll"
+        expect(AppSheetRoute.recentStopsAll.id) == "recentStopsAll"
+        expect(AppSheetRoute.bookmarksAll.id) == "bookmarksAll"
+        expect(AppSheetRoute.tripPlanner.id) == "tripPlanner"
+        expect(AppSheetRoute.routePicker.id) == "routePicker"
+        expect(AppSheetRoute.more.id) == "more"
+    }
+
+    func test_id_embedsAssociatedValues() {
+        expect(AppSheetRoute.stopDetails(stopID: "1_75403").id) == "stopDetails-1_75403"
+        expect(AppSheetRoute.tripDetails(tripID: "trip_42").id) == "tripDetails-trip_42"
+        expect(AppSheetRoute.currentTrip(routeID: "route_8").id) == "currentTrip-route_8"
+        expect(AppSheetRoute.transitAlert(alertID: "alert_99").id) == "transitAlert-alert_99"
+    }
+
+    func test_id_differsBetweenInstancesOfSameCase() {
+        let a = AppSheetRoute.stopDetails(stopID: "1_75403")
+        let b = AppSheetRoute.stopDetails(stopID: "1_75404")
+        expect(a.id) != b.id
+    }
+
+    // MARK: - Stacking preference
+
+    func test_prefersStacking_baseLayerRoutes() {
+        expect(AppSheetRoute.home.prefersStacking) == false
+        expect(AppSheetRoute.search.prefersStacking) == false
+        expect(AppSheetRoute.routePicker.prefersStacking) == false
+    }
+
+    func test_prefersStacking_stackedLayerRoutes() {
+        expect(AppSheetRoute.stopDetails(stopID: "1").prefersStacking) == true
+        expect(AppSheetRoute.tripPlanner.prefersStacking) == true
+        expect(AppSheetRoute.tripDetails(tripID: "t").prefersStacking) == true
+        expect(AppSheetRoute.currentTrip(routeID: "r").prefersStacking) == true
+        expect(AppSheetRoute.transitAlert(alertID: "a").prefersStacking) == true
+        expect(AppSheetRoute.more.prefersStacking) == true
+        expect(AppSheetRoute.nearbyAll.prefersStacking) == true
+        expect(AppSheetRoute.recentStopsAll.prefersStacking) == true
+        expect(AppSheetRoute.bookmarksAll.prefersStacking) == true
+    }
+
+    // MARK: - Detent configuration
+
+    func test_homeDetent_startsAtSmallAndOffersAllThree() {
+        let config = AppSheetRoute.home.detentConfiguration
+        expect(config.detents) == [.height(80), .medium, AppSheetRoute.largeDetent]
+        expect(config.initialDetent) == .height(80)
+        expect(config.showDragIndicator) == true
+        expect(config.isDismissDisabled) == true
+    }
+
+    func test_searchDetent_isFullLargeAndDismissDisabled() {
+        let config = AppSheetRoute.search.detentConfiguration
+        expect(config.detents) == [.large]
+        expect(config.initialDetent) == .large
+        expect(config.isDismissDisabled) == true
+    }
+
+    func test_baseListRoutes_shareSearchConfig() {
+        for route in [AppSheetRoute.nearbyAll, .recentStopsAll, .bookmarksAll] {
+            let config = route.detentConfiguration
+            expect(config.detents) == [.large]
+            expect(config.initialDetent) == .large
+            expect(config.isDismissDisabled) == true
+        }
+    }
+
+    func test_stopDetailsDetent_startsMediumAndIsInteractivelyDismissible() {
+        let config = AppSheetRoute.stopDetails(stopID: "1").detentConfiguration
+        expect(config.detents) == [.medium, .large]
+        expect(config.initialDetent) == .medium
+        expect(config.isDismissDisabled) == false
+    }
+
+    func test_stackedDetailRoutes_shareLargeStartAndAllowDismiss() {
+        let routes: [AppSheetRoute] = [
+            .tripPlanner,
+            .tripDetails(tripID: "t"),
+            .routePicker,
+            .currentTrip(routeID: "r"),
+            .transitAlert(alertID: "a"),
+            .more
+        ]
+
+        for route in routes {
+            let config = route.detentConfiguration
+            expect(config.detents) == [.medium, .large]
+            expect(config.initialDetent) == .large
+            expect(config.isDismissDisabled) == false
+        }
+    }
+
+    func test_largeDetent_isFractionedJustBelowFullScreen() {
+        expect(AppSheetRoute.largeDetent) == .fraction(0.99)
+    }
+}

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -81,12 +81,15 @@ final class AppSheetRouteTests: XCTestCase {
         expect(config.isDismissDisabled) == true
     }
 
-    func test_baseListRoutes_shareSearchConfig() {
+    func test_stackedAllListRoutes_shareLargeAndAllowDismiss() {
+        // These all-list routes are stacked sheets, so the OS owns dismissal
+        // and `isDismissDisabled` must be `false` for `truncateStacked` to stay
+        // in sync with the drag-down gesture.
         for route in [AppSheetRoute.nearbyAll, .recentStopsAll, .bookmarksAll] {
             let config = route.detentConfiguration
             expect(config.detents) == [.large]
             expect(config.initialDetent) == .large
-            expect(config.isDismissDisabled) == true
+            expect(config.isDismissDisabled) == false
         }
     }
 

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -74,11 +74,20 @@ final class AppSheetRouteTests: XCTestCase {
         expect(config.isDismissDisabled) == true
     }
 
+    func test_homeDetent_flipsToFullScreenAtLargeDetent() {
+        // `upThrough:` isn't honored with custom `.height` detents, so the home
+        // route flips background interaction to `.disabled` only when parked at
+        // `largeDetent` via `fullScreenDetent`.
+        let config = AppSheetRoute.home.detentConfiguration
+        expect(config.fullScreenDetent) == AppSheetRoute.largeDetent
+    }
+
     func test_searchDetent_isFullLargeAndDismissDisabled() {
         let config = AppSheetRoute.search.detentConfiguration
         expect(config.detents) == [.large]
         expect(config.initialDetent) == .large
         expect(config.isDismissDisabled) == true
+        expect(config.fullScreenDetent).to(beNil())
     }
 
     func test_stackedAllListRoutes_shareLargeAndAllowDismiss() {
@@ -90,6 +99,7 @@ final class AppSheetRouteTests: XCTestCase {
             expect(config.detents) == [.large]
             expect(config.initialDetent) == .large
             expect(config.isDismissDisabled) == false
+            expect(config.fullScreenDetent).to(beNil())
         }
     }
 
@@ -98,6 +108,7 @@ final class AppSheetRouteTests: XCTestCase {
         expect(config.detents) == [.medium, .large]
         expect(config.initialDetent) == .medium
         expect(config.isDismissDisabled) == false
+        expect(config.fullScreenDetent).to(beNil())
     }
 
     func test_stackedDetailRoutes_shareLargeStartAndAllowDismiss() {
@@ -116,11 +127,56 @@ final class AppSheetRouteTests: XCTestCase {
             expect(config.detents) == [.medium, .large]
             expect(config.initialDetent) == .large
             expect(config.isDismissDisabled) == false
+            expect(config.fullScreenDetent).to(beNil())
+        }
+    }
+
+    func test_allRoutes_showDragIndicator() {
+        // No route currently opts out of the drag indicator; this guards against
+        // an accidental flip when adding a new case.
+        let routes: [AppSheetRoute] = [
+            .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+            .stopDetails(stopID: "1"), .tripPlanner, .tripDetails(tripID: "t"),
+            .routePicker, .currentTrip(routeID: "r"), .transitAlert(alertID: "a"),
+            .more, .settings
+        ]
+        for route in routes {
+            expect(route.detentConfiguration.showDragIndicator) == true
         }
     }
 
     func test_largeDetent_isFractionedJustBelowFullScreen() {
         expect(AppSheetRoute.largeDetent) == .fraction(0.99)
+    }
+
+    func test_homeCollapsedHeight_matchesMapBottomInset() {
+        // Shared with `MapPanelRootView` so the map's bottom safe-area padding
+        // matches the collapsed sheet — keep the constant pinned.
+        expect(AppSheetRoute.homeCollapsedHeight) == 80
+    }
+
+    // MARK: - SheetDetentConfiguration defaults
+
+    func test_sheetDetentConfiguration_appliesDefaultsForOptionalFields() {
+        let config = SheetDetentConfiguration(
+            detents: [.medium],
+            initialDetent: .medium,
+            isDismissDisabled: false
+        )
+        expect(config.showDragIndicator) == true
+        expect(config.fullScreenDetent).to(beNil())
+    }
+
+    // MARK: - Hashable / Equatable
+
+    func test_equality_sameCaseSameAssociatedValueAreEqual() {
+        expect(AppSheetRoute.stopDetails(stopID: "1_1")) == AppSheetRoute.stopDetails(stopID: "1_1")
+        expect(AppSheetRoute.tripDetails(tripID: "t")) == AppSheetRoute.tripDetails(tripID: "t")
+    }
+
+    func test_equality_differentAssociatedValuesAreNotEqual() {
+        expect(AppSheetRoute.stopDetails(stopID: "1_1")) != AppSheetRoute.stopDetails(stopID: "1_2")
+        expect(AppSheetRoute.currentTrip(routeID: "r1")) != AppSheetRoute.currentTrip(routeID: "r2")
     }
 
     // MARK: - Exhaustiveness guard

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -27,6 +27,7 @@ final class AppSheetRouteTests: XCTestCase {
         expect(AppSheetRoute.tripPlanner.id) == "tripPlanner"
         expect(AppSheetRoute.routePicker.id) == "routePicker"
         expect(AppSheetRoute.more.id) == "more"
+        expect(AppSheetRoute.settings.id) == "settings"
     }
 
     func test_id_embedsAssociatedValues() {
@@ -60,6 +61,7 @@ final class AppSheetRouteTests: XCTestCase {
         expect(AppSheetRoute.nearbyAll.prefersStacking) == true
         expect(AppSheetRoute.recentStopsAll.prefersStacking) == true
         expect(AppSheetRoute.bookmarksAll.prefersStacking) == true
+        expect(AppSheetRoute.settings.prefersStacking) == true
     }
 
     // MARK: - Detent configuration
@@ -102,7 +104,8 @@ final class AppSheetRouteTests: XCTestCase {
             .routePicker,
             .currentTrip(routeID: "r"),
             .transitAlert(alertID: "a"),
-            .more
+            .more,
+            .settings
         ]
 
         for route in routes {
@@ -115,5 +118,18 @@ final class AppSheetRouteTests: XCTestCase {
 
     func test_largeDetent_isFractionedJustBelowFullScreen() {
         expect(AppSheetRoute.largeDetent) == .fraction(0.99)
+    }
+
+    // MARK: - Exhaustiveness guard
+
+    /// Adding a new `AppSheetRoute` case must fail to compile here, forcing
+    /// the author to extend the id / stacking / detent tests above.
+    private func exhaustivenessGuard(_ route: AppSheetRoute) {
+        switch route {
+        case .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+             .stopDetails, .tripPlanner, .tripDetails, .routePicker,
+             .currentTrip, .transitAlert, .more, .settings:
+            break
+        }
     }
 }

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -1,0 +1,187 @@
+//
+//  SheetCoordinatorTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+
+/// Behavior tests for `SheetCoordinator`'s content-swap and stacked navigation,
+/// using `AppSheetRoute` as the concrete `SheetRouteable` driver.
+@MainActor
+final class SheetCoordinatorTests: XCTestCase {
+
+    // MARK: - Init
+
+    func test_init_seedsRouteStackWithRoot() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.routeStack.count) == 1
+        expect(coordinator.currentRoute) == .home
+        expect(coordinator.canPop) == false
+    }
+
+    func test_init_setsCurrentDetentToRootInitialDetent() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.currentDetent) == AppSheetRoute.home.detentConfiguration.initialDetent
+    }
+
+    func test_init_stackedLayerStartsEmpty() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.stackedRoutes).to(beEmpty())
+        expect(coordinator.stackedDetents).to(beEmpty())
+    }
+
+    // MARK: - Push dispatches by prefersStacking
+
+    func test_push_nonStackingRoute_appendsContentStackAndResetsDetent() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.search)
+
+        expect(coordinator.routeStack.count) == 2
+        expect(coordinator.currentRoute) == .search
+        expect(coordinator.stackedRoutes).to(beEmpty())
+        expect(coordinator.canPop) == true
+        expect(coordinator.currentDetent) == AppSheetRoute.search.detentConfiguration.initialDetent
+    }
+
+    func test_push_stackingRoute_appendsToStackedAndLeavesContentStackAlone() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.search)
+
+        coordinator.push(.tripPlanner)
+
+        expect(coordinator.routeStack.count) == 2
+        expect(coordinator.currentRoute) == .search
+        expect(coordinator.stackedRoutes) == [.tripPlanner]
+        expect(coordinator.stackedDetents) == [AppSheetRoute.tripPlanner.detentConfiguration.initialDetent]
+    }
+
+    func test_push_stackingRoute_stacksMultipleSheets() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.recentStopsAll)
+        coordinator.push(.stopDetails(stopID: "1_75403"))
+        coordinator.push(.tripDetails(tripID: "t1"))
+
+        expect(coordinator.stackedRoutes) == [
+            .recentStopsAll,
+            .stopDetails(stopID: "1_75403"),
+            .tripDetails(tripID: "t1")
+        ]
+        expect(coordinator.stackedDetents.count) == 3
+    }
+
+    // MARK: - Pop removes topmost layer
+
+    func test_pop_withStackedPresented_removesTopStackedAndPreservesContentStack() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.search)
+        coordinator.push(.tripPlanner)
+        coordinator.push(.stopDetails(stopID: "1"))
+
+        coordinator.pop()
+
+        expect(coordinator.stackedRoutes) == [.tripPlanner]
+        expect(coordinator.stackedDetents.count) == 1
+        expect(coordinator.routeStack.count) == 2
+        expect(coordinator.currentRoute) == .search
+    }
+
+    func test_pop_lastStackedRoute_emptiesStackedLayer() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+
+        coordinator.pop()
+
+        expect(coordinator.stackedRoutes).to(beEmpty())
+        expect(coordinator.stackedDetents).to(beEmpty())
+    }
+
+    func test_pop_withoutStacked_removesTopAndRestoresPreviousInitialDetent() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.search)
+        coordinator.currentDetent = .medium
+
+        coordinator.pop()
+
+        expect(coordinator.routeStack.count) == 1
+        expect(coordinator.currentRoute) == .home
+        expect(coordinator.canPop) == false
+        expect(coordinator.currentDetent) == AppSheetRoute.home.detentConfiguration.initialDetent
+    }
+
+    func test_pop_atRoot_isNoOp() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.currentDetent = .large
+
+        coordinator.pop()
+
+        expect(coordinator.routeStack.count) == 1
+        expect(coordinator.currentRoute) == .home
+        expect(coordinator.currentDetent) == .large
+    }
+
+    // MARK: - truncateStacked (OS-driven dismiss)
+
+    func test_truncateStacked_removesEverythingAtAndAboveDepth() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.recentStopsAll)
+        coordinator.push(.stopDetails(stopID: "1"))
+        coordinator.push(.tripDetails(tripID: "t"))
+
+        coordinator.truncateStacked(toDepth: 1)
+
+        expect(coordinator.stackedRoutes) == [.recentStopsAll]
+        expect(coordinator.stackedDetents.count) == 1
+    }
+
+    func test_truncateStacked_ignoresOutOfRangeDepth() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+
+        coordinator.truncateStacked(toDepth: 5)
+
+        expect(coordinator.stackedRoutes) == [.tripPlanner]
+    }
+
+    // MARK: - canPop / popToRoot / currentDetents
+
+    func test_canPop_isTrueWhenOnlyStackedPresented() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.canPop) == false
+
+        coordinator.push(.tripPlanner)
+        expect(coordinator.canPop) == true
+    }
+
+    func test_popToRoot_clearsStackedAndUnwindsContentStack() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.search)
+        coordinator.push(.nearbyAll)        // stacked
+        coordinator.push(.recentStopsAll)   // also stacked
+
+        coordinator.popToRoot()
+
+        expect(coordinator.routeStack.count) == 1
+        expect(coordinator.currentRoute) == .home
+        expect(coordinator.stackedRoutes).to(beEmpty())
+        expect(coordinator.stackedDetents).to(beEmpty())
+        expect(coordinator.canPop) == false
+        expect(coordinator.currentDetent) == AppSheetRoute.home.detentConfiguration.initialDetent
+    }
+
+    func test_currentDetents_reflectsContentStackTopRegardlessOfStacked() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.currentDetents) == AppSheetRoute.home.detentConfiguration.detents
+
+        coordinator.push(.search)
+        expect(coordinator.currentDetents) == AppSheetRoute.search.detentConfiguration.detents
+
+        coordinator.push(.tripPlanner) // stacked — must not alter currentDetents
+        expect(coordinator.currentDetents) == AppSheetRoute.search.detentConfiguration.detents
+    }
+}

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -148,6 +148,61 @@ final class SheetCoordinatorTests: XCTestCase {
         expect(coordinator.stackedRoutes) == [.tripPlanner]
     }
 
+    // MARK: - setStackedDetent
+
+    func test_setStackedDetent_persistsAtGivenDepth() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+        coordinator.push(.stopDetails(stopID: "1"))
+
+        coordinator.setStackedDetent(.medium, at: 0)
+        coordinator.setStackedDetent(.large, at: 1)
+
+        expect(coordinator.stackedDetents) == [.medium, .large]
+    }
+
+    func test_setStackedDetent_ignoresOutOfRangeDepth() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+        let original = coordinator.stackedDetents
+
+        coordinator.setStackedDetent(.medium, at: 5)
+
+        expect(coordinator.stackedDetents) == original
+    }
+
+    // MARK: - stackedRoute(at:) / stackedDetent(at:fallback:)
+
+    func test_stackedRoute_atDepth_returnsRouteWhenInRange() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+        coordinator.push(.stopDetails(stopID: "1"))
+
+        expect(coordinator.stackedRoute(at: 0)) == .tripPlanner
+        expect(coordinator.stackedRoute(at: 1)) == .stopDetails(stopID: "1")
+    }
+
+    func test_stackedRoute_atDepth_returnsNilWhenOutOfRange() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.stackedRoute(at: 0)).to(beNil())
+
+        coordinator.push(.tripPlanner)
+        expect(coordinator.stackedRoute(at: 1)).to(beNil())
+    }
+
+    func test_stackedDetent_atDepth_returnsStoredDetent() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner)
+        coordinator.setStackedDetent(.medium, at: 0)
+
+        expect(coordinator.stackedDetent(at: 0, fallback: .large)) == .medium
+    }
+
+    func test_stackedDetent_atDepth_returnsFallbackWhenOutOfRange() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        expect(coordinator.stackedDetent(at: 0, fallback: .large)) == .large
+    }
+
     // MARK: - canPop / popToRoot / currentDetents
 
     func test_canPop_isTrueWhenOnlyStackedPresented() {


### PR DESCRIPTION
## Summary

  Introduces the foundation for a SwiftUI-based **map panel experience** that replaces the classic UIKit tab bar with a full-screen map and a floating bottom sheet. The
  new experience is gated behind an experimental settings toggle and ships alongside the existing classic UI — no behavior change for users by default.

  ## What's included

  ### Sheet coordinator foundation
  - `SheetRoute` — typed enum describing every sheet destination (home, search, stop details, trip planner, etc.).
  - `SheetCoordinator` — `@MainActor` navigation stack driving sheet presentation.
  - `FloatingSheetContainer` — SwiftUI container that hosts the bottom sheet over the map.

  ### Content & DI
  - `HomeSheetView` + `HomeSheetViewModel` — initial home sheet content.
  - `AppSheetViewFactory` — single DI seam mapping `SheetRoute` cases to views, with compiler-enforced exhaustiveness.
  - `MapPanelRootView` — SwiftUI root that composes the map and floating sheet.

  ### Integration
  - `ApplicationRootControllerFactory` (`@objc`) reads the feature flag and returns either `ClassicApplicationRootController` (unchanged) or `MapPanelRootController` (hosts `MapPanelRootView`). AppDelegates call the factory directly.
  - `BulletinOverlayWindow` presents `BLTNItemManager` in a dedicated `.alert`-level `UIWindow` so bulletins aren't clamped by the floating sheet's detent.
  - `SettingsViewController` adds an **Experimental** section with the "Use map panel experience" toggle (requires app restart).

  ### Tests
  - `AppSheetRouteTests` — covers route identity and equality.
  - `SheetCoordinatorTests` — covers push/pop/replace/reset behavior.

  ## Rollout

  - Default OFF. Opt-in via Settings → Experimental → "Use map panel experience".
  - Restart required to switch experiences (root controller is constructed once at launch).
  
  ### Video 

https://github.com/user-attachments/assets/df44d2b2-be11-4dfc-8e4d-1295e3e918fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an experimental **Map Panel Experience** toggle in Preferences.
  * Introduced a new **Map Panel** UI mode (map-first experience) alongside the classic tabbed interface.
  * Added a persistent **floating sheet** system with expandable Home search, per-destination detents, and optional stacked-sheet navigation.

* **Bug Fixes**
  * Updated map tab tapping and page navigation behavior to respect the active UI mode.

* **Tests**
  * Added unit tests for sheet routing IDs, detent configuration, and coordinator navigation (push/pop/truncate/pop-to-root).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
