### PR TITLE
Polish #1141 follow-ups (post-#1142)

### DIFF
--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -379,6 +379,8 @@ private extension MapFloatingPanelController {
         // EC11: map PanelDetent to FloatingPanel state so UIKit and future SwiftUI share the same source of truth.
         viewModel.$requestedPanelDetent
             .dropFirst()
+            // Re-publishing the same detent shouldn't re-trigger a `move(to:)` animation.
+            .removeDuplicates()
             .sink { [weak self] detent in
                 guard let self else { return }
                 let state: FloatingPanelState

--- a/OBAKit/ViewModels/MapPanelViewModel.swift
+++ b/OBAKit/ViewModels/MapPanelViewModel.swift
@@ -13,7 +13,7 @@ import OBAKitCore
 
 /// Describes the desired expansion state of the bottom panel (EC11).
 /// `MapFloatingPanelController` maps each case to a `FloatingPanelState`.
-// TODO: add a SwiftUI `PresentationDetent` mapping when the SwiftUI sheet lands.
+/// - TODO: add a SwiftUI `PresentationDetent` mapping when the SwiftUI sheet lands.
 enum PanelDetent: Equatable {
     case tip
     case half
@@ -31,7 +31,7 @@ class MapPanelViewModel: ObservableObject {
 
     /// Desired panel expansion level. `MapFloatingPanelController` observes this and calls
     /// `floatingPanel.move(to:)` (EC11).
-    // TODO: bind to SwiftUI `presentationDetent` when the SwiftUI sheet lands.
+    /// - TODO: bind to SwiftUI `presentationDetent` when the SwiftUI sheet lands.
     @Published var requestedPanelDetent: PanelDetent = .tip
 
     /// Nearby stops visible in the current map region.

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -179,8 +179,39 @@ class StopViewModelTests: OBATestCase {
 
         await expect(emissions).toEventually(equal(1))
         // Guard against regression to per-refresh fetching: emissions must not climb past 1.
-        // Without this, `toEventually` would latch onto the transient `1` on its way to 2/3.
+        // Without this, `toEventually` would latch onto the transient `1` on its way to a higher count.
         await expect(emissions).toNever(beGreaterThan(1))
+    }
+
+    /// A *failed* survey fetch records `lastError` and must NOT emit `surveysDidRefresh` —
+    /// otherwise every failed fetch would trigger a pointless, no-op list re-render. This
+    /// guards the `lastError == nil` gate in `refreshSurveys()`, the one branch the happy
+    /// path can't distinguish from an unconditional emit.
+    @MainActor
+    func test_surveys_failedFetch_doesNotEmit() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let analytics = AnalyticsMock()
+
+        // Register a malformed surveys payload *before* `createApplication` appends its
+        // success stub: `MockDataLoader` returns the first matching mock, so this one wins.
+        // The wrong shape fails `StudyResponse` decoding, landing on `SurveyService.lastError`.
+        let malformedSurveys = #"{"unexpected":true}"#.data(using: .utf8)!
+        dataLoader.mock(data: malformedSurveys) { request in
+            request.url?.path.contains("/surveys.json") ?? false
+        }
+
+        let app = createApplication(dataLoader: dataLoader, analytics: analytics)
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+
+        var emissions = 0
+        let cancellable = viewModel.surveysDidRefresh.sink { emissions += 1 }
+        defer { cancellable.cancel() }
+
+        await viewModel.refresh()
+
+        // Poll the full window so the detached fetch Task has time to run and (correctly)
+        // stay silent — a regression that drops the error gate would push this past 0.
+        await expect(emissions).toNever(beGreaterThan(0))
     }
 
     // MARK: - Filter invariant on initial load (issue #2)


### PR DESCRIPTION
Follow-up to #1142 (merged), tidying up the review findings that didn't block that merge.

## Changes

- **Clear the new SwiftLint warnings.** #1142 wedged two `// TODO:` lines between the `///` doc blocks and their declarations in `MapPanelViewModel.swift`, which detaches the doc comments and trips `orphaned_doc_comment` — ironic for a PR whose job was clearing #1141's lint noise. Folded both into the `///` block as `/// - TODO:` so they stay attached. Verified clean with `swiftlint`.
- **Make `Equatable` on `PanelDetent` earn its keep.** Added `.removeDuplicates()` to the `requestedPanelDetent` binding in `MapFloatingPanelController.bindPanelDetent()`, so re-publishing the same detent no longer re-triggers a `floatingPanel.move(to:)` animation. (#1142 added the conformance with no caller; this is the caller.)
- **Cover the survey error gate.** New `test_surveys_failedFetch_doesNotEmit` drives a malformed `/surveys.json` payload (registered first so it wins `MockDataLoader`'s first-match resolution) and asserts `surveysDidRefresh` stays silent — guarding the `lastError == nil` gate in `refreshSurveys()`, the one branch the happy-path test can't distinguish from an unconditional emit.
- **Decouple a test comment** from the literal refresh count ("2/3" → "a higher count").

## Testing

`xcodebuild test -only-testing:OBAKitTests/StopViewModelTests` — all 8 pass (including the new negative test). `swiftlint` clean on both edited source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary panel state animations that occurred when requesting the same panel position multiple times.

* **Tests**
  * Added test coverage for survey fetch failure handling to ensure reliable error handling and prevent unintended emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->