### PR TITLE
WeatherFormatter: derive icon fallbacks from a single metadata table

### DIFF
--- a/OBAKit/Sheet/Root/WeatherDetailPopup.swift
+++ b/OBAKit/Sheet/Root/WeatherDetailPopup.swift
@@ -232,21 +232,26 @@ private struct StatsRow: View {
 // MARK: - Weather Icon
 
 /// Pulls the SF Symbol name from `WeatherFormatter` (single source of truth) and
-/// pairs it with a SwiftUI-only color palette.
+/// pairs it with a SwiftUI-only color palette. The palette lives here rather
+/// than in OBAKitCore because `Color` isn't reachable from the extension-safe
+/// core; `WeatherIconPalette.colors` is `internal` so tests can assert every
+/// key in `WeatherFormatter.knownIconKeys` also has a palette entry.
 private struct WeatherIcon: View {
     let iconName: String
     let size: CGFloat
 
     var body: some View {
         let symbol = WeatherFormatter.systemImageName(for: iconName)
-        let palette = Self.colors[iconName] ?? (.gray, .clear)
+        let palette = WeatherIconPalette.colors[iconName] ?? (.gray, .clear)
         Image(systemName: symbol)
             .symbolRenderingMode(.palette)
             .foregroundStyle(palette.primary, palette.secondary)
             .font(.system(size: size))
     }
+}
 
-    private static let colors: [String: (primary: Color, secondary: Color)] = [
+enum WeatherIconPalette {
+    static let colors: [String: (primary: Color, secondary: Color)] = [
         "clear-day": (.yellow, .orange),
         "clear-night": (.gray, .yellow),
         "partly-cloudy-day": (.yellow, .gray),

--- a/OBAKitCore/Weather/WeatherFormatter.swift
+++ b/OBAKitCore/Weather/WeatherFormatter.swift
@@ -16,59 +16,86 @@ public enum WeatherFormatter {
 
     // MARK: - Icon Mapping
 
+    /// A single icon "condition family" — day/night variants share one case
+    /// because the SF Symbol already conveys time-of-day and the localized
+    /// word is the same either way.
+    private enum ConditionKey {
+        case clear, partlyCloudy, cloudy, rain, sleet, snow, wind, fog
+
+        var localizedText: String {
+            switch self {
+            case .clear:
+                return OBALoc("weather.condition.clear", value: "Clear", comment: "Weather condition label for clear skies.")
+            case .partlyCloudy:
+                return OBALoc("weather.condition.partly_cloudy", value: "Partly Cloudy", comment: "Weather condition label for partly cloudy skies.")
+            case .cloudy:
+                return OBALoc("weather.condition.cloudy", value: "Cloudy", comment: "Weather condition label for cloudy skies.")
+            case .rain:
+                return OBALoc("weather.condition.rain", value: "Rain", comment: "Weather condition label for rain.")
+            case .sleet:
+                return OBALoc("weather.condition.sleet", value: "Sleet", comment: "Weather condition label for sleet.")
+            case .snow:
+                return OBALoc("weather.condition.snow", value: "Snow", comment: "Weather condition label for snow.")
+            case .wind:
+                return OBALoc("weather.condition.wind", value: "Windy", comment: "Weather condition label for windy conditions.")
+            case .fog:
+                return OBALoc("weather.condition.fog", value: "Fog", comment: "Weather condition label for foggy conditions.")
+            }
+        }
+    }
+
+    /// Metadata for a single Obaco icon key. Bundling the SF Symbol and the
+    /// condition-text key here means adding a new condition is a single edit
+    /// (one new entry in `iconMetadata`) and the drift-warning gate
+    /// (`isKnownIconKey`) automatically covers both fallbacks.
+    private struct IconMetadata {
+        let symbol: String
+        let conditionKey: ConditionKey
+    }
+
+    /// Single source of truth for Obaco icon keys the app renders. Every
+    /// public helper below reads from this table — no parallel lookup tables.
+    private static let iconMetadata: [String: IconMetadata] = [
+        "clear-day": IconMetadata(symbol: "sun.max.fill", conditionKey: .clear),
+        "clear-night": IconMetadata(symbol: "moon.stars.fill", conditionKey: .clear),
+        "partly-cloudy-day": IconMetadata(symbol: "cloud.sun.fill", conditionKey: .partlyCloudy),
+        "partly-cloudy-night": IconMetadata(symbol: "cloud.moon.fill", conditionKey: .partlyCloudy),
+        "cloudy": IconMetadata(symbol: "cloud.fill", conditionKey: .cloudy),
+        "rain": IconMetadata(symbol: "cloud.rain.fill", conditionKey: .rain),
+        "sleet": IconMetadata(symbol: "cloud.sleet.fill", conditionKey: .sleet),
+        "snow": IconMetadata(symbol: "cloud.snow.fill", conditionKey: .snow),
+        "wind": IconMetadata(symbol: "wind", conditionKey: .wind),
+        "fog": IconMetadata(symbol: "cloud.fog.fill", conditionKey: .fog)
+    ]
+
     /// Maps an Obaco icon key (Dark Sky-style) to an SF Symbol name.
     /// Returns a generic cloud symbol for unknown keys so the UI never goes blank.
     public static func systemImageName(for iconKey: String) -> String {
-        iconToSymbol[iconKey] ?? "cloud.fill"
+        iconMetadata[iconKey]?.symbol ?? "cloud.fill"
     }
 
-    /// Whether the given Obaco icon key has both a symbol and a condition-text
-    /// mapping. Callers (e.g. `WeatherDisplay.Header`) use this to log a single
-    /// warning when Obaco starts shipping a new condition we don't render —
-    /// the fallbacks keep the UI usable, but without this signal the drift is
-    /// silent.
+    /// Whether the given Obaco icon key is modeled by the app. Callers
+    /// (e.g. `WeatherDisplay.Header`) use this to log a single warning when
+    /// Obaco starts shipping a new condition we don't render — the fallbacks
+    /// keep the UI usable, but without this signal the drift is silent.
     public static func isKnownIconKey(_ iconKey: String) -> Bool {
-        iconToSymbol[iconKey] != nil
+        iconMetadata[iconKey] != nil
     }
 
-    private static let iconToSymbol: [String: String] = [
-        "clear-day": "sun.max.fill",
-        "clear-night": "moon.stars.fill",
-        "partly-cloudy-day": "cloud.sun.fill",
-        "partly-cloudy-night": "cloud.moon.fill",
-        "cloudy": "cloud.fill",
-        "rain": "cloud.rain.fill",
-        "sleet": "cloud.sleet.fill",
-        "snow": "cloud.snow.fill",
-        "wind": "wind",
-        "fog": "cloud.fog.fill"
-    ]
+    /// Snapshot of every Obaco icon key the app currently models. Exposed so
+    /// downstream tables (e.g. the SwiftUI color palette in `WeatherIcon`)
+    /// can be asserted complete against this source of truth in tests.
+    public static var knownIconKeys: Set<String> {
+        Set(iconMetadata.keys)
+    }
 
     // MARK: - Condition Text
 
     /// Localized human-readable condition (e.g. "Clear", "Cloudy"). Day/night
     /// variants collapse to the same word since the icon already conveys time-of-day.
     public static func conditionText(for iconKey: String) -> String {
-        switch iconKey {
-        case "clear-day", "clear-night":
-            return OBALoc("weather.condition.clear", value: "Clear", comment: "Weather condition label for clear skies.")
-        case "partly-cloudy-day", "partly-cloudy-night":
-            return OBALoc("weather.condition.partly_cloudy", value: "Partly Cloudy", comment: "Weather condition label for partly cloudy skies.")
-        case "cloudy":
-            return OBALoc("weather.condition.cloudy", value: "Cloudy", comment: "Weather condition label for cloudy skies.")
-        case "rain":
-            return OBALoc("weather.condition.rain", value: "Rain", comment: "Weather condition label for rain.")
-        case "sleet":
-            return OBALoc("weather.condition.sleet", value: "Sleet", comment: "Weather condition label for sleet.")
-        case "snow":
-            return OBALoc("weather.condition.snow", value: "Snow", comment: "Weather condition label for snow.")
-        case "wind":
-            return OBALoc("weather.condition.wind", value: "Windy", comment: "Weather condition label for windy conditions.")
-        case "fog":
-            return OBALoc("weather.condition.fog", value: "Fog", comment: "Weather condition label for foggy conditions.")
-        default:
-            return OBALoc("weather.condition.unknown", value: "—", comment: "Weather condition placeholder when the icon key is unknown.")
-        }
+        iconMetadata[iconKey]?.conditionKey.localizedText
+            ?? OBALoc("weather.condition.unknown", value: "—", comment: "Weather condition placeholder when the icon key is unknown.")
     }
 
     // MARK: - Temperature

--- a/OBAKitTests/Weather/WeatherDisplayTests.swift
+++ b/OBAKitTests/Weather/WeatherDisplayTests.swift
@@ -185,6 +185,17 @@ final class WeatherDisplayTests: XCTestCase {
         expect(WeatherFormatter.isKnownIconKey("thunderstorm")) == false
     }
 
+    /// The SwiftUI color palette in `WeatherIcon` is layered on top of
+    /// `WeatherFormatter`'s icon table. This asserts the palette covers every
+    /// key the formatter models, so adding a new condition to the metadata
+    /// without a matching palette entry fails here instead of silently
+    /// rendering as gray.
+    func test_weatherIconPalette_coversAllKnownIconKeys() {
+        let paletteKeys = Set(WeatherIconPalette.colors.keys)
+        let missing = WeatherFormatter.knownIconKeys.subtracting(paletteKeys)
+        expect(missing) == []
+    }
+
     // MARK: - Full WeatherDisplay (fixture-driven)
 
     private func loadPugetSoundForecast() throws -> WeatherForecast {

--- a/OBAKitTests/Weather/WeatherFormatterTests.swift
+++ b/OBAKitTests/Weather/WeatherFormatterTests.swift
@@ -51,6 +51,24 @@ final class WeatherFormatterTests: XCTestCase {
         expect(WeatherFormatter.conditionText(for: "tornado")) == "—"
     }
 
+    // MARK: - Metadata single-source-of-truth
+
+    /// Guards against the drift the fix for #1174 removes: every icon key the
+    /// warning gate accepts must also produce a real condition string, not
+    /// the "—" fallback. If a future key is added to the metadata table
+    /// without a matching `ConditionKey` case, this fails.
+    func test_isKnownIconKey_impliesConditionText() {
+        let placeholder = OBALoc(
+            "weather.condition.unknown",
+            value: "—",
+            comment: "Weather condition placeholder when the icon key is unknown."
+        )
+        for key in WeatherFormatter.knownIconKeys {
+            expect(WeatherFormatter.isKnownIconKey(key)) == true
+            expect(WeatherFormatter.conditionText(for: key)) != placeholder
+        }
+    }
+
     // MARK: - formatTemp (locale-dependent)
 
     func test_formatTemp_usLocaleKeepsFahrenheit() {


### PR DESCRIPTION
Fixes #1174.

`WeatherFormatter` had three parallel tables keyed by the same Obaco icon strings (symbol map, condition-text switch, and the SwiftUI color palette), and the drift-warning gate only checked one of them. Collapses the OBAKitCore side into a single `iconMetadata: [String: IconMetadata]` (icon → symbol + condition family) that `systemImageName`, `conditionText`, and `isKnownIconKey` all read from — adding a condition is now one edit.

- New `ConditionKey` enum + `IconMetadata` struct back the table; day/night variants share one `ConditionKey` case.
- New public `WeatherFormatter.knownIconKeys` exposes the modeled set so downstream tables can assert coverage.
- The SwiftUI color palette in `WeatherDetailPopup` moves out of the private `WeatherIcon` view into an internal `WeatherIconPalette` so it can be verified from tests.

## Tests
- `test_isKnownIconKey_impliesConditionText` — every known key produces a real localized string, never the `—` fallback.
- `test_weatherIconPalette_coversAllKnownIconKeys` — the SwiftUI palette has an entry for every `knownIconKeys` key.

Full weather test suite (26 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified weather icon and condition handling into a more consistent, table-driven setup.
  * Separated icon color palette data into a dedicated place for easier maintenance.

* **Bug Fixes**
  * Improved consistency between weather symbols, condition text, and icon colors.
  * Reduced the chance of new weather icons falling back to unintended default styling.

* **Tests**
  * Added coverage to ensure all known weather icons have matching palette colors.
  * Added checks that known icon keys always return valid condition text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->