### PR TITLE
Add Live Activity support

### DIFF
--- a/Apps/OneBusAway/project.yml
+++ b/Apps/OneBusAway/project.yml
@@ -30,6 +30,7 @@ targets:
       path: Apps/OneBusAway/Info.plist
       properties:
         NSSupportsLiveActivities: true
+        NSSupportsLiveActivitiesFrequentUpdates: true
         CFBundleDisplayName: OneBusAway
         CFBundleURLTypes: [{CFBundleTypeRole: "Editor", CFBundleURLIconFile: "", CFBundleURLName: "onebusaway", CFBundleURLSchemes: ["onebusaway"]}]
         LSApplicationQueriesSchemes:

--- a/Apps/OneBusAway/project.yml
+++ b/Apps/OneBusAway/project.yml
@@ -29,6 +29,7 @@ targets:
     info:
       path: Apps/OneBusAway/Info.plist
       properties:
+        NSSupportsLiveActivities: true
         CFBundleDisplayName: OneBusAway
         CFBundleURLTypes: [{CFBundleTypeRole: "Editor", CFBundleURLIconFile: "", CFBundleURLName: "onebusaway", CFBundleURLSchemes: ["onebusaway"]}]
         LSApplicationQueriesSchemes:

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -71,6 +71,11 @@ public class BookmarksViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        liveActivityTokenTasks.values.forEach { $0.cancel() }
+        liveActivityLifecycleTasks.values.forEach { $0.cancel() }
+    }
+
     private var sortBookmarksByGroup: Bool {
         get { viewModel.sortByGroup }
         set { viewModel.updateSortType(byGroup: newValue) }
@@ -386,16 +391,12 @@ public class BookmarksViewController: UIViewController,
 
         let attributes = TripAttributes(staticData: staticData)
         do {
-            // Note: pushType is set to .token in preparation for future backend support.
-            // There is currently no server-side infrastructure to receive push tokens
-            // or send APNs updates to Live Activities. When a backend is implemented,
-            // add a Task to iterate over activity.pushTokenUpdates and send tokens
-            // to the server. That Task must be stored and cancelled in deinit.
             let activity = try Activity.request(
                 attributes: attributes,
                 content: .init(state: contentState, staleDate: nil),
                 pushType: .token
             )
+            registerForPushUpdates(activity: activity, viewModel: viewModel)
             Logger.info("Started Live Activity with ID: \(activity.id)")
             showLiveActivityStartedAlert()
         } catch {
@@ -457,6 +458,93 @@ public class BookmarksViewController: UIViewController,
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
         present(alert, animated: true)
+    }
+
+    // MARK: - Live Activity Push Registration
+
+    /// One token-forwarding Task per activity id; cancelled in deinit.
+    private var liveActivityTokenTasks: [String: Task<Void, Never>] = [:]
+    /// One lifecycle-observation Task per activity id; cancelled in deinit.
+    private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
+
+    private static let liveActivityURLDefaultsKey = "liveActivityDeleteURLs"
+
+    /// The server's DELETE URLs survive app relaunches so an activity that ends
+    /// after a relaunch still unregisters.
+    private func storeDeleteURL(_ url: URL, activityID: String) {
+        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
+        urls[activityID] = url.absoluteString
+        application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey)
+    }
+
+    private func removeDeleteURL(activityID: String) -> URL? {
+        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
+        defer { application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey) }
+        guard let raw = urls.removeValue(forKey: activityID) else { return nil }
+        return URL(string: raw)
+    }
+
+    private func registerForPushUpdates(activity: Activity<TripAttributes>, viewModel: BookmarkArrivalViewModel) {
+        let activityID = activity.id
+        let firstArrival = viewModel.arrivalDepartures?.first
+
+        liveActivityTokenTasks[activityID]?.cancel()
+        liveActivityTokenTasks[activityID] = Task { [weak self] in
+            for await tokenData in activity.pushTokenUpdates {
+                let token = tokenData.map { String(format: "%02x", $0) }.joined()
+                await self?.postRegistration(
+                    activity: activity,
+                    pushToken: token,
+                    tripID: firstArrival?.tripID,
+                    serviceDate: firstArrival?.serviceDate,
+                    vehicleID: firstArrival?.vehicleID,
+                    stopSequence: firstArrival?.stopSequence
+                )
+            }
+        }
+
+        liveActivityLifecycleTasks[activityID]?.cancel()
+        liveActivityLifecycleTasks[activityID] = Task { [weak self] in
+            for await state in activity.activityStateUpdates where state == .dismissed || state == .ended {
+                await self?.unregister(activityID: activityID)
+                break
+            }
+        }
+    }
+
+    private func postRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
+        guard let obacoService = application.obacoService else { return }
+        let staticData = activity.attributes.staticData
+        do {
+            let deleteURL = try await obacoService.postLiveActivity(
+                activityID: activity.id,
+                pushToken: pushToken,
+                stopID: staticData.stopID,
+                routeShortName: staticData.routeShortName,
+                tripHeadsign: staticData.routeHeadsign,
+                tripID: tripID,
+                serviceDate: serviceDate,
+                vehicleID: vehicleID,
+                stopSequence: stopSequence
+            )
+            storeDeleteURL(deleteURL, activityID: activity.id)
+            Logger.info("Registered Live Activity push token for activity \(activity.id)")
+        } catch {
+            Logger.error("Failed to register Live Activity push token: \(error)")
+        }
+    }
+
+    private func unregister(activityID: String) async {
+        liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
+        liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
+        guard let obacoService = application.obacoService,
+              let deleteURL = removeDeleteURL(activityID: activityID) else { return }
+        do {
+            try await obacoService.deleteLiveActivity(url: deleteURL)
+            Logger.info("Unregistered Live Activity \(activityID)")
+        } catch {
+            Logger.error("Failed to unregister Live Activity \(activityID): \(error)")
+        }
     }
 
     // MARK: - Arrival departure highlight updates

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -378,10 +378,12 @@ public class BookmarksViewController: UIViewController,
         let routeShortName = viewModel.bookmark.routeShortName ?? viewModel.name
         let routeHeadsign = viewModel.bookmark.tripHeadsign ?? ""
 
+        let routeColorHex = viewModel.arrivalDepartures?.first?.route.color?.toHex()
         let staticData = TripAttributes.StaticData(
             routeShortName: routeShortName,
             routeHeadsign: routeHeadsign,
-            stopID: viewModel.stopID
+            stopID: viewModel.stopID,
+            routeColorHex: routeColorHex
         )
 
         guard let contentState = buildContentState(for: viewModel) else {

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -432,23 +432,15 @@ public class BookmarksViewController: UIViewController,
               !arrivalDepartures.isEmpty else {
             return nil
         }
-        let formatters = application.formatters
-        let firstArrival = arrivalDepartures[0]
-        let statusText = TripBookmarkRow.buildStatusText(from: firstArrival, formatters: formatters)
-        let statusColor = formatters.colorForScheduleStatus(firstArrival.scheduleStatus)
-        let minutes = arrivalDepartures.prefix(3).map { arrivalDeparture -> TripAttributes.MinuteInfo in
-            let minuteText = formatters.shortFormattedTime(until: arrivalDeparture)
-            let color = formatters.colorForScheduleStatus(arrivalDeparture.scheduleStatus)
-            return TripAttributes.MinuteInfo(text: minuteText, color: color)
+        let arrivals = arrivalDepartures.prefix(3).map { arrDep in
+            TripAttributes.ContentState.ArrivalInfo(
+                departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),
+                scheduleStatus: .init(arrDep.scheduleStatus),
+                scheduleDeviation: arrDep.deviationFromScheduleInMinutes * 60,
+                isArrival: arrDep.arrivalDepartureStatus == .arriving
+            )
         }
-        let shouldHighlight = !viewModel.arrivalDeparturesPair.isEmpty &&
-                            viewModel.arrivalDeparturesPair[0].shouldHighlightOnDisplay
-        return TripAttributes.ContentState(
-            statusText: statusText,
-            statusColor: statusColor,
-            minutes: Array(minutes),
-            shouldHighlight: shouldHighlight
-        )
+        return TripAttributes.ContentState(arrivals: Array(arrivals))
     }
 
     private func showLiveActivityStartedAlert() {

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -71,11 +71,6 @@ public class BookmarksViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        liveActivityTokenTasks.values.forEach { $0.cancel() }
-        liveActivityLifecycleTasks.values.forEach { $0.cancel() }
-    }
-
     private var sortBookmarksByGroup: Bool {
         get { viewModel.sortByGroup }
         set { viewModel.updateSortType(byGroup: newValue) }
@@ -398,7 +393,7 @@ public class BookmarksViewController: UIViewController,
                 content: .init(state: contentState, staleDate: nil),
                 pushType: .token
             )
-            registerForPushUpdates(activity: activity, viewModel: viewModel)
+            trackLiveActivity(activity, for: viewModel)
             Logger.info("Started Live Activity with ID: \(activity.id)")
             showLiveActivityStartedAlert()
         } catch {
@@ -419,13 +414,18 @@ public class BookmarksViewController: UIViewController,
                 let viewModel = buildListItem(bookmark),
                 let contentState = buildContentState(for: viewModel) {
                 // Re-arm the push token/lifecycle observers on relaunch. `startLiveActivity`
-                // only registers activities it creates in-session, so without this a Live
-                // Activity that's still running after a relaunch would never re-establish its
-                // observers and would never unregister when it later ends. Guarded so repeated
-                // calls to updateRunningLiveActivities() don't cancel/rebuild an already-armed
-                // task (and don't clobber one armed earlier in this same session).
-                if liveActivityTokenTasks[activity.id] == nil {
-                    registerForPushUpdates(activity: activity, viewModel: viewModel)
+                // only tracks activities it creates in-session, so without this a Live Activity
+                // that's still running after a relaunch would never re-establish its observers
+                // and would never unregister when it later ends. Guarded so repeated calls to
+                // updateRunningLiveActivities() don't cancel/rebuild an already-armed task — and
+                // because the tracker is app-scoped, the guard also covers an activity started
+                // from the stop page, which we must not steal the observers out from under.
+                //
+                // Deliberately keyed on the token task and not on `isTracking`: an activity that
+                // the sweep below could only lifecycle-observe (no matching bookmark at the time)
+                // must still be upgradable to a full registration once its bookmark reappears.
+                if !application.liveActivityTracker.isForwardingPushToken(activityID: activity.id) {
+                    trackLiveActivity(activity, for: viewModel)
                 }
                 Task {
                     await activity.update(
@@ -433,11 +433,11 @@ public class BookmarksViewController: UIViewController,
                     )
                     Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")
                 }
-            } else if liveActivityTokenTasks[activity.id] == nil && liveActivityLifecycleTasks[activity.id] == nil {
+            } else if !application.liveActivityTracker.isTracking(activityID: activity.id) {
                 // No bookmark/viewModel to register push updates with, but the activity is
                 // still running (and may have a delete URL persisted from a prior session).
                 // Arm just the lifecycle observer so dismiss/end still triggers `unregister`.
-                armLifecycleObserver(activity: activity)
+                application.liveActivityTracker.observeLifecycle(of: activity)
             }
         }
     }
@@ -460,126 +460,17 @@ public class BookmarksViewController: UIViewController,
         return TripAttributes.ContentState(arrivals: Array(arrivals))
     }
 
-    private func showLiveActivityStartedAlert() {
-        let title = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Alert title when a Live Activity starts")
-        let message = OBALoc("live_activity.started.message", value: "You'll see live arrival updates on your Lock Screen and Dynamic Island.", comment: "Alert message explaining where to find the Live Activity")
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
-        present(alert, animated: true)
-    }
-
-    private func showLiveActivityErrorAlert() {
-        let title = OBALoc("live_activity.error.title", value: "Unable to Start Tracking", comment: "Alert title when Live Activity fails to start")
-        let message = OBALoc("live_activity.error.message", value: "Please check your Live Activities settings in System Preferences.", comment: "Alert message for Live Activity error")
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
-        present(alert, animated: true)
-    }
-
     // MARK: - Live Activity Push Registration
 
-    /// One token-forwarding Task per activity id; cancelled in deinit.
-    private var liveActivityTokenTasks: [String: Task<Void, Never>] = [:]
-    /// One lifecycle-observation Task per activity id; cancelled in deinit.
-    private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
-
-    /// Persistence of delete URLs, registration, and unregistration all live in the registry;
-    /// this controller only owns the observers that feed it. An activity that ended while the
-    /// app wasn't running is never observed here at all — `LiveActivityRegistry.reconcile()`,
-    /// run from `Application.applicationDidBecomeActive`, is what cleans that case up.
-    private var liveActivityRegistry: LiveActivityRegistry {
-        application.liveActivityRegistry
-    }
-
-    private func registerForPushUpdates(activity: Activity<TripAttributes>, viewModel: BookmarkArrivalViewModel) {
-        let activityID = activity.id
-        let firstArrival = viewModel.arrivalDepartures?.first
-
-        liveActivityTokenTasks[activityID]?.cancel()
-        liveActivityTokenTasks[activityID] = Task { [weak self] in
-            for await tokenData in activity.pushTokenUpdates {
-                let token = tokenData.map { String(format: "%02x", $0) }.joined()
-                await self?.postRegistration(
-                    activity: activity,
-                    pushToken: token,
-                    tripID: firstArrival?.tripID,
-                    serviceDate: firstArrival?.serviceDate,
-                    vehicleID: firstArrival?.vehicleID,
-                    stopSequence: firstArrival?.stopSequence
-                )
-            }
-        }
-
-        armLifecycleObserver(activity: activity)
-    }
-
-    /// Observes `activity`'s dismiss/end state so `unregister` runs (deleting the server-side
-    /// registration via its persisted delete URL). Armed both as part of a full registration
-    /// (`registerForPushUpdates`, alongside the token-forwarding task) and, after a relaunch,
-    /// on its own for running activities whose bookmark can no longer be matched
-    /// (`updateRunningLiveActivities`) — there's no viewModel to register a push token with in
-    /// that case, but the delete URL persisted from a prior session still needs to be cleaned
-    /// up once the activity ends.
-    private func armLifecycleObserver(activity: Activity<TripAttributes>) {
-        let activityID = activity.id
-        liveActivityLifecycleTasks[activityID]?.cancel()
-        liveActivityLifecycleTasks[activityID] = Task { [weak self] in
-            for await state in activity.activityStateUpdates where state == .dismissed || state == .ended {
-                await self?.unregister(activityID: activityID)
-                break
-            }
-        }
-    }
-
-    private func postRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
-        await liveActivityRegistry.register(
-            activityID: activity.id,
-            staticData: activity.attributes.staticData,
-            pushToken: pushToken,
-            tripID: tripID,
-            serviceDate: serviceDate,
-            vehicleID: vehicleID,
-            stopSequence: stopSequence,
-            confirm: { [weak self] in
-                // `unregister` is only cooperatively cancelled, so it can finish tearing down
-                // this activity's tasks while the POST is still in flight. If that happened, the
-                // lifecycle task that would eventually DELETE this registration is already gone,
-                // so persisting the delete URL now would orphan it forever. The registry
-                // evaluates this immediately before the write (both this method and `unregister`
-                // run on the MainActor, so the check is race-free) and cleans up the row the
-                // server just created for us when it returns false.
-                guard let self else { return false }
-                return self.liveActivityLifecycleTasks[activity.id] != nil && !Task.isCancelled
-            }
+    /// Hands `activity` to the app-scoped tracker, which owns the push-token and lifecycle
+    /// observers. They deliberately outlive this controller — and every other screen — so that an
+    /// activity is unregistered when it actually ends rather than when a view controller happens
+    /// to be deallocated. See `LiveActivityTracker`.
+    private func trackLiveActivity(_ activity: Activity<TripAttributes>, for viewModel: BookmarkArrivalViewModel) {
+        application.liveActivityTracker.track(
+            activity: activity,
+            metadata: .init(viewModel.arrivalDepartures?.first)
         )
-    }
-
-    /// Tears down the observers for `activityID` and deletes its server-side push subscription.
-    ///
-    /// The ordering below is load-bearing, and the tempting tidy-up — cancelling both tasks
-    /// together, up front — is a bug. This method's usual caller is the lifecycle task itself
-    /// (`armLifecycleObserver`), so cancelling that task here cancels *the task we are currently
-    /// running inside*. `URLSession` honors task cancellation, so the DELETE that follows would
-    /// fail instantly with `URLError.cancelled` (-999) without a byte leaving the device —
-    /// silently, since unregistration has no UI. That shipped: every dismissal leaked its
-    /// subscription and the server kept pushing to a Live Activity the user had cleared.
-    ///
-    /// So: drop the lifecycle task from the dictionary (which is what `confirm` in
-    /// `postRegistration` reads, and what stops a second unregister), but cancel it only *after*
-    /// the network call. When we're running inside it, it's about to `break` out of its loop
-    /// anyway; when called from anywhere else, it still gets torn down properly.
-    ///
-    /// The token task is a different task and is safe to cancel up front.
-    ///
-    /// `LiveActivityRegistry` independently refuses to let its DELETEs inherit cancellation, so
-    /// this is belt-and-braces — but the belt is here, where the reasoning is visible.
-    private func unregister(activityID: String) async {
-        liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
-        let lifecycleTask = liveActivityLifecycleTasks.removeValue(forKey: activityID)
-
-        await liveActivityRegistry.unregister(activityID: activityID)
-
-        lifecycleTask?.cancel()
     }
 
     // MARK: - Arrival departure highlight updates

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -416,12 +416,26 @@ public class BookmarksViewController: UIViewController,
             }),
                 let viewModel = buildListItem(bookmark),
                 let contentState = buildContentState(for: viewModel) {
+                // Re-arm the push token/lifecycle observers on relaunch. `startLiveActivity`
+                // only registers activities it creates in-session, so without this a Live
+                // Activity that's still running after a relaunch would never re-establish its
+                // observers and would never unregister when it later ends. Guarded so repeated
+                // calls to updateRunningLiveActivities() don't cancel/rebuild an already-armed
+                // task (and don't clobber one armed earlier in this same session).
+                if liveActivityTokenTasks[activity.id] == nil {
+                    registerForPushUpdates(activity: activity, viewModel: viewModel)
+                }
                 Task {
                     await activity.update(
                         .init(state: contentState, staleDate: nil)
                     )
                     Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")
                 }
+            } else if liveActivityTokenTasks[activity.id] == nil && liveActivityLifecycleTasks[activity.id] == nil {
+                // No bookmark/viewModel to register push updates with, but the activity is
+                // still running (and may have a delete URL persisted from a prior session).
+                // Arm just the lifecycle observer so dismiss/end still triggers `unregister`.
+                armLifecycleObserver(activity: activity)
             }
         }
     }
@@ -469,8 +483,13 @@ public class BookmarksViewController: UIViewController,
 
     private static let liveActivityURLDefaultsKey = "liveActivityDeleteURLs"
 
-    /// The server's DELETE URLs survive app relaunches so an activity that ends
-    /// after a relaunch still unregisters.
+    /// The server's DELETE URLs survive app relaunches so a running activity that's later
+    /// dismissed/ends can still unregister, as long as `updateRunningLiveActivities()` has had
+    /// a chance to re-arm its lifecycle observer since relaunch. This does *not* cover an
+    /// activity that already ended while the app wasn't running at all: it won't appear in
+    /// `Activity<TripAttributes>.activities` on next launch, so no observer is ever armed for
+    /// it and its persisted delete URL is orphaned server-side until something else cleans it
+    /// up.
     private func storeDeleteURL(_ url: URL, activityID: String) {
         var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
         urls[activityID] = url.absoluteString
@@ -503,6 +522,18 @@ public class BookmarksViewController: UIViewController,
             }
         }
 
+        armLifecycleObserver(activity: activity)
+    }
+
+    /// Observes `activity`'s dismiss/end state so `unregister` runs (deleting the server-side
+    /// registration via its persisted delete URL). Armed both as part of a full registration
+    /// (`registerForPushUpdates`, alongside the token-forwarding task) and, after a relaunch,
+    /// on its own for running activities whose bookmark can no longer be matched
+    /// (`updateRunningLiveActivities`) — there's no viewModel to register a push token with in
+    /// that case, but the delete URL persisted from a prior session still needs to be cleaned
+    /// up once the activity ends.
+    private func armLifecycleObserver(activity: Activity<TripAttributes>) {
+        let activityID = activity.id
         liveActivityLifecycleTasks[activityID]?.cancel()
         liveActivityLifecycleTasks[activityID] = Task { [weak self] in
             for await state in activity.activityStateUpdates where state == .dismissed || state == .ended {
@@ -527,6 +558,23 @@ public class BookmarksViewController: UIViewController,
                 vehicleID: vehicleID,
                 stopSequence: stopSequence
             )
+
+            // `unregister` is only cooperatively cancelled, so it can finish tearing down this
+            // activity's tasks while the POST above is still in flight. If that happened, the
+            // lifecycle task that would eventually DELETE this registration is already gone, so
+            // storing the delete URL now would orphan it forever. Guard immediately before the
+            // write (both this method and `unregister` run on the MainActor, so this check is
+            // race-free), and best-effort clean up the row the server just created for us.
+            guard liveActivityLifecycleTasks[activity.id] != nil, !Task.isCancelled else {
+                do {
+                    try await obacoService.deleteLiveActivity(url: deleteURL)
+                    Logger.info("Discarded Live Activity registration for \(activity.id): activity was unregistered mid-request")
+                } catch {
+                    Logger.error("Failed to clean up orphaned Live Activity registration for \(activity.id): \(error)")
+                }
+                return
+            }
+
             storeDeleteURL(deleteURL, activityID: activity.id)
             Logger.info("Registered Live Activity push token for activity \(activity.id)")
         } catch {

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -483,26 +483,12 @@ public class BookmarksViewController: UIViewController,
     /// One lifecycle-observation Task per activity id; cancelled in deinit.
     private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
 
-    private static let liveActivityURLDefaultsKey = "liveActivityDeleteURLs"
-
-    /// The server's DELETE URLs survive app relaunches so a running activity that's later
-    /// dismissed/ends can still unregister, as long as `updateRunningLiveActivities()` has had
-    /// a chance to re-arm its lifecycle observer since relaunch. This does *not* cover an
-    /// activity that already ended while the app wasn't running at all: it won't appear in
-    /// `Activity<TripAttributes>.activities` on next launch, so no observer is ever armed for
-    /// it and its persisted delete URL is orphaned server-side until something else cleans it
-    /// up.
-    private func storeDeleteURL(_ url: URL, activityID: String) {
-        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
-        urls[activityID] = url.absoluteString
-        application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey)
-    }
-
-    private func removeDeleteURL(activityID: String) -> URL? {
-        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
-        defer { application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey) }
-        guard let raw = urls.removeValue(forKey: activityID) else { return nil }
-        return URL(string: raw)
+    /// Persistence of delete URLs, registration, and unregistration all live in the registry;
+    /// this controller only owns the observers that feed it. An activity that ended while the
+    /// app wasn't running is never observed here at all — `LiveActivityRegistry.reconcile()`,
+    /// run from `Application.applicationDidBecomeActive`, is what cleans that case up.
+    private var liveActivityRegistry: LiveActivityRegistry {
+        application.liveActivityRegistry
     }
 
     private func registerForPushUpdates(activity: Activity<TripAttributes>, viewModel: BookmarkArrivalViewModel) {
@@ -546,55 +532,31 @@ public class BookmarksViewController: UIViewController,
     }
 
     private func postRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
-        guard let obacoService = application.obacoService else { return }
-        let staticData = activity.attributes.staticData
-        do {
-            let deleteURL = try await obacoService.postLiveActivity(
-                activityID: activity.id,
-                pushToken: pushToken,
-                stopID: staticData.stopID,
-                routeShortName: staticData.routeShortName,
-                tripHeadsign: staticData.routeHeadsign,
-                tripID: tripID,
-                serviceDate: serviceDate,
-                vehicleID: vehicleID,
-                stopSequence: stopSequence
-            )
-
-            // `unregister` is only cooperatively cancelled, so it can finish tearing down this
-            // activity's tasks while the POST above is still in flight. If that happened, the
-            // lifecycle task that would eventually DELETE this registration is already gone, so
-            // storing the delete URL now would orphan it forever. Guard immediately before the
-            // write (both this method and `unregister` run on the MainActor, so this check is
-            // race-free), and best-effort clean up the row the server just created for us.
-            guard liveActivityLifecycleTasks[activity.id] != nil, !Task.isCancelled else {
-                do {
-                    try await obacoService.deleteLiveActivity(url: deleteURL)
-                    Logger.info("Discarded Live Activity registration for \(activity.id): activity was unregistered mid-request")
-                } catch {
-                    Logger.error("Failed to clean up orphaned Live Activity registration for \(activity.id): \(error)")
-                }
-                return
+        await liveActivityRegistry.register(
+            activity: activity,
+            pushToken: pushToken,
+            tripID: tripID,
+            serviceDate: serviceDate,
+            vehicleID: vehicleID,
+            stopSequence: stopSequence,
+            confirm: { [weak self] in
+                // `unregister` is only cooperatively cancelled, so it can finish tearing down
+                // this activity's tasks while the POST is still in flight. If that happened, the
+                // lifecycle task that would eventually DELETE this registration is already gone,
+                // so persisting the delete URL now would orphan it forever. The registry
+                // evaluates this immediately before the write (both this method and `unregister`
+                // run on the MainActor, so the check is race-free) and cleans up the row the
+                // server just created for us when it returns false.
+                guard let self else { return false }
+                return self.liveActivityLifecycleTasks[activity.id] != nil && !Task.isCancelled
             }
-
-            storeDeleteURL(deleteURL, activityID: activity.id)
-            Logger.info("Registered Live Activity push token for activity \(activity.id)")
-        } catch {
-            Logger.error("Failed to register Live Activity push token: \(error)")
-        }
+        )
     }
 
     private func unregister(activityID: String) async {
         liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
         liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
-        guard let obacoService = application.obacoService,
-              let deleteURL = removeDeleteURL(activityID: activityID) else { return }
-        do {
-            try await obacoService.deleteLiveActivity(url: deleteURL)
-            Logger.info("Unregistered Live Activity \(activityID)")
-        } catch {
-            Logger.error("Failed to unregister Live Activity \(activityID): \(error)")
-        }
+        await liveActivityRegistry.unregister(activityID: activityID)
     }
 
     // MARK: - Arrival departure highlight updates

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -533,7 +533,8 @@ public class BookmarksViewController: UIViewController,
 
     private func postRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
         await liveActivityRegistry.register(
-            activity: activity,
+            activityID: activity.id,
+            staticData: activity.attributes.staticData,
             pushToken: pushToken,
             tripID: tripID,
             serviceDate: serviceDate,
@@ -553,10 +554,32 @@ public class BookmarksViewController: UIViewController,
         )
     }
 
