### PR TITLE
CurrentTripViewModel: tighten pendingNavigation contract + close follow-ups from #1154

### DIFF
--- a/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
+++ b/OBAKit/Sheet/Content/CurrentTrip/CurrentTripView.swift
@@ -82,7 +82,7 @@ struct CurrentTripView: View {
             feedback.dataLoad(.success)
             onPresentTrip(arrival)
             // Re-arm so a second single-match (e.g., user retries) can fire.
-            viewModel.pendingNavigation = nil
+            viewModel.clearPendingNavigation()
         }
         .onChange(of: viewModel.state) { _, newState in
             // Pattern-match because `.error` carries an associated value —

--- a/OBAKit/Trip/CurrentTripViewController.swift
+++ b/OBAKit/Trip/CurrentTripViewController.swift
@@ -111,7 +111,7 @@ class CurrentTripViewController: UIViewController,
                 var stack = nav.viewControllers
                 stack[stack.count - 1] = tripController
                 nav.setViewControllers(stack, animated: true)
-                self.viewModel.pendingNavigation = nil
+                self.viewModel.clearPendingNavigation()
             }
             .store(in: &cancellables)
     }

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -180,7 +180,7 @@ class CurrentTripViewModel: ObservableObject {
     /// already holds the single result from `handle(results:)`.
     func pendingNavigationUnavailable() {
         state = .multipleResults
-        pendingNavigation = nil
+        clearPendingNavigation()
     }
 
     /// Called by a consumer after it has acted on `pendingNavigation` (e.g. pushed

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -28,9 +28,9 @@ class CurrentTripViewModel: ObservableObject {
     /// single match has just produced a `pendingNavigation` event.
     @Published private(set) var matchResults: [NearbyTripMatcher.MatchResult] = []
 
-    /// Set when exactly one match is found. UIKit consumers sink this and perform
-    /// the navigation push; SwiftUI consumers observe it via `.navigationDestination(item:)`.
-    /// Call `clearPendingNavigation()` after acting on it.
+    /// Set when exactly one match is found. UIKit consumers subscribe to it and
+    /// SwiftUI consumers observe it with `onChange`. Call `clearPendingNavigation()`
+    /// after acting on the value.
     @Published private(set) var pendingNavigation: ArrivalDeparture?
 
     // MARK: - Configuration

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -29,10 +29,9 @@ class CurrentTripViewModel: ObservableObject {
     @Published private(set) var matchResults: [NearbyTripMatcher.MatchResult] = []
 
     /// Set when exactly one match is found. UIKit consumers sink this and perform
-    /// the navigation push; SwiftUI consumers bind it to `.navigationDestination(item:)`.
-    /// Settable so consumers can clear it after acting (and so SwiftUI bindings can
-    /// drive it to `nil` on pop).
-    @Published var pendingNavigation: ArrivalDeparture?
+    /// the navigation push; SwiftUI consumers observe it via `.navigationDestination(item:)`.
+    /// Call `clearPendingNavigation()` after acting on it.
+    @Published private(set) var pendingNavigation: ArrivalDeparture?
 
     // MARK: - Configuration
 
@@ -161,11 +160,14 @@ class CurrentTripViewModel: ObservableObject {
         }
     }
 
-    /// Maps a matcher error onto VM state. `MatchError.noRealtimeData` gets its own
-    /// `.noRealtime` state; everything else surfaces as `.error(error)`.
+    /// Maps a matcher error onto VM state. Known `MatchError` cases get benign states;
+    /// everything else surfaces as `.error(error)`.
     func handle(error: Error) {
-        if let matchError = error as? NearbyTripMatcher.MatchError, matchError == .noRealtimeData {
-            state = .noRealtime
+        if let matchError = error as? NearbyTripMatcher.MatchError {
+            switch matchError {
+            case .noRealtimeData: state = .noRealtime
+            case .noStopsNearby:  state = .noResults
+            }
         } else {
             Logger.error("Failed to find trips: \(error)")
             state = .error(error)
@@ -178,6 +180,13 @@ class CurrentTripViewModel: ObservableObject {
     /// already holds the single result from `handle(results:)`.
     func pendingNavigationUnavailable() {
         state = .multipleResults
+        pendingNavigation = nil
+    }
+
+    /// Called by a consumer after it has acted on `pendingNavigation` (e.g. pushed
+    /// `TripViewController`). Clears the value so subsequent state changes do not
+    /// re-trigger navigation.
+    func clearPendingNavigation() {
         pendingNavigation = nil
     }
 

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -39,15 +39,18 @@ final class CurrentTripViewModelTests: OBATestCase {
     /// Builds an `Application` whose REST API service routes through the supplied `MockDataLoader`.
     /// When `withLocation` is false, the location service has no current location — useful for
     /// driving the `.noLocation` branch.
-    private func createApplication(dataLoader: MockDataLoader, withLocation: Bool = true) -> Application {
+    private func createApplication(dataLoader: MockDataLoader, withLocation: Bool = true, withRegion: Bool = true) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
 
         let locationService: LocationService
         if withLocation {
+            // When withRegion is false we use a location outside every OBA region (Null Island)
+            // so that RegionsService geo-selection cannot resolve a region and apiService stays nil.
+            let updateLocation = withRegion ? userLocation : CLLocation(latitude: 0, longitude: 0)
             let locManager = MockAuthorizedLocationManager(
-                updateLocation: userLocation,
+                updateLocation: updateLocation,
                 updateHeading: TestData.mockHeading
             )
             locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
@@ -70,7 +73,7 @@ final class CurrentTripViewModelTests: OBATestCase {
             bundledRegionsFilePath: bundledRegionsPath,
             regionsAPIPath: regionsAPIPath,
             dataLoader: dataLoader,
-            fixedRegionName: Fixtures.pugetSoundRegion.name
+            fixedRegionName: withRegion ? Fixtures.pugetSoundRegion.name : nil
         )
 
         return Application(config: config)
@@ -310,18 +313,18 @@ final class CurrentTripViewModelTests: OBATestCase {
         #expect((surfaced as NSError).code == 42)
     }
 
-    /// `noStopsNearby` is a `MatchError` but not `noRealtimeData` — it must fall through
-    /// to the generic `.error` branch, not be silently mapped to `.noRealtime`.
+    /// `noStopsNearby` is a benign geographic condition — no failure haptic, no log noise,
+    /// and no retry button that can't help. It maps to `.noResults`, not `.error`.
     @Test @MainActor
-    func `Handle error no stops nearby falls through to error`() throws {
+    func `Handle error no stops nearby sets no results`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
 
         viewModel.handle(error: NearbyTripMatcher.MatchError.noStopsNearby)
 
-        guard case .error = viewModel.state else {
-            Issue.record("Expected .error for .noStopsNearby, got \(viewModel.state)")
+        guard case .noResults = viewModel.state else {
+            Issue.record("Expected .noResults for .noStopsNearby, got \(viewModel.state)")
             return
         }
     }
@@ -389,6 +392,22 @@ final class CurrentTripViewModelTests: OBATestCase {
             Issue.record("Expected .noLocation, got \(viewModel.state)")
             return
         }
+    }
+
+    @MainActor
+    func test_findVehicle_noApiService_setsErrorState() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, withLocation: true, withRegion: false)
+        let viewModel = CurrentTripViewModel(application: app, route: route30())
+
+        viewModel.findVehicle()
+        for _ in 0..<5 { await Task.yield() }
+
+        guard case .error(let error) = viewModel.state else {
+            XCTFail("Expected .error for nil apiService, got \(viewModel.state)")
+            return
+        }
+        expect((error as NSError).domain) == "CurrentTripViewModel"
     }
 
 }

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -179,7 +179,7 @@ final class CurrentTripViewModelTests: OBATestCase {
 
         // Consumer acknowledges by clearing pendingNavigation (mirrors what the
         // SwiftUI `.onChange(of: pendingNavigation)` handler does).
-        viewModel.pendingNavigation = nil
+        viewModel.clearPendingNavigation()
 
         // Same trip surfaces again on the next timer tick.
         viewModel.handle(results: [result])
@@ -200,7 +200,7 @@ final class CurrentTripViewModelTests: OBATestCase {
         let result = makeMatchResult()
         viewModel.handle(results: [result])
         #expect(viewModel.pendingNavigation != nil)
-        viewModel.pendingNavigation = nil
+        viewModel.clearPendingNavigation()
 
         // User taps Try Again. resetState:true (default) resets to .loading
         // and clears the latch; because there's no location, the task terminates
@@ -406,7 +406,9 @@ final class CurrentTripViewModelTests: OBATestCase {
         let viewModel = CurrentTripViewModel(application: app, route: route30())
 
         viewModel.findVehicle()
-        for _ in 0..<5 { await Task.yield() }
+        await poll(until: {
+            if case .error = viewModel.state { true } else { false }
+        }, "Expected .error for nil apiService, got \(viewModel.state)")
 
         guard case .error(let error) = viewModel.state else {
             Issue.record("Expected .error for nil apiService, got \(viewModel.state)")

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -399,8 +399,8 @@ final class CurrentTripViewModelTests: OBATestCase {
         }
     }
 
-    @MainActor
-    func test_findVehicle_noApiService_setsErrorState() async throws {
+    @Test @MainActor
+    func `Find vehicle no API service sets error state`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, withLocation: true, withRegion: false)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -409,10 +409,10 @@ final class CurrentTripViewModelTests: OBATestCase {
         for _ in 0..<5 { await Task.yield() }
 
         guard case .error(let error) = viewModel.state else {
-            XCTFail("Expected .error for nil apiService, got \(viewModel.state)")
+            Issue.record("Expected .error for nil apiService, got \(viewModel.state)")
             return
         }
-        expect((error as NSError).domain) == "CurrentTripViewModel"
+        #expect((error as NSError).domain == "CurrentTripViewModel")
     }
 
 }

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -37,8 +37,13 @@ final class CurrentTripViewModelTests: OBATestCase {
     // MARK: - Application Builder
 
     /// Builds an `Application` whose REST API service routes through the supplied `MockDataLoader`.
-    /// When `withLocation` is false, the location service has no current location — useful for
-    /// driving the `.noLocation` branch.
+    /// - Parameters:
+    ///   - dataLoader: The mock data loader that stubs HTTP responses.
+    ///   - withLocation: When `false`, the location service has no current location — useful for
+    ///     driving the `.noLocation` branch.
+    ///   - withRegion: When `false`, places the user at Null Island (0, 0) so `RegionsService`
+    ///     cannot resolve a region and `apiService` stays `nil` — useful for driving the
+    ///     `.error` / no-service branch.
     private func createApplication(dataLoader: MockDataLoader, withLocation: Bool = true, withRegion: Bool = true) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)


### PR DESCRIPTION
Closes #1168

Follow-ups from #1154 review. Nothing here changes observable behavior except the `noStopsNearby` fix.

**`pendingNavigation` is now `private(set)`**
Only the VM sets it. Consumers call the new `clearPendingNavigation()` after acting on it instead of writing `= nil` directly. Prevents arbitrary external writes that would leave `state` and `matchResults` inconsistent.

**`noStopsNearby` maps to `.noResults` instead of `.error`**
No stops near the user is a geographic outcome, not a failure. The old mapping fired a failure haptic, logged an error, and showed a retry button that couldn't help. Now treated the same as an empty match.

**`handle(error:)` unwraps `MatchError` once**
Two chained `if let … == .noRealtimeData` / `if let … == .noStopsNearby` became a single unwrap + exhaustive switch. Matches how `handle(results:)` is written and will force a decision if `MatchError` gains new cases.

**Test coverage for `apiService == nil`**
Added `test_findVehicle_noApiService_setsErrorState`. Extended `createApplication` with `withRegion: false` — uses an out-of-region location so `RegionsService` can't geo-select a region and `apiService` stays nil.

**Behavior changes from #1154 investigated (Task 3)**
Both flagged changes (`findVehicle()` on every `viewWillAppear`, failure haptic on `apiService == nil`) are improvements over the original controller. No revert needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completed trip navigation from retriggering by ensuring the pending-navigation state is cleared after navigation finishes.
  * Improved trip matching feedback: “no nearby stops” now shows a dedicated “no results” state (and no-realtime behavior remains specific).
  * Added clearer error handling when required service data is unavailable, avoiding silent failures.
* **Tests**
  * Expanded coverage for nearby-match error states and missing-service scenarios, including new test helper options to simulate missing region data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->