### PR TITLE
Feature/panel routes picker

### DIFF
--- a/OBAKit/Controls/SwiftUI/AppSymbol.swift
+++ b/OBAKit/Controls/SwiftUI/AppSymbol.swift
@@ -1,0 +1,54 @@
+//
+//  AppSymbol.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Centralised SF Symbol names used across the SwiftUI surfaces.
+///
+/// Use this for symbols whose *semantic role* recurs across views (loading,
+/// error, retry, search, etc.). View-private symbols that name a single
+/// concrete state in one screen can still live in a file-local `Symbol`
+/// enum next to that view; promote them here once a second consumer
+/// appears. The UIKit equivalent for `UIImage`-based icons is `Icons`.
+enum AppSymbol {
+
+    // MARK: - Generic status
+
+    /// "Something went wrong." Use for error-state placeholders.
+    static let error = "exclamationmark.triangle"
+
+    /// Generic loading / in-progress indicator. Also doubles as the canonical
+    /// refresh/retry glyph because Apple uses the same symbol for both.
+    static let loading = "arrow.clockwise"
+
+    /// "Try again." Same glyph as `loading` by design — both communicate
+    /// "this will fire a fresh fetch."
+    static let retry = "arrow.clockwise"
+
+    // MARK: - Search
+
+    /// Search field icon / "no search results" placeholder.
+    static let search = "magnifyingglass"
+
+    // MARK: - Location
+
+    /// "Location services unavailable" / permission-denied state.
+    static let locationUnavailable = "location.slash"
+
+    /// "Finding your location" / acquiring a fix.
+    static let locationFinding = "location.viewfinder"
+
+    // MARK: - Transit
+
+    /// Bus icon. Used for transit-related empty states.
+    static let bus = "bus"
+
+    /// "No real-time tracking available." Crossed-out broadcast antenna.
+    static let noRealtime = "antenna.radiowaves.left.and.right.slash"
+}

--- a/OBAKit/Controls/SwiftUI/EmptyStateView.swift
+++ b/OBAKit/Controls/SwiftUI/EmptyStateView.swift
@@ -1,0 +1,54 @@
+//
+//  EmptyStateView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Reusable empty / loading / informational state for SwiftUI views.
+///
+/// Wraps `ContentUnavailableView` so call sites declare *what* to display
+/// (title, SF Symbol, optional action) instead of re-spelling the underlying
+/// initializer each time. Use `ErrorView` for richer error rendering with
+/// classification; use this for plain status messages (loading, empty list,
+/// "no results", info).
+struct EmptyStateView<Actions: View>: View {
+    let title: String
+    let systemImage: String
+    @ViewBuilder let actions: () -> Actions
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(title, systemImage: systemImage)
+        } actions: {
+            actions()
+        }
+    }
+}
+
+// MARK: - No-actions convenience
+
+extension EmptyStateView where Actions == EmptyView {
+    init(title: String, systemImage: String) {
+        self.init(title: title, systemImage: systemImage, actions: { EmptyView() })
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Informational") {
+    EmptyStateView(title: "No routes found nearby.", systemImage: "magnifyingglass")
+}
+
+#Preview("With Action") {
+    EmptyStateView(title: "No active vehicle found on this route near you", systemImage: "bus") {
+        Button("Try Again") { }
+    }
+}
+#endif

--- a/OBAKit/Extensions/SwiftUIExtensions.swift
+++ b/OBAKit/Extensions/SwiftUIExtensions.swift
@@ -67,3 +67,28 @@ public extension View {
         }
     }
 }
+
+// MARK: - liquidGlassButtonStyle
+
+public extension View {
+    /// Apply to a `Button` to give it Apple's interactive Liquid Glass surface
+    /// on iOS 26+ (the press/morph "grab" response that comes with
+    /// `.buttonStyle(.glass)`), with a `.plain` + `.regularMaterial` fallback
+    /// on older systems so the button still reads as floating.
+    ///
+    /// Two shape parameters because the two surfaces use different APIs:
+    /// `borderShape` drives the iOS 26 glass morphing, `fallbackShape` fills
+    /// the pre-26 material background. Pass matching shapes (e.g. `.circle` +
+    /// `Circle()`) for a consistent look across versions.
+    @ViewBuilder
+    func liquidGlassButtonStyle(
+        borderShape: ButtonBorderShape = .capsule,
+        fallbackShape: some Shape = Capsule()
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            self.buttonStyle(.glass).buttonBorderShape(borderShape)
+        } else {
+            self.buttonStyle(.plain).background(.regularMaterial, in: fallbackShape)
+        }
+    }
+}