+    /// Tears down the observers for `activityID` and deletes its server-side push subscription.
+    ///
+    /// The ordering below is load-bearing, and the tempting tidy-up — cancelling both tasks
+    /// together, up front — is a bug. This method's usual caller is the lifecycle task itself
+    /// (`armLifecycleObserver`), so cancelling that task here cancels *the task we are currently
+    /// running inside*. `URLSession` honors task cancellation, so the DELETE that follows would
+    /// fail instantly with `URLError.cancelled` (-999) without a byte leaving the device —
+    /// silently, since unregistration has no UI. That shipped: every dismissal leaked its
+    /// subscription and the server kept pushing to a Live Activity the user had cleared.
+    ///
+    /// So: drop the lifecycle task from the dictionary (which is what `confirm` in
+    /// `postRegistration` reads, and what stops a second unregister), but cancel it only *after*
+    /// the network call. When we're running inside it, it's about to `break` out of its loop
+    /// anyway; when called from anywhere else, it still gets torn down properly.
+    ///
+    /// The token task is a different task and is safe to cancel up front.
+    ///
+    /// `LiveActivityRegistry` independently refuses to let its DELETEs inherit cancellation, so
+    /// this is belt-and-braces — but the belt is here, where the reasoning is visible.
     private func unregister(activityID: String) async {
         liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
-        liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
+        let lifecycleTask = liveActivityLifecycleTasks.removeValue(forKey: activityID)
+
         await liveActivityRegistry.unregister(activityID: activityID)
+
+        lifecycleTask?.cancel()
     }
 
     // MARK: - Arrival departure highlight updates

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -12,6 +12,7 @@ import Combine
 import CoreLocation
 import OBAKitCore
 import WidgetKit
+import ActivityKit
 
 /// The view controller that powers the Bookmarks tab of the app.
 @objc(OBABookmarksViewController)
@@ -187,26 +188,41 @@ public class BookmarksViewController: UIViewController,
     ///   - id: The unique ID of the section. Used for diffing.
     ///   - title: The section header title.
     private func buildListSection(bookmarks: [Bookmark], id: String, title: String) -> OBAListViewSection? {
-        let arrivalData = bookmarks
-            .filter { $0.regionIdentifier == application.regionsService.currentRegion?.id }
-            .compactMap { bookmark -> BookmarkArrivalViewModel? in
-                let deps = viewModel.arrivalDepartures(for: bookmark)
-                let arrDeps = deps.map { arrDep -> BookmarkArrivalViewModel.ArrivalDepartureShouldHighlightPair in
-                    return (arrDep, shouldHighlight(arrivalDeparture: arrDep))
-                }
-                return BookmarkArrivalViewModel(bookmark: bookmark, arrivalDepartures: arrDeps, onSelect: onSelectBookmark)
-            }
+        let currentRegionID = application.regionsService.currentRegion?.id
+        let activeBookmarks = bookmarks.filter { $0.regionIdentifier == currentRegionID }
 
-        guard arrivalData.count > 0 else { return nil }
+        guard !activeBookmarks.isEmpty else { return nil }
 
-        var section = OBAListViewSection(id: id, title: title, contents: arrivalData)
+        let items = activeBookmarks.compactMap { buildListItem($0) }
+        var section = OBAListViewSection(id: id, title: title, contents: items)
         section.configuration = .appearance(.plain)
         return section
     }
 
+    /// Builds a `BookmarkArrivalViewModel` for a single bookmark, loading arrival data if available.
+    private func buildListItem(_ bookmark: Bookmark) -> BookmarkArrivalViewModel? {
+        // Build arrival/departure pairs if this is a trip bookmark with data.
+        var arrDeps: [BookmarkArrivalViewModel.ArrivalDepartureShouldHighlightPair] = []
+
+        if bookmark.isTripBookmark {
+            let data = viewModel.arrivalDepartures(for: bookmark)
+            arrDeps = data.map { arrDep in
+                (arrDep, shouldHighlight(arrivalDeparture: arrDep))
+            }
+        }
+
+        return BookmarkArrivalViewModel(
+            bookmark: bookmark,
+            arrivalDepartures: arrDeps,
+            onSelect: { [weak self] viewModel in
+                self?.onSelectBookmark(viewModel)
+            }
+        )
+    }
+
     public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        let title: String
-        let body: String
+        var title: String
+        var body: String
 
         if application.hasDataToMigrate {
             title = Strings.emptyBookmarkTitle
@@ -217,10 +233,8 @@ public class BookmarksViewController: UIViewController,
             body = Strings.emptyBookmarkBody
         }
         else {
-            // Don't show empty state if we have bookmarks
             return nil
         }
-
         return .standard(.init(title: title, body: body))
     }
 
@@ -305,12 +319,31 @@ public class BookmarksViewController: UIViewController,
         }
     }
 
+    // MARK: - Context Menu with Live Activity Support
+
     var currentPreviewingViewController: UIViewController?
+
+    // MARK: - Context Menu
     public func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
         guard let item = item.as(BookmarkArrivalViewModel.self) else { return nil }
 
-        let menu: OBAListViewMenuActions.MenuProvider = { _ -> UIMenu? in
-            let children: [UIMenuElement] = [self.editAction(for: item), self.deleteAction(for: item)]
+        let menu: OBAListViewMenuActions.MenuProvider = { [weak self] _ -> UIMenu? in
+            guard let self else { return nil }
+
+            var children: [UIMenuElement] = []
+            // Check if Live Activities are enabled
+            if ActivityAuthorizationInfo().areActivitiesEnabled {
+                let title = OBALoc("bookmarks_controller.context_menu.track_live_activity", value: "Track", comment: "Action to start a Live Activity for a specific bookmark")
+                let liveActivityAction = UIAction(
+                    title: title,
+                    image: Icons.liveActivity
+                ) { [weak self] _ in
+                    self?.startLiveActivity(for: item)
+                }
+                children.append(liveActivityAction)
+            }
+            children.append(self.editAction(for: item))
+            children.append(self.deleteAction(for: item))
             return UIMenu(title: item.name, children: children)
         }
 
@@ -325,9 +358,113 @@ public class BookmarksViewController: UIViewController,
             self.application.viewRouter.navigate(to: vc, from: self)
         }
 
