### PR TITLE
Tighten ViewModel test coverage and docstrings

### DIFF
--- a/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
+++ b/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
@@ -13,8 +13,8 @@ import Combine
 @testable import OBAKit
 @testable import OBAKitCore
 
-/// Tests for `AgenciesViewModel`. Verifies the success path sorts by name,
-/// and that loading state resets to `false` after completion.
+/// Tests for `AgenciesViewModel`. Covers the success path in `loadData()` (agencies sorted by name)
+/// and the nil-`apiService` error path.
 @Suite(.serialized)
 final class AgenciesViewModelTests: OBATestCase {
     var queue: OperationQueue!
@@ -69,7 +69,7 @@ final class AgenciesViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Load data success populates agencies sorted by name`() async {
+    func `Load data success populates agencies sorted by name`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -79,11 +79,47 @@ final class AgenciesViewModelTests: OBATestCase {
         }
 
         let viewModel = AgenciesViewModel(application: app)
-        _ = try? await viewModel.loadData()
+        _ = try await viewModel.loadData()
 
         #expect(!viewModel.agencies.isEmpty)
 
         let names = viewModel.agencies.map { $0.agency.name }
         #expect(names == names.sorted())
+    }
+
+    @Test @MainActor
+    func `Load data with nil API service throws`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        // LocationManagerMock is unauthorized and provides no location, so
+        // regionsService.currentRegion stays nil and apiService is never set.
+        let locManager = LocationManagerMock()
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader
+            // no fixedRegionName → currentRegion stays nil → apiService stays nil
+        )
+
+        let app = Application(config: config)
+        #expect(app.apiService == nil)
+
+        let viewModel = AgenciesViewModel(application: app)
+
+        await #expect(throws: (any Error).self) {
+            try await viewModel.loadData()
+        }
     }
 }

--- a/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
+++ b/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
@@ -30,16 +30,19 @@ final class AgenciesViewModelTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
-    private func createApplication(dataLoader: MockDataLoader) -> Application {
+    private func createApplication(
+        dataLoader: MockDataLoader,
+        locationManager: LocationManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        ),
+        fixedRegionName: String? = Fixtures.pugetSoundRegion.name
+    ) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
 
-        let locManager = MockAuthorizedLocationManager(
-            updateLocation: TestData.mockSeattleLocation,
-            updateHeading: TestData.mockHeading
-        )
-        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locationManager)
 
         let config = AppConfig(
             regionsBaseURL: regionsURL,
@@ -52,7 +55,7 @@ final class AgenciesViewModelTests: OBATestCase {
             bundledRegionsFilePath: bundledRegionsPath,
             regionsAPIPath: regionsAPIPath,
             dataLoader: dataLoader,
-            fixedRegionName: Fixtures.pugetSoundRegion.name
+            fixedRegionName: fixedRegionName
         )
 
         return Application(config: config)
@@ -90,36 +93,20 @@ final class AgenciesViewModelTests: OBATestCase {
     @Test @MainActor
     func `Load data with nil API service throws`() async {
         let dataLoader = MockDataLoader(testName: name)
-        stubRegions(dataLoader: dataLoader)
-        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
-        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
-
         // LocationManagerMock is unauthorized and provides no location, so
         // regionsService.currentRegion stays nil and apiService is never set.
-        let locManager = LocationManagerMock()
-        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
-
-        let config = AppConfig(
-            regionsBaseURL: regionsURL,
-            apiKey: apiKey,
-            appVersion: appVersion,
-            userDefaults: userDefaults,
-            analytics: AnalyticsMock(),
-            queue: queue,
-            locationService: locationService,
-            bundledRegionsFilePath: bundledRegionsPath,
-            regionsAPIPath: regionsAPIPath,
-            dataLoader: dataLoader
-            // no fixedRegionName → currentRegion stays nil → apiService stays nil
+        let app = createApplication(
+            dataLoader: dataLoader,
+            locationManager: LocationManagerMock(),
+            fixedRegionName: nil
         )
-
-        let app = Application(config: config)
         #expect(app.apiService == nil)
 
         let viewModel = AgenciesViewModel(application: app)
 
-        await #expect(throws: (any Error).self) {
+        let thrown = await #expect(throws: UnstructuredError.self) {
             try await viewModel.loadData()
         }
+        #expect(thrown?.errorDescription == "No API Service")
     }
 }

--- a/OBAKitTests/ViewModels/AgencyAlertsViewModelTests.swift
+++ b/OBAKitTests/ViewModels/AgencyAlertsViewModelTests.swift
@@ -13,9 +13,9 @@ import Combine
 @testable import OBAKit
 @testable import OBAKitCore
 
-/// Tests for `AgencyAlertsViewModel`. Verifies the share-activity helper,
-/// `collapsedSections` round-trip, and the loading flag transitions on
-/// `agencyAlertsUpdated()`.
+/// Tests for `AgencyAlertsViewModel`. Covers `isLoading` flag transitions,
+/// `collapsedSections` round-trip, error-delegate handling, both branches of
+/// `shareActivityItems(for:)`, and deduplication via `dedupedAlerts()`.
 @Suite(.serialized)
 final class AgencyAlertsViewModelTests: OBATestCase {
     var queue: OperationQueue!
@@ -29,6 +29,62 @@ final class AgencyAlertsViewModelTests: OBATestCase {
 
     isolated deinit {
         queue.cancelAllOperations()
+    }
+
+    /// Builds a region-wide `AgencyAlert` (no agency, empty agencyID).
+    /// Accepting an explicit `id` lets callers create two alerts that share the
+    /// same id but differ in proto content, so both survive `Set<AgencyAlert>`
+    /// insertion while `dedupedAlerts()` still collapses them to one.
+    private func makeAgencyAlert(
+        id: String,
+        title: String,
+        body: String = "",
+        urlString: String? = nil
+    ) throws -> AgencyAlert {
+        var entitySelector = TransitRealtime_EntitySelector()
+        entitySelector.agencyID = ""
+
+        var titleTranslation = TransitRealtime_TranslatedString.Translation()
+        titleTranslation.language = "en"
+        titleTranslation.text = title
+
+        var bodyTranslation = TransitRealtime_TranslatedString.Translation()
+        bodyTranslation.language = "en"
+        bodyTranslation.text = body
+
+        var transitAlert = TransitRealtime_Alert()
+        transitAlert.informedEntity = [entitySelector]
+        transitAlert.headerText.translation = [titleTranslation]
+        transitAlert.descriptionText.translation = [bodyTranslation]
+
+        if let urlString {
+            var urlTranslation = TransitRealtime_TranslatedString.Translation()
+            urlTranslation.language = "en"
+            urlTranslation.text = urlString
+            transitAlert.url.translation = [urlTranslation]
+        }
+
+        var feedEntity = TransitRealtime_FeedEntity()
+        feedEntity.id = id
+        feedEntity.alert = transitAlert
+
+        return try AgencyAlert(feedEntity: feedEntity, agency: nil)
+    }
+
+    /// Wraps `makeAgencyAlert` in a `TransitAlertDataListViewModel` for use in
+    /// `shareActivityItems` assertions. Uses a UUID-based id so each call is unique.
+    private func makeAlertVM(
+        title: String,
+        body: String,
+        urlString: String? = nil
+    ) throws -> TransitAlertDataListViewModel {
+        let alert = try makeAgencyAlert(
+            id: "share-test-\(UUID().uuidString)",
+            title: title,
+            body: body,
+            urlString: urlString
+        )
+        return TransitAlertDataListViewModel(alert, forLocale: Locale(identifier: "en"))
     }
 
     private func createApplication(dataLoader: MockDataLoader) -> Application {
@@ -121,5 +177,67 @@ final class AgencyAlertsViewModelTests: OBATestCase {
         viewModel.agencyAlertsStore(app.alertsStore, displayError: URLError(.badServerResponse))
 
         #expect(!viewModel.isLoading)
+    }
+
+    @Test @MainActor
+    func `Share activity items with URL returns URL`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = AgencyAlertsViewModel(application: app)
+
+        let alertVM = try makeAlertVM(
+            title: "Service Disruption",
+            body: "Buses delayed due to traffic.",
+            urlString: "https://alerts.example.com/1"
+        )
+
+        let items = viewModel.shareActivityItems(for: alertVM)
+
+        #expect(items.count == 1)
+        #expect(items.first as? URL == URL(string: "https://alerts.example.com/1"))
+    }
+
+    @Test @MainActor
+    func `Deduped alerts collapses alerts with same ID`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = AgencyAlertsViewModel(application: app)
+
+        // Two alerts share the same id string but differ in proto content (title).
+        // AgencyAlert equality uses full proto content, so both occupy distinct
+        // slots in the store's Set<AgencyAlert>.
+        let sharedID = "dedup-test-alert"
+        let alertA = try makeAgencyAlert(id: sharedID, title: "Version A")
+        let alertB = try makeAgencyAlert(id: sharedID, title: "Version B")
+
+        app.alertsStore.insertAlerts([alertA, alertB])
+
+        // Pre-condition: the store holds both objects. If this is 1, the Set
+        // already deduplicated by content and dedupedAlerts() has nothing to do.
+        #expect(app.alertsStore.agencyAlerts.count == 2)
+
+        // agencyAlertsUpdated() is the only caller of dedupedAlerts().
+        viewModel.agencyAlertsUpdated()
+
+        #expect(viewModel.alerts.count == 1)
+        #expect(viewModel.alerts.first?.id == sharedID)
+    }
+
+    @Test @MainActor
+    func `Share activity items without URL returns title and body`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let viewModel = AgencyAlertsViewModel(application: app)
+
+        let alertVM = try makeAlertVM(
+            title: "Service Disruption",
+            body: "Buses delayed due to traffic."
+        )
+
+        let items = viewModel.shareActivityItems(for: alertVM)
+
+        #expect(items.count == 2)
+        #expect(items[0] as? String == "Service Disruption")
+        #expect(items[1] as? String == "Buses delayed due to traffic.")
     }
 }


### PR DESCRIPTION
## Summary

This PR completes the required test-layer follow-up work from #1167.

### Changes

- Fix inaccurate class-level docstrings in `AgencyAlertsViewModelTests` and `AgenciesViewModelTests`.
- Replace `try?` with `try` in the `loadData()` success test so failures surface their underlying error.
- Add deterministic tests covering both branches of `AgencyAlertsViewModel.shareActivityItems(for:)`.
- Add a real-data test covering the `dedupedAlerts()` path using `AgencyAlertsStore.insertAlerts(_:)`.
- Add a test covering the `nil` `apiService` error path in `AgenciesViewModel.loadData()`.
- Refactor private test helpers to remove duplicated fixture construction while preserving behavior.

### Verification

- [x] Project builds successfully.
- [x] `AgencyAlertsViewModelTests` pass.
- [x] `AgenciesViewModelTests` pass.
- [x] No production code changed.

Closes #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for agency loading, including successful name-sorted results and failure when no API service is available.
  * Updated agency loading assertions to use async/throws and improved setup for scenario-specific configurations.
  * Expanded alert view model tests to cover loading-state transitions, error-delegate handling, collapsed section persistence, alert sharing with/without URLs, and alert deduplication behavior.
* **Documentation**
  * Improved test descriptions and scenario clarity to reflect the newly covered behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->