--- a/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
+++ b/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
@@ -1,0 +1,213 @@
+//
+//  CurrentTripView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import OBAKitCore
+
+/// SwiftUI surface for the "find my current trip on this route" flow. Pushed
+/// onto the stacked sheet layer from `RoutePickerView`. Owns the UIKit-flavored
+/// side effects the merged `CurrentTripViewModel` intentionally doesn't:
+/// idle-timer ownership, haptic feedback, and the VoiceOver gate.
+struct CurrentTripView: View {
+    @StateObject private var viewModel: CurrentTripViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.scenePhase) private var scenePhase
+
+    let onPresentTrip: (ArrivalDeparture) -> Void
+
+    @State private var wasIdleTimerDisabledByUs = false
+    private let feedback: DataLoadFeedbackGenerator
+    private let formatters: Formatters
+
+    init(
+        viewModel: @autoclosure @escaping () -> CurrentTripViewModel,
+        feedback: DataLoadFeedbackGenerator,
+        formatters: Formatters,
+        onPresentTrip: @escaping (ArrivalDeparture) -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+        self.feedback = feedback
+        self.formatters = formatters
+        self.onPresentTrip = onPresentTrip
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(OBALoc(
+                    "current_trip_controller.my_trip",
+                    value: "My Trip",
+                    comment: "Title for the current trip screen."
+                )))
+                .navigationBarTitleDisplayMode(.inline)
+        }
+        .onAppear {
+            viewModel.shouldSkipProgrammaticRefresh = { UIAccessibility.isVoiceOverRunning }
+            disableIdleTimer()
+            viewModel.start()
+        }
+        .onDisappear {
+            viewModel.deactivate()
+            reEnableIdleTimer()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase != .active {
+                viewModel.deactivate()
+                reEnableIdleTimer()
+            }
+        }
+        .onChange(of: viewModel.pendingNavigation) { _, arrival in
+            guard let arrival else { return }
+            feedback.dataLoad(.success)
+            onPresentTrip(arrival)
+            // Re-arm so a second single-match (e.g., user retries) can fire.
+            viewModel.pendingNavigation = nil
+        }
+        .onChange(of: stateKey) { _, newKey in
+            if newKey == .error || newKey == .noRealtime {
+                feedback.dataLoad(.failed)
+            }
+        }
+    }
+
+    // MARK: - Idle Timer
+
+    private func disableIdleTimer() {
+        guard !UIApplication.shared.isIdleTimerDisabled else { return }
+        UIApplication.shared.isIdleTimerDisabled = true
+        wasIdleTimerDisabledByUs = true
+    }
+
+    private func reEnableIdleTimer() {
+        guard wasIdleTimerDisabledByUs else { return }
+        UIApplication.shared.isIdleTimerDisabled = false
+        wasIdleTimerDisabledByUs = false
+    }
+
+    // MARK: - State observation key
+    //
+    // `CurrentTripViewModel.State` carries an associated `Error` so it isn't
+    // Equatable. Map to a small enum the `.onChange` modifier can compare.
+    private enum StateKey: Equatable {
+        case loading, noLocation, noResults, noRealtime, multipleResults, error
+    }
+
+    private var stateKey: StateKey {
+        switch viewModel.state {
+        case .loading:          return .loading
+        case .noLocation:       return .noLocation
+        case .noResults:        return .noResults
+        case .noRealtime:       return .noRealtime
+        case .multipleResults:  return .multipleResults
+        case .error:            return .error
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .loading:
+            ContentUnavailableView(
+                OBALoc("current_trip_controller.detecting", value: "Finding your vehicle…", comment: "Loading message while searching for the user's vehicle."),
+                systemImage: "location.viewfinder"
+            )
+
+        case .noLocation:
+            ContentUnavailableView(
+                OBALoc("current_trip_controller.location_unavailable", value: "Location unavailable. Please enable location services.", comment: "Error message when the user's location is not available."),
+                systemImage: "location.slash"
+            )
+
+        case .noResults:
+            ContentUnavailableView(label: {
+                Label(
+                    OBALoc("current_trip_controller.no_results", value: "No active vehicle found on this route near you", comment: "Message when no active vehicle is found near the user on the selected route."),
+                    systemImage: "bus"
+                )
+            }, actions: { retryButton })
+
+        case .noRealtime:
+            ContentUnavailableView(
+                OBALoc("current_trip_controller.no_realtime", value: "No real-time tracking available for this route", comment: "Message when the route has no real-time tracking data."),
+                systemImage: "antenna.radiowaves.left.and.right.slash"
+            )
+
+        case .error(let error):
+            ContentUnavailableView(label: {
+                Label(error.localizedDescription, systemImage: "exclamationmark.triangle")
+            }, actions: { retryButton })
+
+        case .multipleResults:
+            resultsList
+        }
+    }
+
+    private var retryButton: some View {
+        Button {
+            viewModel.findVehicle()
+        } label: {
+            Label(
+                OBALoc("current_trip_controller.retry", value: "Try Again", comment: "Button to retry finding the user's vehicle."),
+                systemImage: "arrow.clockwise"
+            )
+        }
+    }
+
+    private var resultsList: some View {
+        List {
+            Section(
+                header: Text(OBALoc(
+                    "current_trip_controller.multiple_vehicles",
+                    value: "Multiple vehicles found",
+                    comment: "Section header when multiple vehicles are found on the selected route."
+                ))
+            ) {
+                ForEach(viewModel.matchResults, id: \.arrivalDeparture.tripID) { result in
+                    Button {
+                        onPresentTrip(result.arrivalDeparture)
+                    } label: {
+                        resultRow(result)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func resultRow(_ result: NearbyTripMatcher.MatchResult) -> some View {
+        // Subtitle preserves the UIKit empty-vehicleID branch from
+        // CurrentTripViewController.swift:289-290.
+        let arrival = result.arrivalDeparture
+        let distance = formatters.distanceFormatter.string(fromDistance: result.distanceFromUser)
+        let distanceLabel = String(
+            format: OBALoc(
+                "current_trip_controller.distance_fmt",
+                value: "%@ away",
+                comment: "Distance from user to vehicle. e.g. '0.2 mi away'"
+            ),
+            distance
+        )
+        let vehicleID = arrival.vehicleID ?? ""
+        let subtitle = vehicleID.isEmpty ? distanceLabel : "\(vehicleID) · \(distanceLabel)"
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text(arrival.routeAndHeadsign)
+                .font(.body)
+                .foregroundStyle(.primary)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
+++ b/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
@@ -41,12 +41,13 @@ struct CurrentTripView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle(Text(OBALoc(
-                    "current_trip_controller.my_trip",
-                    value: "My Trip",
-                    comment: "Title for the current trip screen."
-                )))
+                .navigationTitle(Text(Strings.currentTripTitle))
                 .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { coordinator.pop() }
+                    }
+                }
         }
         .onAppear {
             viewModel.shouldSkipProgrammaticRefresh = { UIAccessibility.isVoiceOverRunning }
@@ -70,9 +71,14 @@ struct CurrentTripView: View {
             // Re-arm so a second single-match (e.g., user retries) can fire.
             viewModel.pendingNavigation = nil
         }
-        .onChange(of: stateKey) { _, newKey in
-            if newKey == .error || newKey == .noRealtime {
+        .onChange(of: viewModel.state) { _, newState in
+            // Pattern-match because `.error` carries an associated value —
+            // `newState == .error` would need a payload to compare against.
+            switch newState {
+            case .error, .noRealtime:
                 feedback.dataLoad(.failed)
+            default:
+                break
             }
         }
     }
@@ -91,61 +97,21 @@ struct CurrentTripView: View {
         wasIdleTimerDisabledByUs = false
     }
 
-    // MARK: - State observation key
-    //
-    // `CurrentTripViewModel.State` carries an associated `Error` so it isn't
-    // Equatable. Map to a small enum the `.onChange` modifier can compare.
-    private enum StateKey: Equatable {
-        case loading, noLocation, noResults, noRealtime, multipleResults, error
-    }
-
-    private var stateKey: StateKey {
-        switch viewModel.state {
-        case .loading:          return .loading
-        case .noLocation:       return .noLocation
-        case .noResults:        return .noResults
-        case .noRealtime:       return .noRealtime
-        case .multipleResults:  return .multipleResults
-        case .error:            return .error
-        }
-    }
-
     // MARK: - Content
 
     @ViewBuilder
     private var content: some View {
         switch viewModel.state {
         case .loading:
-            ContentUnavailableView(
-                OBALoc("current_trip_controller.detecting", value: "Finding your vehicle…", comment: "Loading message while searching for the user's vehicle."),
-                systemImage: "location.viewfinder"
-            )
-
+            EmptyStateView(title: Strings.currentTripFindingVehicle, systemImage: AppSymbol.locationFinding)
         case .noLocation:
-            ContentUnavailableView(
-                OBALoc("current_trip_controller.location_unavailable", value: "Location unavailable. Please enable location services.", comment: "Error message when the user's location is not available."),
-                systemImage: "location.slash"
-            )
-
+            EmptyStateView(title: Strings.currentTripLocationUnavailable, systemImage: AppSymbol.locationUnavailable)
         case .noResults:
-            ContentUnavailableView(label: {
-                Label(
-                    OBALoc("current_trip_controller.no_results", value: "No active vehicle found on this route near you", comment: "Message when no active vehicle is found near the user on the selected route."),
-                    systemImage: "bus"
-                )
-            }, actions: { retryButton })
-
+            EmptyStateView(title: Strings.currentTripNoActiveVehicle, systemImage: AppSymbol.bus) { retryButton }
         case .noRealtime:
-            ContentUnavailableView(
-                OBALoc("current_trip_controller.no_realtime", value: "No real-time tracking available for this route", comment: "Message when the route has no real-time tracking data."),
-                systemImage: "antenna.radiowaves.left.and.right.slash"
-            )
-
+            EmptyStateView(title: Strings.currentTripNoRealtime, systemImage: AppSymbol.noRealtime)
         case .error(let error):
-            ContentUnavailableView(label: {
-                Label(error.localizedDescription, systemImage: "exclamationmark.triangle")
-            }, actions: { retryButton })
-
+            EmptyStateView(title: error.localizedDescription, systemImage: AppSymbol.error) { retryButton }
         case .multipleResults:
             resultsList
         }
@@ -155,22 +121,13 @@ struct CurrentTripView: View {
         Button {
             viewModel.findVehicle()
         } label: {
-            Label(
-                OBALoc("current_trip_controller.retry", value: "Try Again", comment: "Button to retry finding the user's vehicle."),
-                systemImage: "arrow.clockwise"
-            )
+            Label(Strings.currentTripTryAgain, systemImage: AppSymbol.retry)
         }
     }
 
     private var resultsList: some View {
         List {
-            Section(
-                header: Text(OBALoc(
-                    "current_trip_controller.multiple_vehicles",
-                    value: "Multiple vehicles found",
-                    comment: "Section header when multiple vehicles are found on the selected route."
-                ))
-            ) {
+            Section(header: Text(Strings.currentTripMultipleVehicles)) {
                 ForEach(viewModel.matchResults, id: \.arrivalDeparture.tripID) { result in
                     Button {
                         onPresentTrip(result.arrivalDeparture)
@@ -180,33 +137,24 @@ struct CurrentTripView: View {
                 }
             }
         }
-        .listStyle(.plain)
+        .listStyle(.insetGrouped)
     }
 
     @ViewBuilder
     private func resultRow(_ result: NearbyTripMatcher.MatchResult) -> some View {
-        // Subtitle preserves the UIKit empty-vehicleID branch from
-        // CurrentTripViewController.swift:289-290.
         let arrival = result.arrivalDeparture
         let distance = formatters.distanceFormatter.string(fromDistance: result.distanceFromUser)
-        let distanceLabel = String(
-            format: OBALoc(
-                "current_trip_controller.distance_fmt",
-                value: "%@ away",
-                comment: "Distance from user to vehicle. e.g. '0.2 mi away'"
-            ),
-            distance
-        )
+        let distanceLabel = String(format: Strings.currentTripDistanceFormat, distance)
         let vehicleID = arrival.vehicleID ?? ""
         let subtitle = vehicleID.isEmpty ? distanceLabel : "\(vehicleID) · \(distanceLabel)"
 
         VStack(alignment: .leading, spacing: 2) {
             Text(arrival.routeAndHeadsign)
                 .font(.body)
-                .foregroundStyle(.primary)
+                .foregroundStyle(Color(ThemeColors.shared.label))
             Text(subtitle)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color(ThemeColors.shared.secondaryLabel))
         }
         .accessibilityElement(children: .combine)
     }

--- a/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
+++ b/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
@@ -58,17 +58,23 @@ struct CurrentTripView: View {
             viewModel.deactivate()
             reEnableIdleTimer()
         }
-        .onChange(of: scenePhase) { _, phase in
-            if phase == .active {
-                // Coming back from a backgrounding cycle: re-acquire the idle
-                // timer hold and re-arm the refresh loop. Without this branch
-                // the user returns to a frozen state with no live updates,
-                // and has to pop+re-push to recover.
-                disableIdleTimer()
-                viewModel.start()
-            } else {
+        .onChange(of: scenePhase) { previous, phase in
+            switch phase {
+            case .active:
+                // Only re-arm on the .background → .active edge. `.inactive → .active`
+                // (returning from Control Center / a banner / a system alert) never
+                // stopped the timer, so re-arming would issue a redundant network call.
+                if previous == .background {
+                    disableIdleTimer()
+                    viewModel.start()
+                }
+            case .background:
                 viewModel.deactivate()
                 reEnableIdleTimer()
+            case .inactive:
+                break
+            @unknown default:
+                break
             }
         }
         .onChange(of: viewModel.pendingNavigation) { _, arrival in

--- a/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
+++ b/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
@@ -59,7 +59,14 @@ struct CurrentTripView: View {
             reEnableIdleTimer()
         }
         .onChange(of: scenePhase) { _, phase in
-            if phase != .active {
+            if phase == .active {
+                // Coming back from a backgrounding cycle: re-acquire the idle
+                // timer hold and re-arm the refresh loop. Without this branch
+                // the user returns to a frozen state with no live updates,
+                // and has to pop+re-push to recover.
+                disableIdleTimer()
+                viewModel.start()
+            } else {
                 viewModel.deactivate()
                 reEnableIdleTimer()
             }

--- a/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
+++ b/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
@@ -1,0 +1,104 @@
+//
+//  RoutePickerView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// SwiftUI route picker surfaced by `AppSheetRoute.routePicker`. Drives the
+/// already-merged `RoutePickerViewModel`; on selection, pushes
+/// `.currentTrip(route:)` onto the sheet stack.
+struct RoutePickerView: View {
+    @StateObject private var viewModel: RoutePickerViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+
+    @State private var searchText: String = ""
+    @State private var loadTask: Task<Void, Never>?
+
+    init(viewModel: @autoclosure @escaping () -> RoutePickerViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(OBALoc(
+                    "route_picker.title",
+                    value: "Select Your Route",
+                    comment: "Title for the route picker screen where the user selects their transit route."
+                )))
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(
+                    text: $searchText,
+                    placement: .navigationBarDrawer(displayMode: .always),
+                    prompt: Text(OBALoc(
+                        "route_picker.search_placeholder",
+                        value: "Search routes…",
+                        comment: "Placeholder text in the route search field."
+                    ))
+                )
+                .onChange(of: searchText) { _, newValue in
+                    viewModel.updateSearch(newValue)
+                }
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { coordinator.pop() }
+                    }
+                }
+        }
+        .onAppear {
+            // Re-entrant guard: SwiftUI re-attaches on scenePhase changes; only
+            // kick a load if no Task is already in flight.
+            guard loadTask == nil else { return }
+            loadTask = Task { [viewModel] in
+                await viewModel.loadRoutes()
+            }
+        }
+        .onDisappear {
+            loadTask?.cancel()
+            loadTask = nil
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !viewModel.didFinishLoading {
+            ContentUnavailableView(
+                OBALoc("route_picker.loading", value: "Loading routes…", comment: "Loading message while fetching nearby routes."),
+                systemImage: "arrow.clockwise"
+            )
+        } else if let error = viewModel.loadError {
+            ContentUnavailableView(
+                error.localizedDescription,
+                systemImage: "exclamationmark.triangle"
+            )
+        } else if viewModel.allRoutes.isEmpty {
+            ContentUnavailableView(
+                OBALoc("route_picker.no_routes", value: "No routes found nearby.", comment: "Message when no routes are found near the user's location."),
+                systemImage: "magnifyingglass"
+            )
+        } else {
+            List(viewModel.filteredRoutes, id: \.id) { route in
+                Button {
+                    coordinator.push(.currentTrip(route: route))
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(route.shortName)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                        Text(route.longName ?? route.agency.name)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+            }
+            .listStyle(.plain)
+        }
+    }
+}

--- a/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
+++ b/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
@@ -44,16 +44,21 @@ struct RoutePickerView: View {
                 }
         }
         .onAppear {
-            // Re-entrant guard: SwiftUI re-attaches on scenePhase changes; only
-            // kick a load if no Task is already in flight.
-            guard loadTask == nil else { return }
-            loadTask = Task { [viewModel] in
-                await viewModel.loadRoutes()
-            }
+            startLoad()
         }
         .onDisappear {
             loadTask?.cancel()
             loadTask = nil
+        }
+    }
+
+    /// Kicks off a fresh `loadRoutes()` unless one is already in flight. Re-entrant
+    /// safe: SwiftUI can re-attach on scenePhase changes, and the retry button
+    /// funnels through the same entry point.
+    private func startLoad() {
+        guard loadTask == nil else { return }
+        loadTask = Task { [viewModel] in
+            await viewModel.loadRoutes()
         }
     }
 
@@ -62,12 +67,25 @@ struct RoutePickerView: View {
         if !viewModel.didFinishLoading {
             EmptyStateView(title: Strings.routePickerLoading, systemImage: AppSymbol.loading)
         } else if let error = viewModel.loadError {
-            EmptyStateView(title: error.localizedDescription, systemImage: AppSymbol.error)
+            EmptyStateView(title: error.localizedDescription, systemImage: AppSymbol.error) { retryButton }
         } else if viewModel.allRoutes.isEmpty {
             EmptyStateView(title: Strings.routePickerNoRoutes, systemImage: AppSymbol.search)
         } else {
             routesList
         }
+    }
+
+    private var retryButton: some View {
+        Button {
+            // A completed load leaves `loadTask` non-nil; drop it first so
+            // `startLoad()` doesn't guard-return.
+            loadTask?.cancel()
+            loadTask = nil
+            startLoad()
+        } label: {
+            Label(Strings.currentTripTryAgain, systemImage: AppSymbol.retry)
+        }
+        .padding(.top, 8)
     }
 
     private var routesList: some View {

--- a/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
+++ b/OBAKit/Sheet/Content/RoutePicker/RoutePickerView.swift
@@ -27,20 +27,12 @@ struct RoutePickerView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle(Text(OBALoc(
-                    "route_picker.title",
-                    value: "Select Your Route",
-                    comment: "Title for the route picker screen where the user selects their transit route."
-                )))
+                .navigationTitle(Text(Strings.routePickerTitle))
                 .navigationBarTitleDisplayMode(.inline)
                 .searchable(
                     text: $searchText,
                     placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: Text(OBALoc(
-                        "route_picker.search_placeholder",
-                        value: "Search routes…",
-                        comment: "Placeholder text in the route search field."
-                    ))
+                    prompt: Text(Strings.routePickerSearchPlaceholder)
                 )
                 .onChange(of: searchText) { _, newValue in
                     viewModel.updateSearch(newValue)
@@ -68,37 +60,36 @@ struct RoutePickerView: View {
     @ViewBuilder
     private var content: some View {
         if !viewModel.didFinishLoading {
-            ContentUnavailableView(
-                OBALoc("route_picker.loading", value: "Loading routes…", comment: "Loading message while fetching nearby routes."),
-                systemImage: "arrow.clockwise"
-            )
+            EmptyStateView(title: Strings.routePickerLoading, systemImage: AppSymbol.loading)
         } else if let error = viewModel.loadError {
-            ContentUnavailableView(
-                error.localizedDescription,
-                systemImage: "exclamationmark.triangle"
-            )
+            EmptyStateView(title: error.localizedDescription, systemImage: AppSymbol.error)
         } else if viewModel.allRoutes.isEmpty {
-            ContentUnavailableView(
-                OBALoc("route_picker.no_routes", value: "No routes found nearby.", comment: "Message when no routes are found near the user's location."),
-                systemImage: "magnifyingglass"
-            )
+            EmptyStateView(title: Strings.routePickerNoRoutes, systemImage: AppSymbol.search)
         } else {
-            List(viewModel.filteredRoutes, id: \.id) { route in
-                Button {
-                    coordinator.push(.currentTrip(route: route))
-                } label: {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(route.shortName)
-                            .font(.body)
-                            .foregroundStyle(.primary)
-                        Text(route.longName ?? route.agency.name)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .accessibilityElement(children: .combine)
-            }
-            .listStyle(.plain)
+            routesList
         }
+    }
+
+    private var routesList: some View {
+        List(viewModel.filteredRoutes, id: \.id) { route in
+            routeRow(route)
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func routeRow(_ route: Route) -> some View {
+        Button {
+            coordinator.push(.currentTrip(route: route))
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(route.shortName)
+                    .font(.body)
+                    .foregroundStyle(Color(ThemeColors.shared.label))
+                Text(route.longName ?? route.agency.name)
+                    .font(.subheadline)
+                    .foregroundStyle(Color(ThemeColors.shared.secondaryLabel))
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -81,7 +81,7 @@ enum AppSheetRoute: SheetRouteable {
     case tripPlanner
     case tripDetails(tripID: TripIdentifier)
     case routePicker
-    case currentTrip(routeID: RouteID)
+    case currentTrip(route: Route)
     case transitAlert(alertID: String)
 
     case more

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -118,8 +118,8 @@ extension AppSheetRoute {
             return "\(caseName)-\(stopID)"
         case .tripDetails(let tripID):
             return "\(caseName)-\(tripID)"
-        case .currentTrip(let routeID):
-            return "\(caseName)-\(routeID)"
+        case .currentTrip(let route):
+            return "\(caseName)-\(route.id)"
         case .transitAlert(let alertID):
             return "\(caseName)-\(alertID)"
         }

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -124,6 +124,16 @@ extension AppSheetRoute {
             return "\(caseName)-\(alertID)"
         }
     }
+
+    // MARK: Hashable / Equatable
+
+    static func == (lhs: AppSheetRoute, rhs: AppSheetRoute) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 }
 
 extension AppSheetRoute {

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -52,6 +52,9 @@ final class AppSheetViewFactory {
 
         case .routePicker:
             routePickerView()
+
+        case .currentTrip(let route):
+            currentTripView(route: route)
         }
     }
 
@@ -63,6 +66,15 @@ final class AppSheetViewFactory {
 
     func routePickerView() -> RoutePickerView {
         RoutePickerView(viewModel: RoutePickerViewModel(application: self.application))
+    }
+
+    private func currentTripView(route: Route) -> CurrentTripView {
+        CurrentTripView(
+            viewModel: CurrentTripViewModel(application: self.application, route: route),
+            feedback: DataLoadFeedbackGenerator(application: self.application),
+            formatters: self.application.formatters,
+            onPresentTrip: onPresentTrip
+        )
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -46,8 +46,7 @@ final class AppSheetViewFactory {
             // (the home sheet only knows how to push, not pop), otherwise the
             // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-                .stopDetails, .tripPlanner, .tripDetails,
-                .currentTrip, .transitAlert, .more, .settings:
+                .stopDetails, .tripPlanner, .tripDetails, .transitAlert, .more, .settings:
             unimplementedView(for: route)
 
         case .routePicker:

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -23,9 +23,11 @@ import OBAKitCore
 final class AppSheetViewFactory {
 
     let application: Application
+    let onPresentTrip: (ArrivalDeparture) -> Void
 
-    init(application: Application) {
+    init(application: Application, onPresentTrip: @escaping (ArrivalDeparture) -> Void) {
         self.application = application
+        self.onPresentTrip = onPresentTrip
     }
 
     // MARK: - Dispatcher

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -46,9 +46,12 @@ final class AppSheetViewFactory {
             // (the home sheet only knows how to push, not pop), otherwise the
             // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-                .stopDetails, .tripPlanner, .tripDetails, .routePicker,
+                .stopDetails, .tripPlanner, .tripDetails,
                 .currentTrip, .transitAlert, .more, .settings:
             unimplementedView(for: route)
+
+        case .routePicker:
+            routePickerView()
         }
     }
 
@@ -56,6 +59,10 @@ final class AppSheetViewFactory {
 
     func homeView() -> HomeSheetView {
         HomeSheetView(viewModel: HomeSheetViewModel())
+    }
+
+    func routePickerView() -> RoutePickerView {
+        RoutePickerView(viewModel: RoutePickerViewModel(application: self.application))
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -66,7 +66,10 @@ public final class MapPanelRootController: UIViewController {
         weak var application: Application?
 
         func present(_ arrival: ArrivalDeparture) {
-            guard let host, let application else { return }
+            guard let host, let application else {
+                Logger.error("TripPresentationBridge: dropping present for trip \(arrival.tripID) — host or application is nil")
+                return
+            }
             let trip = TripViewController(application: application, arrivalDeparture: arrival)
             // Wrap in our own UINavigationController and modally present from
             // the topmost presented controller, not `host` directly:

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -97,6 +97,16 @@ public final class MapPanelRootController: UIViewController {
             while let next = presenter.presentedViewController {
                 presenter = next
             }
+            // Skip if the topmost presented controller is already a
+            // `TripViewController` (or a nav rooted at one). `CurrentTripView`
+            // stays mounted under the modal trip and its 20-second refresh
+            // timer keeps firing — without this guard, repeat single-match
+            // hits would stack a fresh `TripViewController` on top of the
+            // existing one each tick.
+            if presenter is TripViewController { return }
+            if let nav = presenter as? UINavigationController, nav.viewControllers.first is TripViewController {
+                return
+            }
             presenter.present(navigation, animated: true)
         }
     }

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -23,14 +23,16 @@ public final class MapPanelRootController: UIViewController {
     private let host: UIHostingController<MapPanelRootView>
 
     public init(application: Application) {
-        // Task 6 swaps this for the live TripPresentationBridge.
+        let bridge = TripPresentationBridge()
         let factory = AppSheetViewFactory(
             application: application,
-            onPresentTrip: { _ in }
+            onPresentTrip: { [weak bridge] arrival in bridge?.present(arrival) }
         )
         let rootView = MapPanelRootView(application: application, factory: factory)
         self.host = UIHostingController(rootView: rootView)
         super.init(nibName: nil, bundle: nil)
+        bridge.host = self
+        bridge.application = application
     }
 
     required init?(coder: NSCoder) {
@@ -50,5 +52,21 @@ public final class MapPanelRootController: UIViewController {
             host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         host.didMove(toParent: self)
+    }
+
+    /// Bridges single-match navigation from `CurrentTripView` back to the UIKit
+    /// `TripViewController`. Exists as a separate type because `self` isn't
+    /// available before `super.init`, and the closure baked into the factory
+    /// needs to reach it.
+    @MainActor
+    private final class TripPresentationBridge {
+        weak var host: UIViewController?
+        weak var application: Application?
+
+        func present(_ arrival: ArrivalDeparture) {
+            guard let host, let application else { return }
+            let trip = TripViewController(application: application, arrivalDeparture: arrival)
+            application.viewRouter.navigate(to: trip, from: host)
+        }
     }
 }

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -21,6 +21,7 @@ import OBAKitCore
 public final class MapPanelRootController: UIViewController {
 
     private let host: UIHostingController<MapPanelRootView>
+    private let bridge: TripPresentationBridge
 
     public init(application: Application) {
         let bridge = TripPresentationBridge()
@@ -30,9 +31,10 @@ public final class MapPanelRootController: UIViewController {
         )
         let rootView = MapPanelRootView(application: application, factory: factory)
         self.host = UIHostingController(rootView: rootView)
+        self.bridge = bridge
         super.init(nibName: nil, bundle: nil)
-        bridge.host = self
-        bridge.application = application
+        self.bridge.host = self
+        self.bridge.application = application
     }
 
     required init?(coder: NSCoder) {

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -68,7 +68,36 @@ public final class MapPanelRootController: UIViewController {
         func present(_ arrival: ArrivalDeparture) {
             guard let host, let application else { return }
             let trip = TripViewController(application: application, arrivalDeparture: arrival)
-            application.viewRouter.navigate(to: trip, from: host)
+            // Wrap in our own UINavigationController and modally present from
+            // the topmost presented controller, not `host` directly:
+            //
+            // 1. `ViewRouter.navigate(to:from:)` asserts the source controller
+            //    has a `navigationController`. The SwiftUI host is the root of
+            //    the window's hierarchy — no nav stack wraps it — so the UIKit
+            //    "push" path can't be reused here.
+            // 2. The floating sheet system uses SwiftUI `.sheet(...)`, which
+            //    UIKit-bridges as modals on the host. By the time we're
+            //    invoked, `host.presentedViewController` chains up through the
+            //    base sheet (`.home`), the picker (`.routePicker`), and the
+            //    stacked CurrentTrip sheet. Presenting from `host` would land
+            //    underneath that chain (UIKit ignores presents on a controller
+            //    that already has a `presentedViewController`); we have to
+            //    walk up to the top and present from there so the trip view
+            //    lands above the sheet stack.
+            //
+            // Done button dismisses back to the (still-intact) sheet stack.
+            trip.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                systemItem: .done,
+                primaryAction: UIAction { [weak trip] _ in
+                    trip?.dismiss(animated: true)
+                }
+            )
+            let navigation = application.viewRouter.buildNavigation(controller: trip)
+            var presenter: UIViewController = host
+            while let next = presenter.presentedViewController {
+                presenter = next
+            }
+            presenter.present(navigation, animated: true)
         }
     }
 }

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -23,7 +23,13 @@ public final class MapPanelRootController: UIViewController {
     private let host: UIHostingController<MapPanelRootView>
 
     public init(application: Application) {
-        self.host = UIHostingController(rootView: MapPanelRootView(application: application))
+        // Task 6 swaps this for the live TripPresentationBridge.
+        let factory = AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in }
+        )
+        let rootView = MapPanelRootView(application: application, factory: factory)
+        self.host = UIHostingController(rootView: rootView)
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -33,6 +33,16 @@ struct MapPanelRootView: View {
 
     @Environment(\.scenePhase) private var scenePhase
 
+    @State private var sheetHeight: CGFloat = 0
+    @State private var toolbarsAnimationDuration: CGFloat = 0
+    @State private var toolbarsOpacity: CGFloat = 1
+
+    @State private var halfScreenHeight: CGFloat = 350
+
+    /// Points of fade band immediately below the clamp ceiling. Toolbar
+    /// opacity ramps from 1 → 0 across this window as the sheet approaches `halfScreenHeight`.
+    private let toolbarFadeRange: CGFloat = 50
+
     private let factory: AppSheetViewFactory
 
     init(application: Application, factory: AppSheetViewFactory) {
@@ -58,6 +68,12 @@ struct MapPanelRootView: View {
         Map(position: $cameraPosition) {
             UserAnnotation()
         }
+        .safeAreaPadding(.bottom, 180)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height / 2
+        } action: { _, newValue in
+            halfScreenHeight = newValue
+        }
         // TODO: Detent-aware bottom padding. Pinned to the collapsed sheet
         // height today, so dragging the sheet up to `.medium` or
         // `largeDetent` lets the user-location annotation and any future map
@@ -67,11 +83,7 @@ struct MapPanelRootView: View {
             weatherButton
         }
         .overlay(alignment: .bottomLeading) {
-            MyTripButton {
-                coordinator.push(.routePicker)
-            }
-            .padding(.leading, ThemeMetrics.controllerMargin)
-            .padding(.bottom, AppSheetRoute.homeCollapsedHeight + ThemeMetrics.controllerMargin)
+            bottomFloatingTripButton
         }
         .floatingSheet(coordinator: coordinator) { route in
             factory.view(for: route)
@@ -82,6 +94,23 @@ struct MapPanelRootView: View {
                     )
                     .presentationBackground(.clear)
                 }
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    max(min(proxy.size.height, halfScreenHeight), 0)
+                } action: { oldValue, newValue in
+                    sheetHeight = newValue
+
+                    /// Opacity calculation — fade band sits immediately
+                    /// below `halfScreenHeight`.
+                    let fadeStart = halfScreenHeight - toolbarFadeRange
+                    let progress = max(min((newValue - fadeStart) / toolbarFadeRange, 1), 0)
+                    toolbarsOpacity = 1 - progress
+
+                    /// Animation duration
+                    let diff = abs(newValue - oldValue)
+                    let duration = max(min(diff / 100, 0.3), 0)
+                    toolbarsAnimationDuration = duration
+                }
+                .ignoresSafeArea()
         }
         .onAppear {
             mapViewModel.start()
@@ -102,4 +131,18 @@ struct MapPanelRootView: View {
             .padding(ThemeMetrics.controllerMargin)
         }
     }
+
+    private var bottomFloatingTripButton: some View {
+        MyTripButton {
+            coordinator.push(.routePicker)
+        }
+        .padding(.leading, ThemeMetrics.controllerMargin)
+        .offset(y: -sheetHeight)
+        .opacity(toolbarsOpacity)
+        .animation(
+            .interpolatingSpring(duration: toolbarsAnimationDuration, bounce: 0, initialVelocity: 0),
+            value: sheetHeight
+        )
+    }
+
 }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -35,10 +35,10 @@ struct MapPanelRootView: View {
 
     private let factory: AppSheetViewFactory
 
-    init(application: Application) {
+    init(application: Application, factory: AppSheetViewFactory) {
         _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application))
-        factory = AppSheetViewFactory(application: application)
+        self.factory = factory
     }
 
     var body: some View {
@@ -53,19 +53,13 @@ struct MapPanelRootView: View {
         .overlay(alignment: .topLeading) {
             weatherButton
         }
-        .onAppear {
-            mapViewModel.start()
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
-                mapViewModel.onAppBecameActive()
+        .overlay(alignment: .bottomLeading) {
+            MyTripButton {
+                coordinator.push(.routePicker)
             }
+            .padding(.leading, ThemeMetrics.controllerMargin)
+            .padding(.bottom, AppSheetRoute.homeCollapsedHeight + ThemeMetrics.controllerMargin)
         }
-        // The popup cover is attached INSIDE the sheet content so it's
-        // presented from the floating sheet's `UISheetPresentationController` —
-        // a host-level `.fullScreenCover` ends up under the sheet because the
-        // sheet owns the topmost presentation context. `.presentationBackground(.clear)`
-        // keeps the map and sheet visible behind the dim+card.
         .floatingSheet(coordinator: coordinator) { route in
             factory.view(for: route)
                 .fullScreenCover(isPresented: $isWeatherPopupPresented) {
@@ -75,6 +69,14 @@ struct MapPanelRootView: View {
                     )
                     .presentationBackground(.clear)
                 }
+        }
+        .onAppear {
+            mapViewModel.start()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                mapViewModel.onAppBecameActive()
+            }
         }
     }
 

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -42,6 +42,19 @@ struct MapPanelRootView: View {
     }
 
     var body: some View {
+        // TODO: Wire this SwiftUI `Map` to `application.mapRegionManager`.
+        // The UIKit `MapViewController` flow populates
+        // `mapRegionManager.stops` via `MapRegionManager.requestStops`
+        // whenever its MKMapView's region changes; both `RoutePickerViewModel`
+        // and `CurrentTripViewModel` read from that cache before falling back
+        // to a coordinate-based API call. Because this SwiftUI `Map` never
+        // touches `MapRegionManager`, the cache stays empty here and the
+        // pickers always hit the coordinate-fallback path — producing a
+        // different (often larger) route list than the UIKit picker shows for
+        // the same on-screen viewport. Fix is to observe `cameraPosition`
+        // changes, convert to an `MKCoordinateRegion`, and feed it into
+        // `MapRegionManager` so both surfaces agree on the cached stop set
+        // (also unblocks rendering stop annotations on the SwiftUI map).
         Map(position: $cameraPosition) {
             UserAnnotation()
         }

--- a/OBAKit/Sheet/Root/MyTripButton.swift
+++ b/OBAKit/Sheet/Root/MyTripButton.swift
@@ -1,0 +1,33 @@
+//
+//  MyTripButton.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Floating bus pill rendered over `MapPanelRootView`'s map. Always visible —
+/// the UIKit `MapViewController.myTripButton` is unconditional too.
+struct MyTripButton: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Image(uiImage: Icons.busButton)
+                .renderingMode(.template)
+                .font(.body.bold())
+                .padding(12)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(OBALoc(
+            "map_controller.my_trip_button",
+            value: "My Trip",
+            comment: "Accessibility label for the My Trip button on the map toolbar."
+        )))
+    }
+}

--- a/OBAKit/Sheet/Root/MyTripButton.swift
+++ b/OBAKit/Sheet/Root/MyTripButton.swift
@@ -23,7 +23,7 @@ struct MyTripButton: View {
                 .padding(12)
                 .contentShape(Circle())
         }
-        .buttonStyle(.plain)
+        .liquidGlassButtonStyle(borderShape: .circle, fallbackShape: Circle())
         .accessibilityLabel(Text(OBALoc(
             "map_controller.my_trip_button",
             value: "My Trip",

--- a/OBAKit/Sheet/Root/MyTripButton.swift
+++ b/OBAKit/Sheet/Root/MyTripButton.swift
@@ -19,7 +19,6 @@ struct MyTripButton: View {
         Button(action: onTap) {
             Image(uiImage: Icons.busButton)
                 .renderingMode(.template)
-                .font(.body.bold())
                 .padding(12)
                 .contentShape(Circle())
         }

--- a/OBAKit/Strings/Strings+Sheet.swift
+++ b/OBAKit/Strings/Strings+Sheet.swift
@@ -1,0 +1,92 @@
+//
+//  Strings+Sheet.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Localized strings consumed by the SwiftUI sheet surfaces
+/// (`MapPanelRootView` and its views).
+public extension Strings {
+
+    // MARK: - Route Picker
+
+    static let routePickerTitle = OBALoc(
+        "route_picker.title",
+        value: "Select Your Route",
+        comment: "Title for the route picker screen where the user selects their transit route."
+    )
+
+    static let routePickerSearchPlaceholder = OBALoc(
+        "route_picker.search_placeholder",
+        value: "Search routes…",
+        comment: "Placeholder text in the route search field."
+    )
+
+    static let routePickerLoading = OBALoc(
+        "route_picker.loading",
+        value: "Loading routes…",
+        comment: "Loading message while fetching nearby routes."
+    )
+
+    static let routePickerNoRoutes = OBALoc(
+        "route_picker.no_routes",
+        value: "No routes found nearby.",
+        comment: "Message when no routes are found near the user's location."
+    )
+
+    // MARK: - Current Trip
+
+    static let currentTripTitle = OBALoc(
+        "current_trip_controller.my_trip",
+        value: "My Trip",
+        comment: "Title for the current trip screen."
+    )
+
+    static let currentTripFindingVehicle = OBALoc(
+        "current_trip_controller.detecting",
+        value: "Finding your vehicle…",
+        comment: "Loading message while searching for the user's vehicle."
+    )
+
+    static let currentTripLocationUnavailable = OBALoc(
+        "current_trip_controller.location_unavailable",
+        value: "Location unavailable. Please enable location services.",
+        comment: "Error message when the user's location is not available."
+    )
+
+    static let currentTripNoActiveVehicle = OBALoc(
+        "current_trip_controller.no_results",
+        value: "No active vehicle found on this route near you",
+        comment: "Message when no active vehicle is found near the user on the selected route."
+    )
+
+    static let currentTripNoRealtime = OBALoc(
+        "current_trip_controller.no_realtime",
+        value: "No real-time tracking available for this route",
+        comment: "Message when the route has no real-time tracking data."
+    )
+
+    static let currentTripTryAgain = OBALoc(
+        "current_trip_controller.retry",
+        value: "Try Again",
+        comment: "Button to retry finding the user's vehicle."
+    )
+
+    static let currentTripMultipleVehicles = OBALoc(
+        "current_trip_controller.multiple_vehicles",
+        value: "Multiple vehicles found",
+        comment: "Section header when multiple vehicles are found on the selected route."
+    )
+
+    static let currentTripDistanceFormat = OBALoc(
+        "current_trip_controller.distance_fmt",
+        value: "%@ away",
+        comment: "Distance from user to vehicle. e.g. '0.2 mi away'"
+    )
+}

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -20,23 +20,6 @@ import OBAKitCore
 @MainActor
 class CurrentTripViewModel: ObservableObject {
 
-    /// Loading / error / result state for the screen.
-    enum State {
-        /// Initial state, and while a find is in flight.
-        case loading
-        /// No user location is available — the location service returned `nil`.
-        case noLocation
-        /// The matcher returned an empty array — no active vehicle is currently
-        /// on the selected route near the user.
-        case noResults
-        /// The selected route has no real-time tracking data.
-        case noRealtime
-        /// Two or more vehicles matched; the UI shows a disambiguation list.
-        case multipleResults
-        /// A network or service error surfaced from the matcher.
-        case error(Error)
-    }
-
     // MARK: - Published State
 
     @Published private(set) var state: State = .loading
@@ -203,5 +186,45 @@ class CurrentTripViewModel: ObservableObject {
                 comment: "Error when the API service is unavailable."
             )]
         )
+    }
+}
+
+// MARK: - State
+extension CurrentTripViewModel {
+    /// Loading / error / result state for the screen.
+    enum State: Equatable {
+        /// Initial state, and while a find is in flight.
+        case loading
+        /// No user location is available — the location service returned `nil`.
+        case noLocation
+        /// The matcher returned an empty array — no active vehicle is currently
+        /// on the selected route near the user.
+        case noResults
+        /// The selected route has no real-time tracking data.
+        case noRealtime
+        /// Two or more vehicles matched; the UI shows a disambiguation list.
+        case multipleResults
+        /// A network or service error surfaced from the matcher.
+        case error(Error)
+
+        // Manual `==` because `case error(Error)` blocks synthesis (Swift's
+        // `Error` existential isn't `Equatable`). Two `.error` cases compare
+        // equal when their `localizedDescription`s match — the only error
+        // surface SwiftUI consumers render, so this matches what the View's
+        // `.onChange(of: state)` actually cares about.
+        static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.loading, .loading),
+                 (.noLocation, .noLocation),
+                 (.noResults, .noResults),
+                 (.noRealtime, .noRealtime),
+                 (.multipleResults, .multipleResults):
+                return true
+            case let (.error(lhsErr), .error(rhsErr)):
+                return lhsErr.localizedDescription == rhsErr.localizedDescription
+            default:
+                return false
+            }
+        }
     }
 }

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -98,6 +98,11 @@ class CurrentTripViewModel: ObservableObject {
     /// Cancels any in-flight find, then starts a new search.
     func findVehicle() {
         findVehicleTask?.cancel()
+        // Reset to `.loading` so a retry from `.noResults` / `.error` /
+        // `.noRealtime` actually surfaces a state change — without this the
+        // View re-renders the same content while the network call is in
+        // flight, and the tap looks dead to the user.
+        state = .loading
 
         findVehicleTask = Task { [weak self] in
             guard let self else { return }

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -47,6 +47,10 @@ class CurrentTripViewModel: ObservableObject {
     private static let refreshInterval: TimeInterval = 20.0
     private var refreshTimer: Timer?
     private var findVehicleTask: Task<Void, Never>?
+    /// Trip ID we last handed to the consumer via `pendingNavigation`. Prevents
+    /// the 20-second background refresh from re-firing navigation for the trip
+    /// the user just dismissed. Cleared on user-initiated retry / `start()`.
+    private var lastFiredTripID: TripIdentifier?
 
     // MARK: - Init
 
@@ -79,13 +83,19 @@ class CurrentTripViewModel: ObservableObject {
     // MARK: - Intent
 
     /// Cancels any in-flight find, then starts a new search.
-    func findVehicle() {
+    ///
+    /// - Parameter resetState: When `true` (user-initiated retry or `start()`),
+    ///   force the UI back to `.loading` so the tap surfaces a state change and
+    ///   the "already presented" latch is cleared. When `false` (background
+    ///   auto-refresh from `startRefreshTimer`), keep the existing state so the
+    ///   user's screen isn't wiped every 20 seconds — updates happen in place.
+    func findVehicle(resetState: Bool = true) {
         findVehicleTask?.cancel()
-        // Reset to `.loading` so a retry from `.noResults` / `.error` /
-        // `.noRealtime` actually surfaces a state change — without this the
-        // View re-renders the same content while the network call is in
-        // flight, and the tap looks dead to the user.
-        state = .loading
+        if resetState {
+            state = .loading
+            // Fresh explicit retry: allow re-navigation for the same trip ID.
+            lastFiredTripID = nil
+        }
 
         findVehicleTask = Task { [weak self] in
             guard let self else { return }
@@ -94,11 +104,13 @@ class CurrentTripViewModel: ObservableObject {
             if Task.isCancelled { return }
 
             guard let userLocation = self.application.locationService.currentLocation else {
+                Logger.error("CurrentTripViewModel: no user location available for route \(self.route.id)")
                 self.state = .noLocation
                 return
             }
 
             guard let apiService = self.application.apiService else {
+                Logger.error("CurrentTripViewModel: no apiService available for route \(self.route.id)")
                 self.state = .error(Self.noServiceError())
                 return
             }
@@ -123,7 +135,9 @@ class CurrentTripViewModel: ObservableObject {
     }
 
     /// Routes a fresh set of matches into the appropriate state transition:
-    /// empty → `.noResults`, one → `pendingNavigation`, more → `.multipleResults`.
+    /// empty → `.noResults`, one → `pendingNavigation` (once per trip) plus a
+    /// `.multipleResults` fallback so the underlying view isn't a frozen
+    /// spinner, more → `.multipleResults`.
     func handle(results: [NearbyTripMatcher.MatchResult]) {
         matchResults = results
 
@@ -131,7 +145,17 @@ class CurrentTripViewModel: ObservableObject {
         case 0:
             state = .noResults
         case 1:
-            pendingNavigation = results[0].arrivalDeparture
+            let arrival = results[0].arrivalDeparture
+            // Only fire pendingNavigation once per trip. The consumer clears it
+            // after presenting; a background refresh that finds the same trip
+            // shouldn't re-fire the modal after a user-initiated dismiss.
+            if lastFiredTripID != arrival.tripID {
+                pendingNavigation = arrival
+                lastFiredTripID = arrival.tripID
+            }
+            // Move to a terminal, tappable state so the underlying view shows
+            // the match as a single-row list instead of a permanent spinner.
+            state = .multipleResults
         default:
             state = .multipleResults
         }
@@ -167,7 +191,10 @@ class CurrentTripViewModel: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self, !(self.shouldSkipProgrammaticRefresh?() ?? false) else { return }
-                self.findVehicle()
+                // Background refresh: don't reset UI state, and preserve the
+                // "already presented" latch so we don't re-fire pendingNavigation
+                // for a trip the user just dismissed.
+                self.findVehicle(resetState: false)
             }
         }
     }

--- a/OBAKit/ViewModels/RoutePickerViewModel.swift
+++ b/OBAKit/ViewModels/RoutePickerViewModel.swift
@@ -77,8 +77,8 @@ final class RoutePickerViewModel: ObservableObject {
     // MARK: - Load
 
     func loadRoutes() async {
-        // Clear any error from a prior attempt so a retry doesn't leave the VC
-        // short-circuiting on stale state.
+
+        didFinishLoading = false
         loadError = nil
 
         // Primary: extract routes from stops already loaded by MapRegionManager.
@@ -118,8 +118,8 @@ final class RoutePickerViewModel: ObservableObject {
             let isCancelled = Task.isCancelled
                 || error is CancellationError
                 || (nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled)
+
             if isCancelled {
-                didFinishLoading = true
                 return
             }
             Logger.error("Failed to load routes for picker: \(error)")

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -91,4 +91,14 @@ class Fixtures {
             || request.url!.absoluteString.contains("alerts.pb")
         }
     }
+
+    class func createRoute(id: String) throws -> Route {
+        let dictionary: [String: Any] = [
+            "agencyId": "test_agency",
+            "id": id,
+            "shortName": "1",
+            "type": 3
+        ]
+        return try dictionaryToModel(type: Route.self, dictionary: dictionary)
+    }
 }

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -30,10 +30,11 @@ final class AppSheetRouteTests: XCTestCase {
         expect(AppSheetRoute.settings.id) == "settings"
     }
 
-    func test_id_embedsAssociatedValues() {
+    func test_id_embedsAssociatedValues() throws {
         expect(AppSheetRoute.stopDetails(stopID: "1_75403").id) == "stopDetails-1_75403"
         expect(AppSheetRoute.tripDetails(tripID: "trip_42").id) == "tripDetails-trip_42"
-        expect(AppSheetRoute.currentTrip(routeID: "route_8").id) == "currentTrip-route_8"
+        let route = try Fixtures.createRoute(id: "route_8")
+        expect(AppSheetRoute.currentTrip(route: route).id) == "currentTrip-route_8"
         expect(AppSheetRoute.transitAlert(alertID: "alert_99").id) == "transitAlert-alert_99"
     }
 
@@ -51,11 +52,12 @@ final class AppSheetRouteTests: XCTestCase {
         expect(AppSheetRoute.routePicker.prefersStacking) == false
     }
 
-    func test_prefersStacking_stackedLayerRoutes() {
+    func test_prefersStacking_stackedLayerRoutes() throws {
         expect(AppSheetRoute.stopDetails(stopID: "1").prefersStacking) == true
         expect(AppSheetRoute.tripPlanner.prefersStacking) == true
         expect(AppSheetRoute.tripDetails(tripID: "t").prefersStacking) == true
-        expect(AppSheetRoute.currentTrip(routeID: "r").prefersStacking) == true
+        let route = try Fixtures.createRoute(id: "r")
+        expect(AppSheetRoute.currentTrip(route: route).prefersStacking) == true
         expect(AppSheetRoute.transitAlert(alertID: "a").prefersStacking) == true
         expect(AppSheetRoute.more.prefersStacking) == true
         expect(AppSheetRoute.nearbyAll.prefersStacking) == true
@@ -111,12 +113,13 @@ final class AppSheetRouteTests: XCTestCase {
         expect(config.fullScreenDetent).to(beNil())
     }
 
-    func test_stackedDetailRoutes_shareLargeStartAndAllowDismiss() {
+    func test_stackedDetailRoutes_shareLargeStartAndAllowDismiss() throws {
+        let currentTripRoute = try Fixtures.createRoute(id: "r")
         let routes: [AppSheetRoute] = [
             .tripPlanner,
             .tripDetails(tripID: "t"),
             .routePicker,
-            .currentTrip(routeID: "r"),
+            .currentTrip(route: currentTripRoute),
             .transitAlert(alertID: "a"),
             .more,
             .settings
@@ -131,13 +134,14 @@ final class AppSheetRouteTests: XCTestCase {
         }
     }
 
-    func test_allRoutes_showDragIndicator() {
+    func test_allRoutes_showDragIndicator() throws {
         // No route currently opts out of the drag indicator; this guards against
         // an accidental flip when adding a new case.
+        let currentTripRoute = try Fixtures.createRoute(id: "r")
         let routes: [AppSheetRoute] = [
             .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
             .stopDetails(stopID: "1"), .tripPlanner, .tripDetails(tripID: "t"),
-            .routePicker, .currentTrip(routeID: "r"), .transitAlert(alertID: "a"),
+            .routePicker, .currentTrip(route: currentTripRoute), .transitAlert(alertID: "a"),
             .more, .settings
         ]
         for route in routes {
@@ -200,9 +204,20 @@ final class AppSheetRouteTests: XCTestCase {
         expect(AppSheetRoute.tripDetails(tripID: "t")) == AppSheetRoute.tripDetails(tripID: "t")
     }
 
-    func test_equality_differentAssociatedValuesAreNotEqual() {
+    func test_equality_differentAssociatedValuesAreNotEqual() throws {
         expect(AppSheetRoute.stopDetails(stopID: "1_1")) != AppSheetRoute.stopDetails(stopID: "1_2")
-        expect(AppSheetRoute.currentTrip(routeID: "r1")) != AppSheetRoute.currentTrip(routeID: "r2")
+        let route1 = try Fixtures.createRoute(id: "r1")
+        let route2 = try Fixtures.createRoute(id: "r2")
+        expect(AppSheetRoute.currentTrip(route: route1)) != AppSheetRoute.currentTrip(route: route2)
+    }
+
+    func test_hash_consistency_forValueEqualRoutes() throws {
+        let route1 = try Fixtures.createRoute(id: "r1")
+        let route2 = try Fixtures.createRoute(id: "r1")
+        let sheetRoute1 = AppSheetRoute.currentTrip(route: route1)
+        let sheetRoute2 = AppSheetRoute.currentTrip(route: route2)
+        // Two routes with the same ID should hash to the same value
+        expect(sheetRoute1.hashValue) == sheetRoute2.hashValue
     }
 
     // MARK: - Exhaustiveness guard

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -143,11 +143,120 @@ class CurrentTripViewModelTests: OBATestCase {
         expect(viewModel.pendingNavigation).toNot(beNil())
         expect(viewModel.pendingNavigation?.tripID) == result.arrivalDeparture.tripID
         expect(viewModel.matchResults.count) == 1
-        // State remains `.loading` — the consumer is expected to navigate away.
-        guard case .loading = viewModel.state else {
-            XCTFail("State should stay .loading for single match, got \(viewModel.state)")
+        // State moves to `.multipleResults` so the underlying view shows the
+        // single match as a tappable row instead of a permanent spinner. The
+        // consumer navigates away via `pendingNavigation`; if they dismiss the
+        // modal, the list is what greets them, not a frozen loading indicator.
+        guard case .multipleResults = viewModel.state else {
+            XCTFail("State should move to .multipleResults for single match, got \(viewModel.state)")
             return
         }
+    }
+
+    /// After the consumer handles the initial single match and clears
+    /// `pendingNavigation`, a background refresh (or any re-entry into
+    /// `handle(results:)`) that finds the SAME trip must not re-fire
+    /// `pendingNavigation` — otherwise the user is snapped back to the modal
+    /// they just dismissed every 20 seconds.
+    @MainActor
+    func test_handleResults_repeatSingleMatch_doesNotRefirePendingNavigation() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let result = makeMatchResult()
+        viewModel.handle(results: [result])
+        expect(viewModel.pendingNavigation).toNot(beNil())
+
+        // Consumer acknowledges by clearing pendingNavigation (mirrors what the
+        // SwiftUI `.onChange(of: pendingNavigation)` handler does).
+        viewModel.pendingNavigation = nil
+
+        // Same trip surfaces again on the next timer tick.
+        viewModel.handle(results: [result])
+
+        expect(viewModel.pendingNavigation).to(beNil())
+        expect(viewModel.matchResults.count) == 1
+    }
+
+    /// A user-initiated retry (`findVehicle()` with `resetState: true`, the
+    /// default) must clear the "already presented" latch — otherwise tapping
+    /// Try Again after dismissing a single-match modal would silently no-op.
+    @MainActor
+    func test_findVehicle_userInitiatedRetry_clearsPresentedLatch() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, withLocation: false)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        let result = makeMatchResult()
+        viewModel.handle(results: [result])
+        expect(viewModel.pendingNavigation).toNot(beNil())
+        viewModel.pendingNavigation = nil
+
+        // User taps Try Again. resetState:true (default) resets to .loading
+        // and clears the latch; because there's no location, the task terminates
+        // in .noLocation before ever calling handle(results:).
+        viewModel.findVehicle()
+        guard case .loading = viewModel.state else {
+            XCTFail("findVehicle() should reset to .loading, got \(viewModel.state)")
+            return
+        }
+
+        // Simulate the next find returning the same trip — pendingNavigation
+        // must fire again because the latch was cleared.
+        viewModel.handle(results: [result])
+        expect(viewModel.pendingNavigation).toNot(beNil())
+        expect(viewModel.pendingNavigation?.tripID) == result.arrivalDeparture.tripID
+    }
+
+    /// A background refresh (`findVehicle(resetState: false)`) must NOT reset
+    /// the UI to `.loading` — the whole point of splitting the two entry points
+    /// is to keep the user's screen intact between the 20-second ticks.
+    @MainActor
+    func test_findVehicle_backgroundRefresh_preservesState() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, withLocation: false)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        // Park the VM in `.multipleResults` — a state a real user could be
+        // looking at when the background refresh fires.
+        let first = makeMatchResult()
+        let second = makeMatchResult()
+        viewModel.handle(results: [first, second])
+        guard case .multipleResults = viewModel.state else {
+            XCTFail("Precondition: expected .multipleResults, got \(viewModel.state)")
+            return
+        }
+
+        // Simulate a timer tick. `resetState: false` skips the `.loading` reset;
+        // the task will still resolve to `.noLocation` async (no location
+        // configured), but the crucial assertion is *synchronous*: the state
+        // must NOT have flipped to `.loading` before the task runs.
+        viewModel.findVehicle(resetState: false)
+        guard case .multipleResults = viewModel.state else {
+            XCTFail("Background refresh must preserve .multipleResults, got \(viewModel.state)")
+            return
+        }
+
+        viewModel.deactivate()
+    }
+
+    // MARK: - State.==
+
+    /// Two `.error` cases compare equal iff their `localizedDescription`s match
+    /// — SwiftUI's `.onChange(of: state)` depends on this to decide when to
+    /// fire failure haptics, so a typo here would silently break the trigger.
+    @MainActor
+    func test_stateEquality_error_comparesByLocalizedDescription() throws {
+        let errorA1 = NSError(domain: "A", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        let errorA2 = NSError(domain: "B", code: 2, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        let errorB = NSError(domain: "C", code: 3, userInfo: [NSLocalizedDescriptionKey: "different"])
+
+        expect(CurrentTripViewModel.State.error(errorA1)) == CurrentTripViewModel.State.error(errorA2)
+        expect(CurrentTripViewModel.State.error(errorA1)) != CurrentTripViewModel.State.error(errorB)
+        // Cross-case: `.error` never equals a non-error case.
+        expect(CurrentTripViewModel.State.error(errorA1)) != CurrentTripViewModel.State.loading
+        expect(CurrentTripViewModel.State.error(errorA1)) != CurrentTripViewModel.State.multipleResults
     }
 
     @MainActor

--- a/OBAKitTests/ViewModels/RoutePickerViewModelTests.swift
+++ b/OBAKitTests/ViewModels/RoutePickerViewModelTests.swift
@@ -453,7 +453,7 @@ class RoutePickerViewModelTests: OBATestCase {
 
         await vm.loadRoutes()
 
-        expect(vm.didFinishLoading).to(beTrue())
+        expect(vm.didFinishLoading).to(beFalse())
         expect(vm.loadError).to(beNil())
         expect(vm.allRoutes).to(beEmpty())
     }

--- a/docs/superpowers/plans/2026-07-02-more-floating-button.md
+++ b/docs/superpowers/plans/2026-07-02-more-floating-button.md
@@ -1,0 +1,700 @@
+# More Floating Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-trailing floating "More" button on `MapPanelRootView` that routes through the existing sheet coordinator to a `UIViewControllerRepresentable` hosting the current UIKit `MoreViewController` inside a `UINavigationController`.
+
+**Architecture:** Push `AppSheetRoute.more` from the button's action; `AppSheetViewFactory` returns a new `MoreSheetHost` (`UIViewControllerRepresentable`) that wraps `UINavigationController(rootViewController: MoreViewController(application:))`. Introduce a `regularGlassEffectIfAvailable(in:)` view modifier so the button matches the WeatherButton style from #1166 across iOS 26+ and pre-26.
+
+**Tech Stack:** Swift 5, SwiftUI, UIKit interop via `UIViewControllerRepresentable`, XCTest + Nimble for unit tests, XcodeGen for project generation, xcodebuild for CI-shaped builds/tests.
+
+**Spec:** [docs/superpowers/specs/2026-07-02-more-floating-button-design.md](../specs/2026-07-02-more-floating-button-design.md)
+
+## Global Constraints
+
+- **Branch:** `feature/more-floating-button`.
+- **Target iOS version:** 17.0+ (Swift 5.3+). Any iOS 26 API must be feature-gated via `#available(iOS 26.0, *)`.
+- **Frameworks:** Product code goes in `OBAKit` (UI). Do **not** touch `OBAKitCore` (extension-safe core).
+- **No changes to `MoreViewController` itself.** The wrapper exists to keep it untouched.
+- **No new feature flag.** The button appears whenever `MapPanelRootView` renders (which is itself gated by `FeatureFlags.useMapPanelExperienceKey`).
+- **Regenerate project after adding files:** run `scripts/generate_project OneBusAway` after any file add/rename before building.
+- **No auto-commits.** Individual commit steps in this plan are guidance; the human operator will decide when to stage/commit (per the "no auto commit" user preference).
+- **Commit messages:** one-line subjects, no `Co-Authored-By: Claude` trailer (per project git conventions).
+
+---
+
+## File Structure
+
+**New files:**
+
+- `OBAKit/Sheet/Root/MoreButton.swift` — SwiftUI floating button rendered in the `MapPanelRootView` top-trailing overlay slot.
+- `OBAKit/Sheet/Root/MoreSheetHost.swift` — `UIViewControllerRepresentable` wrapping `UINavigationController(rootViewController: MoreViewController(application:))`.
+- `OBAKitTests/Sheet/MoreSheetHostTests.swift` — XCTest verifying `makeUIViewController` returns a `UINavigationController` whose `topViewController` is a `MoreViewController`.
+- `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift` — XCTest verifying `AppSheetViewFactory.view(for: .more)` renders a `MoreSheetHost` rather than falling through to `unimplementedView`.
+
+**Modified files:**
+
+- `OBAKit/Extensions/SwiftUIExtensions.swift` — add `regularGlassEffectIfAvailable(in:)` view modifier.
+- `OBAKit/Sheet/DI/AppSheetViewFactory.swift` — split `.more` out of the shared `unimplementedView` branch; add `moreView()` builder.
+- `OBAKit/Sheet/Root/MapPanelRootView.swift` — add `.overlay(alignment: .topTrailing) { moreButton }` and its computed view.
+
+**Unchanged (called out explicitly):**
+
+- `OBAKit/Settings/MoreViewController.swift` — no edits.
+- `OBAKit/Sheet/Coordinator/SheetRoute.swift` — `.more` case, detent config, `prefersStacking` already correct.
+- `OBAKit/Sheet/Coordinator/SheetCoordinator.swift` — no changes.
+
+---
+
+## Task 1: Add `regularGlassEffectIfAvailable` view modifier
+
+**Files:**
+- Modify: `OBAKit/Extensions/SwiftUIExtensions.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```swift
+  public extension View {
+      func regularGlassEffectIfAvailable(in shape: some Shape = Capsule()) -> some View
+  }
+  ```
+
+**Rationale:** `MoreButton` (Task 3) and (later) `WeatherButton` from #1166 both need iOS 26 Liquid Glass with a `.regularMaterial` fallback. Introducing the modifier here matches #1166's signature verbatim so a post-merge collision is a trivial "keep one copy" resolution.
+
+- [ ] **Step 1: Extend `SwiftUIExtensions.swift` with the modifier**
+
+Append below the existing `FirstAppear` block:
+
+```swift
+// MARK: - glassEffectIfAvailable
+
+public extension View {
+    /// Applies the iOS 26+ Liquid Glass effect when available, falling back to
+    /// `.regularMaterial` on older systems. Handles the surface fill itself —
+    /// call sites do not need to add a background.
+    @ViewBuilder
+    func regularGlassEffectIfAvailable(in shape: some Shape = Capsule()) -> some View {
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular, in: shape)
+        } else {
+            self.background(.regularMaterial, in: shape)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify the OBAKit target still builds**
+
+Run:
+```bash
+scripts/generate_project OneBusAway
+xcodebuild build -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16' -quiet
+```
+Expected: `** BUILD SUCCEEDED **`. No new warnings.
+
+- [ ] **Step 3: (Optional) Commit — only if the user asks**
+
+```bash
+git add OBAKit/Extensions/SwiftUIExtensions.swift
+git commit -m "Add regularGlassEffectIfAvailable view modifier"
+```
+
+---
+
+## Task 2: Add `MoreSheetHost` with failing tests
+
+**Files:**
+- Create: `OBAKit/Sheet/Root/MoreSheetHost.swift`
+- Create: `OBAKitTests/Sheet/MoreSheetHostTests.swift`
+
+**Interfaces:**
+- Consumes: `Application` (from `OBAKitCore`), `MoreViewController` (from `OBAKit/Settings/`).
+- Produces:
+  ```swift
+  struct MoreSheetHost: UIViewControllerRepresentable {
+      let application: Application
+      func makeUIViewController(context: Context) -> UINavigationController
+      func updateUIViewController(_ uiViewController: UINavigationController, context: Context)
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `OBAKitTests/Sheet/MoreSheetHostTests.swift`:
+
+```swift
+//
+//  MoreSheetHostTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import SwiftUI
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Smoke-tests for the UIKit wiring wrapper around `MoreViewController`.
+/// The wrapping is the entire product surface of `MoreSheetHost`, so these
+/// tests exercise the representable by embedding it in a `UIHostingController`
+/// and inspecting the resulting child controller.
+final class MoreSheetHostTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    /// `OBATestCase` doesn't own an `Application`; tests build one per-case,
+    /// mirroring the pattern in `MapPanelViewModelTests`. Only the pieces
+    /// `MoreViewController.init` actually reaches for (regions service,
+    /// analytics, user defaults) need to be real — everything else can rely
+    /// on the standard stubs.
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+        return Application(config: config)
+    }
+
+    @MainActor
+    func test_makeUIViewController_returnsNavigationControllerWrappingMoreViewController() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = createApplication(dataLoader: dataLoader)
+
+        let host = MoreSheetHost(application: application)
+
+        // The Context type is opaque and not user-constructable outside a real
+        // SwiftUI update pass, so we drive `makeUIViewController` via a
+        // throwaway UIHostingController.
+        let probe = UIHostingController(rootView: host)
+        _ = probe.view // force the SwiftUI view body to load, which invokes makeUIViewController.
+
+        // Walk the child hierarchy to find the wrapped nav controller.
+        let nav = probe.children.compactMap { $0 as? UINavigationController }.first
+        expect(nav).toNot(beNil())
+        expect(nav?.topViewController).to(beAKindOf(MoreViewController.self))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project so the new test file is picked up**
+
+```bash
+scripts/generate_project OneBusAway
+```
+
+Expected: no errors from XcodeGen; `OBAKit.xcodeproj` regenerated.
+
+- [ ] **Step 3: Run the test and confirm it fails to compile**
+
+```bash
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests/MoreSheetHostTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: build failure — `cannot find 'MoreSheetHost' in scope`.
+
+- [ ] **Step 4: Create `MoreSheetHost.swift`**
+
+Create `OBAKit/Sheet/Root/MoreSheetHost.swift`:
+
+```swift
+//
+//  MoreSheetHost.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import OBAKitCore
+
+/// UIKit wiring wrapper: presents the existing `MoreViewController` inside
+/// a `UINavigationController` so its `navigationItem` bar buttons render
+/// correctly when reached via `AppSheetRoute.more`.
+///
+/// Deliberately minimal — a future SwiftUI `MoreView` will replace this
+/// wrapper in `AppSheetViewFactory` without touching the coordinator or
+/// route enum.
+struct MoreSheetHost: UIViewControllerRepresentable {
+    let application: Application
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let more = MoreViewController(application: application)
+        return UINavigationController(rootViewController: more)
+    }
+
+    // `MoreViewController` reads `application` and its stores directly, so
+    // nothing SwiftUI-side changes over the sheet's lifetime.
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+}
+```
+
+- [ ] **Step 5: Regenerate the project (new source file)**
+
+```bash
+scripts/generate_project OneBusAway
+```
+
+- [ ] **Step 6: Re-run the test — expect it to pass**
+
+```bash
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests/MoreSheetHostTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: `Test Suite 'MoreSheetHostTests' passed`.
+
+- [ ] **Step 7: (Optional) Commit — only if the user asks**
+
+```bash
+git add OBAKit/Sheet/Root/MoreSheetHost.swift OBAKitTests/Sheet/MoreSheetHostTests.swift
+git commit -m "Add MoreSheetHost representable and smoke tests"
+```
+
+---
+
+## Task 3: Add `MoreButton` SwiftUI view
+
+**Files:**
+- Create: `OBAKit/Sheet/Root/MoreButton.swift`
+
+**Interfaces:**
+- Consumes: `regularGlassEffectIfAvailable(in:)` (Task 1), `ThemeMetrics.controllerMargin` (already `20.0` in `OBAKitCore/Theme/Theme.swift`).
+- Produces:
+  ```swift
+  struct MoreButton: View {
+      let action: () -> Void
+  }
+  ```
+
+**Rationale:** pure presentational button — no unit test. Snapshot testing isn't part of the project's suite; the build compiling and manual verification in Task 5 cover it.
+
+- [ ] **Step 1: Create `MoreButton.swift`**
+
+Create `OBAKit/Sheet/Root/MoreButton.swift`:
+
+```swift
+//
+//  MoreButton.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Floating capsule button rendered in the top-trailing overlay slot of
+/// `MapPanelRootView`. Tapping it pushes `AppSheetRoute.more` onto the
+/// sheet coordinator; the button itself is pure presentation.
+struct MoreButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "line.3.horizontal")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .regularGlassEffectIfAvailable(in: Capsule())
+        .accessibilityLabel(Text(OBALoc(
+            "more_controller.title",
+            value: "More",
+            comment: "Title of the More tab / accessibility label for the map-panel more button."
+        )))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the project**
+
+```bash
+scripts/generate_project OneBusAway
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+xcodebuild build -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16' -quiet
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: (Optional) Commit — only if the user asks**
+
+```bash
+git add OBAKit/Sheet/Root/MoreButton.swift
+git commit -m "Add MoreButton SwiftUI view for map-panel top-trailing slot"
+```
+
+---
+
+## Task 4: Route `.more` through `AppSheetViewFactory.moreView()`
+
+**Files:**
+- Modify: `OBAKit/Sheet/DI/AppSheetViewFactory.swift`
+- Create: `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`
+
+**Interfaces:**
+- Consumes: `MoreSheetHost(application:)` (Task 2).
+- Produces:
+  ```swift
+  extension AppSheetViewFactory {
+      func moreView() -> MoreSheetHost
+  }
+  ```
+  and swaps the `.more` case out of the shared `unimplementedView` branch inside `view(for:)`.
+
+- [ ] **Step 1: Write the failing factory test**
+
+Create `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`:
+
+```swift
+//
+//  AppSheetViewFactoryTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import SwiftUI
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Per-route factory branch coverage. Each branch that's been "wired up"
+/// (i.e. removed from the shared `unimplementedView` catch-all) gets a
+/// dedicated test so a future refactor that accidentally drops the branch
+/// back into the catch-all fails the suite.
+final class AppSheetViewFactoryTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+        return Application(config: config)
+    }
+
+    @MainActor
+    func test_view_forMore_returnsMoreSheetHost() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = createApplication(dataLoader: dataLoader)
+
+        let factory = AppSheetViewFactory(application: application)
+        let host = UIHostingController(rootView: factory.view(for: .more))
+        _ = host.view // force the view body to evaluate.
+
+        // `MoreSheetHost` embeds a UINavigationController; walk the child
+        // hierarchy to confirm it landed rather than the placeholder Text
+        // from `unimplementedView`.
+        let nav = host.children.compactMap { $0 as? UINavigationController }.first
+        expect(nav).toNot(beNil())
+        expect(nav?.topViewController).to(beAKindOf(MoreViewController.self))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the project**
+
+```bash
+scripts/generate_project OneBusAway
+```
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests/AppSheetViewFactoryTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: **DEBUG builds** — the test *may* crash inside `assertionFailure("AppSheetRoute.more has no view registered yet.")` from `unimplementedView`. That's still an acceptable "failing" signal for TDD; if the assertion aborts the process, the test will be reported as a failure by xcodebuild.
+
+If the assertion halts the test runner in a way that prevents the next task from proceeding, temporarily edit the assertion to just `Logger.error(...)` — but the preferred path is to move straight to Step 4 and land the real branch.
+
+- [ ] **Step 4: Update `AppSheetViewFactory.swift` — split `.more` out and add `moreView()`**
+
+In `OBAKit/Sheet/DI/AppSheetViewFactory.swift`:
+
+Replace the `view(for:)` switch body:
+
+```swift
+    @ViewBuilder
+    func view(for route: AppSheetRoute) -> some View {
+        switch route {
+        case .home:
+            homeView()
+        case .more:
+            moreView()
+        // Wiring a push for one of these routes before its view exists will
+        // trip the debug assertion in `unimplementedView(for:)` — register the
+        // view here before reaching for `SheetCoordinator.push(...)`.
+        //
+        // TODO: `.search` is base-layer and has `isDismissDisabled: true`
+        // — its real view needs to wire up an explicit back affordance
+        // (the home sheet only knows how to push, not pop), otherwise the
+        // route is unreachable once entered.
+        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+             .stopDetails, .tripPlanner, .tripDetails, .routePicker,
+             .currentTrip, .transitAlert, .settings:
+            unimplementedView(for: route)
+        }
+    }
+```
+
+Below `homeView()`, add:
+
+```swift
+    /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`
+    /// via `MoreSheetHost`. Swap this branch's return type once the SwiftUI
+    /// `MoreView` lands.
+    func moreView() -> MoreSheetHost {
+        MoreSheetHost(application: application)
+    }
+```
+
+- [ ] **Step 5: Regenerate and re-run**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests/AppSheetViewFactoryTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: `Test Suite 'AppSheetViewFactoryTests' passed`.
+
+- [ ] **Step 6: Run the wider Sheet test suite to catch regressions**
+
+```bash
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests/AppSheetRouteTests \
+  -only-testing:OBAKitTests/SheetCoordinatorTests \
+  -only-testing:OBAKitTests/MoreSheetHostTests \
+  -only-testing:OBAKitTests/AppSheetViewFactoryTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: all four suites pass.
+
+- [ ] **Step 7: (Optional) Commit — only if the user asks**
+
+```bash
+git add OBAKit/Sheet/DI/AppSheetViewFactory.swift OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+git commit -m "Route AppSheetRoute.more through MoreSheetHost factory branch"
+```
+
+---
+
+## Task 5: Wire the top-trailing overlay in `MapPanelRootView`
+
+**Files:**
+- Modify: `OBAKit/Sheet/Root/MapPanelRootView.swift`
+
+**Interfaces:**
+- Consumes: `MoreButton(action:)` (Task 3), `SheetCoordinator<AppSheetRoute>.push(_:)` (existing), `AppSheetRoute.more` (existing).
+- Produces: no new symbols; strictly additive to the view body.
+
+- [ ] **Step 1: Update `MapPanelRootView.swift`**
+
+Change the body from:
+
+```swift
+    var body: some View {
+        Map(position: $cameraPosition) {
+            UserAnnotation()
+        }
+        .safeAreaPadding(.bottom, AppSheetRoute.homeCollapsedHeight)
+        .floatingSheet(coordinator: coordinator) { route in
+            factory.view(for: route)
+        }
+    }
+```
+
+to:
+
+```swift
+    var body: some View {
+        Map(position: $cameraPosition) {
+            UserAnnotation()
+        }
+        // TODO: Detent-aware bottom padding. Pinned to the collapsed sheet
+        // height today, so dragging the sheet up to `.medium` or
+        // `largeDetent` lets the user-location annotation and any future map
+        // overlays slip under the sheet.
+        .safeAreaPadding(.bottom, AppSheetRoute.homeCollapsedHeight)
+        .overlay(alignment: .topTrailing) {
+            moreButton
+        }
+        .floatingSheet(coordinator: coordinator) { route in
+            factory.view(for: route)
+        }
+    }
+
+    private var moreButton: some View {
+        MoreButton {
+            coordinator.push(.more)
+        }
+        .padding(ThemeMetrics.controllerMargin)
+    }
+```
+
+- [ ] **Step 2: Regenerate and build**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild build -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16' -quiet
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Run the full unit-test target**
+
+```bash
+xcodebuild test-without-building \
+  -only-testing:OBAKitTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Expected: all suites pass. If any suite unrelated to this feature fails, hand back — do not proceed to manual verification with a red suite.
+
+- [ ] **Step 4: Manual verification (required — this is a UI change)**
+
+Boot the app on an iPhone 16 simulator with the map-panel experience flag enabled. The flag lives in `FeatureFlags.useMapPanelExperienceKey` and is toggled from **Settings → Experimental** (`SettingsViewController`), or by seeding `UserDefaults` before launch.
+
+Verify:
+
+1. A capsule "line.3.horizontal" button appears in the map's top-trailing corner (below the safe area, matching `ThemeMetrics.controllerMargin` inset).
+2. Tapping the button presents a sheet stacked over the home sheet, initial detent `.large`.
+3. The presented sheet's navigation bar shows **Contact Us** on the left and **Settings** on the right; both bar buttons activate their existing flows.
+4. Dragging the sheet down dismisses it cleanly; no orphaned VC state (verify by tapping the button again — the presented content is fresh).
+5. On iOS 26+ the button renders with Liquid Glass; on iOS 17–18 it renders with `.regularMaterial` — no visual glitches.
+6. VoiceOver announces the button as "More".
+
+Attach screenshots (or a short screen recording) to the PR description.
+
+- [ ] **Step 5: SwiftLint**
+
+```bash
+scripts/swiftlint.sh
+```
+
+Expected: no new warnings introduced by this change.
+
+- [ ] **Step 6: (Optional) Commit — only if the user asks**
+
+```bash
+git add OBAKit/Sheet/Root/MapPanelRootView.swift
+git commit -m "Wire top-trailing More button overlay on MapPanelRootView"
+```
+
+---
+
+## Self-Review Checklist (post-implementation)
+
+Before opening a PR, walk this list once:
+
+- [ ] `MoreViewController.swift` is untouched (`git diff main -- OBAKit/Settings/MoreViewController.swift` is empty).
+- [ ] `AppSheetRoute` enum is untouched (`git diff main -- OBAKit/Sheet/Coordinator/SheetRoute.swift` is empty).
+- [ ] `regularGlassEffectIfAvailable` is the only new modifier in `SwiftUIExtensions.swift` — no unrelated cleanup.
+- [ ] `MapPanelRootView.body` gains only the `.overlay(alignment: .topTrailing)` line and a `moreButton` computed view — no other refactoring.
+- [ ] Tests: `MoreSheetHostTests`, `AppSheetViewFactoryTests`, and the pre-existing `AppSheetRouteTests` all pass.
+- [ ] Manual verification steps in Task 5 Step 4 are attached to the PR (screenshot or short clip).
+- [ ] No commit contains a `Co-Authored-By: Claude` trailer.
+
+---
+
+## Rollback
+
+If the feature needs to be reverted post-merge, the following order is safe:
+
+1. Revert the `MapPanelRootView` overlay diff — the button disappears; nothing else regresses (the map + sheet still work).
+2. Revert `AppSheetViewFactory.moreView()` and put `.more` back in the shared `unimplementedView` catch-all — `push(.more)` again renders the placeholder.
+3. Delete `MoreSheetHost.swift`, `MoreButton.swift`, and the two new test files.
+4. Revert `regularGlassEffectIfAvailable` from `SwiftUIExtensions.swift` — only necessary if #1166 hasn't landed by then; otherwise it's shared with the WeatherButton and must stay.

--- a/docs/superpowers/specs/2026-07-02-more-floating-button-design.md
+++ b/docs/superpowers/specs/2026-07-02-more-floating-button-design.md
@@ -1,0 +1,127 @@
+# More Floating Button — Design
+
+**Branch:** `feature/more-floating-button`
+**Reference:** [PR #1166 — Weather overlay](https://github.com/OneBusAway/onebusaway-ios/pull/1166/changes) (established the floating-button + overlay pattern this feature mirrors)
+**Date:** 2026-07-02
+
+## Goal
+
+Add a top-trailing floating "More" button to `MapPanelRootView`, and route its tap through the existing sheet coordinator to a wiring `UIViewControllerRepresentable` that hosts the current UIKit `MoreViewController`. The wiring is a deliberate bridge until the More screen is rewritten in SwiftUI.
+
+## Non-goals
+
+- Modifying `MoreViewController` internals. The wrapper exists precisely to leave it untouched.
+- Building a SwiftUI `MoreView`. Deferred to a follow-up.
+- Adding a programmatic close hook from `MoreViewController` back into the sheet coordinator. Not needed today; added only when a concrete use case appears.
+- Adding a new feature flag. The button appears whenever `MapPanelRootView` renders, which is itself gated by `FeatureFlags.useMapPanelExperienceKey`.
+
+## Architecture
+
+Three additions inside `OBAKit/`:
+
+### `MoreButton` (SwiftUI)
+
+- Location: `OBAKit/Sheet/Root/MoreButton.swift`
+- Sibling to the `WeatherButton` introduced in #1166.
+- Renders an SF Symbol (`line.3.horizontal`) inside a capsule with `regularGlassEffectIfAvailable(in: Capsule())` — iOS 26 Liquid Glass, `.regularMaterial` fallback pre-26.
+- Purely presentational: takes a `() -> Void` action closure. No state, no VM.
+- Accessibility label localized as "More" (existing `more_controller.title` string is reused).
+
+### `MoreSheetHost` (`UIViewControllerRepresentable`)
+
+- Location: `OBAKit/Sheet/Root/MoreSheetHost.swift`
+- Wraps `UINavigationController(rootViewController: MoreViewController(application:))`.
+- The `UINavigationController` is required — `MoreViewController` wires up `navigationItem.leftBarButtonItem` ("Contact Us") and `navigationItem.rightBarButtonItem` ("Settings") in its initializer, and both are dead unless a nav bar is on screen.
+- Owned by the SwiftUI view identity of `AppSheetRoute.more`: created once per push, torn down when the sheet dismisses.
+- Deliberately minimal:
+  - No SwiftUI-side close button. The `.more` route's `SheetDetentConfiguration` already has `isDismissDisabled: false`, so the drag-down handle is the dismissal (consistent with the other stacked routes).
+  - Empty `updateUIViewController(_:context:)`: `MoreViewController` reads `application` and its stores directly, so nothing SwiftUI-side changes over the sheet's lifetime.
+
+```swift
+struct MoreSheetHost: UIViewControllerRepresentable {
+    let application: Application
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let more = MoreViewController(application: application)
+        return UINavigationController(rootViewController: more)
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+}
+```
+
+### `AppSheetViewFactory.moreView()`
+
+- The `.more` case moves out of the shared `unimplementedView(for:)` branch into a real per-route builder that returns `MoreSheetHost(application: application)`.
+- No change to `AppSheetRoute` (the case already exists) and no change to `SheetCoordinator`.
+
+## Wiring in `MapPanelRootView`
+
+- Add `.overlay(alignment: .topTrailing) { moreButton }` mirroring where `WeatherButton` sits at `.topLeading` in #1166.
+- `moreButton`'s action calls `coordinator.push(.more)`.
+- No local `@State` presentation bool — presentation lives in the coordinator, so `AppSheetRoute.more.detentConfiguration` (already `[.medium, .large]`, initial `.large`, `prefersStacking: true`) drives the sheet automatically.
+- Padding matches `WeatherButton`: `ThemeMetrics.controllerMargin`.
+
+## Glass modifier
+
+`regularGlassEffectIfAvailable(in:)` is introduced on `View` in `OBAKit/Extensions/SwiftUIExtensions.swift` with the same signature as #1166:
+
+```swift
+@ViewBuilder
+func regularGlassEffectIfAvailable(in shape: some Shape = Capsule()) -> some View {
+    if #available(iOS 26.0, *) {
+        self.glassEffect(.regular, in: shape)
+    } else {
+        self.background(.regularMaterial, in: shape)
+    }
+}
+```
+
+If #1166 lands first, resolution is trivial — identical modifiers, keep one.
+
+## Data flow
+
+```
+User taps MoreButton (topTrailing overlay on MapPanelRootView)
+        │
+        ▼
+coordinator.push(.more)               // existing SheetCoordinator
+        │
+        ▼
+AppSheetViewFactory.view(for: .more) → moreView()
+        │
+        ▼
+MoreSheetHost (UIViewControllerRepresentable)
+        │
+        ▼
+UINavigationController
+        │
+        └── MoreViewController(application:)   // unchanged
+                • navigationItem.leftBarButtonItem  → showContactUsDialog
+                • navigationItem.rightBarButtonItem → showSettings
+```
+
+`MoreViewController` presents its own child VCs (Settings, Safari, Mail) via `present(_:animated:)`; those already work from any host and need no extra plumbing from the wrapper.
+
+## Testing
+
+- **`AppSheetRouteTests` extension** — assert `AppSheetViewFactory.view(for: .more)` returns a non-nil view (mirrors the pattern used for other factory branches today).
+- **`MoreSheetHostTests` (new, XCTest)** — assert that `makeUIViewController(context:)` returns a `UINavigationController` whose `topViewController` is a `MoreViewController`. The wrapping is the entire product surface of this type.
+- **No test for `MoreButton`** — it's a `Button` around an SF Symbol and a closure. Snapshot testing is not part of this project's suite.
+- **Manual verification** — boot the app with the map-panel feature flag enabled:
+  1. Tap the top-trailing button; sheet presents at `.large`.
+  2. Verify "Contact Us" (left) and "Settings" (right) bar buttons work.
+  3. Drag the sheet down to dismiss; verify no orphaned VC state.
+  4. Verify the button hit target does not overlap the top-leading weather slot (once #1166 lands).
+
+## Merge considerations
+
+- The `regularGlassEffectIfAvailable` modifier is introduced here even though #1166 is not yet merged. If #1166 lands first, the merge conflict is a duplicate modifier — resolved by keeping one copy.
+- `MapPanelRootView`'s overlay change is additive (`.overlay(alignment: .topTrailing)`), orthogonal to #1166's `.topLeading` overlay. Both can coexist post-merge without further work.
+- No changes to `AppSheetRoute`, `SheetCoordinator`, or `FloatingSheetContainer` — the design deliberately stays inside the existing seams.
+
+## Follow-ups (out of scope)
+
+- Rewrite `MoreView` in SwiftUI; swap `MoreSheetHost` for the native view in the factory.
+- Introduce a `@Environment(\.dismiss)`-style bridge if a nav action inside More ever needs to close the containing sheet.
+- Consolidate glass modifier(s) once #1166 lands.


### PR DESCRIPTION
 ## Summary

Adds the SwiftUI Route Picker and Current Trip surfaces over the existing view models and wires them into the floating sheet routing layer.

  ## What's in this PR

  ### Route Picker & Current Trip SwiftUI surfaces
  - **`RoutePickerView`** — SwiftUI view over the existing route-picker view model, surfaced through the sheet route stack.
  - **`CurrentTripView`** — SwiftUI view over `CurrentTripViewModel`, with a Close button and proper empty/loading/error states.
  - `CurrentTripViewModel`:
    - `State` moved to an extension and made `Equatable`.
    - `findVehicle` now resets state to `.loading` at the start so retries clear stale errors.

  ### Trip presentation hand-off
  - New **`TripPresentationBridge`** carries an `onPresentTrip` closure from the SwiftUI host down to where a single matched route needs to push the legacy
  `TripViewController`.
  - Threaded `onPresentTrip` through `AppSheetViewFactory` (initially a no-op, then wired up).
  - Bridge is retained on the SwiftUI side so the single-match navigation actually fires instead of being deallocated mid-flight.
  - `TripViewController` is presented via a modal-chain walk so the SwiftUI host can hand off cleanly to UIKit.

  ### Sheet routing
  - `.currentTrip` sheet case now carries a `Route` so `CurrentTripViewModel` can be initialized with the right input.
  - Added `Strings+Sheet` entries and localizable strings for the new route-picker and current-trip surfaces.

  ### Floating "My Trip" button
  - New **`MyTripButton`** floating overlay on `MapPanelRootView`.
  - Button slides and fades along the sheet drag so it gets out of the way as the sheet expands.
  - Extracted **`liquidGlassButtonStyle`** view modifier (with pre-iOS 26 fallback) and applied it to `MyTripButton`.

  ### Shared SwiftUI primitives
  - **`EmptyStateView`** — reusable status component (icon + title + message + optional action) used by both new views.
  - **`AppSymbol`** — shared SF Symbol vocabulary so SwiftUI views stop hard-coding symbol names.
  - Adopted in both `RoutePickerView` and `CurrentTripView`.
  
 ## Trade-off: `MapPanelRootView` is not wired to `MapRegionManager`

  The SwiftUI `Map` in `MapPanelRootView` is intentionally **not** connected to `application.mapRegionManager` in this PR. That's a known gap.
  
## Effect on the Route Picker

  Because `MapPanelRootView`'s SwiftUI `Map` doesn't feed `MapRegionManager`, the Route Picker behaves differently when launched from the new SwiftUI surface than it
  does from the existing UIKit `MapViewController` flow.
  
### Follow-up
  A follow-up PR should:
  1. Observe `cameraPosition` on the SwiftUI `Map`.
  2. Convert it to an `MKCoordinateRegion` and feed it into `MapRegionManager` (matching what `MapViewController` does today).
  3. Render the cached stops as annotations on the SwiftUI map.
  
  This should be merged after #1166 

### Video
https://github.com/user-attachments/assets/93209bf7-7ce8-4934-b49a-4e8d983bf215
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new route picker with search, loading, and empty states.
  * Added a “My Trip” floating button and trip-finding flow with multiple-results support.
  * Introduced a refreshed empty-state experience with clearer actions and icons.
  * Improved button styling for a more polished glass-like appearance on supported devices.

* **Bug Fixes**
  * Prevented repeated trip presentations and improved refresh behavior while keeping the current screen stable.
  * Fixed loading/cancellation handling so canceled route loads no longer show completion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->