-        return OBAListViewMenuActions(previewProvider: previewProvider,
-                                      performPreviewAction: commitPreviewAction,
-                                      contextMenuProvider: menu)
+        return OBAListViewMenuActions(
+            previewProvider: previewProvider,
+            performPreviewAction: commitPreviewAction,
+            contextMenuProvider: menu
+        )
+    }
+
+    // MARK: - Live Activity Management
+
+    func startLiveActivity(for viewModel: BookmarkArrivalViewModel) {
+        // Use structured properties directly from the Bookmark model instead of parsing
+        // the display name, which would break on hyphenated route names like "A-Line".
+        let routeShortName = viewModel.bookmark.routeShortName ?? viewModel.name
+        let routeHeadsign = viewModel.bookmark.tripHeadsign ?? ""
+
+        let staticData = TripAttributes.StaticData(
+            routeShortName: routeShortName,
+            routeHeadsign: routeHeadsign,
+            stopID: viewModel.stopID
+        )
+
+        guard let contentState = buildContentState(for: viewModel) else {
+            Logger.error("Failed to build content state for Live Activity")
+            return
+        }
+
+        let attributes = TripAttributes(staticData: staticData)
+        do {
+            // Note: pushType is set to .token in preparation for future backend support.
+            // There is currently no server-side infrastructure to receive push tokens
+            // or send APNs updates to Live Activities. When a backend is implemented,
+            // add a Task to iterate over activity.pushTokenUpdates and send tokens
+            // to the server. That Task must be stored and cancelled in deinit.
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: contentState, staleDate: nil),
+                pushType: .token
+            )
+            Logger.info("Started Live Activity with ID: \(activity.id)")
+            showLiveActivityStartedAlert()
+        } catch {
+            Logger.error("Failed to start Live Activity: \(error)")
+            showLiveActivityErrorAlert()
+        }
+    }
+
+    func updateRunningLiveActivities() {
+        let activities = Activity<TripAttributes>.activities
+        for activity in activities {
+            let staticData = activity.attributes.staticData
+            if let bookmark = application.userDataStore.bookmarks.first(where: { bookmark in
+                return bookmark.stopID == staticData.stopID &&
+                       bookmark.routeShortName == staticData.routeShortName &&
+                       bookmark.tripHeadsign == staticData.routeHeadsign
+            }),
+                let viewModel = buildListItem(bookmark),
+                let contentState = buildContentState(for: viewModel) {
+                Task {
+                    await activity.update(
+                        .init(state: contentState, staleDate: nil)
+                    )
+                    Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Live Activity Helper Methods
+
+    private func buildContentState(for viewModel: BookmarkArrivalViewModel) -> TripAttributes.ContentState? {
+        guard let arrivalDepartures = viewModel.arrivalDepartures,
+              !arrivalDepartures.isEmpty else {
+            return nil
+        }
+        let formatters = application.formatters
+        let firstArrival = arrivalDepartures[0]
+        let statusText = TripBookmarkRow.buildStatusText(from: firstArrival, formatters: formatters)
+        let statusColor = formatters.colorForScheduleStatus(firstArrival.scheduleStatus)
+        let minutes = arrivalDepartures.prefix(3).map { arrivalDeparture -> TripAttributes.MinuteInfo in
+            let minuteText = formatters.shortFormattedTime(until: arrivalDeparture)
+            let color = formatters.colorForScheduleStatus(arrivalDeparture.scheduleStatus)
+            return TripAttributes.MinuteInfo(text: minuteText, color: color)
+        }
+        let shouldHighlight = !viewModel.arrivalDeparturesPair.isEmpty &&
+                            viewModel.arrivalDeparturesPair[0].shouldHighlightOnDisplay
+        return TripAttributes.ContentState(
+            statusText: statusText,
+            statusColor: statusColor,
+            minutes: Array(minutes),
+            shouldHighlight: shouldHighlight
+        )
+    }
+
+    private func showLiveActivityStartedAlert() {
+        let title = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Alert title when a Live Activity starts")
+        let message = OBALoc("live_activity.started.message", value: "You'll see live arrival updates on your Lock Screen and Dynamic Island.", comment: "Alert message explaining where to find the Live Activity")
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
+    }
+
+    private func showLiveActivityErrorAlert() {
+        let title = OBALoc("live_activity.error.title", value: "Unable to Start Tracking", comment: "Alert title when Live Activity fails to start")
+        let message = OBALoc("live_activity.error.message", value: "Please check your Live Activities settings in System Preferences.", comment: "Alert message for Live Activity error")
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Arrival departure highlight updates
@@ -406,7 +543,9 @@ private extension BookmarksViewController {
         // times update as soon as that bookmark's data lands.
         viewModel.didUpdate
             .sink { [weak self] _ in
-                self?.listView.applyData(animated: false)
+                guard let self else { return }
+                listView.applyData(animated: false)
+                updateRunningLiveActivities()
             }
             .store(in: &cancellables)
     }

--- a/OBAKit/Bookmarks/TripBookmarkCell.swift
+++ b/OBAKit/Bookmarks/TripBookmarkCell.swift
@@ -8,245 +8,102 @@
 //
 
 import UIKit
+import SwiftUI
 import OBAKitCore
 
-/// This view displays the information of a `Bookmark`. If the bookmark is a trip, then it will display route,
-/// headsign, and predicted arrival/departure times.
-///
-/// # Trip Layout
-/// This view will adapt to accessibility settings.
-///
-/// ## Standard Content Size
-/// ```
-/// +----------------------------stackView--------------------------------+
-/// |                +-------infoStack-------+  +------minutesStack-----+ |
-/// |                | routeHeadsignLabel    |  |   primaryMinutesLabel | |
-/// |  pinImageView  |                       |  | secondaryMinutesLabel | |
-/// |                | fullExplanationlabel  |  |  tertiaryMinutesLabel | |
-/// |                +-----------------------+  +-----------------------+ |
-/// +---------------------------------------------------------------------+
-/// ```
-///
-/// ## Accessibility Content Size
-/// ```
-/// +--------------------------------stackView----------------------------------+
-/// | pinImageView                                                              |
-/// | +------------------------------infoStack--------------------------------+ |
-/// | | routeHeadsignLabel                                                    | |
-/// | | accessibilityTimeLabel                                                | |
-/// | | accessibilityScheduleDeviationLabel                                   | |
-/// | +-----------------------------------------------------------------------+ |
-/// | +----------------------------minutesStack-------------------------------+ |
-/// | | primaryMinutesLabel    secondaryMinutesLabel     tertiaryMinutesLabel | |
-/// | +-----------------------------------------------------------------------+ |
-/// +---------------------------------------------------------------------------+
-/// ```
-///
-/// ## Standard → Accessibility:
-/// - Display accessibility labels
-/// - stackView becomes vertical stack; minutesStack becomes horizontal stack.
+/// A UIKit table cell that displays bookmark arrival/departure information using SwiftUI.
+/// Uses shared `TripBookmarkRow` view to ensure consistency with Live Activities.
 final class TripBookmarkTableCell: OBAListViewCell {
 
-    // MARK: - Info Label Stack
-    public let routeHeadsignLabel = buildLabel(textStyle: .headline)
-
-    /// Second line in the view; contains the arrival/departure time and status relative to schedule.
-    ///
-    /// For example, this might contain the text `11:20 AM - arriving on time`.
-    private let fullExplanationLabel = buildLabel(textStyle: .body)
-
-    /// Accessibility feature for one-column compact view. For example, `11:20 AM`
-    private let accessibilityTimeLabel = buildLabel(textStyle: .subheadline)
-
-    /// Accessibility feature for one-column compact view. For example, `arriving on time`.
-    private let accessibilityScheduleDeviationLabel = buildLabel(textStyle: .caption1)
-
-    /// Views to set visible when not in accessibility.
-    private var standardInfoStack: [UIView] {
-        [fullExplanationLabel]
-    }
-
-    /// Views to set visible when user is in accessibility.
-    private var accessibilityInfoStack: [UIView] {
-        [accessibilityTimeLabel,
-         accessibilityScheduleDeviationLabel]
-    }
-
-    /// Views containing info elements. To simplify logic, we will include all info views into the stack view.
-    private lazy var infoStackView = UIStackView.stack(axis: .vertical, alignment: .leading, arrangedSubviews: [
-        routeHeadsignLabel,
-        fullExplanationLabel,
-        accessibilityTimeLabel,
-        accessibilityScheduleDeviationLabel
-    ])
-
-    // MARK: - Minutes to Departure Labels
-    private lazy var primaryMinutesLabel: DepartureTimeBadge = {
-        let label = DepartureTimeBadge.autolayoutNew()
-        label.minimumScaleFactor = 3/4
-        label.adjustsFontForContentSizeCategory = true
-        return label
-    }()
-
-    private let secondaryMinutesLabel = TripBookmarkTableCell.buildMinutesLabel
-    private let tertiaryMinutesLabel = TripBookmarkTableCell.buildMinutesLabel
-
-    // MARK: Should highlight updates on display
-    private var primaryLabelHighlightOnDisplay = false
-    private var secondaryLabelHighlightOnDisplay = false
-    private var tertiaryLabelHighlightOnDisplay = false
-
-    static var buildMinutesLabel: HighlightChangeLabel {
-        let label = HighlightChangeLabel.autolayoutNew()
-        label.font = .preferredFont(forTextStyle: .subheadline)
-        label.adjustsFontForContentSizeCategory = true
-        return label
-    }
-
-    lazy var minutesStackView = UIStackView(arrangedSubviews: [
-        primaryMinutesLabel,
-        secondaryMinutesLabel,
-        tertiaryMinutesLabel])
-
-    // MARK: - Outer Stack
-
-    lazy var stackView = UIStackView.stack(alignment: .leading, arrangedSubviews: [
-        infoStackView,
-        minutesStackView
-    ])
-
-    // MARK: - UI Builders
-
-    private static func buildLabel(textStyle: UIFont.TextStyle) -> UILabel {
-        let label = UILabel.obaLabel(font: .preferredFont(forTextStyle: textStyle))
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
-        label.setCompressionResistance(horizontal: .defaultHigh, vertical: .required)
-        label.setHugging(horizontal: .defaultLow, vertical: .defaultLow)
-
-        return label
-    }
-
-    // MARK: - Init
+    // MARK: - Initialization
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        contentView.backgroundColor = ThemeColors.shared.systemBackground
-
-        contentView.addSubview(stackView)
-        stackView.pinToSuperview(.readableContent)
-
-        NSLayoutConstraint.activate([
-            primaryMinutesLabel.widthAnchor.constraint(greaterThanOrEqualTo: self.widthAnchor, multiplier: 1/8)
-        ])
-
         isAccessibilityElement = true
         accessibilityTraits = [.button, .updatesFrequently]
-
-        let sizeTraits: [UITrait] = [UITraitVerticalSizeClass.self, UITraitHorizontalSizeClass.self]
-        registerForTraitChanges(sizeTraits) { (self: Self, _) in
-            self.layoutView()
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Data
-
     override func apply(_ config: OBAContentConfiguration) {
         guard let config = config as? BookmarkArrivalContentConfiguration else { return }
-        routeHeadsignLabel.text = config.viewModel.name
+
+        let routeShortName = config.viewModel.bookmark.routeShortName ?? config.viewModel.name
+        let routeHeadsign = config.viewModel.bookmark.tripHeadsign ?? ""
+
+        accessibilityLabel = config.viewModel.name
 
         guard let arrivalDepartures = config.viewModel.arrivalDepartures,
+              !arrivalDepartures.isEmpty,
               let formatters = config.formatters else {
-                  accessibilityLabel = config.viewModel.name
-                  return
-              }
-
-        if let arrivalDeparture = arrivalDepartures.first {
-            fullExplanationLabel.attributedText = formatters.fullAttributedExplanation(from: arrivalDeparture)
-            accessibilityTimeLabel.text = formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate)
-
-            if arrivalDeparture.scheduleStatus == .unknown {
-                accessibilityScheduleDeviationLabel.text = Strings.scheduledNotRealTime
-            }
-            else {
-                accessibilityScheduleDeviationLabel.text = formatters.formattedScheduleDeviation(for: arrivalDeparture)
-            }
-
-            accessibilityScheduleDeviationLabel.textColor = formatters.colorForScheduleStatus(arrivalDeparture.scheduleStatus)
+            applySwiftUIView(TripBookmarkRow(
+                routeShortName: routeShortName,
+                routeHeadsign: routeHeadsign,
+                statusText: OBALoc("loading", value: "Loading...", comment: "Loading state text"),
+                statusColor: Color(ThemeColors.shared.secondaryLabel),
+                minutes: [],
+                isLiveActivity: false
+            ))
+            return
         }
 
-        layoutView()
+        let firstArrival = arrivalDepartures[0]
+        let statusText = TripBookmarkRow.buildStatusText(from: firstArrival, formatters: formatters)
+        let statusUIColor = formatters.colorForScheduleStatus(firstArrival.scheduleStatus)
+        let minutes = buildMinuteDisplays(
+            arrivalDepartures: arrivalDepartures,
+            formatters: formatters,
+            highlightFlags: config.viewModel.arrivalDeparturesPair.map { $0.shouldHighlightOnDisplay }
+        )
 
-        // Update data
-        func update(view: ArrivalDepartureDrivenUI, shouldHighlightOnDisplay: inout Bool, withDataAtIndex index: Int) {
-            if arrivalDepartures.count > index {
-                view.configure(with: arrivalDepartures[index], formatters: formatters)
-                shouldHighlightOnDisplay = config.viewModel.arrivalDeparturesPair[index].shouldHighlightOnDisplay
-                view.isHidden = false
-            } else {
-                view.isHidden = true
-            }
-        }
+        let swiftUIView = TripBookmarkRow(
+            routeShortName: routeShortName,
+            routeHeadsign: routeHeadsign,
+            statusText: statusText,
+            statusColor: Color(statusUIColor),
+            minutes: minutes,
+            isLiveActivity: false
+        )
 
-        update(view: primaryMinutesLabel, shouldHighlightOnDisplay: &primaryLabelHighlightOnDisplay, withDataAtIndex: 0)
-        update(view: secondaryMinutesLabel, shouldHighlightOnDisplay: &secondaryLabelHighlightOnDisplay, withDataAtIndex: 1)
-        update(view: tertiaryMinutesLabel, shouldHighlightOnDisplay: &tertiaryLabelHighlightOnDisplay, withDataAtIndex: 2)
+        applySwiftUIView(swiftUIView)
 
         accessibilityLabel = formatters.accessibilityLabel(for: config.viewModel)
         accessibilityValue = formatters.accessibilityValue(for: config.viewModel)
     }
 
-    override func willDisplayCell(in listView: OBAListView) {
-        // Highlight arrival departure changes, if needed.
-        if primaryLabelHighlightOnDisplay {
-            primaryMinutesLabel.highlightBackground()
-            primaryLabelHighlightOnDisplay = false
+    /// Applies a `TripBookmarkRow` SwiftUI view as the cell's content configuration.
+    private func applySwiftUIView(_ view: TripBookmarkRow) {
+        contentConfiguration = UIHostingConfiguration {
+            view
         }
-
-        if secondaryLabelHighlightOnDisplay {
-            secondaryMinutesLabel.highlightBackground()
-            secondaryLabelHighlightOnDisplay = false
-        }
-
-        if tertiaryLabelHighlightOnDisplay {
-            tertiaryMinutesLabel.highlightBackground()
-            tertiaryLabelHighlightOnDisplay = false
-        }
+        .margins(.all, 0)
     }
 
-    func layoutView() {
-        // Do accessibility
-        standardInfoStack.forEach { $0.isHidden = isAccessibility }
-        accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
-
-        stackView.axis = isAccessibility ? .vertical : .horizontal
-        minutesStackView.axis = isAccessibility ? .horizontal : .vertical
-
-        stackView.spacing = isAccessibility ? ThemeMetrics.accessibilityPadding : ThemeMetrics.compactPadding
-        minutesStackView.spacing = isAccessibility ? ThemeMetrics.accessibilityPadding : ThemeMetrics.compactPadding
-
-        minutesStackView.alignment = isAccessibility ? .center : .trailing
-        minutesStackView.distribution = isAccessibility ? .fillProportionally : .fill
+    private func buildMinuteDisplays(
+        arrivalDepartures: [ArrivalDeparture],
+        formatters: Formatters,
+        highlightFlags: [Bool]
+    ) -> [TripBookmarkRow.MinuteDisplay] {
+        let displayCount = min(3, arrivalDepartures.count)
+        return (0..<displayCount).map { index in
+            let arrivalDeparture = arrivalDepartures[index]
+            let minuteText = formatters.shortFormattedTime(until: arrivalDeparture)
+            let uiColor = formatters.backgroundColorForScheduleStatus(arrivalDeparture.scheduleStatus)
+            let shouldHighlight = index < highlightFlags.count ? highlightFlags[index] : false
+            return TripBookmarkRow.MinuteDisplay(
+                text: minuteText,
+                color: Color(uiColor),
+                isPrimary: index == 0,
+                shouldHighlight: shouldHighlight
+            )
+        }
     }
-
-    // MARK: - UICollectionViewCell Overrides
 
     override func prepareForReuse() {
         super.prepareForReuse()
-
-        routeHeadsignLabel.text = nil
-        fullExplanationLabel.text = nil
-        accessibilityTimeLabel.text = nil
-        accessibilityScheduleDeviationLabel.text = nil
-
-        primaryMinutesLabel.prepareForReuse()
-        secondaryMinutesLabel.text = nil
-        tertiaryMinutesLabel.text = nil
-
+        contentConfiguration = nil
         accessibilityLabel = nil
         accessibilityValue = nil
     }

--- a/OBAKit/LiveActivities/UIViewController+LiveActivityAlerts.swift
+++ b/OBAKit/LiveActivities/UIViewController+LiveActivityAlerts.swift
@@ -1,0 +1,35 @@
+//
+//  UIViewController+LiveActivityAlerts.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+/// The user-facing outcome of starting a Live Activity. Shared by every screen that can start
+/// one — currently the bookmarks list and the stop page — so the copy stays identical between
+/// them rather than drifting apart in two private copies.
+extension UIViewController {
+
+    func showLiveActivityStartedAlert() {
+        let title = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Alert title when a Live Activity starts")
+        let message = OBALoc("live_activity.started.message", value: "You'll see live arrival updates on your Lock Screen and Dynamic Island.", comment: "Alert message explaining where to find the Live Activity")
+        showLiveActivityAlert(title: title, message: message)
+    }
+
+    func showLiveActivityErrorAlert() {
+        let title = OBALoc("live_activity.error.title", value: "Unable to Start Tracking", comment: "Alert title when Live Activity fails to start")
+        let message = OBALoc("live_activity.error.message", value: "Please check your Live Activities settings in System Preferences.", comment: "Alert message for Live Activity error")
+        showLiveActivityAlert(title: title, message: message)
+    }
+
+    private func showLiveActivityAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
+    }
+}

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -412,6 +412,13 @@ public class Application: CoreApplication, PushServiceDelegate {
 
         configureConnectivity()
 
+        // Clean up Live Activity subscriptions whose activities are gone. This has to run on an
+        // app-lifecycle hook rather than in a view controller: an activity the user dismissed
+        // while the app wasn't running has no observer to notice it, and the server will keep
+        // pushing to it until the subscription is deleted. (The scene delegate calls this on
+        // launch as well as on every foreground.)
+        Task { await liveActivityRegistry.reconcile() }
+
         #if DEBUG
         // Lets UI tests exercise the modal alert bulletin deterministically,
         // without depending on a high-severity alert being live in the region.

--- a/OBAKit/PushNotifications/AlarmBuilder.swift
+++ b/OBAKit/PushNotifications/AlarmBuilder.swift
@@ -48,6 +48,9 @@ class AlarmBuilder: NSObject {
 
     private let timePickerPage: AlarmTimePickerItem
 
+    /// Whether the "Track on Lock Screen" toggle was on when the user tapped Add Alarm.
+    var trackOnLockScreen: Bool { timePickerPage.trackOnLockScreen }
+
     // MARK: - Init
 
     /// - Parameter initialMinutes: Pre-selects this lead time in the picker.
@@ -60,7 +63,8 @@ class AlarmBuilder: NSObject {
         self.delegate = delegate
         self.timePickerPage = AlarmTimePickerItem(
             arrivalDeparture: arrivalDeparture,
-            initialMinutes: initialMinutes ?? application.userDataStore.defaultAlarmLeadTimeMinutes
+            initialMinutes: initialMinutes ?? application.userDataStore.defaultAlarmLeadTimeMinutes,
+            userDefaults: application.userDefaults
         )
 
         super.init()
@@ -143,13 +147,23 @@ class AlarmBuilder: NSObject {
 class AlarmTimePickerItem: ThemedBulletinPage {
     private let arrivalDeparture: ArrivalDeparture
     let timePickerManager: AlarmTimePickerManager
+    private let userDefaults: UserDefaults
+    private weak var trackSwitch: UISwitch?
 
-    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int) {
+    private static let trackOnLockScreenKey = "AlarmTimePickerItem.trackOnLockScreen"
+
+    /// The current value of the "Track on Lock Screen" toggle.
+    var trackOnLockScreen: Bool { userDefaults.bool(forKey: Self.trackOnLockScreenKey) }
+
+    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int, userDefaults: UserDefaults) {
         self.arrivalDeparture = arrivalDeparture
+        self.userDefaults = userDefaults
         self.timePickerManager = AlarmTimePickerManager(arrivalDeparture: arrivalDeparture, initialMinutes: initialMinutes)
 
         let title = OBALoc("alarm_time_picker.title", value: "Add Reminder", comment: "Title of the Alarm Time Picker page.")
         super.init(title: title)
+
+        userDefaults.register(defaults: [Self.trackOnLockScreenKey: true])
 
         descriptionText = OBALoc("alarm_time_picker.description", value: "Remind me when this vehicle will depart in:", comment: "Explains what the Alarm Time Picker page does.")
         isDismissable = true
@@ -158,7 +172,48 @@ class AlarmTimePickerItem: ThemedBulletinPage {
 
     override func makeViewsUnderDescription(with interfaceBuilder: BLTNInterfaceBuilder) -> [UIView]? {
         timePickerManager.prepareForDisplay()
-        return [timePickerManager.pickerView]
+        return [timePickerManager.pickerView, makeTrackOnLockScreenRow()]
+    }
+
+    private func makeTrackOnLockScreenRow() -> UIView {
+        let label = UILabel()
+        label.text = OBALoc(
+            "alarm_time_picker.track_on_lock_screen",
+            value: "Track on Lock Screen",
+            comment: "Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set."
+        )
+        label.font = .preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+
+        let toggle = UISwitch()
+        toggle.isOn = trackOnLockScreen
+        toggle.addTarget(self, action: #selector(trackSwitchChanged(_:)), for: .valueChanged)
+        trackSwitch = toggle
+
+        toggle.setContentHuggingPriority(.required, for: .horizontal)
+        toggle.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [label, toggle])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 16
+
+        let container = UIView()
+        container.addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            row.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            row.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8)
+        ])
+
+        return container
+    }
+
+    @objc private func trackSwitchChanged(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: Self.trackOnLockScreenKey)
     }
 }
 

--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -73,14 +73,17 @@ struct ChronologicalListView: View {
     private func rows(_ departures: [ArrivalDeparture], style: DepartureRowView.Style) -> some View {
         // Identity: ArrivalDeparture.id (stable across prediction refreshes).
         ForEach(departures, id: \.id) { departure in
+            let actions = actionsProvider(departure)
             DepartureRowView(
                 departure: departure,
                 status: statusProvider(departure),
                 hasAlarm: alarmLookup(departure) != nil,
+                canAlarm: actions.canAlarm,
+                onAlarmToggle: actions.onAlarmToggle,
                 style: style,
                 onTap: { onToggleExpand(departure) }
             )
-            .departureRowActions(actionsProvider(departure))
+            .departureRowActions(actions)
 
             // Accordion: the panel is an INSERTED SIBLING ROW, keyed off the
             // expanded id — List animates insert/remove smoothly.

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -28,13 +28,18 @@ struct DepartureRowView: View {
     let departure: ArrivalDeparture
     let status: DepartureStatus
     let hasAlarm: Bool
+    let canAlarm: Bool
+    let onAlarmToggle: () -> Void
     var style: Style = .normal
     let onTap: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.obaFormatters) private var formatters
+    @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
 
     private var dimmed: Bool { style == .past }
+
+    private var showsAlarmAffordance: Bool { canAlarm || hasAlarm }
 
     private var scheduledTimeText: String {
         formatters.timeFormatter.string(from: departure.scheduledDate)
@@ -50,6 +55,7 @@ struct DepartureRowView: View {
                 HStack(alignment: .center) {
                     routeBadge
                     Spacer(minLength: 8)
+                    alarmCircleButton
                     countdown
                 }
                 headsignText
@@ -57,10 +63,7 @@ struct DepartureRowView: View {
                     .font(.footnote)
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
-                HStack(spacing: 6) {
-                    statusText
-                    alarmBell
-                }
+                statusText
                 occupancyBadge
             } else {
                 HStack(alignment: .center, spacing: 13) {
@@ -74,12 +77,14 @@ struct DepartureRowView: View {
                                 .foregroundStyle(.secondary)
                             Text("·").foregroundStyle(.tertiary)
                             statusText
-                            alarmBell
                         }
                         occupancyBadge
                     }
                     Spacer(minLength: 8)
-                    countdown
+                    VStack(alignment: .center, spacing: 4) {
+                        countdown
+                        alarmCircleButton
+                    }
                 }
             }
         }
@@ -89,6 +94,13 @@ struct DepartureRowView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityText)
         .accessibilityAddTraits(.isButton)
+        .accessibilityActions {
+            if showsAlarmAffordance {
+                Button(hasAlarm ? removeAlarmTitle : Strings.addAlarm) {
+                    onAlarmToggle()
+                }
+            }
+        }
     }
 
     // MARK: - Shared pieces (both layouts)
@@ -116,11 +128,20 @@ struct DepartureRowView: View {
     }
 
     @ViewBuilder
-    private var alarmBell: some View {
-        if hasAlarm {
-            Image(systemName: "bell.fill")
-                .font(.caption)
-                .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+    private var alarmCircleButton: some View {
+        if showsAlarmAffordance {
+            Image(systemName: hasAlarm ? "bell.fill" : "bell")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(hasAlarm ? Color.white : Color.secondary)
+                .frame(width: alarmCircleSize, height: alarmCircleSize)
+                .background(hasAlarm ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: hasAlarm ? 0 : 1.5))
+                // Use onTapGesture, not Button: inner gestures beat the outer
+                // .onTapGesture(perform: onTap) on the row VStack, so tapping the
+                // bell fires only the alarm action and never also expands the row.
+                // A Button here creates two competing UIGestureRecognizers that enter
+                // an infinite resolution loop, pegging the CPU at 100%.
+                .onTapGesture { onAlarmToggle() }
         }
     }
 

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import ActivityKit
 import OBAKitCore
 
 /// Everything that navigates away from — or presents a modal over — the Stop
@@ -37,6 +38,8 @@ struct StopPageNavigationHandler {
     /// panel's Set-an-alarm button), reusing `AlarmBuilder` from the legacy
     /// stop screen.
     let showAlarmPicker: (ArrivalDeparture) -> Void
+    /// Starts a Live Activity for a departure (the trip panel's Track button).
+    let startLiveActivity: (ArrivalDeparture) -> Void
     /// Shows the "couldn't open survey" alert when an external survey link fails.
     let showExternalSurveyError: () -> Void
     /// Presents the donation learn-more/donate modal.
@@ -373,24 +376,21 @@ struct StopPageView: View {
     /// live-only VM fetch; the alarm closures route through the single alarm index.
     private func makePanel(for departure: ArrivalDeparture) -> TripDetailPanelView {
         let status = DepartureStatus(arrivalDeparture: departure)
-        let alarm = viewModel.alarm(for: departure)
         return TripDetailPanelView(
             departure: departure,
             status: status,
-            alarm: alarm,
-            alarmLeadTimeMinutes: alarm.map { viewModel.alarmLeadTimeMinutes($0) } ?? viewModel.defaultAlarmLeadTime,
-            canAlarm: viewModel.canCreateAlarm(for: departure),
+            alarm: nil,
+            alarmLeadTimeMinutes: 0,
+            canAlarm: ActivityAuthorizationInfo().areActivitiesEnabled,
             // Bumps on every successful refresh so the panel re-fetches its
             // approach timeline while it stays open (scheduled→live flips and
             // failed first fetches retry on the next refresh).
             refreshToken: viewModel.lastUpdated,
             cachedTripDetails: viewModel.cachedApproachTripDetails(for: departure),
             approachLoader: { await viewModel.approachTripDetails(for: departure) },
-            onSetAlarm: { navigation.showAlarmPicker(departure) },
-            onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
-            // Change re-presents the same alarm picker bulletin as create; the
-            // controller's alarmCreated callback replaces the existing alarm.
-            onChangeAlarm: { navigation.showAlarmPicker(departure) },
+            onSetAlarm: { navigation.startLiveActivity(departure) },
+            onCancelAlarm: {},
+            onChangeAlarm: {},
             canSchedule: navigation.canScheduleForRoute,
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -404,7 +404,11 @@ struct StopPageView: View {
             canSchedule: navigation.canScheduleForRoute,
             hasAlarm: viewModel.alarm(for: departure) != nil,
             onAlarmToggle: {
-                Task { await viewModel.toggleAlarm(for: departure) }
+                if viewModel.alarm(for: departure) != nil {
+                    Task { await viewModel.cancelAlarm(for: departure) }
+                } else {
+                    navigation.showAlarmPicker(departure)
+                }
             },
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -44,19 +44,6 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     /// `StopViewController.bindArrivalsSink()`; later refreshes are silent.
     private var firstLoad = true
 
-    // MARK: - Live Activity storage
-
-    /// One token-forwarding Task per activity id; cancelled in deinit.
-    private var liveActivityTokenTasks: [String: Task<Void, Never>] = [:]
-    /// One lifecycle-observation Task per activity id; cancelled in deinit.
-    private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
-
-    /// Persistence of delete URLs, registration, and unregistration all live in the registry;
-    /// this controller only owns the observers that feed it.
-    private var liveActivityRegistry: LiveActivityRegistry {
-        application.liveActivityRegistry
-    }
-
     #if !targetEnvironment(simulator)
     /// `application.canOpenURL` is an XPC round-trip and Google Maps can't be
     /// installed or removed within a screen's lifetime, so resolve availability
@@ -119,11 +106,6 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     @available(*, unavailable)
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        liveActivityTokenTasks.values.forEach { $0.cancel() }
-        liveActivityLifecycleTasks.values.forEach { $0.cancel() }
     }
 
     override func viewDidLoad() {
@@ -432,7 +414,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
                 content: .init(state: contentState, staleDate: nil),
                 pushType: .token
             )
-            registerForLiveActivityPushUpdates(activity: activity, departure: departure)
+            application.liveActivityTracker.track(activity: activity, metadata: .init(departure))
             Logger.info("Started Live Activity with ID: \(activity.id)")
             showLiveActivityStartedAlert()
         } catch {
@@ -454,101 +436,6 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             )
         }
         return TripAttributes.ContentState(arrivals: arrivals)
-    }
-
-    private func showLiveActivityStartedAlert() {
-        let title = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Alert title when a Live Activity starts")
-        let message = OBALoc("live_activity.started.message", value: "You'll see live arrival updates on your Lock Screen and Dynamic Island.", comment: "Alert message explaining where to find the Live Activity")
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
-        present(alert, animated: true)
-    }
-
-    private func showLiveActivityErrorAlert() {
-        let title = OBALoc("live_activity.error.title", value: "Unable to Start Tracking", comment: "Alert title when Live Activity fails to start")
-        let message = OBALoc("live_activity.error.message", value: "Please check your Live Activities settings in System Preferences.", comment: "Alert message for Live Activity error")
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
-        present(alert, animated: true)
-    }
-
-    private func registerForLiveActivityPushUpdates(activity: Activity<TripAttributes>, departure: ArrivalDeparture) {
-        let activityID = activity.id
-
-        liveActivityTokenTasks[activityID]?.cancel()
-        liveActivityTokenTasks[activityID] = Task { [weak self] in
-            for await tokenData in activity.pushTokenUpdates {
-                let token = tokenData.map { String(format: "%02x", $0) }.joined()
-                await self?.postLiveActivityRegistration(
-                    activity: activity,
-                    pushToken: token,
-                    tripID: departure.tripID,
-                    serviceDate: departure.serviceDate,
-                    vehicleID: departure.vehicleID,
-                    stopSequence: departure.stopSequence
-                )
-            }
-        }
-
-        armLiveActivityLifecycleObserver(activity: activity)
-    }
-
-    private func armLiveActivityLifecycleObserver(activity: Activity<TripAttributes>) {
-        let activityID = activity.id
-        liveActivityLifecycleTasks[activityID]?.cancel()
-        liveActivityLifecycleTasks[activityID] = Task { [weak self] in
-            for await state in activity.activityStateUpdates where state == .dismissed || state == .ended {
-                await self?.unregisterLiveActivity(activityID: activityID)
-                break
-            }
-        }
-    }
-
-    private func postLiveActivityRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
-        await liveActivityRegistry.register(
-            activityID: activity.id,
-            staticData: activity.attributes.staticData,
-            pushToken: pushToken,
-            tripID: tripID,
-            serviceDate: serviceDate,
-            vehicleID: vehicleID,
-            stopSequence: stopSequence,
-            confirm: { [weak self] in
-                // Guard against the lifecycle task having been cancelled before this async POST
-                // completed, to avoid orphaning the server-side record. Returning false makes the
-                // registry delete the row it just created instead of persisting its delete URL.
-                guard let self else { return false }
-                return self.liveActivityLifecycleTasks[activity.id] != nil && !Task.isCancelled
-            }
-        )
-    }
-
-    /// Tears down the observers for `activityID` and deletes its server-side push subscription.
-    ///
-    /// The ordering below is load-bearing, and the tempting tidy-up — cancelling both tasks
-    /// together, up front — is a bug. This method's usual caller is the lifecycle task itself
-    /// (`armLiveActivityLifecycleObserver`), so cancelling that task here cancels *the task we
-    /// are currently running inside*. `URLSession` honors task cancellation, so the DELETE that
-    /// follows would fail instantly with `URLError.cancelled` (-999) without a byte leaving the
-    /// device — silently, since unregistration has no UI. That shipped: every dismissal leaked
-    /// its subscription and the server kept pushing to a Live Activity the user had cleared.
-    ///
-    /// So: drop the lifecycle task from the dictionary (which is what `confirm` in
-    /// `postLiveActivityRegistration` reads, and what stops a second unregister), but cancel it
-    /// only *after* the network call. When we're running inside it, it's about to `break` out of
-    /// its loop anyway; when called from anywhere else, it still gets torn down properly.
-    ///
-    /// The token task is a different task and is safe to cancel up front.
-    ///
-    /// `LiveActivityRegistry` independently refuses to let its DELETEs inherit cancellation, so
-    /// this is belt-and-braces — but the belt is here, where the reasoning is visible.
-    private func unregisterLiveActivity(activityID: String) async {
-        liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
-        let lifecycleTask = liveActivityLifecycleTasks.removeValue(forKey: activityID)
-
-        await liveActivityRegistry.unregister(activityID: activityID)
-
-        lifecycleTask?.cancel()
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -502,7 +502,8 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
 
     private func postLiveActivityRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
         await liveActivityRegistry.register(
-            activity: activity,
+            activityID: activity.id,
+            staticData: activity.attributes.staticData,
             pushToken: pushToken,
             tripID: tripID,
             serviceDate: serviceDate,
@@ -518,10 +519,32 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         )
     }
 
+    /// Tears down the observers for `activityID` and deletes its server-side push subscription.
+    ///
+    /// The ordering below is load-bearing, and the tempting tidy-up — cancelling both tasks
+    /// together, up front — is a bug. This method's usual caller is the lifecycle task itself
+    /// (`armLiveActivityLifecycleObserver`), so cancelling that task here cancels *the task we
+    /// are currently running inside*. `URLSession` honors task cancellation, so the DELETE that
+    /// follows would fail instantly with `URLError.cancelled` (-999) without a byte leaving the
+    /// device — silently, since unregistration has no UI. That shipped: every dismissal leaked
+    /// its subscription and the server kept pushing to a Live Activity the user had cleared.
+    ///
+    /// So: drop the lifecycle task from the dictionary (which is what `confirm` in
+    /// `postLiveActivityRegistration` reads, and what stops a second unregister), but cancel it
+    /// only *after* the network call. When we're running inside it, it's about to `break` out of
+    /// its loop anyway; when called from anywhere else, it still gets torn down properly.
+    ///
+    /// The token task is a different task and is safe to cancel up front.
+    ///
+    /// `LiveActivityRegistry` independently refuses to let its DELETEs inherit cancellation, so
+    /// this is belt-and-braces — but the belt is here, where the reasoning is visible.
     private func unregisterLiveActivity(activityID: String) async {
         liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
-        liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
+        let lifecycleTask = liveActivityLifecycleTasks.removeValue(forKey: activityID)
+
         await liveActivityRegistry.unregister(activityID: activityID)
+
+        lifecycleTask?.cancel()
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import ActivityKit
 import OBAKitCore
 
 /// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
@@ -42,6 +43,15 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     /// Gates the one-shot success haptic to the first arrivals load, matching
     /// `StopViewController.bindArrivalsSink()`; later refreshes are silent.
     private var firstLoad = true
+
+    // MARK: - Live Activity storage
+
+    /// One token-forwarding Task per activity id; cancelled in deinit.
+    private var liveActivityTokenTasks: [String: Task<Void, Never>] = [:]
+    /// One lifecycle-observation Task per activity id; cancelled in deinit.
+    private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
+
+    private static let liveActivityURLDefaultsKey = "liveActivityDeleteURLs"
 
     #if !targetEnvironment(simulator)
     /// `application.canOpenURL` is an XPC round-trip and Google Maps can't be
@@ -107,6 +117,11 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        liveActivityTokenTasks.values.forEach { $0.cancel() }
+        liveActivityLifecycleTasks.values.forEach { $0.cancel() }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.largeTitleDisplayMode = .never
@@ -155,6 +170,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showAlertDetail: { _ in },
         showBookmarkEditor: { _ in },
         showAlarmPicker: { _ in },
+        startLiveActivity: { _ in },
         showExternalSurveyError: {},
         showDonation: {},
         dismissDonation: { _ in },
@@ -177,6 +193,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             },
             showBookmarkEditor: { [weak self] departure in self?.showBookmarkEditor(for: departure) },
             showAlarmPicker: { [weak self] departure in self?.showAlarmPicker(for: departure) },
+            startLiveActivity: { [weak self] departure in self?.startLiveActivity(for: departure) },
             showExternalSurveyError: { [weak self] in self?.showExternalSurveyError() },
             showDonation: { [weak self] in self?.showDonationUI() },
             dismissDonation: { [weak self] onHide in self?.showDonationDismissUI(onHide: onHide) },
@@ -380,6 +397,164 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         Task { @MainActor in
             await AlertPresenter.show(error: error, presentingController: self)
         }
+    }
+
+    // MARK: - Live Activity
+
+    func startLiveActivity(for departure: ArrivalDeparture) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let routeColorHex = departure.route.color?.toHex()
+        let staticData = TripAttributes.StaticData(
+            routeShortName: departure.routeShortName,
+            routeHeadsign: departure.tripHeadsign ?? "",
+            stopID: departure.stopID,
+            routeColorHex: routeColorHex
+        )
+
+        guard let contentState = buildLiveActivityContentState(for: departure) else {
+            Logger.error("Failed to build content state for Live Activity")
+            return
+        }
+
+        let attributes = TripAttributes(staticData: staticData)
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: contentState, staleDate: nil),
+                pushType: .token
+            )
+            registerForLiveActivityPushUpdates(activity: activity, departure: departure)
+            Logger.info("Started Live Activity with ID: \(activity.id)")
+            showLiveActivityStartedAlert()
+        } catch {
+            Logger.error("Failed to start Live Activity: \(error)")
+            showLiveActivityErrorAlert()
+        }
+    }
+
+    private func buildLiveActivityContentState(for departure: ArrivalDeparture) -> TripAttributes.ContentState? {
+        let allArrivals = viewModel.stopArrivals?.arrivalsAndDepartures ?? [departure]
+        let sameRoute = allArrivals.filter { $0.routeID == departure.routeID }
+        let upcoming = sameRoute.isEmpty ? [departure] : Array(sameRoute.prefix(3))
+        let arrivals = upcoming.map { arrDep in
+            TripAttributes.ContentState.ArrivalInfo(
+                departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),
+                scheduleStatus: .init(arrDep.scheduleStatus),
+                scheduleDeviation: arrDep.deviationFromScheduleInMinutes * 60,
+                isArrival: arrDep.arrivalDepartureStatus == .arriving
+            )
+        }
+        return TripAttributes.ContentState(arrivals: arrivals)
+    }
+
+    private func showLiveActivityStartedAlert() {
+        let title = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Alert title when a Live Activity starts")
+        let message = OBALoc("live_activity.started.message", value: "You'll see live arrival updates on your Lock Screen and Dynamic Island.", comment: "Alert message explaining where to find the Live Activity")
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
+    }
+
+    private func showLiveActivityErrorAlert() {
+        let title = OBALoc("live_activity.error.title", value: "Unable to Start Tracking", comment: "Alert title when Live Activity fails to start")
+        let message = OBALoc("live_activity.error.message", value: "Please check your Live Activities settings in System Preferences.", comment: "Alert message for Live Activity error")
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
+    }
+
+    private func registerForLiveActivityPushUpdates(activity: Activity<TripAttributes>, departure: ArrivalDeparture) {
+        let activityID = activity.id
+
+        liveActivityTokenTasks[activityID]?.cancel()
+        liveActivityTokenTasks[activityID] = Task { [weak self] in
+            for await tokenData in activity.pushTokenUpdates {
+                let token = tokenData.map { String(format: "%02x", $0) }.joined()
+                await self?.postLiveActivityRegistration(
+                    activity: activity,
+                    pushToken: token,
+                    tripID: departure.tripID,
+                    serviceDate: departure.serviceDate,
+                    vehicleID: departure.vehicleID,
+                    stopSequence: departure.stopSequence
+                )
+            }
+        }
+
+        armLiveActivityLifecycleObserver(activity: activity)
+    }
+
+    private func armLiveActivityLifecycleObserver(activity: Activity<TripAttributes>) {
+        let activityID = activity.id
+        liveActivityLifecycleTasks[activityID]?.cancel()
+        liveActivityLifecycleTasks[activityID] = Task { [weak self] in
+            for await state in activity.activityStateUpdates where state == .dismissed || state == .ended {
+                await self?.unregisterLiveActivity(activityID: activityID)
+                break
+            }
+        }
+    }
+
+    private func postLiveActivityRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
+        guard let obacoService = application.obacoService else { return }
+        let staticData = activity.attributes.staticData
+        do {
+            let deleteURL = try await obacoService.postLiveActivity(
+                activityID: activity.id,
+                pushToken: pushToken,
+                stopID: staticData.stopID,
+                routeShortName: staticData.routeShortName,
+                tripHeadsign: staticData.routeHeadsign,
+                tripID: tripID,
+                serviceDate: serviceDate,
+                vehicleID: vehicleID,
+                stopSequence: stopSequence
+            )
+
+            // Guard against the lifecycle task having been cancelled before
+            // this async POST completed, to avoid orphaning the server-side record.
+            guard liveActivityLifecycleTasks[activity.id] != nil, !Task.isCancelled else {
+                do {
+                    try await obacoService.deleteLiveActivity(url: deleteURL)
+                    Logger.info("Discarded Live Activity registration for \(activity.id): activity was unregistered mid-request")
+                } catch {
+                    Logger.error("Failed to clean up orphaned Live Activity registration for \(activity.id): \(error)")
+                }
+                return
+            }
+
+            storeLiveActivityDeleteURL(deleteURL, activityID: activity.id)
+            Logger.info("Registered Live Activity push token for activity \(activity.id)")
+        } catch {
+            Logger.error("Failed to register Live Activity push token: \(error)")
+        }
+    }
+
+    private func unregisterLiveActivity(activityID: String) async {
+        liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
+        liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
+        guard let obacoService = application.obacoService,
+              let deleteURL = removeLiveActivityDeleteURL(activityID: activityID) else { return }
+        do {
+            try await obacoService.deleteLiveActivity(url: deleteURL)
+            Logger.info("Unregistered Live Activity \(activityID)")
+        } catch {
+            Logger.error("Failed to unregister Live Activity \(activityID): \(error)")
+        }
+    }
+
+    private func storeLiveActivityDeleteURL(_ url: URL, activityID: String) {
+        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
+        urls[activityID] = url.absoluteString
+        application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey)
+    }
+
+    private func removeLiveActivityDeleteURL(activityID: String) -> URL? {
+        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
+        defer { application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey) }
+        guard let raw = urls.removeValue(forKey: activityID) else { return nil }
+        return URL(string: raw)
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -51,7 +51,11 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     /// One lifecycle-observation Task per activity id; cancelled in deinit.
     private var liveActivityLifecycleTasks: [String: Task<Void, Never>] = [:]
 
-    private static let liveActivityURLDefaultsKey = "liveActivityDeleteURLs"
+    /// Persistence of delete URLs, registration, and unregistration all live in the registry;
+    /// this controller only owns the observers that feed it.
+    private var liveActivityRegistry: LiveActivityRegistry {
+        application.liveActivityRegistry
+    }
 
     #if !targetEnvironment(simulator)
     /// `application.canOpenURL` is an XPC round-trip and Google Maps can't be
@@ -497,64 +501,27 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     }
 
     private func postLiveActivityRegistration(activity: Activity<TripAttributes>, pushToken: String, tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) async {
-        guard let obacoService = application.obacoService else { return }
-        let staticData = activity.attributes.staticData
-        do {
-            let deleteURL = try await obacoService.postLiveActivity(
-                activityID: activity.id,
-                pushToken: pushToken,
-                stopID: staticData.stopID,
-                routeShortName: staticData.routeShortName,
-                tripHeadsign: staticData.routeHeadsign,
-                tripID: tripID,
-                serviceDate: serviceDate,
-                vehicleID: vehicleID,
-                stopSequence: stopSequence
-            )
-
-            // Guard against the lifecycle task having been cancelled before
-            // this async POST completed, to avoid orphaning the server-side record.
-            guard liveActivityLifecycleTasks[activity.id] != nil, !Task.isCancelled else {
-                do {
-                    try await obacoService.deleteLiveActivity(url: deleteURL)
-                    Logger.info("Discarded Live Activity registration for \(activity.id): activity was unregistered mid-request")
-                } catch {
-                    Logger.error("Failed to clean up orphaned Live Activity registration for \(activity.id): \(error)")
-                }
-                return
+        await liveActivityRegistry.register(
+            activity: activity,
+            pushToken: pushToken,
+            tripID: tripID,
+            serviceDate: serviceDate,
+            vehicleID: vehicleID,
+            stopSequence: stopSequence,
+            confirm: { [weak self] in
+                // Guard against the lifecycle task having been cancelled before this async POST
+                // completed, to avoid orphaning the server-side record. Returning false makes the
+                // registry delete the row it just created instead of persisting its delete URL.
+                guard let self else { return false }
+                return self.liveActivityLifecycleTasks[activity.id] != nil && !Task.isCancelled
             }
-
-            storeLiveActivityDeleteURL(deleteURL, activityID: activity.id)
-            Logger.info("Registered Live Activity push token for activity \(activity.id)")
-        } catch {
-            Logger.error("Failed to register Live Activity push token: \(error)")
-        }
+        )
     }
 
     private func unregisterLiveActivity(activityID: String) async {
         liveActivityTokenTasks.removeValue(forKey: activityID)?.cancel()
         liveActivityLifecycleTasks.removeValue(forKey: activityID)?.cancel()
-        guard let obacoService = application.obacoService,
-              let deleteURL = removeLiveActivityDeleteURL(activityID: activityID) else { return }
-        do {
-            try await obacoService.deleteLiveActivity(url: deleteURL)
-            Logger.info("Unregistered Live Activity \(activityID)")
-        } catch {
-            Logger.error("Failed to unregister Live Activity \(activityID): \(error)")
-        }
-    }
-
-    private func storeLiveActivityDeleteURL(_ url: URL, activityID: String) {
-        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
-        urls[activityID] = url.absoluteString
-        application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey)
-    }
-
-    private func removeLiveActivityDeleteURL(activityID: String) -> URL? {
-        var urls = application.userDefaults.dictionary(forKey: Self.liveActivityURLDefaultsKey) as? [String: String] ?? [:]
-        defer { application.userDefaults.set(urls, forKey: Self.liveActivityURLDefaultsKey) }
-        guard let raw = urls.removeValue(forKey: activityID) else { return nil }
-        return URL(string: raw)
+        await liveActivityRegistry.unregister(activityID: activityID)
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -388,6 +388,10 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             // delete when the departure had no prior alarm, so it serves both
             // the create and change flows.
             Task { await viewModel.replaceAlarm(with: alarm, for: departure) }
+
+            if alarmBuilder.trackOnLockScreen {
+                startLiveActivity(for: departure)
+            }
         } else {
             viewModel.recordAlarmCreated(alarm)
         }

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -10,11 +10,10 @@
 import SwiftUI
 import OBAKitCore
 
-/// The trip panel's alarm block: a single "Set an alarm" button by default;
-/// once set, an info row with Change and Cancel. Change re-presents the same
-/// alarm-time-picker bulletin used to create the alarm.
+/// The trip panel's Live Activity block: a single "Track" button that starts
+/// a Live Activity for this departure on the Lock Screen and Dynamic Island.
 ///
-/// Text uses Dynamic Type text styles; the fixed bell-circle dimension scales
+/// Text uses Dynamic Type text styles; the fixed circle dimension scales
 /// with Dynamic Type via `@ScaledMetric`.
 struct AlarmControlView: View {
     let alarmIsSet: Bool
@@ -23,75 +22,16 @@ struct AlarmControlView: View {
     let onCancel: () -> Void
     let onChange: () -> Void
 
-    /// The bell circle grows with Dynamic Type the way the grouped alarm badge
-    /// does: fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
-    @ScaledMetric(relativeTo: .body) private var bellCircleSize: CGFloat = 32
-
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-    private var onTimeColor: Color { Color(uiColor: ThemeColors.shared.departureOnTime) }
-
-    /// At accessibility sizes the alarm block stacks (the guide's committed
-    /// layout): Change/Cancel drop below the label instead of competing with
-    /// it for one line's width.
-    private var isAccessibilitySize: Bool { dynamicTypeSize.isAccessibilitySize }
-
     var body: some View {
-        VStack(spacing: 0) {
-            if !alarmIsSet {
-                Button(action: onSet) {
-                    Label(OBALoc("stop_page.alarm.set", value: "Set an alarm", comment: "Primary alarm button in the trip panel"), systemImage: "bell")
-                        .frame(maxWidth: .infinity, minHeight: 46)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color(uiColor: ThemeColors.shared.brand))
-                .foregroundStyle(.white)
-                .font(.body.weight(.semibold))
-            } else {
-                HStack(spacing: 10) {
-                    Image(systemName: "bell.fill")
-                        .foregroundStyle(onTimeColor)
-                        .frame(width: bellCircleSize, height: bellCircleSize)
-                        .background(onTimeColor.opacity(0.14), in: Circle())
-                        .accessibilityHidden(true) // decorative; the "Alarm set" text carries the meaning
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(OBALoc("stop_page.alarm.set_title", value: "Alarm set", comment: "Title of the set-alarm info row"))
-                            .font(.subheadline.weight(.bold))
-                        Text(String(format: OBALoc("stop_page.alarm.buzz_fmt", value: "Buzz %d min before it arrives", comment: "Subtitle of the set-alarm info row. %d is lead-time minutes."), leadTimeMinutes))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if !isAccessibilitySize {
-                        changeCancelButtons
-                    }
-                }
-                if isAccessibilitySize {
-                    // Side by side below the label when both fit; at the
-                    // largest sizes each becomes its own full-width row.
-                    ViewThatFits(in: .horizontal) {
-                        HStack(spacing: 10) {
-                            changeCancelButtons
-                        }
-                        VStack(spacing: 10) {
-                            changeCancelButtons
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 10)
-                }
-            }
+        Button(action: onSet) {
+            Label(OBALoc("stop_page.live_activity.track", value: "Track", comment: "Button in the trip panel to start a Live Activity for this departure on the Lock Screen and Dynamic Island"), systemImage: "waveform.circle.fill")
+                .frame(maxWidth: .infinity, minHeight: 46)
         }
-    }
-
-    /// Change + Cancel, shared by the inline (default) and stacked
-    /// (accessibility-size) placements.
-    @ViewBuilder
-    private var changeCancelButtons: some View {
-        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Re-presents the alarm time picker for an existing alarm"), action: onChange)
-            .buttonStyle(.bordered)
-        Button(Strings.cancel, role: .destructive, action: onCancel)
-            .buttonStyle(.bordered)
+        .buttonStyle(.borderedProminent)
+        .tint(Color(uiColor: ThemeColors.shared.brand))
+        .foregroundStyle(.white)
+        .font(.body.weight(.semibold))
     }
 }

--- a/OBAKit/Theme/Icons.swift
+++ b/OBAKit/Theme/Icons.swift
@@ -137,6 +137,13 @@ class Icons: NSObject {
         systemImage(named: "trash.fill")
     }
 
+    // MARK: - Live Activity
+
+    // An icon used for Live Activities ..
+    public class var liveActivity: UIImage {
+        systemImage(named: "waveform.circle.fill")
+    }
+
     // MARK: - Bookmarks
 
     /// An icon used to represent bookmarked stops and trips.

--- a/OBAKitCore/LiveActivities/LiveActivityRegistry.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityRegistry.swift
@@ -20,11 +20,23 @@ import ActivityKit
 /// activity until its subscription is deleted (or it hits an 8-hour expiry). Observing
 /// `Activity.activityStateUpdates` covers a dismissal that happens while the app is running,
 /// but if the user clears the Live Activity while the app *isn't* running, nothing observes
-/// it. On the next launch the activity is simply absent from
-/// `Activity<TripAttributes>.activities`, so no lifecycle observer is ever armed for it and
-/// its delete URL is orphaned. `reconcile()` is the sweep that closes that gap: any persisted
-/// delete URL whose activity is no longer known to ActivityKit belongs to a dead activity, so
-/// the subscription is deleted server-side.
+/// it: no lifecycle observer is ever armed for it and its delete URL is orphaned.
+/// `reconcile()` is the sweep that closes that gap.
+///
+/// ## What "dead" means (this was gotten wrong once)
+///
+/// A dismissed activity does **not** vanish from `Activity<TripAttributes>.activities`.
+/// ActivityKit keeps it in the array and reports its state as `.dismissed` (or `.ended`) —
+/// that's exactly what `.dismissed`/`.ended` exist to express, and it's the same signal the
+/// view controllers' `activityStateUpdates` observers act on. A sweep that treats mere
+/// *presence* in `activities` as proof of life therefore skips the dismissed activity it was
+/// written to clean up, and the server keeps pushing to it forever.
+///
+/// So an activity is alive only if it is present in `activities` **and** its `activityState`
+/// is not `.dismissed`/`.ended` (`.active`, `.stale` and `.pending` are all alive). An
+/// activityID that is absent from the array entirely is dead too — the system does eventually
+/// purge dismissed activities. `reconcile()` deletes the server-side subscription for every
+/// persisted delete URL whose activityID is not in that live set.
 ///
 /// ## Why a delete URL is only forgotten on confirmation
 ///
@@ -34,6 +46,17 @@ import ActivityKit
 /// entry is forgotten only when the server has confirmed the removal (2xx) or confirmed the
 /// row is already gone (404/410). Every other failure leaves the entry in place to be retried
 /// by a later `reconcile()`.
+///
+/// ## Why the DELETEs ignore task cancellation
+///
+/// Every DELETE this type issues is *teardown* for an activity that is already dead on-device,
+/// and it is reached from tasks whose whole job is to observe that death — which means the
+/// caller is frequently being torn down in the same breath. Swift's `URLSession` honors task
+/// cancellation, so a DELETE started in an already-cancelled task fails instantly with
+/// `URLError.cancelled` (-999) and never leaves the device; the subscription then leaks until
+/// its server-side expiry and the user keeps getting pushes for a Live Activity they dismissed.
+/// That shipped. See `withoutInheritingCancellation(_:)`: cancelling a cleanup request only
+/// ever loses the cleanup, so these deletes deliberately outlive their caller.
 public final class LiveActivityRegistry {
 
     /// Field-persisted UserDefaults key: `[activityID: deleteURLString]`. Do not rename —
@@ -43,21 +66,36 @@ public final class LiveActivityRegistry {
 
     private let userDefaults: UserDefaults
     private let obacoServiceProvider: () -> ObacoAPIService?
-    private let runningActivityIDs: () -> Set<String>
+    private let liveActivityIDs: () -> Set<String>
+
+    /// Whether an activity in `Activity<TripAttributes>.activities` is still alive.
+    ///
+    /// `.dismissed` and `.ended` activities remain in the array — being listed there is not
+    /// evidence of life. Written as a pair of `!=` checks rather than an allow-list of live
+    /// states so that a state case added by a future OS defaults to "alive": a false negative
+    /// here would delete the subscription of an activity the user is still looking at, which is
+    /// worse than a bounded leak.
+    public static func isLive(_ state: ActivityState) -> Bool {
+        state != .dismissed && state != .ended
+    }
 
     /// - parameter userDefaults: The store for persisted delete URLs.
     /// - parameter obacoServiceProvider: Resolved per call, because `obacoService` is recreated
     ///   on region change (and is nil until a region is available).
-    /// - parameter runningActivityIDs: The IDs of the Live Activities ActivityKit still knows
-    ///   about. Injectable for testing; production callers should use the default.
+    /// - parameter liveActivityIDs: The IDs of the Live Activities that are both known to
+    ///   ActivityKit *and* in a live state — see `isLive(_:)` and the type's documentation; an
+    ///   ID missing from this set is treated as dead and its subscription is swept. Injectable
+    ///   for testing; production callers should use the default.
     public init(
         userDefaults: UserDefaults,
         obacoServiceProvider: @escaping () -> ObacoAPIService?,
-        runningActivityIDs: @escaping () -> Set<String> = { Set(Activity<TripAttributes>.activities.map { $0.id }) }
+        liveActivityIDs: @escaping () -> Set<String> = {
+            Set(Activity<TripAttributes>.activities.lazy.filter { isLive($0.activityState) }.map { $0.id })
+        }
     ) {
         self.userDefaults = userDefaults
         self.obacoServiceProvider = obacoServiceProvider
-        self.runningActivityIDs = runningActivityIDs
+        self.liveActivityIDs = liveActivityIDs
     }
 
     // MARK: - Persistence
@@ -87,8 +125,13 @@ public final class LiveActivityRegistry {
 
     // MARK: - Register
 
-    /// Registers (or re-registers, on token rotation) `activity`'s push token with OBACloud and
+    /// Registers (or re-registers, on token rotation) an activity's push token with OBACloud and
     /// persists the delete URL the server hands back.
+    ///
+    /// Takes the activity's `id` and `attributes.staticData` rather than the `Activity` itself:
+    /// `Activity` can't be constructed outside a Live-Activity-capable process, so a method that
+    /// demanded one would drag the whole registration path — including the orphan cleanup below,
+    /// which is exactly the sort of code that rots unobserved — out of reach of the test suite.
     ///
     /// - parameter confirm: Evaluated immediately before the delete URL is persisted. Callers
     ///   that may have torn the activity down while the POST was in flight return `false` here;
@@ -96,7 +139,8 @@ public final class LiveActivityRegistry {
     ///   nothing will ever act on. Both this method and `unregister(activityID:)` run on the
     ///   caller's actor (the view controllers' MainActor), so the check is race-free there.
     public func register(
-        activity: Activity<TripAttributes>,
+        activityID: String,
+        staticData: TripAttributes.StaticData,
         pushToken: String,
         tripID: String?,
         serviceDate: Date?,
@@ -105,9 +149,6 @@ public final class LiveActivityRegistry {
         confirm: () -> Bool = { true }
     ) async {
         guard let obacoService = obacoServiceProvider() else { return }
-
-        let activityID = activity.id
-        let staticData = activity.attributes.staticData
 
         do {
             let deleteURL = try await obacoService.postLiveActivity(
@@ -124,7 +165,12 @@ public final class LiveActivityRegistry {
 
             guard confirm() else {
                 do {
-                    try await obacoService.deleteLiveActivity(url: deleteURL)
+                    // `confirm()` returns false precisely because the caller's task was torn down
+                    // mid-POST — so this cleanup runs inside an already-cancelled task, and must
+                    // opt out of that cancellation or it would never be sent. See the type docs.
+                    try await withoutInheritingCancellation {
+                        _ = try await obacoService.deleteLiveActivity(url: deleteURL)
+                    }
                     Logger.info("Discarded Live Activity registration for \(activityID): activity was unregistered mid-request")
                 } catch {
                     // Nothing to persist and nothing to retry against: the activity is already
@@ -152,21 +198,32 @@ public final class LiveActivityRegistry {
 
     // MARK: - Reconcile
 
-    /// Deletes every persisted subscription whose Live Activity no longer exists on-device.
+    /// Deletes every persisted subscription whose Live Activity is dead on-device — dismissed,
+    /// ended, or gone from `Activity<TripAttributes>.activities` altogether. See the type's
+    /// documentation: a dismissed activity is still *listed* by ActivityKit, so presence in that
+    /// array is not what makes an activity alive.
     ///
     /// Call this from an app-lifecycle hook (launch/foreground), not from a view controller:
     /// the orphaned registration this cleans up belongs to an activity nothing else observes
     /// anymore, so the sweep has to run regardless of which screen the user opens.
     ///
-    /// Entries whose activity is still running are left alone — they're either being observed
-    /// by a live lifecycle observer or will be re-armed by one.
+    /// Entries whose activity is still alive are left alone — they're either being observed by
+    /// a live lifecycle observer or will be re-armed by one.
     public func reconcile() async {
         let persisted = persistedDeleteURLs
-        guard !persisted.isEmpty else { return }
+        guard !persisted.isEmpty else {
+            Logger.info("Live Activity reconcile: no persisted subscriptions; nothing to sweep")
+            return
+        }
 
-        let liveActivityIDs = runningActivityIDs()
+        let liveIDs = liveActivityIDs()
+        let dead = persisted.filter { !liveIDs.contains($0.key) }
 
-        for (activityID, urlString) in persisted where !liveActivityIDs.contains(activityID) {
+        // Logged unconditionally, including the do-nothing case: a sweep that wrongly decides
+        // every subscription is alive is precisely the bug that shipped, and it was silent.
+        Logger.info("Live Activity reconcile: \(persisted.count) persisted subscription(s), \(liveIDs.count) live on-device, sweeping \(dead.count) dead")
+
+        for (activityID, urlString) in dead {
             guard let deleteURL = URL(string: urlString) else {
                 // Unusable handle: there's no request we could ever make with it, so keeping it
                 // would just fail this check on every launch forever.
@@ -192,7 +249,9 @@ public final class LiveActivityRegistry {
         }
 
         do {
-            try await obacoService.deleteLiveActivity(url: deleteURL)
+            try await withoutInheritingCancellation {
+                _ = try await obacoService.deleteLiveActivity(url: deleteURL)
+            }
             forget(activityID: activityID)
             Logger.info("Unregistered Live Activity \(activityID)")
         } catch {
@@ -204,6 +263,20 @@ public final class LiveActivityRegistry {
             forget(activityID: activityID)
             Logger.info("Live Activity subscription \(activityID) was already gone server-side; dropped its delete URL")
         }
+    }
+
+    /// Runs `work` in a task that does not inherit the caller's cancellation.
+    ///
+    /// Every caller of this is a *cleanup* request: a DELETE for a Live Activity that is already
+    /// dead on-device. Such a request is reached from a task that is being torn down at that very
+    /// moment (a lifecycle observer that just saw `.dismissed`, a push-token task cancelled
+    /// mid-registration), and `URLSession` refuses to send a request from a cancelled task —
+    /// `URLError.cancelled`, -999, before a single byte goes out. Honoring cancellation here can
+    /// therefore only ever *lose* the cleanup and leak the subscription; there is no caller for
+    /// whom "abandon the DELETE" is the desired outcome. `Task.detached` is what buys the
+    /// immunity: unlike `Task {}`, it has no parent to inherit a cancelled state from.
+    private func withoutInheritingCancellation(_ work: @escaping @Sendable () async throws -> Void) async throws {
+        try await Task.detached(operation: work).value
     }
 
     /// Whether `error` means the server *told us* the subscription no longer exists, as opposed

--- a/OBAKitCore/LiveActivities/LiveActivityRegistry.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityRegistry.swift
@@ -1,0 +1,228 @@
+//
+//  LiveActivityRegistry.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import ActivityKit
+
+/// Owns the lifecycle of the app's Live Activity push subscriptions with OBACloud:
+/// registering an activity's push token, unregistering it when the activity ends, and
+/// reconciling the persisted registrations against the activities iOS still knows about.
+///
+/// ## Why reconciliation exists
+///
+/// A registration is only cleaned up by the app: the server keeps pushing updates to an
+/// activity until its subscription is deleted (or it hits an 8-hour expiry). Observing
+/// `Activity.activityStateUpdates` covers a dismissal that happens while the app is running,
+/// but if the user clears the Live Activity while the app *isn't* running, nothing observes
+/// it. On the next launch the activity is simply absent from
+/// `Activity<TripAttributes>.activities`, so no lifecycle observer is ever armed for it and
+/// its delete URL is orphaned. `reconcile()` is the sweep that closes that gap: any persisted
+/// delete URL whose activity is no longer known to ActivityKit belongs to a dead activity, so
+/// the subscription is deleted server-side.
+///
+/// ## Why a delete URL is only forgotten on confirmation
+///
+/// The persisted delete URL is the *only* handle the app has on the server-side row. If it's
+/// dropped after a DELETE that failed because the network was down, the row can never be
+/// deleted again — an permanent leak, worse than the bounded one reconciliation fixes. So an
+/// entry is forgotten only when the server has confirmed the removal (2xx) or confirmed the
+/// row is already gone (404/410). Every other failure leaves the entry in place to be retried
+/// by a later `reconcile()`.
+public final class LiveActivityRegistry {
+
+    /// Field-persisted UserDefaults key: `[activityID: deleteURLString]`. Do not rename —
+    /// installs in the wild have orphaned delete URLs stored under it that `reconcile()`
+    /// exists to clean up.
+    static let deleteURLsDefaultsKey = "liveActivityDeleteURLs"
+
+    private let userDefaults: UserDefaults
+    private let obacoServiceProvider: () -> ObacoAPIService?
+    private let runningActivityIDs: () -> Set<String>
+
+    /// - parameter userDefaults: The store for persisted delete URLs.
+    /// - parameter obacoServiceProvider: Resolved per call, because `obacoService` is recreated
+    ///   on region change (and is nil until a region is available).
+    /// - parameter runningActivityIDs: The IDs of the Live Activities ActivityKit still knows
+    ///   about. Injectable for testing; production callers should use the default.
+    public init(
+        userDefaults: UserDefaults,
+        obacoServiceProvider: @escaping () -> ObacoAPIService?,
+        runningActivityIDs: @escaping () -> Set<String> = { Set(Activity<TripAttributes>.activities.map { $0.id }) }
+    ) {
+        self.userDefaults = userDefaults
+        self.obacoServiceProvider = obacoServiceProvider
+        self.runningActivityIDs = runningActivityIDs
+    }
+
+    // MARK: - Persistence
+
+    /// `[activityID: deleteURLString]`
+    var persistedDeleteURLs: [String: String] {
+        userDefaults.dictionary(forKey: Self.deleteURLsDefaultsKey) as? [String: String] ?? [:]
+    }
+
+    func deleteURL(forActivityID activityID: String) -> URL? {
+        persistedDeleteURLs[activityID].flatMap(URL.init(string:))
+    }
+
+    private func store(deleteURL: URL, activityID: String) {
+        var urls = persistedDeleteURLs
+        urls[activityID] = deleteURL.absoluteString
+        userDefaults.set(urls, forKey: Self.deleteURLsDefaultsKey)
+    }
+
+    /// Drops the persisted delete URL for `activityID`. Only call once the server has confirmed
+    /// the subscription is gone — see the type's documentation.
+    private func forget(activityID: String) {
+        var urls = persistedDeleteURLs
+        guard urls.removeValue(forKey: activityID) != nil else { return }
+        userDefaults.set(urls, forKey: Self.deleteURLsDefaultsKey)
+    }
+
+    // MARK: - Register
+
+    /// Registers (or re-registers, on token rotation) `activity`'s push token with OBACloud and
+    /// persists the delete URL the server hands back.
+    ///
+    /// - parameter confirm: Evaluated immediately before the delete URL is persisted. Callers
+    ///   that may have torn the activity down while the POST was in flight return `false` here;
+    ///   the registry then deletes the row the server just created rather than persisting a URL
+    ///   nothing will ever act on. Both this method and `unregister(activityID:)` run on the
+    ///   caller's actor (the view controllers' MainActor), so the check is race-free there.
+    public func register(
+        activity: Activity<TripAttributes>,
+        pushToken: String,
+        tripID: String?,
+        serviceDate: Date?,
+        vehicleID: String?,
+        stopSequence: Int?,
+        confirm: () -> Bool = { true }
+    ) async {
+        guard let obacoService = obacoServiceProvider() else { return }
+
+        let activityID = activity.id
+        let staticData = activity.attributes.staticData
+
+        do {
+            let deleteURL = try await obacoService.postLiveActivity(
+                activityID: activityID,
+                pushToken: pushToken,
+                stopID: staticData.stopID,
+                routeShortName: staticData.routeShortName,
+                tripHeadsign: staticData.routeHeadsign,
+                tripID: tripID,
+                serviceDate: serviceDate,
+                vehicleID: vehicleID,
+                stopSequence: stopSequence
+            )
+
+            guard confirm() else {
+                do {
+                    try await obacoService.deleteLiveActivity(url: deleteURL)
+                    Logger.info("Discarded Live Activity registration for \(activityID): activity was unregistered mid-request")
+                } catch {
+                    // Nothing to persist and nothing to retry against: the activity is already
+                    // gone locally, so the server row expires on its own.
+                    Logger.error("Failed to clean up orphaned Live Activity registration for \(activityID): \(error)")
+                }
+                return
+            }
+
+            store(deleteURL: deleteURL, activityID: activityID)
+            Logger.info("Registered Live Activity push token for activity \(activityID)")
+        } catch {
+            Logger.error("Failed to register Live Activity push token for \(activityID): \(error)")
+        }
+    }
+
+    // MARK: - Unregister
+
+    /// Deletes the server-side subscription for `activityID`, which has ended or been dismissed
+    /// on-device. A no-op when nothing is persisted for it.
+    public func unregister(activityID: String) async {
+        guard let deleteURL = deleteURL(forActivityID: activityID) else { return }
+        await deleteSubscription(activityID: activityID, deleteURL: deleteURL)
+    }
+
+    // MARK: - Reconcile
+
+    /// Deletes every persisted subscription whose Live Activity no longer exists on-device.
+    ///
+    /// Call this from an app-lifecycle hook (launch/foreground), not from a view controller:
+    /// the orphaned registration this cleans up belongs to an activity nothing else observes
+    /// anymore, so the sweep has to run regardless of which screen the user opens.
+    ///
+    /// Entries whose activity is still running are left alone — they're either being observed
+    /// by a live lifecycle observer or will be re-armed by one.
+    public func reconcile() async {
+        let persisted = persistedDeleteURLs
+        guard !persisted.isEmpty else { return }
+
+        let liveActivityIDs = runningActivityIDs()
+
+        for (activityID, urlString) in persisted where !liveActivityIDs.contains(activityID) {
+            guard let deleteURL = URL(string: urlString) else {
+                // Unusable handle: there's no request we could ever make with it, so keeping it
+                // would just fail this check on every launch forever.
+                Logger.error("Discarding unparseable Live Activity delete URL for \(activityID): \(urlString)")
+                forget(activityID: activityID)
+                continue
+            }
+
+            Logger.info("Reconciling orphaned Live Activity subscription for \(activityID)")
+            await deleteSubscription(activityID: activityID, deleteURL: deleteURL)
+        }
+    }
+
+    // MARK: - Deletion
+
+    /// DELETEs `deleteURL`, and forgets the persisted entry only if the server confirms the
+    /// subscription is gone. A transient failure (offline, timeout, 5xx) leaves the entry
+    /// persisted so a later `reconcile()` retries it.
+    private func deleteSubscription(activityID: String, deleteURL: URL) async {
+        guard let obacoService = obacoServiceProvider() else {
+            // No region, so no service to talk to. Keep the entry and retry on a later pass.
+            return
+        }
+
+        do {
+            try await obacoService.deleteLiveActivity(url: deleteURL)
+            forget(activityID: activityID)
+            Logger.info("Unregistered Live Activity \(activityID)")
+        } catch {
+            guard Self.serverConfirmedSubscriptionIsGone(error) else {
+                Logger.error("Failed to unregister Live Activity \(activityID), will retry: \(error)")
+                return
+            }
+
+            forget(activityID: activityID)
+            Logger.info("Live Activity subscription \(activityID) was already gone server-side; dropped its delete URL")
+        }
+    }
+
+    /// Whether `error` means the server *told us* the subscription no longer exists, as opposed
+    /// to us failing to reach the server at all.
+    ///
+    /// `APIService.data(for:)` maps a 404 to `APIError.requestNotFound` and every other non-2xx
+    /// status to `APIError.requestFailure`, so 410 Gone has to be picked out by status code.
+    /// Anything else — `URLError`, `APIError.networkFailure`, a 5xx `requestFailure` — is
+    /// treated as transient and the delete URL is retained.
+    static func serverConfirmedSubscriptionIsGone(_ error: Error) -> Bool {
+        guard let apiError = error as? APIError else { return false }
+
+        switch apiError {
+        case .requestNotFound:
+            return true
+        case .requestFailure(let response):
+            return response.statusCode == 410
+        default:
+            return false
+        }
+    }
+}

--- a/OBAKitCore/LiveActivities/LiveActivityTracker.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityTracker.swift
@@ -1,0 +1,180 @@
+//
+//  LiveActivityTracker.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import ActivityKit
+
+/// Owns the ActivityKit observers that feed `LiveActivityRegistry`: one task per activity
+/// forwarding its push token, and one watching for its dismissal.
+///
+/// ## Why this is app-scoped and not per-view-controller
+///
+/// These observers outlive the screen that started the activity. A Live Activity begun from a
+/// stop page keeps running after the user taps back, and the only thing that deletes its
+/// server-side subscription when they finally swipe it away is its lifecycle observer. Parking
+/// that observer on the view controller ties its life to the screen: popping `StopPageViewController`
+/// deallocates it, cancels the observer, and the eventual dismissal is then seen by nobody, so
+/// the server keeps pushing to an activity the user has cleared. (`LiveActivityRegistry.reconcile()`
+/// sweeps that up, but only on the next foreground — the leak lasts as long as the app stays open.)
+///
+/// A single tracker hanging off `CoreApplication` lives as long as the process, so there is no
+/// `deinit` teardown here at all: an observer is retired when its activity ends, not when a screen
+/// closes. It also means an activity has exactly one set of observers no matter which screen
+/// started it, so two view controllers can't independently arm — and independently tear down —
+/// the same activity.
+///
+/// Being a single `@MainActor` owner is also what makes the `confirm` check in
+/// `LiveActivityRegistry.register` race-free: the read of `lifecycleTasks` and the write in
+/// `unregister` are on the same actor, and now there is only one dictionary to be the truth.
+@MainActor
+public final class LiveActivityTracker {
+
+    private let registry: LiveActivityRegistry
+
+    /// One token-forwarding task per activity id.
+    private var tokenTasks: [String: Task<Void, Never>] = [:]
+
+    /// One lifecycle-observation task per activity id.
+    private var lifecycleTasks: [String: Task<Void, Never>] = [:]
+
+    public nonisolated init(registry: LiveActivityRegistry) {
+        self.registry = registry
+    }
+
+    /// The trip context that OBACloud needs in order to push updates to an activity. All fields
+    /// are optional because a bookmark with no loaded arrivals has none of them; the server
+    /// falls back to matching on the activity's stop and route in that case.
+    public struct TripMetadata {
+        public let tripID: String?
+        public let serviceDate: Date?
+        public let vehicleID: String?
+        public let stopSequence: Int?
+
+        public init(tripID: String?, serviceDate: Date?, vehicleID: String?, stopSequence: Int?) {
+            self.tripID = tripID
+            self.serviceDate = serviceDate
+            self.vehicleID = vehicleID
+            self.stopSequence = stopSequence
+        }
+
+        public init(_ arrivalDeparture: ArrivalDeparture?) {
+            self.init(
+                tripID: arrivalDeparture?.tripID,
+                serviceDate: arrivalDeparture?.serviceDate,
+                vehicleID: arrivalDeparture?.vehicleID,
+                stopSequence: arrivalDeparture?.stopSequence
+            )
+        }
+    }
+
+    /// Whether anything is watching `activityID` for its death. False means no one will delete
+    /// its server-side subscription when it ends, so at minimum `observeLifecycle(of:)` is owed.
+    public func isTracking(activityID: String) -> Bool {
+        tokenTasks[activityID] != nil || lifecycleTasks[activityID] != nil
+    }
+
+    /// Whether `activityID`'s push token is being forwarded to OBACloud — i.e. it has a *full*
+    /// registration and not just the lifecycle observer that `observeLifecycle(of:)` arms alone.
+    ///
+    /// Distinct from `isTracking(activityID:)` because an activity can legitimately be upgraded
+    /// from lifecycle-only to fully tracked: a relaunch sweep that can't match an activity to a
+    /// bookmark arms only the lifecycle observer, and if that bookmark later reappears the sweep
+    /// must still be able to arm the token task. Gating that on `isTracking` would see the
+    /// lifecycle observer, conclude the activity was handled, and leave it without push updates
+    /// forever.
+    public func isForwardingPushToken(activityID: String) -> Bool {
+        tokenTasks[activityID] != nil
+    }
+
+    /// Forwards `activity`'s push token to OBACloud as it rotates, and unregisters the activity
+    /// when it ends. Call this for an activity you just started, or for one found still running
+    /// after a relaunch whose trip context you can still resolve.
+    public func track(activity: Activity<TripAttributes>, metadata: TripMetadata) {
+        let activityID = activity.id
+
+        tokenTasks[activityID]?.cancel()
+        tokenTasks[activityID] = Task { [weak self] in
+            for await tokenData in activity.pushTokenUpdates {
+                let token = tokenData.map { String(format: "%02x", $0) }.joined()
+                await self?.register(activity: activity, pushToken: token, metadata: metadata)
+            }
+        }
+
+        observeLifecycle(of: activity)
+    }
+
+    /// Observes `activity`'s dismiss/end state so its server-side subscription is deleted, without
+    /// registering a push token.
+    ///
+    /// This is the relaunch case for an activity whose bookmark can no longer be matched: there's
+    /// no trip context to register with, but a delete URL persisted in a previous session still
+    /// needs to be cleaned up once the activity ends.
+    public func observeLifecycle(of activity: Activity<TripAttributes>) {
+        let activityID = activity.id
+
+        lifecycleTasks[activityID]?.cancel()
+        lifecycleTasks[activityID] = Task { [weak self] in
+            for await state in activity.activityStateUpdates where !LiveActivityRegistry.isLive(state) {
+                await self?.unregister(activityID: activityID)
+                break
+            }
+        }
+    }
+
+    private func register(activity: Activity<TripAttributes>, pushToken: String, metadata: TripMetadata) async {
+        await registry.register(
+            activityID: activity.id,
+            staticData: activity.attributes.staticData,
+            pushToken: pushToken,
+            tripID: metadata.tripID,
+            serviceDate: metadata.serviceDate,
+            vehicleID: metadata.vehicleID,
+            stopSequence: metadata.stopSequence,
+            confirm: { [weak self] in
+                // `unregister` is only cooperatively cancelled, so it can finish tearing down this
+                // activity's tasks while the POST is still in flight. If that happened, the
+                // lifecycle task that would eventually DELETE this registration is already gone, so
+                // persisting the delete URL now would orphan it forever. The registry evaluates
+                // this immediately before the write (both this method and `unregister` are on the
+                // MainActor, so the check is race-free) and cleans up the row the server just
+                // created for us when it returns false.
+                guard let self else { return false }
+                return self.lifecycleTasks[activity.id] != nil && !Task.isCancelled
+            }
+        )
+    }
+
+    /// Tears down the observers for `activityID` and deletes its server-side push subscription.
+    ///
+    /// The ordering below is load-bearing, and the tempting tidy-up — cancelling both tasks
+    /// together, up front — is a bug. This method's usual caller is the lifecycle task itself
+    /// (`observeLifecycle(of:)`), so cancelling that task here cancels *the task we are currently
+    /// running inside*. `URLSession` honors task cancellation, so the DELETE that follows would
+    /// fail instantly with `URLError.cancelled` (-999) without a byte leaving the device —
+    /// silently, since unregistration has no UI. That shipped: every dismissal leaked its
+    /// subscription and the server kept pushing to a Live Activity the user had cleared.
+    ///
+    /// So: drop the lifecycle task from the dictionary (which is what `confirm` in `register`
+    /// reads, and what stops a second unregister), but cancel it only *after* the network call.
+    /// When we're running inside it, it's about to `break` out of its loop anyway; when called
+    /// from anywhere else, it still gets torn down properly.
+    ///
+    /// The token task is a different task and is safe to cancel up front.
+    ///
+    /// `LiveActivityRegistry` independently refuses to let its DELETEs inherit cancellation, so
+    /// this is belt-and-braces — but the belt is here, where the reasoning is visible.
+    private func unregister(activityID: String) async {
+        tokenTasks.removeValue(forKey: activityID)?.cancel()
+        let lifecycleTask = lifecycleTasks.removeValue(forKey: activityID)
+
+        await registry.unregister(activityID: activityID)
+
+        lifecycleTask?.cancel()
+    }
+}

--- a/OBAKitCore/Models/TripAttributes.swift
+++ b/OBAKitCore/Models/TripAttributes.swift
@@ -1,0 +1,121 @@
+//
+//  TripAttributes.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import ActivityKit
+import UIKit
+
+/// Live Activities data contract for trip bookmark tracking.
+public struct TripAttributes: ActivityAttributes {
+    public struct StaticData: Codable, Hashable {
+        public let routeShortName: String
+        public let routeHeadsign: String
+        public let stopID: String
+
+        public init(routeShortName: String, routeHeadsign: String, stopID: String) {
+            self.routeShortName = routeShortName
+            self.routeHeadsign = routeHeadsign
+            self.stopID = stopID
+        }
+    }
+
+    public struct MinuteInfo: Codable, Hashable {
+        public let text: String
+        public let color: CodableColor
+
+        public init(text: String, color: UIColor) {
+            self.text = text
+            self.color = CodableColor(color)
+        }
+    }
+
+    public struct ContentState: Codable, Hashable {
+        public let statusText: String
+        public let statusColor: CodableColor
+        public let minutes: [MinuteInfo]
+        public let shouldHighlight: Bool
+
+        public init(statusText: String, statusColor: UIColor, minutes: [MinuteInfo], shouldHighlight: Bool = false) {
+            self.statusText = statusText
+            self.statusColor = CodableColor(statusColor)
+            self.minutes = minutes
+            self.shouldHighlight = shouldHighlight
+        }
+    }
+
+    public let staticData: StaticData
+
+    public init(staticData: StaticData) {
+        self.staticData = staticData
+    }
+}
+
+// MARK: - CodableColor Wrapper
+
+/// Wraps `UIColor` to make it `Codable` for ActivityKit storage.
+///
+/// Colors are converted to the sRGB color space before extracting components,
+/// ensuring correct encoding even for colors in extended color spaces (e.g., Display P3).
+public struct CodableColor: Codable, Hashable {
+    private let red: CGFloat
+    private let green: CGFloat
+    private let blue: CGFloat
+    private let alpha: CGFloat
+
+    public init(_ color: UIColor) {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+
+        // false for colors not in a compatible color space (e.g., P3 system colors).
+        let sRGBColor: UIColor
+        if let converted = color.cgColor.converted(
+            to: CGColorSpace(name: CGColorSpace.sRGB)!,
+            intent: .defaultIntent,
+            options: nil
+        ) {
+            sRGBColor = UIColor(cgColor: converted)
+        } else {
+            sRGBColor = color
+        }
+
+        guard sRGBColor.getRed(&r, green: &g, blue: &b, alpha: &a) else {
+            // Fallback: opaque black if conversion still fails (should not happen).
+            self.red = 0
+            self.green = 0
+            self.blue = 0
+            self.alpha = 1
+            return
+        }
+
+        self.red = r
+        self.green = g
+        self.blue = b
+        self.alpha = a
+    }
+
+    public var uiColor: UIColor {
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension TripAttributes.MinuteInfo {
+    public var uiColor: UIColor {
+        return color.uiColor
+    }
+}
+
+extension TripAttributes.ContentState {
+    public var uiStatusColor: UIColor {
+        return statusColor.uiColor
+    }
+}

--- a/OBAKitCore/Models/TripAttributes.swift
+++ b/OBAKitCore/Models/TripAttributes.swift
@@ -9,9 +9,19 @@
 
 import Foundation
 import ActivityKit
-import UIKit
+
+// swiftlint:disable nesting
 
 /// Live Activities data contract for trip bookmark tracking.
+///
+/// `ContentState` is the semantic wire contract with OBACloud: the server
+/// pushes exactly this JSON shape (snake_case keys, epoch-second dates) via
+/// APNs `content-state`, and the app builds the identical shape locally for
+/// foreground refreshes. Apple decodes pushed content-state with a
+/// default-strategy JSONDecoder, so every struct declares explicit
+/// CodingKeys and dates travel as epoch-second integers, never `Date`.
+/// The canonical fixture is OBAKitTests/fixtures/live_activity_content_state.json,
+/// mirrored in the obacloud repo.
 public struct TripAttributes: ActivityAttributes {
     public struct StaticData: Codable, Hashable {
         public let routeShortName: String
@@ -25,27 +35,70 @@ public struct TripAttributes: ActivityAttributes {
         }
     }
 
-    public struct MinuteInfo: Codable, Hashable {
-        public let text: String
-        public let color: CodableColor
-
-        public init(text: String, color: UIColor) {
-            self.text = text
-            self.color = CodableColor(color)
-        }
-    }
-
     public struct ContentState: Codable, Hashable {
-        public let statusText: String
-        public let statusColor: CodableColor
-        public let minutes: [MinuteInfo]
-        public let shouldHighlight: Bool
+        public enum ScheduleStatusValue: String, Codable, Hashable {
+            case onTime = "on_time"
+            case early
+            case delayed
+            case unknown
 
-        public init(statusText: String, statusColor: UIColor, minutes: [MinuteInfo], shouldHighlight: Bool = false) {
-            self.statusText = statusText
-            self.statusColor = CodableColor(statusColor)
-            self.minutes = minutes
-            self.shouldHighlight = shouldHighlight
+            /// Bridges to the presentation enum used by Formatters.
+            public var scheduleStatus: ScheduleStatus {
+                switch self {
+                case .onTime: return .onTime
+                case .early: return .early
+                case .delayed: return .delayed
+                case .unknown: return .unknown
+                }
+            }
+
+            public init(_ status: ScheduleStatus) {
+                switch status {
+                case .onTime: self = .onTime
+                case .early: self = .early
+                case .delayed: self = .delayed
+                default: self = .unknown
+                }
+            }
+        }
+
+        public struct ArrivalInfo: Codable, Hashable {
+            /// Epoch seconds. An Int (not Date): the default JSONDecoder
+            /// would decode a Date as seconds-since-2001 and corrupt it.
+            public let departureTime: Int
+            public let scheduleStatus: ScheduleStatusValue
+            /// Seconds late (positive) or early (negative).
+            public let scheduleDeviation: Int
+            public let isArrival: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case departureTime = "departure_time"
+                case scheduleStatus = "schedule_status"
+                case scheduleDeviation = "schedule_deviation"
+                case isArrival = "is_arrival"
+            }
+
+            public init(departureTime: Int, scheduleStatus: ScheduleStatusValue, scheduleDeviation: Int, isArrival: Bool) {
+                self.departureTime = departureTime
+                self.scheduleStatus = scheduleStatus
+                self.scheduleDeviation = scheduleDeviation
+                self.isArrival = isArrival
+            }
+
+            public var departureDate: Date {
+                Date(timeIntervalSince1970: TimeInterval(departureTime))
+            }
+        }
+
+        /// Up to 3 upcoming arrivals, soonest first.
+        public let arrivals: [ArrivalInfo]
+
+        enum CodingKeys: String, CodingKey {
+            case arrivals
+        }
+
+        public init(arrivals: [ArrivalInfo]) {
+            self.arrivals = arrivals
         }
     }
 
@@ -56,66 +109,4 @@ public struct TripAttributes: ActivityAttributes {
     }
 }
 
-// MARK: - CodableColor Wrapper
-
-/// Wraps `UIColor` to make it `Codable` for ActivityKit storage.
-///
-/// Colors are converted to the sRGB color space before extracting components,
-/// ensuring correct encoding even for colors in extended color spaces (e.g., Display P3).
-public struct CodableColor: Codable, Hashable {
-    private let red: CGFloat
-    private let green: CGFloat
-    private let blue: CGFloat
-    private let alpha: CGFloat
-
-    public init(_ color: UIColor) {
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-
-        // false for colors not in a compatible color space (e.g., P3 system colors).
-        let sRGBColor: UIColor
-        if let converted = color.cgColor.converted(
-            to: CGColorSpace(name: CGColorSpace.sRGB)!,
-            intent: .defaultIntent,
-            options: nil
-        ) {
-            sRGBColor = UIColor(cgColor: converted)
-        } else {
-            sRGBColor = color
-        }
-
-        guard sRGBColor.getRed(&r, green: &g, blue: &b, alpha: &a) else {
-            // Fallback: opaque black if conversion still fails (should not happen).
-            self.red = 0
-            self.green = 0
-            self.blue = 0
-            self.alpha = 1
-            return
-        }
-
-        self.red = r
-        self.green = g
-        self.blue = b
-        self.alpha = a
-    }
-
-    public var uiColor: UIColor {
-        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
-    }
-}
-
-// MARK: - Convenience Extensions
-
-extension TripAttributes.MinuteInfo {
-    public var uiColor: UIColor {
-        return color.uiColor
-    }
-}
-
-extension TripAttributes.ContentState {
-    public var uiStatusColor: UIColor {
-        return statusColor.uiColor
-    }
-}
+// swiftlint:enable nesting

--- a/OBAKitCore/Models/TripAttributes.swift
+++ b/OBAKitCore/Models/TripAttributes.swift
@@ -27,11 +27,13 @@ public struct TripAttributes: ActivityAttributes {
         public let routeShortName: String
         public let routeHeadsign: String
         public let stopID: String
+        public let routeColorHex: String?
 
-        public init(routeShortName: String, routeHeadsign: String, stopID: String) {
+        public init(routeShortName: String, routeHeadsign: String, stopID: String, routeColorHex: String? = nil) {
             self.routeShortName = routeShortName
             self.routeHeadsign = routeHeadsign
             self.stopID = stopID
+            self.routeColorHex = routeColorHex
         }
     }
 
@@ -92,6 +94,13 @@ public struct TripAttributes: ActivityAttributes {
 
         /// Up to 3 upcoming arrivals, soonest first.
         public let arrivals: [ArrivalInfo]
+
+        /// Arrivals whose departure time is at or after `now`, soonest first.
+        /// Push updates and stale content states may include already-departed
+        /// trips; use this for display rather than `arrivals` directly.
+        public func upcomingArrivals(now: Date = Date()) -> [ArrivalInfo] {
+            arrivals.filter { $0.departureDate >= now }
+        }
 
         enum CodingKeys: String, CodingKey {
             case arrivals

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -157,6 +157,56 @@ public actor ObacoAPIService: @preconcurrency APIService {
         return try await data(for: request as URLRequest)
     }
 
+    // MARK: - Live Activities
+
+    private struct LiveActivityRegistrationResponse: Codable {
+        let url: URL
+    }
+
+    /// Registers (or re-registers, on ActivityKit token rotation) a Live
+    /// Activity push token with OBACloud. Returns the URL to DELETE when the
+    /// activity ends locally. POST is an upsert keyed by `activityID`.
+    public nonisolated func postLiveActivity(
+        activityID: String,
+        pushToken: String,
+        stopID: StopID,
+        routeShortName: String,
+        tripHeadsign: String,
+        tripID: String?,
+        serviceDate: Date?,
+        vehicleID: String?,
+        stopSequence: Int?
+    ) async throws -> URL {
+        let url = await buildURL(path: String(format: "/api/v2/regions/%d/live_activities", regionID))
+        let urlRequest = NSMutableURLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
+        urlRequest.httpMethod = "POST"
+
+        var params: [String: Any] = [
+            "activity_id": activityID,
+            "push_token": pushToken,
+            "stop_id": stopID,
+            "route_short_name": routeShortName,
+            "trip_headsign": tripHeadsign
+        ]
+        if let tripID { params["trip_id"] = tripID }
+        if let serviceDate { params["service_date"] = Int64(serviceDate.timeIntervalSince1970 * 1000) }
+        if let vehicleID { params["vehicle_id"] = vehicleID }
+        if let stopSequence { params["stop_sequence"] = stopSequence }
+
+        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
+
+        let (data, _) = try await data(for: urlRequest as URLRequest)
+        return try JSONDecoder.obacoServiceDecoder.decode(LiveActivityRegistrationResponse.self, from: data).url
+    }
+
+    /// Unregisters a Live Activity subscription (the server sends no push; the
+    /// activity already ended on-device).
+    @discardableResult public nonisolated func deleteLiveActivity(url: URL) async throws -> (Data, URLResponse) {
+        let request = NSMutableURLRequest(url: url)
+        request.httpMethod = "DELETE"
+        return try await data(for: request as URLRequest)
+    }
+
     // MARK: - Vehicles
     public nonisolated func getVehicles(matching query: String) async throws -> [AgencyVehicle] {
         let apiPath = String(format: "/api/v1/regions/%d/vehicles", regionID)

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -193,6 +193,14 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let vehicleID { params["vehicle_id"] = vehicleID }
         if let stopSequence { params["stop_sequence"] = stopSequence }
 
+        #if DEBUG
+        // A debug build's ActivityKit push token is a sandbox token. The server
+        // persists this flag and uses it for every update and end push over the
+        // activity's lifetime. Without it, pushes bounce with BadDeviceToken and
+        // the server retires the subscription.
+        params["apns_sandbox"] = "1"
+        #endif
+
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 
         let (data, _) = try await data(for: urlRequest as URLRequest)

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -202,6 +202,11 @@ open class CoreApplication: NSObject,
         obacoServiceProvider: { [weak self] in self?.obacoService }
     )
 
+    /// Owns the ActivityKit observers that feed `liveActivityRegistry`. App-scoped rather than
+    /// per-screen on purpose: a Live Activity outlives the view controller that started it, and
+    /// so must the observer that unregisters it. See `LiveActivityTracker`.
+    public private(set) lazy var liveActivityTracker = LiveActivityTracker(registry: liveActivityRegistry)
+
     /// Reloads the Obaco Service stack, including the network queue, api service manager, and model service manager.
     /// This must be called when the region changes.
     private func refreshObacoService() {

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -189,6 +189,19 @@ open class CoreApplication: NSObject,
 
     public let obacoServiceUpdatedNotification = NSNotification.Name("ObacoServiceUpdatedNotification")
 
+    // MARK: - Live Activities
+
+    /// Owns the Live Activity push subscriptions registered with OBACloud: registration,
+    /// unregistration, and the launch-time reconciliation sweep that cleans up activities the
+    /// user dismissed while the app wasn't running.
+    ///
+    /// `obacoService` is resolved lazily on each call because it's recreated when the region
+    /// changes and is nil until a region is available.
+    public private(set) lazy var liveActivityRegistry = LiveActivityRegistry(
+        userDefaults: userDefaults,
+        obacoServiceProvider: { [weak self] in self?.obacoService }
+    )
+
     /// Reloads the Obaco Service stack, including the network queue, api service manager, and model service manager.
     /// This must be called when the region changes.
     private func refreshObacoService() {

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -1,6 +1,6 @@
 //
 //  Theme.swift
-//  OBAKit
+//  OBAKitCore
 //
 //  Copyright © Open Transit Software Foundation
 //  This source code is licensed under the Apache 2.0 license found in the

--- a/OBAKitCore/UI/CountdownView.swift
+++ b/OBAKitCore/UI/CountdownView.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The "{n}m" countdown with its real-time glyph. Public so the widget extension can use it.
+public struct CountdownView: View {
+    public let minutes: Int
+    public let isRealTime: Bool
+    public let color: Color
+    /// `true` = card-header size, `false` = compact.
+    public var emphasized: Bool = true
+
+    public init(minutes: Int, isRealTime: Bool, color: Color, emphasized: Bool = true) {
+        self.minutes = minutes
+        self.isRealTime = isRealTime
+        self.color = color
+        self.emphasized = emphasized
+    }
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: 2) {
+            Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
+                .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
+                .monospacedDigit()
+                .foregroundStyle(color)
+            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
+                .padding(.top, 1)
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/OBAKitCore/UI/RealtimeGlyph.swift
+++ b/OBAKitCore/UI/RealtimeGlyph.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Animated wave glyph for real-time trips, static clock for scheduled-only. Public so the widget can use it.
+public struct RealtimeGlyph: View {
+    public let isRealTime: Bool
+    public let color: Color
+    public var size: CGFloat = 14
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+
+    public init(isRealTime: Bool, color: Color, size: CGFloat = 14) {
+        self.isRealTime = isRealTime
+        self.color = color
+        self.size = size
+    }
+
+    public var body: some View {
+        Image(systemName: isRealTime ? "dot.radiowaves.up.forward" : "clock")
+            .font(.system(size: size * scale, weight: .semibold))
+            .foregroundStyle(isRealTime ? color : Color(uiColor: .secondaryLabel))
+            .symbolEffect(.variableColor.iterative, options: .repeating, isActive: isRealTime && !reduceMotion)
+            .accessibilityHidden(true)
+    }
+}

--- a/OBAKitCore/UI/RouteBadgeView.swift
+++ b/OBAKitCore/UI/RouteBadgeView.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Rounded-square route identity badge. Public so the widget extension can use it.
+public struct RouteBadgeView: View {
+    public let routeShortName: String
+    public let routeColor: Color
+    public var size: CGFloat = 44
+
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+
+    public init(routeShortName: String, routeColor: Color, size: CGFloat = 44) {
+        self.routeShortName = routeShortName
+        self.routeColor = routeColor
+        self.size = size
+    }
+
+    public var body: some View {
+        Text(routeShortName)
+            .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size * scale, height: size * scale)
+            .background(routeColor.gradient, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .accessibilityHidden(true)
+    }
+}

--- a/OBAKitCore/UI/TripActivityPresenter.swift
+++ b/OBAKitCore/UI/TripActivityPresenter.swift
@@ -44,7 +44,7 @@ public struct TripActivityPresenter {
             deviationText = formatters.formattedScheduleDeviation(
                 temporalState: temporalState(minutes: minutes),
                 arrivalDepartureStatus: arrival.isArrival ? .arriving : .departing,
-                scheduleDeviation: arrival.scheduleDeviation / 60
+                scheduleDeviation: Int((Double(arrival.scheduleDeviation) / 60.0).rounded())
             )
         }
 

--- a/OBAKitCore/UI/TripActivityPresenter.swift
+++ b/OBAKitCore/UI/TripActivityPresenter.swift
@@ -51,9 +51,23 @@ public struct TripActivityPresenter {
         return "\(timeString) - \(deviationText)"
     }
 
-    /// Color for the first (primary) arrival; gray-ish unknown when empty.
-    public func primaryColor(for state: TripAttributes.ContentState) -> UIColor {
-        guard let first = state.arrivals.first else {
+    /// Just the adherence deviation text, e.g. "arrives on time" or "2 min late".
+    /// Used by card-header layouts that display the scheduled time separately.
+    public func deviationLabel(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date = Date()) -> String {
+        if arrival.scheduleStatus == .unknown {
+            return Strings.scheduledNotRealTime
+        }
+        let minutes = Int(arrival.departureDate.timeIntervalSince(now) / 60.0)
+        return formatters.formattedScheduleDeviation(
+            temporalState: temporalState(minutes: minutes),
+            arrivalDepartureStatus: arrival.isArrival ? .arriving : .departing,
+            scheduleDeviation: Int((Double(arrival.scheduleDeviation) / 60.0).rounded())
+        )
+    }
+
+    /// Color for the first upcoming arrival; gray when all have departed or empty.
+    public func primaryColor(for state: TripAttributes.ContentState, now: Date = Date()) -> UIColor {
+        guard let first = state.upcomingArrivals(now: now).first else {
             return formatters.colorForScheduleStatus(.unknown)
         }
         return color(for: first)

--- a/OBAKitCore/UI/TripActivityPresenter.swift
+++ b/OBAKitCore/UI/TripActivityPresenter.swift
@@ -1,0 +1,67 @@
+//
+//  TripActivityPresenter.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import UIKit
+
+/// Derives presentation (minute chips, colors, status line) from the semantic
+/// Live Activity `ContentState`. Both the widget extension and the in-app
+/// bookmark row use this, so pushed updates and local refreshes render
+/// identically. Presentation lives on-device — the server never sends
+/// localized strings or colors.
+public struct TripActivityPresenter {
+    private let formatters: Formatters
+
+    public init(formatters: Formatters = Formatters(locale: .autoupdatingCurrent, calendar: .autoupdatingCurrent, themeColors: ThemeColors.shared)) {
+        self.formatters = formatters
+    }
+
+    public func minuteText(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date = Date()) -> String {
+        let minutes = Int(arrival.departureDate.timeIntervalSince(now) / 60.0)
+        return formatters.shortFormattedTime(untilMinutes: minutes, temporalState: temporalState(minutes: minutes))
+    }
+
+    public func color(for arrival: TripAttributes.ContentState.ArrivalInfo) -> UIColor {
+        formatters.colorForScheduleStatus(arrival.scheduleStatus.scheduleStatus)
+    }
+
+    /// e.g. "3:26 PM - arrives on time" / "3:26 PM - Scheduled/not real-time".
+    /// Mirrors TripBookmarkRow.buildStatusText's phrasing.
+    public func statusText(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date = Date()) -> String {
+        let timeString = formatters.timeFormatter.string(from: arrival.departureDate)
+
+        let deviationText: String
+        if arrival.scheduleStatus == .unknown {
+            deviationText = Strings.scheduledNotRealTime
+        } else {
+            let minutes = Int(arrival.departureDate.timeIntervalSince(now) / 60.0)
+            deviationText = formatters.formattedScheduleDeviation(
+                temporalState: temporalState(minutes: minutes),
+                arrivalDepartureStatus: arrival.isArrival ? .arriving : .departing,
+                scheduleDeviation: arrival.scheduleDeviation / 60
+            )
+        }
+
+        return "\(timeString) - \(deviationText)"
+    }
+
+    /// Color for the first (primary) arrival; gray-ish unknown when empty.
+    public func primaryColor(for state: TripAttributes.ContentState) -> UIColor {
+        guard let first = state.arrivals.first else {
+            return formatters.colorForScheduleStatus(.unknown)
+        }
+        return color(for: first)
+    }
+
+    private func temporalState(minutes: Int) -> TemporalState {
+        if minutes < 0 { return .past }
+        if minutes == 0 { return .present }
+        return .future
+    }
+}

--- a/OBAKitCore/UI/TripBookmarkRow.swift
+++ b/OBAKitCore/UI/TripBookmarkRow.swift
@@ -1,0 +1,334 @@
+//
+//  TripBookmarkRow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Shared SwiftUI view for trip bookmarks — used in both the main app (BookmarksViewController)
+/// and Live Activities (TripLiveActivity).
+public struct TripBookmarkRow: View {
+    public let routeShortName: String
+    public let routeHeadsign: String
+    public let statusText: String
+    public let statusColor: Color
+    public let minutes: [MinuteDisplay]
+    public let isLiveActivity: Bool
+
+    @State private var highlightedBadges: Set<String> = []
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    // MARK: - MinuteDisplay
+
+    public struct MinuteDisplay: Identifiable, Equatable {
+        /// Stable identifier derived from the minute text content, avoiding index-based IDs
+        /// that can cause incorrect SwiftUI diff animations when the array changes.
+        public let id: String
+        public let text: String
+        public let color: Color
+        public let isPrimary: Bool
+        public let shouldHighlight: Bool
+
+        public init(text: String, color: Color, isPrimary: Bool, shouldHighlight: Bool = false) {
+            self.id = "\(isPrimary ? "primary" : "secondary")-\(text)"
+            self.text = text
+            self.color = color
+            self.isPrimary = isPrimary
+            self.shouldHighlight = shouldHighlight
+        }
+    }
+
+    // MARK: - Initialization
+
+    public init(
+        routeShortName: String,
+        routeHeadsign: String,
+        statusText: String,
+        statusColor: Color,
+        minutes: [MinuteDisplay],
+        isLiveActivity: Bool = false
+    ) {
+        self.routeShortName = routeShortName
+        self.routeHeadsign = routeHeadsign
+        self.statusText = statusText
+        self.statusColor = statusColor
+        self.minutes = minutes
+        self.isLiveActivity = isLiveActivity
+    }
+
+    // MARK: - Shared Status Text Builder
+
+    /// Builds a status string from an `ArrivalDeparture` using the `Formatters`.
+    ///
+    /// This is for status text, shared between `TripBookmarkCell`
+    /// and `BookmarksViewController` (for Live Activity content state).
+    ///
+    /// - Parameters:
+    ///   - arrivalDeparture: The arrival/departure event.
+    ///   - formatters: The app's `Formatters` instance.
+    /// - Returns: A string like `"3:26 AM - arrives on time"`.
+    public static func buildStatusText(from arrivalDeparture: ArrivalDeparture, formatters: Formatters) -> String {
+        let timeString = formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate)
+        let deviationText: String
+
+        if arrivalDeparture.scheduleStatus == .unknown {
+            deviationText = Strings.scheduledNotRealTime
+        } else {
+            deviationText = formatters.formattedScheduleDeviation(for: arrivalDeparture)
+        }
+
+        return "\(timeString) - \(deviationText)"
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if sizeCategory.isAccessibilityCategory {
+                accessibilityLayout
+            } else {
+                regularLayout
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .systemBackground))
+        .onAppear {
+            guard !isLiveActivity else { return }
+            let badgesToHighlight = minutes.filter { $0.shouldHighlight }.map { $0.id }
+            guard !badgesToHighlight.isEmpty else { return }
+
+            withAnimation(.easeInOut(duration: 0.3)) {
+                highlightedBadges = Set(badgesToHighlight)
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    highlightedBadges.removeAll()
+                }
+            }
+        }
+    }
+
+    // MARK: - Layouts
+
+    private var regularLayout: some View {
+        HStack(alignment: .center, spacing: 12) {
+            routeInfoView
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer(minLength: 8)
+            VStack(alignment: .trailing, spacing: 4) {
+                minutesView
+            }
+            .frame(minWidth: 48)
+        }
+    }
+
+    private var accessibilityLayout: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            routeInfoView
+            HStack(spacing: 8) {
+                minutesView
+            }
+        }
+    }
+
+    private var routeInfoView: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(routeShortName) - \(routeHeadsign)")
+                .font(.headline)
+                .foregroundColor(.primary)
+                .lineLimit(sizeCategory.isAccessibilityCategory ? nil : 1)
+            Text(statusText)
+                .font(.caption)
+                .foregroundColor(statusColor)
+                .lineLimit(1)
+        }
+    }
+
+    private var minutesView: some View {
+        ForEach(minutes) { minute in
+            if minute.isPrimary {
+                Text(minute.text)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(badgeBackgroundColor(for: minute))
+                    )
+                    .minimumScaleFactor(0.75)
+                    .lineLimit(1)
+            } else {
+                Text(minute.text)
+                    .font(.subheadline)
+                    .foregroundColor(minute.color)
+                    .lineLimit(1)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(secondaryBadgeBackgroundColor(for: minute))
+                    )
+            }
+        }
+    }
+
+    // MARK: - Badge Highlight Colors
+
+    private func badgeBackgroundColor(for minute: MinuteDisplay) -> Color {
+        if !isLiveActivity && minute.shouldHighlight && highlightedBadges.contains(minute.id) {
+            return Color(uiColor: ThemeColors.shared.propertyChanged)
+        }
+        return minute.color
+    }
+
+    private func secondaryBadgeBackgroundColor(for minute: MinuteDisplay) -> Color {
+        if !isLiveActivity && minute.shouldHighlight && highlightedBadges.contains(minute.id) {
+            return Color(uiColor: ThemeColors.shared.propertyChanged)
+        }
+        return Color.clear
+    }
+}
+
+// MARK: - Live Activity Convenience Initializer
+
+extension TripBookmarkRow {
+    public init(staticData: TripAttributes.StaticData, contentState: TripAttributes.ContentState) {
+        let statusColor = Color(contentState.statusColor.uiColor)
+        let minuteDisplays = contentState.minutes.enumerated().map { index, minuteInfo in
+            MinuteDisplay(
+                text: minuteInfo.text,
+                color: Color(minuteInfo.color.uiColor),
+                isPrimary: index == 0,
+                shouldHighlight: contentState.shouldHighlight && index == 0
+            )
+        }
+        self.init(
+            routeShortName: staticData.routeShortName,
+            routeHeadsign: staticData.routeHeadsign,
+            statusText: contentState.statusText,
+            statusColor: statusColor,
+            minutes: minuteDisplays,
+            isLiveActivity: true
+        )
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+
+#Preview("Light Mode - Representative States") {
+    VStack(spacing: 0) {
+        // On time with all three badges
+        TripBookmarkRow(
+            routeShortName: "28",
+            routeHeadsign: "Carkeek Park",
+            statusText: "3:26 AM - arrives on time",
+            statusColor: Color(UIColor.systemGreen),
+            minutes: [
+                .init(text: "5m", color: Color(UIColor.systemGreen), isPrimary: true),
+                .init(text: "15m", color: Color(UIColor.systemGreen), isPrimary: false),
+                .init(text: "25m", color: Color(UIColor.systemGreen), isPrimary: false)
+            ]
+        )
+        Divider()
+        // Late departure
+        TripBookmarkRow(
+            routeShortName: "578",
+            routeHeadsign: "Puyallup",
+            statusText: "3:04 AM - arrives 5 min late",
+            statusColor: Color(UIColor.systemBlue),
+            minutes: [
+                .init(text: "6m", color: Color(UIColor.systemBlue), isPrimary: true),
+                .init(text: "31m", color: Color(UIColor.systemBlue), isPrimary: false)
+            ]
+        )
+        Divider()
+        // Scheduled / no real-time data
+        TripBookmarkRow(
+            routeShortName: "590",
+            routeHeadsign: "Commerce / Tacoma",
+            statusText: "2:55 AM - Scheduled/not real-time",
+            statusColor: Color(UIColor.systemGray),
+            minutes: [
+                .init(text: "27m", color: Color(UIColor.systemGray), isPrimary: true)
+            ]
+        )
+        Divider()
+        // Loading state (no data)
+        TripBookmarkRow(
+            routeShortName: "44",
+            routeHeadsign: "Ballard",
+            statusText: "Loading...",
+            statusColor: Color(UIColor.secondaryLabel),
+            minutes: []
+        )
+    }
+}
+
+#Preview("Dark Mode") {
+    VStack(spacing: 0) {
+        TripBookmarkRow(
+            routeShortName: "28",
+            routeHeadsign: "Carkeek Park",
+            statusText: "3:26 AM - arrives on time",
+            statusColor: Color(UIColor.systemGreen),
+            minutes: [
+                .init(text: "5m", color: Color(UIColor.systemGreen), isPrimary: true),
+                .init(text: "15m", color: Color(UIColor.systemGreen), isPrimary: false),
+                .init(text: "25m", color: Color(UIColor.systemGreen), isPrimary: false)
+            ]
+        )
+        Divider()
+        TripBookmarkRow(
+            routeShortName: "578",
+            routeHeadsign: "Puyallup",
+            statusText: "3:04 AM - arrives 5 min late",
+            statusColor: Color(UIColor.systemBlue),
+            minutes: [
+                .init(text: "6m", color: Color(UIColor.systemBlue), isPrimary: true),
+                .init(text: "31m", color: Color(UIColor.systemBlue), isPrimary: false)
+            ]
+        )
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Accessibility XXXLarge") {
+    TripBookmarkRow(
+        routeShortName: "28",
+        routeHeadsign: "Carkeek Park",
+        statusText: "3:26 AM - arrives on time",
+        statusColor: Color(UIColor.systemGreen),
+        minutes: [
+            .init(text: "5m", color: Color(UIColor.systemGreen), isPrimary: true),
+            .init(text: "15m", color: Color(UIColor.systemGreen), isPrimary: false),
+            .init(text: "25m", color: Color(UIColor.systemGreen), isPrimary: false)
+        ]
+    )
+    .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+}
+
+#Preview("Highlight Animation") {
+    TripBookmarkRow(
+        routeShortName: "33",
+        routeHeadsign: "E Magnolia",
+        statusText: "2:46 AM - arrives 1 min late",
+        statusColor: Color(UIColor.systemBlue),
+        minutes: [
+            .init(text: "5m", color: Color(UIColor.systemBlue), isPrimary: true, shouldHighlight: true),
+            .init(text: "15m", color: Color(UIColor.systemBlue), isPrimary: false, shouldHighlight: true),
+            .init(text: "34m", color: Color(UIColor.systemBlue), isPrimary: false, shouldHighlight: true)
+        ]
+    )
+}
+
+#endif

--- a/OBAKitCore/UI/TripBookmarkRow.swift
+++ b/OBAKitCore/UI/TripBookmarkRow.swift
@@ -202,11 +202,13 @@ public struct TripBookmarkRow: View {
 extension TripBookmarkRow {
     public init(staticData: TripAttributes.StaticData, contentState: TripAttributes.ContentState) {
         let presenter = TripActivityPresenter()
-        let statusText = contentState.arrivals.first.map { presenter.statusText(for: $0) } ?? ""
-        let statusColor = Color(presenter.primaryColor(for: contentState))
-        let minuteDisplays = contentState.arrivals.enumerated().map { index, arrival in
+        let now = Date()
+        let upcoming = contentState.upcomingArrivals(now: now)
+        let statusText = upcoming.first.map { presenter.statusText(for: $0, now: now) } ?? ""
+        let statusColor = Color(presenter.primaryColor(for: contentState, now: now))
+        let minuteDisplays = upcoming.enumerated().map { index, arrival in
             MinuteDisplay(
-                text: presenter.minuteText(for: arrival),
+                text: presenter.minuteText(for: arrival, now: now),
                 color: Color(presenter.color(for: arrival)),
                 isPrimary: index == 0
             )

--- a/OBAKitCore/UI/TripBookmarkRow.swift
+++ b/OBAKitCore/UI/TripBookmarkRow.swift
@@ -201,19 +201,20 @@ public struct TripBookmarkRow: View {
 
 extension TripBookmarkRow {
     public init(staticData: TripAttributes.StaticData, contentState: TripAttributes.ContentState) {
-        let statusColor = Color(contentState.statusColor.uiColor)
-        let minuteDisplays = contentState.minutes.enumerated().map { index, minuteInfo in
+        let presenter = TripActivityPresenter()
+        let statusText = contentState.arrivals.first.map { presenter.statusText(for: $0) } ?? ""
+        let statusColor = Color(presenter.primaryColor(for: contentState))
+        let minuteDisplays = contentState.arrivals.enumerated().map { index, arrival in
             MinuteDisplay(
-                text: minuteInfo.text,
-                color: Color(minuteInfo.color.uiColor),
-                isPrimary: index == 0,
-                shouldHighlight: contentState.shouldHighlight && index == 0
+                text: presenter.minuteText(for: arrival),
+                color: Color(presenter.color(for: arrival)),
+                isPrimary: index == 0
             )
         }
         self.init(
             routeShortName: staticData.routeShortName,
             routeHeadsign: staticData.routeHeadsign,
-            statusText: contentState.statusText,
+            statusText: statusText,
             statusColor: statusColor,
             minutes: minuteDisplays,
             isLiveActivity: true

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -1,0 +1,120 @@
+//
+//  TripLiveActivityCardView.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Lock-screen Live Activity card that matches the grouped route card header from StopPageView:
+/// route badge + headsign + scheduled time/adherence status + countdown + departure chips.
+/// No alarm pill or expand chevron.
+public struct TripLiveActivityCardView: View {
+    public let staticData: TripAttributes.StaticData
+    public let contentState: TripAttributes.ContentState
+
+    private let presenter = TripActivityPresenter()
+
+    public init(staticData: TripAttributes.StaticData, contentState: TripAttributes.ContentState) {
+        self.staticData = staticData
+        self.contentState = contentState
+    }
+
+    public var body: some View {
+        let now = Date()
+        let upcoming = contentState.upcomingArrivals(now: now)
+        let primary = upcoming.first
+        let chips = Array(upcoming.dropFirst())
+
+        VStack(alignment: .leading, spacing: 10) {
+            primaryRow(primary: primary, now: now)
+            if !chips.isEmpty {
+                chipsRow(chips: chips, now: now)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    @ViewBuilder
+    private func primaryRow(primary: TripAttributes.ContentState.ArrivalInfo?, now: Date) -> some View {
+        HStack(alignment: .center, spacing: 13) {
+            RouteBadgeView(
+                routeShortName: staticData.routeShortName,
+                routeColor: resolvedRouteColor,
+                size: 48
+            )
+            VStack(alignment: .leading, spacing: 3) {
+                Text(staticData.routeHeadsign)
+                    .font(.headline.weight(.heavy))
+                    .lineLimit(2)
+                if let primary {
+                    timeStatusLine(for: primary, now: now)
+                }
+            }
+            Spacer(minLength: 8)
+            if let primary {
+                countdownBadge(for: primary, now: now)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func timeStatusLine(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+        HStack(spacing: 6) {
+            Text(arrival.departureDate, style: .time)
+                .font(.footnote)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+            Text("·")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+            Text(presenter.deviationLabel(for: arrival, now: now))
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(Color(uiColor: presenter.color(for: arrival)))
+        }
+    }
+
+    @ViewBuilder
+    private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+        CountdownView(
+            minutes: Int(arrival.departureDate.timeIntervalSince(now) / 60.0),
+            isRealTime: arrival.scheduleStatus != .unknown,
+            color: Color(uiColor: presenter.color(for: arrival))
+        )
+    }
+
+    @ViewBuilder
+    private func chipsRow(chips: [TripAttributes.ContentState.ArrivalInfo], now: Date) -> some View {
+        HStack(spacing: 8) {
+            ForEach(chips, id: \.departureTime) { arrival in
+                departurePill(for: arrival, now: now)
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+        let color = Color(uiColor: presenter.color(for: arrival))
+        let minutes = max(0, Int(arrival.departureDate.timeIntervalSince(now) / 60.0))
+        Text(minutes == 0
+             ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now")
+             : "\(minutes)m")
+            .font(.caption.weight(.heavy))
+            .monospacedDigit()
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var resolvedRouteColor: Color {
+        guard let hex = staticData.routeColorHex else { return Color(uiColor: ThemeColors.shared.brand) }
+        return Color(uiColor: UIColor(hex: hex) ?? ThemeColors.shared.brand)
+    }
+}

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -91,7 +91,15 @@ public struct TripLiveActivityCardView: View {
     @ViewBuilder
     private func chipsRow(chips: [TripAttributes.ContentState.ArrivalInfo], now: Date) -> some View {
         HStack(spacing: 8) {
-            ForEach(chips, id: \.departureTime) { arrival in
+            // departureTime is NOT a safe identity here: the server can (and,
+            // due to an upstream OBA bug, briefly did) emit duplicate
+            // departure times, and even with that fixed server-side, two
+            // genuinely distinct trips can legitimately share a departure
+            // time. Duplicate ForEach IDs are undefined behavior in SwiftUI.
+            // `chips` is a small, ordered, server-supplied list that's fully
+            // replaced on every content update, so positional identity is
+            // safe and can't collide.
+            ForEach(Array(chips.enumerated()), id: \.offset) { _, arrival in
                 departurePill(for: arrival, now: now)
             }
             Spacer()

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -8,13 +8,25 @@
 //
 
 import XCTest
+import ActivityKit
 @testable import OBAKit
 @testable import OBAKitCore
 
-/// Covers `LiveActivityRegistry`'s reconciliation sweep and unregistration, both of which have
-/// to be careful about *when* a persisted delete URL may be forgotten: it's the only handle the
-/// app has on the server-side subscription, so dropping it after a failed DELETE leaks the
-/// subscription permanently.
+/// Covers `LiveActivityRegistry`'s reconciliation sweep and unregistration.
+///
+/// Two invariants are load-bearing here:
+///
+/// 1. **Dead means dismissed/ended/absent, not merely absent.** ActivityKit keeps a dismissed
+///    activity in `Activity.activities` with an `activityState` of `.dismissed`. A sweep that
+///    equates "listed" with "alive" skips the very activity it exists to clean up — that bug
+///    shipped, and the server pushed to a dismissed activity indefinitely. Because `Activity`
+///    can't be constructed in a test, the registry takes the *live* activity IDs as an
+///    injectable seam; these tests build that set out of `(id, ActivityState)` pairs run
+///    through the registry's own `isLive(_:)` predicate, so a regression in the predicate fails
+///    here rather than on a device.
+/// 2. **A delete URL may only be forgotten once the server confirms it.** It's the only handle
+///    the app has on the server-side subscription, so dropping it after a failed DELETE leaks
+///    the subscription permanently.
 class LiveActivityRegistryTests: OBATestCase {
 
     private let deadActivityID = "dead-activity"
@@ -34,14 +46,24 @@ class LiveActivityRegistryTests: OBATestCase {
     }
 
     /// Builds a registry backed by the test's UserDefaults suite and mocked Obaco service.
-    /// - parameter runningActivityIDs: Stands in for `Activity<TripAttributes>.activities`.
-    private func buildRegistry(runningActivityIDs: Set<String>) -> LiveActivityRegistry {
+    /// - parameter liveActivityIDs: Stands in for the IDs of the activities in
+    ///   `Activity<TripAttributes>.activities` that are in a live state.
+    private func buildRegistry(liveActivityIDs: Set<String>) -> LiveActivityRegistry {
         let service: ObacoAPIService = obacoService
         return LiveActivityRegistry(
             userDefaults: userDefaults,
             obacoServiceProvider: { service },
-            runningActivityIDs: { runningActivityIDs }
+            liveActivityIDs: { liveActivityIDs }
         )
+    }
+
+    /// Builds a registry whose live set is derived from a stand-in for
+    /// `Activity<TripAttributes>.activities`: every activity ActivityKit still *lists*, paired
+    /// with the state it reports. Filtering happens through the production `isLive(_:)`
+    /// predicate, so "present but `.dismissed`" is a case these tests can actually express.
+    private func buildRegistry(activityKitReports activities: [(id: String, state: ActivityState)]) -> LiveActivityRegistry {
+        let live = Set(activities.filter { LiveActivityRegistry.isLive($0.state) }.map(\.id))
+        return buildRegistry(liveActivityIDs: live)
     }
 
     private func persistDeleteURLs(_ urls: [String: String]) {
@@ -93,41 +115,101 @@ class LiveActivityRegistryTests: OBATestCase {
         }
     }
 
+    // MARK: - What counts as alive
+
+    /// The predicate the whole sweep turns on. `.dismissed`/`.ended` are the two states the view
+    /// controllers' `activityStateUpdates` observers treat as death; everything else is alive.
+    func testOnlyDismissedAndEndedActivitiesAreConsideredDead() {
+        XCTAssertFalse(LiveActivityRegistry.isLive(.dismissed), "A dismissed activity is dead, even though ActivityKit still lists it.")
+        XCTAssertFalse(LiveActivityRegistry.isLive(.ended), "An ended activity is dead, even though ActivityKit still lists it.")
+
+        XCTAssertTrue(LiveActivityRegistry.isLive(.active))
+        XCTAssertTrue(LiveActivityRegistry.isLive(.stale))
+
+        // `.pending` postdates our deployment target, hence the gate. It's also the reason
+        // `isLive(_:)` is written as "not dead" rather than as an allow-list of live states: a
+        // state case the app was never compiled against must not be mistaken for death.
+        if #available(iOS 26.0, *) {
+            XCTAssertTrue(LiveActivityRegistry.isLive(.pending))
+        }
+    }
+
     // MARK: - reconcile()
 
-    /// The bug this type exists to fix: the user cleared a Live Activity while the app wasn't
-    /// running, so nothing ever observed the dismissal and its delete URL was left behind. The
-    /// activity is gone from ActivityKit, so the subscription must be deleted server-side.
+    /// The regression that shipped. The user dismissed the Live Activity, but ActivityKit *still
+    /// lists it* in `Activity.activities` — with a state of `.dismissed`. The original sweep
+    /// checked only for presence in that array, concluded the activity was alive, skipped it, and
+    /// the server went on pushing to a dead activity forever. Presence is not life.
+    func testReconcileSweepsActivityStillListedByActivityKitButDismissed() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(activityKitReports: [(deadActivityID, .dismissed)]).reconcile()
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for a dismissed activity that ActivityKit still lists.")
+        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
+    }
+
+    /// Same regression, other dead state: an `.ended` activity also lingers in `activities`.
+    func testReconcileSweepsActivityStillListedByActivityKitButEnded() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(activityKitReports: [(deadActivityID, .ended)]).reconcile()
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an ended activity that ActivityKit still lists.")
+        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+    }
+
+    /// The user cleared a Live Activity while the app wasn't running and the system has since
+    /// purged it: nothing ever observed the dismissal, so its delete URL was left behind.
     func testReconcileDeletesSubscriptionForActivityThatNoLongerExists() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(activityKitReports: []).reconcile()
 
         XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an activity that no longer exists.")
         XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
     }
 
-    /// A running activity still has (or will get) a lifecycle observer that unregisters it when
-    /// it ends. Reconciliation must not touch it.
-    func testReconcileLeavesStillRunningActivityAlone() async {
+    /// An active activity still has (or will get) a lifecycle observer that unregisters it when
+    /// it ends. Reconciliation must not touch it — sweeping it would kill the updates for a Live
+    /// Activity the user is looking at right now.
+    func testReconcileLeavesActiveActivityAlone() async {
         persistDeleteURLs([liveActivityID: liveDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: [liveActivityID]).reconcile()
+        await buildRegistry(activityKitReports: [(liveActivityID, .active)]).reconcile()
 
-        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for an activity that is still running.")
-        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString], "Expected a still-running activity's delete URL to be retained.")
+        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for an active activity.")
+        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString], "Expected an active activity's delete URL to be retained.")
     }
 
-    func testReconcileOnlySweepsTheDeadActivityWhenBothArePersisted() async {
+    /// `.stale` means "on screen, showing old data" — the exact situation a push update is meant
+    /// to fix. Sweeping it would guarantee it stays stale.
+    func testReconcileLeavesStaleActivityAlone() async {
+        persistDeleteURLs([liveActivityID: liveDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(activityKitReports: [(liveActivityID, .stale)]).reconcile()
+
+        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for a stale (but still live) activity.")
+        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString])
+    }
+
+    /// Both activities are listed by ActivityKit; only their states tell them apart.
+    func testReconcileOnlySweepsTheDismissedActivityWhenBothAreListed() async {
         persistDeleteURLs([
             deadActivityID: deadDeleteURL.absoluteString,
             liveActivityID: liveDeleteURL.absoluteString
         ])
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: [liveActivityID]).reconcile()
+        await buildRegistry(activityKitReports: [
+            (deadActivityID, .dismissed),
+            (liveActivityID, .active)
+        ]).reconcile()
 
         XCTAssertEqual(recorder.urls, [deadDeleteURL])
         XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString])
@@ -140,7 +222,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteFailure(URLError(.notConnectedToInternet))
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertEqual(recorder.urls, [deadDeleteURL])
         XCTAssertEqual(
@@ -154,7 +236,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 500)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertEqual(
             persistedDeleteURLs,
@@ -168,7 +250,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 404)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 404 (the subscription is already gone) to drop the persisted delete URL.")
     }
@@ -177,7 +259,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 410)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 410 Gone to drop the persisted delete URL.")
     }
@@ -188,7 +270,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: ""])
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertTrue(recorder.urls.isEmpty)
         XCTAssertTrue(persistedDeleteURLs.isEmpty)
@@ -197,7 +279,7 @@ class LiveActivityRegistryTests: OBATestCase {
     func testReconcileMakesNoRequestsWhenNothingIsPersisted() async {
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: []).reconcile()
+        await buildRegistry(liveActivityIDs: []).reconcile()
 
         XCTAssertTrue(recorder.urls.isEmpty)
     }
@@ -208,7 +290,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: []).unregister(activityID: deadActivityID)
+        await buildRegistry(liveActivityIDs: []).unregister(activityID: deadActivityID)
 
         XCTAssertEqual(recorder.urls, [deadDeleteURL])
         XCTAssertTrue(persistedDeleteURLs.isEmpty)
@@ -218,7 +300,7 @@ class LiveActivityRegistryTests: OBATestCase {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteFailure(URLError(.timedOut))
 
-        await buildRegistry(runningActivityIDs: []).unregister(activityID: deadActivityID)
+        await buildRegistry(liveActivityIDs: []).unregister(activityID: deadActivityID)
 
         XCTAssertEqual(
             persistedDeleteURLs,
@@ -230,9 +312,154 @@ class LiveActivityRegistryTests: OBATestCase {
     func testUnregisterIsANoOpForAnUnknownActivity() async {
         let recorder = mockDeleteResponse(statusCode: 204)
 
-        await buildRegistry(runningActivityIDs: []).unregister(activityID: "never-registered")
+        await buildRegistry(liveActivityIDs: []).unregister(activityID: "never-registered")
 
         XCTAssertTrue(recorder.urls.isEmpty)
+    }
+
+    // MARK: - Cancellation
+
+    /// The bug a device had to find. `unregister` is reached from the view controllers' lifecycle
+    /// observer — a `Task` that awaits `activityStateUpdates` — and that observer used to cancel
+    /// *itself* before awaiting this call. `URLSession` refuses to send a request from a cancelled
+    /// task, so the DELETE died as `URLError.cancelled` (-999) before a byte left the device, on
+    /// every dismissal, in every scenario. The subscription leaked and the server kept pushing.
+    ///
+    /// So the property under test is not "unregister sends a DELETE" (the tests above already
+    /// pass with the bug present) but "unregister sends a DELETE *even from a cancelled task*".
+    /// `MockDataLoader` models `URLSession`'s cancellation check, so this fails without the fix.
+    func testUnregisterIssuesItsDeleteEvenWhenTheCallingTaskIsCancelled() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        let registry = buildRegistry(liveActivityIDs: [])
+        let activityID = deadActivityID
+        let expectedURL = deadDeleteURL
+
+        // Stands in for the lifecycle observer at the moment it cancels itself: by the time
+        // `unregister` runs, the enclosing task is already cancelled. Spinning until the
+        // cancellation is visible keeps this deterministic rather than a race with `cancel()`.
+        let observer = Task {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            await registry.unregister(activityID: activityID)
+        }
+        observer.cancel()
+        await observer.value
+
+        XCTAssertEqual(
+            recorder.urls,
+            [expectedURL],
+            "The unregister DELETE must reach the network even though the task that triggered it was cancelled — cancelling teardown work only ever leaks the subscription."
+        )
+        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected the confirmed DELETE to drop the persisted delete URL.")
+    }
+
+    /// The same defect, one layer over: the registration POST wins its race with a dismissal, so
+    /// `confirm()` returns false and the registry must DELETE the row the server just created.
+    /// That cleanup runs inside the push-token task — which is cancelled, because being cancelled
+    /// is *why* `confirm()` returned false. Cancellation-honoring cleanup here orphans a row that
+    /// nothing else will ever delete: the app never persisted its delete URL, so `reconcile()`
+    /// can't find it either.
+    func testRegisterCleansUpTheOrphanedRowEvenWhenItsTokenTaskWasCancelledMidRegistration() async {
+        let registry = buildRegistry(liveActivityIDs: [])
+        let deleteRecorder = mockDeleteResponse(statusCode: 204)
+        let activityID = deadActivityID
+        let expectedURL = deadDeleteURL
+
+        // Lets the mocked POST cancel the very task that issued it.
+        let tokenTask = UnsafeTaskBox()
+
+        let registrationBody = Data(#"{"url":"\#(deadDeleteURL.absoluteString)"}"#.utf8)
+        dataLoader.mock(data: registrationBody, statusCode: 200) { request in
+            guard request.httpMethod == "POST" else { return false }
+            // The production race, made deterministic: the user dismisses the Live Activity while
+            // its push token registration is still in flight, so the token task is cancelled after
+            // the server has already created the row.
+            tokenTask.cancel()
+            return true
+        }
+
+        // The token task can't be handed to the box until it exists, so gate its body until it has
+        // been: otherwise the POST could fire before there's anything for the matcher to cancel.
+        let gate = AsyncStream<Void>.makeStream()
+        let task = Task {
+            for await _ in gate.stream { break }
+
+            await registry.register(
+                activityID: activityID,
+                staticData: TripAttributes.StaticData(routeShortName: "49", routeHeadsign: "Downtown", stopID: "1_75403"),
+                pushToken: "deadbeef",
+                tripID: nil,
+                serviceDate: nil,
+                vehicleID: nil,
+                stopSequence: nil,
+                // Mirrors the view controllers' confirm: a cancelled token task means the activity
+                // was torn down mid-request, so the delete URL must not be persisted.
+                confirm: { !Task.isCancelled }
+            )
+        }
+        tokenTask.set(task)
+        gate.continuation.yield(())
+        gate.continuation.finish()
+        await task.value
+
+        XCTAssertEqual(
+            deleteRecorder.urls,
+            [expectedURL],
+            "The orphan-cleanup DELETE must reach the network even though the token task issuing it was cancelled."
+        )
+        XCTAssertTrue(
+            persistedDeleteURLs.isEmpty,
+            "An unconfirmed registration must not leave a persisted delete URL behind."
+        )
+    }
+
+    /// Guards the seam the two tests above lean on. They can only fail against the buggy ordering
+    /// if `MockDataLoader` refuses to serve a request from a cancelled task, the way `URLSession`
+    /// does. If someone "simplifies" that check away, those tests would go on passing while the
+    /// device kept failing — so assert the mock's fidelity directly.
+    func testMockDataLoaderRefusesToServeRequestsFromACancelledTaskLikeURLSession() async {
+        let recorder = mockDeleteResponse(statusCode: 204)
+        let service: ObacoAPIService = obacoService
+        let url = deadDeleteURL
+
+        let task = Task { () -> Error? in
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            do {
+                _ = try await service.deleteLiveActivity(url: url)
+                return nil
+            } catch {
+                return error
+            }
+        }
+        task.cancel()
+        let error = await task.value
+
+        XCTAssertEqual(
+            (error as? URLError)?.code,
+            .cancelled,
+            "Expected the mock to fail a request from a cancelled task with URLError.cancelled (-999), exactly as URLSession does."
+        )
+        XCTAssertTrue(recorder.urls.isEmpty, "A cancelled request is one the server never saw; the mock must not record it.")
+    }
+
+    /// Holds the task that a mocked response needs to cancel. `@unchecked Sendable` because the
+    /// matcher runs on whatever thread the request is issued from; the lock is the real guarantee.
+    private final class UnsafeTaskBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var task: Task<Void, Never>?
+
+        func set(_ task: Task<Void, Never>) {
+            lock.withLock { self.task = task }
+        }
+
+        func cancel() {
+            lock.withLock { task }?.cancel()
+        }
     }
 
     // MARK: - Persistence contract
@@ -244,7 +471,7 @@ class LiveActivityRegistryTests: OBATestCase {
 
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
 
-        let registry = buildRegistry(runningActivityIDs: [])
+        let registry = buildRegistry(liveActivityIDs: [])
         XCTAssertEqual(registry.deleteURL(forActivityID: deadActivityID), deadDeleteURL)
     }
 }

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -1,0 +1,250 @@
+//
+//  LiveActivityRegistryTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Covers `LiveActivityRegistry`'s reconciliation sweep and unregistration, both of which have
+/// to be careful about *when* a persisted delete URL may be forgotten: it's the only handle the
+/// app has on the server-side subscription, so dropping it after a failed DELETE leaks the
+/// subscription permanently.
+class LiveActivityRegistryTests: OBATestCase {
+
+    private let deadActivityID = "dead-activity"
+    private let liveActivityID = "live-activity"
+
+    private var deadDeleteURL: URL {
+        URL(string: "https://alerts.example.com/api/v2/regions/1/live_activities/\(deadActivityID)")!
+    }
+
+    private var liveDeleteURL: URL {
+        URL(string: "https://alerts.example.com/api/v2/regions/1/live_activities/\(liveActivityID)")!
+    }
+
+    private var dataLoader: MockDataLoader {
+        // swiftlint:disable:next force_cast
+        obacoService.dataLoader as! MockDataLoader
+    }
+
+    /// Builds a registry backed by the test's UserDefaults suite and mocked Obaco service.
+    /// - parameter runningActivityIDs: Stands in for `Activity<TripAttributes>.activities`.
+    private func buildRegistry(runningActivityIDs: Set<String>) -> LiveActivityRegistry {
+        let service: ObacoAPIService = obacoService
+        return LiveActivityRegistry(
+            userDefaults: userDefaults,
+            obacoServiceProvider: { service },
+            runningActivityIDs: { runningActivityIDs }
+        )
+    }
+
+    private func persistDeleteURLs(_ urls: [String: String]) {
+        userDefaults.set(urls, forKey: LiveActivityRegistry.deleteURLsDefaultsKey)
+    }
+
+    private var persistedDeleteURLs: [String: String] {
+        userDefaults.dictionary(forKey: LiveActivityRegistry.deleteURLsDefaultsKey) as? [String: String] ?? [:]
+    }
+
+    /// Mocks every DELETE to the live activities endpoint with the given status and records the
+    /// URLs it saw.
+    @discardableResult
+    private func mockDeleteResponse(statusCode: Int) -> DeleteRecorder {
+        let recorder = DeleteRecorder()
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            guard request.httpMethod == "DELETE", let url = request.url else { return false }
+            recorder.record(url)
+            return true
+        }
+        return recorder
+    }
+
+    /// Mocks every DELETE with a transport-level failure — no response at all, as if the device
+    /// were offline.
+    @discardableResult
+    private func mockDeleteFailure(_ error: Error) -> DeleteRecorder {
+        let recorder = DeleteRecorder()
+        let response = MockDataResponse(data: nil, urlResponse: nil, error: error) { request in
+            guard request.httpMethod == "DELETE", let url = request.url else { return false }
+            recorder.record(url)
+            return true
+        }
+        dataLoader.mock(response: response)
+        return recorder
+    }
+
+    /// Thread-safe collector for the DELETEs a registry issued.
+    private final class DeleteRecorder {
+        private let lock = NSLock()
+        private var _urls = [URL]()
+
+        func record(_ url: URL) {
+            lock.withLock { _urls.append(url) }
+        }
+
+        var urls: [URL] {
+            lock.withLock { _urls }
+        }
+    }
+
+    // MARK: - reconcile()
+
+    /// The bug this type exists to fix: the user cleared a Live Activity while the app wasn't
+    /// running, so nothing ever observed the dismissal and its delete URL was left behind. The
+    /// activity is gone from ActivityKit, so the subscription must be deleted server-side.
+    func testReconcileDeletesSubscriptionForActivityThatNoLongerExists() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an activity that no longer exists.")
+        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
+    }
+
+    /// A running activity still has (or will get) a lifecycle observer that unregisters it when
+    /// it ends. Reconciliation must not touch it.
+    func testReconcileLeavesStillRunningActivityAlone() async {
+        persistDeleteURLs([liveActivityID: liveDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: [liveActivityID]).reconcile()
+
+        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for an activity that is still running.")
+        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString], "Expected a still-running activity's delete URL to be retained.")
+    }
+
+    func testReconcileOnlySweepsTheDeadActivityWhenBothArePersisted() async {
+        persistDeleteURLs([
+            deadActivityID: deadDeleteURL.absoluteString,
+            liveActivityID: liveDeleteURL.absoluteString
+        ])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: [liveActivityID]).reconcile()
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL])
+        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString])
+    }
+
+    /// The critical failure mode: if a flaky network let us forget the delete URL, the server-side
+    /// subscription could never be deleted again. A transient failure must leave the entry in
+    /// place so a later launch retries it.
+    func testReconcileRetainsDeleteURLWhenTheDeviceIsOffline() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteFailure(URLError(.notConnectedToInternet))
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL])
+        XCTAssertEqual(
+            persistedDeleteURLs,
+            [deadActivityID: deadDeleteURL.absoluteString],
+            "Expected a transient DELETE failure to retain the persisted delete URL for a later retry."
+        )
+    }
+
+    func testReconcileRetainsDeleteURLOnServerError() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        mockDeleteResponse(statusCode: 500)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertEqual(
+            persistedDeleteURLs,
+            [deadActivityID: deadDeleteURL.absoluteString],
+            "Expected a 500 to be treated as transient and retain the persisted delete URL."
+        )
+    }
+
+    /// A retry that finds the row already deleted has nothing left to do, so the entry can go.
+    func testReconcileForgetsDeleteURLWhenServerReports404() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        mockDeleteResponse(statusCode: 404)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 404 (the subscription is already gone) to drop the persisted delete URL.")
+    }
+
+    func testReconcileForgetsDeleteURLWhenServerReports410() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        mockDeleteResponse(statusCode: 410)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 410 Gone to drop the persisted delete URL.")
+    }
+
+    /// A malformed entry can never produce a request, so retaining it would just fail this check
+    /// forever.
+    func testReconcileDiscardsUnparseableDeleteURL() async {
+        persistDeleteURLs([deadActivityID: ""])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertTrue(recorder.urls.isEmpty)
+        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+    }
+
+    func testReconcileMakesNoRequestsWhenNothingIsPersisted() async {
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: []).reconcile()
+
+        XCTAssertTrue(recorder.urls.isEmpty)
+    }
+
+    // MARK: - unregister()
+
+    func testUnregisterDeletesSubscriptionAndForgetsItsURL() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: []).unregister(activityID: deadActivityID)
+
+        XCTAssertEqual(recorder.urls, [deadDeleteURL])
+        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+    }
+
+    func testUnregisterRetainsDeleteURLWhenTheDeviceIsOffline() async {
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+        mockDeleteFailure(URLError(.timedOut))
+
+        await buildRegistry(runningActivityIDs: []).unregister(activityID: deadActivityID)
+
+        XCTAssertEqual(
+            persistedDeleteURLs,
+            [deadActivityID: deadDeleteURL.absoluteString],
+            "Expected a transient DELETE failure to retain the persisted delete URL so reconcile() can retry it."
+        )
+    }
+
+    func testUnregisterIsANoOpForAnUnknownActivity() async {
+        let recorder = mockDeleteResponse(statusCode: 204)
+
+        await buildRegistry(runningActivityIDs: []).unregister(activityID: "never-registered")
+
+        XCTAssertTrue(recorder.urls.isEmpty)
+    }
+
+    // MARK: - Persistence contract
+
+    /// The key and value shape are a field-persisted contract: delete URLs written by shipped
+    /// builds must still be found (and cleaned up) by this code.
+    func testRegistryReadsTheLegacyUserDefaultsKeyAndShape() {
+        XCTAssertEqual(LiveActivityRegistry.deleteURLsDefaultsKey, "liveActivityDeleteURLs")
+
+        persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
+
+        let registry = buildRegistry(runningActivityIDs: [])
+        XCTAssertEqual(registry.deleteURL(forActivityID: deadActivityID), deadDeleteURL)
+    }
+}

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -88,6 +88,25 @@ class MockDataLoader: NSObject, URLDataLoader {
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        // `URLSession.data(for:)` checks task cancellation before it sends anything: called from
+        // an already-cancelled Task it throws `URLError.cancelled` (-999) and the request never
+        // leaves the device. A mock that answers happily regardless is not a faster network, it's
+        // a *different* one — and the difference hides an entire class of bug, in which cleanup
+        // work is issued from a task that the cleanup itself just cancelled. Exactly that bug
+        // shipped in the Live Activity unregister path (see `LiveActivityRegistry`) and the suite
+        // was green throughout, because this line wasn't here.
+        //
+        // Deliberately ahead of `recordRequest`: a cancelled request is one the server never saw,
+        // so a test asserting "the DELETE went out" must not be able to see it either.
+        //
+        // `URLError.cancelled`, not `CancellationError`: -999 is what production code actually
+        // catches and branches on (`LiveActivityRegistry.serverConfirmedSubscriptionIsGone`
+        // classifies it as transient), so throwing the tidier Swift error would let a test
+        // disagree with the device about what happens next.
+        if Task.isCancelled {
+            throw URLError(.cancelled)
+        }
+
         recordRequest(request.url)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
@@ -60,6 +60,7 @@ class LiveActivityModelOperationTests: OBATestCase {
         XCTAssertNil(params["service_date"])
         XCTAssertNil(params["vehicle_id"])
         XCTAssertNil(params["stop_sequence"])
+        XCTAssertEqual(params["apns_sandbox"], "1", "Expected a debug build to flag the Live Activity for the APNs sandbox, as the ActivityKit token is a sandbox token. Without this flag, server routes pushes to production APNs and they bounce.")
     }
 
     func testSuccessfulLiveActivityDeletion() async throws {

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
@@ -1,0 +1,95 @@
+//
+//  LiveActivityModelOperationTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+import CoreLocation
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_try force_cast
+
+class LiveActivityModelOperationTests: OBATestCase {
+
+    func testSuccessfulLiveActivityRegistration() async throws {
+        let data = """
+        {"url": "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123"}
+        """.data(using: .utf8)!
+
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+
+        var capturedRequest: URLRequest?
+        dataLoader.mock(data: data) { request in
+            capturedRequest = request
+            return request.url?.host == "alerts.example.com" &&
+                request.url?.path == "/api/v2/regions/1/live_activities" &&
+                request.httpMethod == "POST"
+        }
+
+        let url = try await obacoService.postLiveActivity(
+            activityID: "activity-123",
+            pushToken: "push-token-abc",
+            stopID: "1_11420",
+            routeShortName: "10",
+            tripHeadsign: "Downtown Seattle",
+            tripID: nil,
+            serviceDate: nil,
+            vehicleID: nil,
+            stopSequence: nil
+        )
+
+        XCTAssertEqual(url.absoluteString, "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")
+
+        let request = try XCTUnwrap(capturedRequest)
+        let body = try XCTUnwrap(request.httpBody)
+        let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
+        let params = formParams(from: bodyString)
+
+        XCTAssertEqual(params["activity_id"], "activity-123")
+        XCTAssertEqual(params["push_token"], "push-token-abc")
+        XCTAssertEqual(params["stop_id"], "1_11420")
+        XCTAssertEqual(params["route_short_name"], "10")
+        XCTAssertEqual(params["trip_headsign"], "Downtown Seattle")
+        XCTAssertNil(params["trip_id"])
+        XCTAssertNil(params["service_date"])
+        XCTAssertNil(params["vehicle_id"])
+        XCTAssertNil(params["stop_sequence"])
+    }
+
+    func testSuccessfulLiveActivityDeletion() async throws {
+        let liveActivityURL = URL(string: "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")!
+
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data()) { (request) -> Bool in
+            request.url!.absoluteString.starts(with: liveActivityURL.absoluteString) &&
+            request.httpMethod == "DELETE"
+        }
+
+        let (_, response) = try await obacoService.deleteLiveActivity(url: liveActivityURL)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteLiveActivity response to be of type HTTPURLResponse")
+        XCTAssertEqual(httpResponse.statusCode, 200)
+    }
+
+    // MARK: - Helpers
+
+    /// Parses an `application/x-www-form-urlencoded` request body (as produced by
+    /// `NetworkHelpers.dictionary(toHTTPBodyData:)`) into a `[String: String]` for
+    /// per-key assertions, since dictionary key order isn't guaranteed.
+    private func formParams(from body: String) -> [String: String] {
+        var result = [String: String]()
+        for pair in body.components(separatedBy: "&") {
+            let parts = pair.components(separatedBy: "=")
+            guard parts.count == 2 else { continue }
+            let key = parts[0].removingPercentEncoding ?? parts[0]
+            let value = parts[1].removingPercentEncoding ?? parts[1]
+            result[key] = value
+        }
+        return result
+    }
+}

--- a/OBAKitTests/Models/TripActivityPresenterTests.swift
+++ b/OBAKitTests/Models/TripActivityPresenterTests.swift
@@ -1,0 +1,49 @@
+//
+//  TripActivityPresenterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKitCore
+
+class TripActivityPresenterTests: XCTestCase {
+    private let presenter = TripActivityPresenter(
+        formatters: Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+    )
+
+    private func arrival(offsetSeconds: Int, status: TripAttributes.ContentState.ScheduleStatusValue = .onTime, deviation: Int = 0, now: Date) -> TripAttributes.ContentState.ArrivalInfo {
+        TripAttributes.ContentState.ArrivalInfo(
+            departureTime: Int(now.timeIntervalSince1970) + offsetSeconds,
+            scheduleStatus: status,
+            scheduleDeviation: deviation,
+            isArrival: false
+        )
+    }
+
+    /// Whole-second epoch date so departureTime (an Int of epoch seconds)
+    /// represents the offset exactly — a fractional `now` would truncate to
+    /// just under the offset and shift the minute math down by one.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testMinuteTextForFutureDeparture() {
+        let text = presenter.minuteText(for: arrival(offsetSeconds: 300, now: now), now: now)
+        XCTAssertTrue(text.contains("5"), "expected a 5-minute chip, got \(text)")
+    }
+
+    func testColorMatchesFormattersScheduleStatusColor() {
+        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+        XCTAssertEqual(
+            presenter.color(for: arrival(offsetSeconds: 300, status: .delayed, now: now)),
+            formatters.colorForScheduleStatus(.delayed)
+        )
+    }
+
+    func testStatusTextForUnknownStatusSaysScheduled() {
+        let text = presenter.statusText(for: arrival(offsetSeconds: 300, status: .unknown, now: now), now: now)
+        XCTAssertTrue(text.contains(Strings.scheduledNotRealTime))
+    }
+}

--- a/OBAKitTests/Models/TripActivityPresenterTests.swift
+++ b/OBAKitTests/Models/TripActivityPresenterTests.swift
@@ -46,4 +46,19 @@ class TripActivityPresenterTests: XCTestCase {
         let text = presenter.statusText(for: arrival(offsetSeconds: 300, status: .unknown, now: now), now: now)
         XCTAssertTrue(text.contains(Strings.scheduledNotRealTime))
     }
+
+    /// Server-pushed deviations are raw seconds (e.g. 95s). Truncating division
+    /// would report "1 min late"; the app-wide convention (see
+    /// ArrivalDeparture.deviationFromScheduleInMinutes) is to round, which for
+    /// 95s should report "2 min late".
+    func testStatusTextRoundsDeviationMinutes() {
+        let text = presenter.statusText(for: arrival(offsetSeconds: 300, status: .delayed, deviation: 95, now: now), now: now)
+        XCTAssertTrue(text.contains("2 min late"), "95s should round to 2 min late, got \(text)")
+    }
+
+    func testPrimaryColorForEmptyArrivalsIsUnknownStatusColor() {
+        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+        let state = TripAttributes.ContentState(arrivals: [])
+        XCTAssertEqual(presenter.primaryColor(for: state), formatters.colorForScheduleStatus(.unknown))
+    }
 }

--- a/OBAKitTests/Models/TripAttributesContentStateTests.swift
+++ b/OBAKitTests/Models/TripAttributesContentStateTests.swift
@@ -1,0 +1,43 @@
+//
+//  TripAttributesContentStateTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKitCore
+
+/// Contract test: decodes the exact fixture that obacloud's
+/// LiveActivityContentState builder emits (the same JSON file exists in both
+/// repos). Uses a default-configuration JSONDecoder because Apple decodes
+/// pushed content-state with default strategies — no convertFromSnakeCase.
+class TripAttributesContentStateTests: XCTestCase {
+    func testDecodesServerFixtureWithDefaultDecoder() throws {
+        let url = Bundle(for: type(of: self)).url(forResource: "live_activity_content_state", withExtension: "json")!
+        let data = try Data(contentsOf: url)
+
+        let state = try JSONDecoder().decode(TripAttributes.ContentState.self, from: data)
+
+        XCTAssertEqual(state.arrivals.count, 3)
+
+        let first = state.arrivals[0]
+        XCTAssertEqual(first.departureTime, 1767980460)
+        XCTAssertEqual(first.scheduleStatus, .onTime)
+        XCTAssertEqual(first.scheduleDeviation, 60)
+        XCTAssertFalse(first.isArrival)
+        XCTAssertEqual(first.departureDate, Date(timeIntervalSince1970: 1767980460))
+
+        XCTAssertEqual(state.arrivals[1].scheduleStatus, .delayed)
+        XCTAssertEqual(state.arrivals[2].scheduleStatus, .unknown)
+    }
+
+    func testScheduleStatusBridgesToExistingEnum() {
+        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.onTime.scheduleStatus, ScheduleStatus.onTime)
+        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.early.scheduleStatus, ScheduleStatus.early)
+        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.delayed.scheduleStatus, ScheduleStatus.delayed)
+        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.unknown.scheduleStatus, ScheduleStatus.unknown)
+    }
+}

--- a/OBAKitTests/fixtures/live_activity_content_state.json
+++ b/OBAKitTests/fixtures/live_activity_content_state.json
@@ -1,0 +1,22 @@
+{
+  "arrivals": [
+    {
+      "departure_time": 1767980460,
+      "schedule_status": "on_time",
+      "schedule_deviation": 60,
+      "is_arrival": false
+    },
+    {
+      "departure_time": 1767981000,
+      "schedule_status": "delayed",
+      "schedule_deviation": 240,
+      "is_arrival": false
+    },
+    {
+      "departure_time": 1767981600,
+      "schedule_status": "unknown",
+      "schedule_deviation": 0,
+      "is_arrival": false
+    }
+  ]
+}

--- a/OBAWidget/Main/OBAWidgetBundle.swift
+++ b/OBAWidget/Main/OBAWidgetBundle.swift
@@ -5,12 +5,13 @@
 //  Created by Manu on 2024-10-12.
 //
 
-import Foundation
+import WidgetKit
 import SwiftUI
 
 @main
 struct CBWidgetBundle: WidgetBundle {
     var body: some Widget {
         OBAWidget()
+        TripLiveActivity()
     }
 }

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -1,0 +1,125 @@
+//
+//  TripLiveActivity.swift
+//  OBAWidget
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+/*
+ 
+        _________________________________________________________
+      /                                                           \
+     |   [BUS]        C Line                                5m     |  <-- Header
+     |                                                             |      (Route & Primary Time)
+     |   ───────────────────────────────────────────────────────   |  <-- Horizontal Divider
+     |                                                             |
+     |   West Seattle Alaska                               11m     |  <-- Details
+     |   Junction                                          15m     |      (Left: Destination)
+     |   • On Time                                                 |      (Right: Stacked Times)
+      \___________________________________________________________/
+ */
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+import OBAKitCore
+
+struct TripLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TripAttributes.self) { context in
+            TripBookmarkRow(
+                staticData: context.attributes.staticData,
+                contentState: context.state
+            )
+            .activityBackgroundTint(Color(UIColor.systemBackground))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "bus.fill")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Color(context.state.uiStatusColor))
+                        Text(context.attributes.staticData.routeShortName)
+                            .font(.system(.title3, design: .rounded))
+                            .fontWeight(.heavy)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.leading, 6)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    if let primaryMinute = context.state.minutes.first {
+                        Text(primaryMinute.text)
+                            .font(.system(size: 32, weight: .bold, design: .rounded))
+                            .foregroundColor(Color(primaryMinute.uiColor))
+                            .contentTransition(.numericText(value: Double(primaryMinute.text.filter("0123456789".contains)) ?? 0))
+                            .padding(.trailing, 6)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(spacing: 0) {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.15))
+                            .frame(height: 1)
+                            .padding(.vertical, 8)
+                        HStack(alignment: .top, spacing: 0) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(context.attributes.staticData.routeHeadsign)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                                    .minimumScaleFactor(0.85)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                HStack(spacing: 6) {
+                                    Circle()
+                                        .fill(Color(context.state.uiStatusColor))
+                                        .frame(width: 6, height: 6)
+                                    Text(context.state.statusText)
+                                        .font(.caption)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(Color(context.state.uiStatusColor))
+                                }
+                                .padding(.top, 2)
+                            }
+                            .padding(.leading, 6)
+                            Spacer(minLength: 12)
+                            VStack(alignment: .trailing, spacing: 4) {
+                                let nextDepartures = context.state.minutes.dropFirst().prefix(2)
+                                ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, minute in
+                                    Text(minute.text)
+                                        .font(.system(.callout, design: .rounded))
+                                        .fontWeight(.bold)
+                                        .foregroundColor(Color(minute.uiColor))
+                                }
+                            }
+                            .padding(.trailing, 6)
+                        }
+                    }
+                }
+            } compactLeading: {
+                // MARK: - COMPACT LEADING
+                Text(context.attributes.staticData.routeShortName)
+                    .font(.system(.body, design: .rounded))
+                    .fontWeight(.bold)
+                    .foregroundColor(Color(context.state.uiStatusColor))
+                    .padding(.leading, 4)
+            } compactTrailing: {
+                if let primaryMinute = context.state.minutes.first {
+                    Text(primaryMinute.text)
+                        .font(.system(.body, design: .rounded))
+                        .fontWeight(.bold)
+                        .foregroundColor(Color(primaryMinute.uiColor))
+                        .frame(minWidth: 20)
+                }
+            } minimal: {
+                if let primaryMinute = context.state.minutes.first {
+                    Text(primaryMinute.text)
+                        .font(.system(.callout, design: .rounded))
+                        .fontWeight(.heavy)
+                        .foregroundColor(Color(primaryMinute.uiColor))
+                }
+            }
+        }
+    }
+}

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -26,6 +26,8 @@ import SwiftUI
 import OBAKitCore
 
 struct TripLiveActivity: Widget {
+    private let presenter = TripActivityPresenter()
+
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: TripAttributes.self) { context in
             TripBookmarkRow(
@@ -39,7 +41,7 @@ struct TripLiveActivity: Widget {
                     HStack(spacing: 8) {
                         Image(systemName: "bus.fill")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(Color(context.state.uiStatusColor))
+                            .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                         Text(context.attributes.staticData.routeShortName)
                             .font(.system(.title3, design: .rounded))
                             .fontWeight(.heavy)
@@ -48,11 +50,12 @@ struct TripLiveActivity: Widget {
                     .padding(.leading, 6)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    if let primaryMinute = context.state.minutes.first {
-                        Text(primaryMinute.text)
+                    if let primary = context.state.arrivals.first {
+                        let primaryMinuteText = presenter.minuteText(for: primary)
+                        Text(primaryMinuteText)
                             .font(.system(size: 32, weight: .bold, design: .rounded))
-                            .foregroundColor(Color(primaryMinute.uiColor))
-                            .contentTransition(.numericText(value: Double(primaryMinute.text.filter("0123456789".contains)) ?? 0))
+                            .foregroundColor(Color(presenter.color(for: primary)))
+                            .contentTransition(.numericText(value: Double(primaryMinuteText.filter("0123456789".contains)) ?? 0))
                             .padding(.trailing, 6)
                     }
                 }
@@ -73,24 +76,24 @@ struct TripLiveActivity: Widget {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                 HStack(spacing: 6) {
                                     Circle()
-                                        .fill(Color(context.state.uiStatusColor))
+                                        .fill(Color(presenter.primaryColor(for: context.state)))
                                         .frame(width: 6, height: 6)
-                                    Text(context.state.statusText)
+                                    Text(context.state.arrivals.first.map { presenter.statusText(for: $0) } ?? "")
                                         .font(.caption)
                                         .fontWeight(.medium)
-                                        .foregroundColor(Color(context.state.uiStatusColor))
+                                        .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                                 }
                                 .padding(.top, 2)
                             }
                             .padding(.leading, 6)
                             Spacer(minLength: 12)
                             VStack(alignment: .trailing, spacing: 4) {
-                                let nextDepartures = context.state.minutes.dropFirst().prefix(2)
-                                ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, minute in
-                                    Text(minute.text)
+                                let nextDepartures = context.state.arrivals.dropFirst().prefix(2)
+                                ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, arrivalInfo in
+                                    Text(presenter.minuteText(for: arrivalInfo))
                                         .font(.system(.callout, design: .rounded))
                                         .fontWeight(.bold)
-                                        .foregroundColor(Color(minute.uiColor))
+                                        .foregroundColor(Color(presenter.color(for: arrivalInfo)))
                                 }
                             }
                             .padding(.trailing, 6)
@@ -102,22 +105,22 @@ struct TripLiveActivity: Widget {
                 Text(context.attributes.staticData.routeShortName)
                     .font(.system(.body, design: .rounded))
                     .fontWeight(.bold)
-                    .foregroundColor(Color(context.state.uiStatusColor))
+                    .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                     .padding(.leading, 4)
             } compactTrailing: {
-                if let primaryMinute = context.state.minutes.first {
-                    Text(primaryMinute.text)
+                if let primary = context.state.arrivals.first {
+                    Text(presenter.minuteText(for: primary))
                         .font(.system(.body, design: .rounded))
                         .fontWeight(.bold)
-                        .foregroundColor(Color(primaryMinute.uiColor))
+                        .foregroundColor(Color(presenter.color(for: primary)))
                         .frame(minWidth: 20)
                 }
             } minimal: {
-                if let primaryMinute = context.state.minutes.first {
-                    Text(primaryMinute.text)
+                if let primary = context.state.arrivals.first {
+                    Text(presenter.minuteText(for: primary))
                         .font(.system(.callout, design: .rounded))
                         .fontWeight(.heavy)
-                        .foregroundColor(Color(primaryMinute.uiColor))
+                        .foregroundColor(Color(presenter.color(for: primary)))
                 }
             }
         }

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -30,13 +30,15 @@ struct TripLiveActivity: Widget {
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: TripAttributes.self) { context in
-            TripBookmarkRow(
+            TripLiveActivityCardView(
                 staticData: context.attributes.staticData,
                 contentState: context.state
             )
             .activityBackgroundTint(Color(UIColor.systemBackground))
         } dynamicIsland: { context in
-            DynamicIsland {
+            let upcoming = context.state.upcomingArrivals()
+            let primary = upcoming.first
+            return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     HStack(spacing: 8) {
                         Image(systemName: "bus.fill")
@@ -50,7 +52,7 @@ struct TripLiveActivity: Widget {
                     .padding(.leading, 6)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    if let primary = context.state.arrivals.first {
+                    if let primary {
                         let primaryMinuteText = presenter.minuteText(for: primary)
                         Text(primaryMinuteText)
                             .font(.system(size: 32, weight: .bold, design: .rounded))
@@ -78,7 +80,7 @@ struct TripLiveActivity: Widget {
                                     Circle()
                                         .fill(Color(presenter.primaryColor(for: context.state)))
                                         .frame(width: 6, height: 6)
-                                    Text(context.state.arrivals.first.map { presenter.statusText(for: $0) } ?? "")
+                                    Text(primary.map { presenter.statusText(for: $0) } ?? "")
                                         .font(.caption)
                                         .fontWeight(.medium)
                                         .foregroundColor(Color(presenter.primaryColor(for: context.state)))
@@ -88,7 +90,7 @@ struct TripLiveActivity: Widget {
                             .padding(.leading, 6)
                             Spacer(minLength: 12)
                             VStack(alignment: .trailing, spacing: 4) {
-                                let nextDepartures = context.state.arrivals.dropFirst().prefix(2)
+                                let nextDepartures = upcoming.dropFirst().prefix(2)
                                 ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, arrivalInfo in
                                     Text(presenter.minuteText(for: arrivalInfo))
                                         .font(.system(.callout, design: .rounded))
@@ -108,7 +110,7 @@ struct TripLiveActivity: Widget {
                     .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                     .padding(.leading, 4)
             } compactTrailing: {
-                if let primary = context.state.arrivals.first {
+                if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.body, design: .rounded))
                         .fontWeight(.bold)
@@ -116,7 +118,7 @@ struct TripLiveActivity: Widget {
                         .frame(minWidth: 20)
                 }
             } minimal: {
-                if let primary = context.state.arrivals.first {
+                if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.callout, design: .rounded))
                         .fontWeight(.heavy)


### PR DESCRIPTION
## Summary
- adds Live Activity support for trip bookmark tracking
- shares trip bookmark row rendering between the app, widget, and Live Activity
- enables Live Activities for the OneBusAway app target

## Validation
- scripts/generate_project OneBusAway
- xcodebuild build -project OBAKit.xcodeproj -scheme App -destination 'generic/platform=iOS Simulator' -derivedDataPath DerivedData -quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled explicit iOS Live Activities support and per-bookmark “Track” to start trip tracking.
  * Added Live Activity presentation for tracked trips, including Dynamic Island/lock screen UI and a new widget.
  * Introduced shared Live Activity UI components for consistent route/status display.
* **UI Improvements**
  * Refreshed trip bookmark rows using SwiftUI with loading states and improved accessibility.
  * Updated the trip panel to use the new “Track” action.
  * Added a Live Activity icon and new countdown/glyph/badge UI elements.
* **Bug Fixes**
  * Improved Live Activity registration, reconciliation, and cleanup across app lifecycle changes.
* **Tests**
  * Added contract and request/decode/presenter formatting coverage for Live Activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->