### PR TITLE
Stop Page Rethink: SwiftUI rebuild with two list modes, trip panel, one-tap alarms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,13 @@ scripts/generate_project                # Defaults to OneBusAway if no app speci
 ### Building & Testing
 ```bash
 # Build for testing
-xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16'
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 
 # Run unit tests
-xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16'
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 
 # Run specific test class
-xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 16'
+xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 ```
 
 ### Code Quality
@@ -98,7 +98,7 @@ scripts/extract_strings               # Extract strings for localization
 
 ## Configuration & Deployment
 
-- **Target iOS Version**: 17.0+
+- **Target iOS Version**: 18.0+
 - **Swift Version**: 5.3+
 - **Package Manager**: Swift Package Manager
 - **Project Generation**: XcodeGen from YAML configurations

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -315,7 +315,7 @@ public class BookmarksViewController: UIViewController,
         }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: item.stopID)
+            let stopVC = self.application.viewRouter.makeStopController(stopID: item.stopID)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -252,7 +252,7 @@ class MapFloatingPanelController: VisualEffectViewController,
     }
 
     func previewViewController(for stopID: Stop.ID) -> UIViewController? {
-        return StopViewController(application: application, stopID: stopID)
+        return application.viewRouter.makeStopController(stopID: stopID)
     }
 
     func commitPreviewViewController(_ viewController: UIViewController) {
@@ -347,7 +347,7 @@ class MapFloatingPanelController: VisualEffectViewController,
         guard let stopViewModel = item.as(StopRowItem.self) else { return nil }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.stopID)
+            let stopVC = self.application.viewRouter.makeStopController(stopID: stopViewModel.stopID)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1135,8 +1135,8 @@ class MapViewController: UIViewController,
         else { return nil }
 
         let previewController = { () -> UIViewController in
-            let stopController = StopViewController(application: self.application, stop: stop)
-            stopController.enterPreviewMode()
+            let stopController = self.application.viewRouter.makeStopController(stop: stop)
+            (stopController as? Previewable)?.enterPreviewMode()
             return stopController
         }
 

--- a/OBAKit/PushNotifications/AlarmBuilder.swift
+++ b/OBAKit/PushNotifications/AlarmBuilder.swift
@@ -52,22 +52,32 @@ class AlarmBuilder: NSObject {
 
     /// - Parameter initialMinutes: Pre-selects this lead time in the picker.
     ///   Pass the current alarm's lead time when re-presenting the bulletin to
-    ///   change an existing alarm; `nil` uses the default selection.
+    ///   change an existing alarm; `nil` falls back to the user's default alarm
+    ///   lead time preference.
     init(arrivalDeparture: ArrivalDeparture, application: Application, initialMinutes: Int? = nil, delegate: AlarmBuilderDelegate?) {
         self.arrivalDeparture = arrivalDeparture
         self.application = application
         self.delegate = delegate
-        self.timePickerPage = AlarmTimePickerItem(arrivalDeparture: arrivalDeparture, initialMinutes: initialMinutes)
+        self.timePickerPage = AlarmTimePickerItem(
+            arrivalDeparture: arrivalDeparture,
+            initialMinutes: initialMinutes ?? application.userDataStore.defaultAlarmLeadTimeMinutes
+        )
 
         super.init()
 
         self.timePickerPage.actionHandler = { [weak self] item in
             guard
                 let self = self,
-                let item = item as? AlarmTimePickerItem
-            else { return }
+                let item = item as? AlarmTimePickerItem,
+                // No selectable lead time: the departure slipped inside a minute
+                // between the row rendering its alarm affordance and the user
+                // confirming the bulletin. Nothing to arm, so just close.
+                let minutes = item.timePickerManager.selectedMinutes
+            else {
+                self?.bulletinManager.dismissBulletin(animated: true)
+                return
+            }
 
-            let minutes = item.timePickerManager.selectedMinutes
             Task {
                 await self.createAlarm(minutes: minutes)
             }
@@ -134,7 +144,7 @@ class AlarmTimePickerItem: ThemedBulletinPage {
     private let arrivalDeparture: ArrivalDeparture
     let timePickerManager: AlarmTimePickerManager
 
-    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int? = nil) {
+    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int) {
         self.arrivalDeparture = arrivalDeparture
         self.timePickerManager = AlarmTimePickerManager(arrivalDeparture: arrivalDeparture, initialMinutes: initialMinutes)
 
@@ -162,8 +172,9 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
 
     private let arrivalDeparture: ArrivalDeparture
 
-    /// The lead time to pre-select when the picker is displayed. Defaults to
-    /// 10 minutes; the change-alarm flow passes the current alarm's lead time.
+    /// The lead time to pre-select when the picker is displayed: the user's
+    /// default alarm lead time, or the current alarm's lead time in the
+    /// change-alarm flow.
     private let initialMinutes: Int
 
     lazy var pickerView: UIPickerView = {
@@ -174,9 +185,9 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
         return picker
     }()
 
-    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int? = nil) {
+    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int) {
         self.arrivalDeparture = arrivalDeparture
-        self.initialMinutes = initialMinutes ?? 10
+        self.initialMinutes = initialMinutes
         self.pickerItems = AlarmTimePickerManager.incrementsForDeparture(arrivalDeparture.arrivalDepartureMinutes)
     }
 
@@ -187,8 +198,12 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
         pickerView.selectRow(row, inComponent: 0, animated: false)
     }
 
-    var selectedMinutes: Int {
-        pickerItems[pickerView.selectedRow(inComponent: 0)]
+    /// `nil` when the picker has no rows to select — a departure less than two
+    /// minutes out has no valid lead time, and `UIPickerView` reports row -1.
+    var selectedMinutes: Int? {
+        let row = pickerView.selectedRow(inComponent: 0)
+        guard pickerItems.indices.contains(row) else { return nil }
+        return pickerItems[row]
     }
 
     /// Creates an array of `Int`s representing the countdown of minutes that will be displayed in this controller's picker.

--- a/OBAKit/PushNotifications/AlarmBuilder.swift
+++ b/OBAKit/PushNotifications/AlarmBuilder.swift
@@ -50,11 +50,14 @@ class AlarmBuilder: NSObject {
 
     // MARK: - Init
 
-    init(arrivalDeparture: ArrivalDeparture, application: Application, delegate: AlarmBuilderDelegate?) {
+    /// - Parameter initialMinutes: Pre-selects this lead time in the picker.
+    ///   Pass the current alarm's lead time when re-presenting the bulletin to
+    ///   change an existing alarm; `nil` uses the default selection.
+    init(arrivalDeparture: ArrivalDeparture, application: Application, initialMinutes: Int? = nil, delegate: AlarmBuilderDelegate?) {
         self.arrivalDeparture = arrivalDeparture
         self.application = application
         self.delegate = delegate
-        self.timePickerPage = AlarmTimePickerItem(arrivalDeparture: arrivalDeparture)
+        self.timePickerPage = AlarmTimePickerItem(arrivalDeparture: arrivalDeparture, initialMinutes: initialMinutes)
 
         super.init()
 
@@ -131,9 +134,9 @@ class AlarmTimePickerItem: ThemedBulletinPage {
     private let arrivalDeparture: ArrivalDeparture
     let timePickerManager: AlarmTimePickerManager
 
-    init(arrivalDeparture: ArrivalDeparture) {
+    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int? = nil) {
         self.arrivalDeparture = arrivalDeparture
-        self.timePickerManager = AlarmTimePickerManager(arrivalDeparture: arrivalDeparture)
+        self.timePickerManager = AlarmTimePickerManager(arrivalDeparture: arrivalDeparture, initialMinutes: initialMinutes)
 
         let title = OBALoc("alarm_time_picker.title", value: "Add Reminder", comment: "Title of the Alarm Time Picker page.")
         super.init(title: title)
@@ -159,6 +162,10 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
 
     private let arrivalDeparture: ArrivalDeparture
 
+    /// The lead time to pre-select when the picker is displayed. Defaults to
+    /// 10 minutes; the change-alarm flow passes the current alarm's lead time.
+    private let initialMinutes: Int
+
     lazy var pickerView: UIPickerView = {
         let picker = UIPickerView(frame: .zero)
         picker.translatesAutoresizingMaskIntoConstraints = false
@@ -167,14 +174,16 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
         return picker
     }()
 
-    init(arrivalDeparture: ArrivalDeparture) {
+    init(arrivalDeparture: ArrivalDeparture, initialMinutes: Int? = nil) {
         self.arrivalDeparture = arrivalDeparture
+        self.initialMinutes = initialMinutes ?? 10
         self.pickerItems = AlarmTimePickerManager.incrementsForDeparture(arrivalDeparture.arrivalDepartureMinutes)
     }
 
-    /// Configures the picker view's default value
+    /// Configures the picker view's default value: the increment closest to
+    /// `initialMinutes` (exact match when the value came from an increment).
     func prepareForDisplay() {
-        let row = pickerItems.firstIndex(of: 10) ?? 0
+        let row = pickerItems.indices.min { abs(pickerItems[$0] - initialMinutes) < abs(pickerItems[$1] - initialMinutes) } ?? 0
         pickerView.selectRow(row, inComponent: 0, animated: false)
     }
 

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -19,19 +19,78 @@ struct StopRowItem: OBAListViewItem {
     let stopID: Stop.ID
     let routeType: Route.RouteType
 
-    // Hide icon if there is only one type of route in the list
     var configuration: OBAListViewItemConfiguration {
-        let transportIcon = Icons.transportIcon(from: routeType)
         var config = OBAListRowConfiguration(
-            image: transportIcon,
-            text: .string(name),
-            secondaryText: .string(subtitle),
+            image: Self.squircleTransportIcon(for: routeType),
+            text: .attributed(styledTitle),
+            secondaryText: .attributed(styledSubtitle),
             appearance: .subtitle,
             accessoryType: .disclosureIndicator)
-        config.imageConfig.tintColor = .label
-        config.imageConfig.maximumSize = CGSize(width: 24, height: 24)
+        // The squircle icon is pre-rendered with its own colors; don't re-tint.
+        config.imageConfig.tintColor = nil
+        config.imageConfig.maximumSize = CGSize(width: Self.iconSize, height: Self.iconSize)
 
         return .custom(config)
+    }
+
+    private var styledTitle: NSAttributedString {
+        NSAttributedString(string: name, attributes: [
+            .font: UIFont.preferredFont(forTextStyle: .headline),
+            .foregroundColor: UIColor.label
+        ])
+    }
+
+    private var styledSubtitle: NSAttributedString? {
+        guard let subtitle else { return nil }
+        return NSAttributedString(string: subtitle, attributes: [
+            .font: UIFont.preferredFont(forTextStyle: .body),
+            .foregroundColor: UIColor.label
+        ])
+    }
+
+    // MARK: - Squircle icon
+
+    private static let iconSize: CGFloat = 40
+    private static var iconCache = [Route.RouteType: UIImage]()
+
+    /// The transport glyph in white over a brand-color gradient squircle,
+    /// echoing the stop page's `RouteBadgeView` treatment.
+    private static func squircleTransportIcon(for routeType: Route.RouteType) -> UIImage {
+        if let cached = iconCache[routeType] { return cached }
+
+        let rect = CGRect(x: 0, y: 0, width: iconSize, height: iconSize)
+        let image = UIGraphicsImageRenderer(bounds: rect).image { context in
+            let brand = ThemeColors.shared.brand
+            UIBezierPath(roundedRect: rect, cornerRadius: iconSize * 0.28).addClip()
+
+            let colors = [
+                brand.blended(with: .white, amount: 0.18).cgColor,
+                brand.blended(with: .black, amount: 0.12).cgColor
+            ]
+            if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: colors as CFArray, locations: [0, 1]) {
+                context.cgContext.drawLinearGradient(
+                    gradient,
+                    start: CGPoint(x: rect.midX, y: rect.minY),
+                    end: CGPoint(x: rect.midX, y: rect.maxY),
+                    options: [])
+            } else {
+                brand.setFill()
+                context.fill(rect)
+            }
+
+            let glyph = Icons.transportIcon(from: routeType).withTintColor(.white, renderingMode: .alwaysOriginal)
+            let maxGlyphExtent = iconSize * 0.55
+            let scale = min(maxGlyphExtent / glyph.size.width, maxGlyphExtent / glyph.size.height)
+            let glyphSize = CGSize(width: glyph.size.width * scale, height: glyph.size.height * scale)
+            glyph.draw(in: CGRect(
+                x: rect.midX - glyphSize.width / 2.0,
+                y: rect.midY - glyphSize.height / 2.0,
+                width: glyphSize.width,
+                height: glyphSize.height))
+        }.withRenderingMode(.alwaysOriginal)
+
+        iconCache[routeType] = image
+        return image
     }
 
     let onSelectAction: OBAListViewAction<StopRowItem>?
@@ -63,6 +122,22 @@ struct StopRowItem: OBAListViewItem {
             lhs.stopID == rhs.stopID &&
             lhs.name == rhs.name &&
             lhs.routeType == rhs.routeType
+    }
+}
+
+private extension UIColor {
+    /// Linear blend toward `other` in RGB space; `amount` is clamped to 0...1.
+    func blended(with other: UIColor, amount: CGFloat) -> UIColor {
+        var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
+        var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
+        getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        other.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        let t = max(0, min(1, amount))
+        return UIColor(
+            red: r1 + (r2 - r1) * t,
+            green: g1 + (g2 - g1) * t,
+            blue: b1 + (b2 - b1) * t,
+            alpha: a1)
     }
 }
 

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -21,21 +21,21 @@ struct StopRowItem: OBAListViewItem {
 
     var configuration: OBAListViewItemConfiguration {
         var config = OBAListRowConfiguration(
-            image: Self.squircleTransportIcon(for: routeType),
+            image: Icons.squircleTransportIcon(for: routeType),
             text: .attributed(styledTitle),
             secondaryText: .attributed(styledSubtitle),
             appearance: .subtitle,
             accessoryType: .disclosureIndicator)
         // The squircle icon is pre-rendered with its own colors; don't re-tint.
         config.imageConfig.tintColor = nil
-        config.imageConfig.maximumSize = CGSize(width: Self.iconSize, height: Self.iconSize)
+        config.imageConfig.maximumSize = CGSize(width: Icons.squircleIconSize, height: Icons.squircleIconSize)
 
         return .custom(config)
     }
 
     private var styledTitle: NSAttributedString {
         NSAttributedString(string: name, attributes: [
-            .font: UIFont.preferredFont(forTextStyle: .headline),
+            .font: UIFont.preferredFont(forTextStyle: .title3).bold,
             .foregroundColor: UIColor.label
         ])
     }
@@ -46,51 +46,6 @@ struct StopRowItem: OBAListViewItem {
             .font: UIFont.preferredFont(forTextStyle: .body),
             .foregroundColor: UIColor.label
         ])
-    }
-
-    // MARK: - Squircle icon
-
-    private static let iconSize: CGFloat = 40
-    private static var iconCache = [Route.RouteType: UIImage]()
-
-    /// The transport glyph in white over a brand-color gradient squircle,
-    /// echoing the stop page's `RouteBadgeView` treatment.
-    private static func squircleTransportIcon(for routeType: Route.RouteType) -> UIImage {
-        if let cached = iconCache[routeType] { return cached }
-
-        let rect = CGRect(x: 0, y: 0, width: iconSize, height: iconSize)
-        let image = UIGraphicsImageRenderer(bounds: rect).image { context in
-            let brand = ThemeColors.shared.brand
-            UIBezierPath(roundedRect: rect, cornerRadius: iconSize * 0.28).addClip()
-
-            let colors = [
-                brand.blended(with: .white, amount: 0.18).cgColor,
-                brand.blended(with: .black, amount: 0.12).cgColor
-            ]
-            if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: colors as CFArray, locations: [0, 1]) {
-                context.cgContext.drawLinearGradient(
-                    gradient,
-                    start: CGPoint(x: rect.midX, y: rect.minY),
-                    end: CGPoint(x: rect.midX, y: rect.maxY),
-                    options: [])
-            } else {
-                brand.setFill()
-                context.fill(rect)
-            }
-
-            let glyph = Icons.transportIcon(from: routeType).withTintColor(.white, renderingMode: .alwaysOriginal)
-            let maxGlyphExtent = iconSize * 0.55
-            let scale = min(maxGlyphExtent / glyph.size.width, maxGlyphExtent / glyph.size.height)
-            let glyphSize = CGSize(width: glyph.size.width * scale, height: glyph.size.height * scale)
-            glyph.draw(in: CGRect(
-                x: rect.midX - glyphSize.width / 2.0,
-                y: rect.midY - glyphSize.height / 2.0,
-                width: glyphSize.width,
-                height: glyphSize.height))
-        }.withRenderingMode(.alwaysOriginal)
-
-        iconCache[routeType] = image
-        return image
     }
 
     let onSelectAction: OBAListViewAction<StopRowItem>?
@@ -122,22 +77,6 @@ struct StopRowItem: OBAListViewItem {
             lhs.stopID == rhs.stopID &&
             lhs.name == rhs.name &&
             lhs.routeType == rhs.routeType
-    }
-}
-
-private extension UIColor {
-    /// Linear blend toward `other` in RGB space; `amount` is clamped to 0...1.
-    func blended(with other: UIColor, amount: CGFloat) -> UIColor {
-        var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
-        var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
-        getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
-        other.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
-        let t = max(0, min(1, amount))
-        return UIColor(
-            red: r1 + (r2 - r1) * t,
-            green: g1 + (g2 - g1) * t,
-            blue: b1 + (b2 - b1) * t,
-            alpha: a1)
     }
 }
 

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -180,7 +180,7 @@ public class RecentStopsViewController: UIViewController,
         guard let stopViewModel = item.as(StopRowItem.self) else { return nil }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.stopID)
+            let stopVC = self.application.viewRouter.makeStopController(stopID: stopViewModel.stopID)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -65,7 +65,8 @@ class SettingsViewController: FormViewController {
             debugModeEnabled: application.userDataStore.debugMode,
             alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops,
             walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
-            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit
+            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
+            defaultAlarmLeadTimeMinutesKey: application.userDataStore.defaultAlarmLeadTimeMinutes
         ])
     }
 
@@ -101,10 +102,7 @@ class SettingsViewController: FormViewController {
         }
 
         saveExperimentalValues(values)
-
-        if let testAlerts = values[AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts] as? Bool {
-            application.userDefaults.set(testAlerts, forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
-        }
+        saveAlertsValues(values)
 
         if let reportingEnabled = values[privacySectionReportingEnabled] as? Bool {
             application.analytics?.setReportingEnabled(reportingEnabled)
@@ -134,6 +132,16 @@ class SettingsViewController: FormViewController {
 
         if let useNewStopPage = values[FeatureFlags.useNewStopPageKey] as? Bool {
             application.userDefaults.set(useNewStopPage, forKey: FeatureFlags.useNewStopPageKey)
+        }
+    }
+
+    private func saveAlertsValues(_ values: [String: Any?]) {
+        if let testAlerts = values[AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts] as? Bool {
+            application.userDefaults.set(testAlerts, forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
+        }
+
+        if let alarmLeadTime = values[defaultAlarmLeadTimeMinutesKey] as? Int {
+            application.userDataStore.defaultAlarmLeadTimeMinutes = alarmLeadTime
         }
     }
 
@@ -277,12 +285,28 @@ class SettingsViewController: FormViewController {
 
     // MARK: - Agency Alerts
 
+    private let defaultAlarmLeadTimeMinutesKey = "defaultAlarmLeadTimeMinutes"
+
     private lazy var alertsSection: Section = {
         let section = Section(OBALoc("settings_controller.alerts_section.title", value: "Agency Alerts", comment: "Settings > Alerts section title"))
 
         section <<< SwitchRow {
             $0.tag = AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts
             $0.title = OBALoc("settings_controller.alerts_section.display_test_alerts", value: "Display test alerts", comment: "Settings > Alerts section > Display test alerts")
+        }
+
+        section <<< SegmentedRow<Int> {
+            $0.tag = defaultAlarmLeadTimeMinutesKey
+            $0.title = OBALoc("settings_controller.alerts_section.default_alarm_lead_time", value: "Default alarm lead time", comment: "Settings > Alerts section > default minutes-before for one-tap departure alarms")
+            $0.options = [2, 5, 10]
+            $0.displayValueFor = { minutes in
+                switch minutes {
+                case 2: return OBALoc("settings_controller.alerts_section.lead_time_2min", value: "2 min", comment: "Settings > Alerts section > 2-minute alarm lead time option")
+                case 5: return OBALoc("settings_controller.alerts_section.lead_time_5min", value: "5 min", comment: "Settings > Alerts section > 5-minute alarm lead time option")
+                case 10: return OBALoc("settings_controller.alerts_section.lead_time_10min", value: "10 min", comment: "Settings > Alerts section > 10-minute alarm lead time option")
+                default: return nil
+                }
+            }
         }
 
         return section

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -56,6 +56,7 @@ class SettingsViewController: FormViewController {
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
             mapSectionShowsHeading: application.mapRegionManager.mapViewShowsHeading,
             FeatureFlags.useMapPanelExperienceKey: application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey),
+            FeatureFlags.useNewStopPageKey: FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults),
             privacySectionReportingEnabled: application.analytics?.reportingEnabled() ?? false,
             DataLoadFeedbackGenerator.EnabledUserDefaultsKey: application.userDefaults.bool(forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey),
             AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts: application.userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts),
@@ -130,6 +131,10 @@ class SettingsViewController: FormViewController {
         if let useMapPanel = values[FeatureFlags.useMapPanelExperienceKey] as? Bool {
             application.userDefaults.set(useMapPanel, forKey: FeatureFlags.useMapPanelExperienceKey)
         }
+
+        if let useNewStopPage = values[FeatureFlags.useNewStopPageKey] as? Bool {
+            application.userDefaults.set(useNewStopPage, forKey: FeatureFlags.useNewStopPageKey)
+        }
     }
 
     private func saveWalkingSpeedValues(_ values: [String: Any?]) {
@@ -182,6 +187,11 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = FeatureFlags.useMapPanelExperienceKey
             $0.title = OBALoc("settings_controller.experimental_section.map_panel", value: "Use map panel experience", comment: "Settings > Experimental section > Map panel toggle")
+        }
+
+        section <<< SwitchRow {
+            $0.tag = FeatureFlags.useNewStopPageKey
+            $0.title = OBALoc("settings_controller.experimental_section.new_stop_page", value: "Use new stop page", comment: "Settings > Experimental section > New stop page toggle")
         }
 
         return section

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -300,12 +300,8 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc("settings_controller.alerts_section.default_alarm_lead_time", value: "Default alarm lead time", comment: "Settings > Alerts section > default minutes-before for one-tap departure alarms")
             $0.options = [2, 5, 10]
             $0.displayValueFor = { minutes in
-                switch minutes {
-                case 2: return OBALoc("settings_controller.alerts_section.lead_time_2min", value: "2 min", comment: "Settings > Alerts section > 2-minute alarm lead time option")
-                case 5: return OBALoc("settings_controller.alerts_section.lead_time_5min", value: "5 min", comment: "Settings > Alerts section > 5-minute alarm lead time option")
-                case 10: return OBALoc("settings_controller.alerts_section.lead_time_10min", value: "10 min", comment: "Settings > Alerts section > 10-minute alarm lead time option")
-                default: return nil
-                }
+                guard let minutes else { return nil }
+                return String(format: OBALoc("settings_controller.alerts_section.lead_time_fmt", value: "%d min", comment: "Lead-time segment label. %d is minutes."), minutes)
             }
         }
 

--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -10,19 +10,6 @@
 import SwiftUI
 import OBAKitCore
 
-/// Temporary stand-in for `TripDetailPanelView` (Task 10). Keeps the accordion
-/// mechanics testable in the simulator before the panel exists.
-struct TripDetailPanelPlaceholder: View {
-    let departure: ArrivalDeparture
-    var body: some View {
-        Text(departure.routeAndHeadsign)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 8)
-    }
-}
-
 /// Chronological mode: past block, missed block, walk divider, reachable
 /// block. Rendered as Sections inside StopPageView's single List (each
 /// Section is one rounded card in inset-grouped style).
@@ -36,7 +23,7 @@ struct ChronologicalListView: View {
     let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
     let onTogglePast: () -> Void
     let onToggleExpand: (ArrivalDeparture) -> Void
-    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelView
 
     var body: some View {
         // Section header with the Past toggle

--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -1,0 +1,99 @@
+//
+//  ChronologicalListView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Temporary stand-in for `TripDetailPanelView` (Task 10). Keeps the accordion
+/// mechanics testable in the simulator before the panel exists.
+struct TripDetailPanelPlaceholder: View {
+    let departure: ArrivalDeparture
+    var body: some View {
+        Text(departure.routeAndHeadsign)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+    }
+}
+
+/// Chronological mode: past block, missed block, walk divider, reachable
+/// block. Rendered as Sections inside StopPageView's single List (each
+/// Section is one rounded card in inset-grouped style).
+struct ChronologicalListView: View {
+    let partition: StopPageListBuilder.ChronologicalPartition<ArrivalDeparture>
+    let walkMinutes: Int?
+    let showPast: Bool
+    let expandedDepartureID: String?
+    let statusProvider: (ArrivalDeparture) -> DepartureStatus
+    let alarmLookup: (ArrivalDeparture) -> Alarm?
+    let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
+    let onTogglePast: () -> Void
+    let onToggleExpand: (ArrivalDeparture) -> Void
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+
+    var body: some View {
+        // Section header with the Past toggle
+        Section {
+            if showPast {
+                rows(partition.past, style: .past)
+            }
+        } header: {
+            HStack {
+                Text(OBALoc("stop_page.section.arrivals_departures", value: "Arrivals & Departures", comment: "Chronological list section header"))
+                Spacer()
+                if !partition.past.isEmpty {
+                    Button(action: onTogglePast) {
+                        let fmt = OBALoc("stop_page.past_toggle_fmt", value: "Past · %d", comment: "Button revealing recently departed trips. %d is the count.")
+                        Text(showPast ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips") : String(format: fmt, partition.past.count))
+                            .font(.caption.weight(.bold))
+                    }
+                }
+            }
+        }
+
+        if let walkMinutes, !partition.missed.isEmpty {
+            Section {
+                rows(partition.missed, style: .missed)
+            }
+            // Walk divider escapes the card chrome (out-of-card row rules).
+            Section {
+                WalkLineDivider(walkMinutes: walkMinutes)
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+        }
+
+        Section {
+            rows(partition.reachable, style: .normal)
+        }
+    }
+
+    @ViewBuilder
+    private func rows(_ departures: [ArrivalDeparture], style: DepartureRowView.Style) -> some View {
+        // Identity: ArrivalDeparture.id (stable across prediction refreshes).
+        ForEach(departures, id: \.id) { departure in
+            DepartureRowView(
+                departure: departure,
+                status: statusProvider(departure),
+                hasAlarm: alarmLookup(departure) != nil,
+                style: style,
+                onTap: { onToggleExpand(departure) }
+            )
+            .departureRowActions(actionsProvider(departure))
+
+            // Accordion: the panel is an INSERTED SIBLING ROW, keyed off the
+            // expanded id — List animates insert/remove smoothly.
+            if expandedDepartureID == departure.id {
+                panelBuilder(departure)
+            }
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -34,6 +34,7 @@ struct ChronologicalListView: View {
         } header: {
             HStack {
                 Text(OBALoc("stop_page.section.arrivals_departures", value: "Arrivals & Departures", comment: "Chronological list section header"))
+                    .accessibilityAddTraits(.isHeader)
                 Spacer()
                 if !partition.past.isEmpty {
                     Button(action: onTogglePast) {
@@ -41,6 +42,11 @@ struct ChronologicalListView: View {
                         Text(showPast ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips") : String(format: fmt, partition.past.count))
                             .font(.caption.weight(.bold))
                     }
+                    // The visible "Past · 3" is a glanceable token; spoken
+                    // aloud it needs to say what activating actually does.
+                    .accessibilityLabel(showPast
+                        ? OBALoc("stop_page.past_toggle_hide_a11y", value: "Hide past departures", comment: "VoiceOver label for the button hiding recently departed trips")
+                        : String(format: OBALoc("stop_page.past_toggle_show_a11y_fmt", value: "Show %d past departures", comment: "VoiceOver label for the button revealing recently departed trips. %d is the count."), partition.past.count))
                 }
             }
         }

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -13,8 +13,8 @@ import OBAKitCore
 private let removeAlarmTitle = OBALoc("stop_page.row.remove_alarm", value: "Remove Alarm", comment: "Swipe/context menu action that cancels an existing arrival alarm.")
 
 /// One departure row, used by chronological mode and (compact) by grouped
-/// expansion. Unary root HStack; all conditional content is interior so the
-/// List fast path holds.
+/// expansion. Unary root VStack; all conditional content (including the
+/// accessibility-size layout branch) is interior so the List fast path holds.
 struct DepartureRowView: View {
     enum Style {
         case normal
@@ -40,41 +40,47 @@ struct DepartureRowView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 13) {
-            RouteBadgeView(
-                routeShortName: departure.routeShortName,
-                routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
-            )
-            VStack(alignment: .leading, spacing: 3) {
-                Text(departure.tripHeadsign ?? departure.routeShortName)
-                    .font(.system(.body, weight: .bold))
-                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
-                    .strikethrough(style == .missed)
-                HStack(spacing: 6) {
-                    Text(scheduledTimeText)
-                        .font(.footnote)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                    Text("·").foregroundStyle(.tertiary)
-                    Text(status.label)
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(Color(uiColor: status.color))
-                    if hasAlarm {
-                        Image(systemName: "bell.fill")
-                            .font(.caption)
-                            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
-                    }
+        // Unary root; the accessibility-size branch is interior so the List
+        // fast path holds. At accessibility sizes the row "stacks" (the guide's
+        // committed layout): badge + countdown share the first line as glance
+        // tokens, destination + status flow below — nothing is dropped.
+        VStack(alignment: .leading, spacing: 3) {
+            if dynamicTypeSize.isAccessibilitySize {
+                HStack(alignment: .center) {
+                    routeBadge
+                    Spacer(minLength: 8)
+                    countdown
                 }
-                if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
-                    OccupancyBadge(occupancy: occupancy)
+                headsignText
+                Text(scheduledTimeText)
+                    .font(.footnote)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    statusText
+                    alarmBell
+                }
+                occupancyBadge
+            } else {
+                HStack(alignment: .center, spacing: 13) {
+                    routeBadge
+                    VStack(alignment: .leading, spacing: 3) {
+                        headsignText
+                        HStack(spacing: 6) {
+                            Text(scheduledTimeText)
+                                .font(.footnote)
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                            Text("·").foregroundStyle(.tertiary)
+                            statusText
+                            alarmBell
+                        }
+                        occupancyBadge
+                    }
+                    Spacer(minLength: 8)
+                    countdown
                 }
             }
-            Spacer(minLength: 8)
-            CountdownView(
-                minutes: departure.arrivalDepartureMinutes,
-                isRealTime: status.isRealTime,
-                color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
-            )
         }
         .opacity(dimmed ? 0.55 : 1.0)
         .contentShape(Rectangle())
@@ -82,6 +88,55 @@ struct DepartureRowView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityText)
         .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Shared pieces (both layouts)
+
+    private var routeBadge: some View {
+        RouteBadgeView(
+            routeShortName: departure.routeShortName,
+            routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+        )
+    }
+
+    /// Clamped to two lines at every size (the guide's committed "clamp + tap"
+    /// choice): capping row height keeps more departures visible, and tapping
+    /// the row opens the trip panel with the full name.
+    private var headsignText: some View {
+        Text(departure.tripHeadsign ?? departure.routeShortName)
+            .font(.system(.body, weight: .bold))
+            .lineLimit(2)
+            .strikethrough(style == .missed)
+    }
+
+    private var statusText: some View {
+        Text(status.label)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(Color(uiColor: status.color))
+    }
+
+    @ViewBuilder
+    private var alarmBell: some View {
+        if hasAlarm {
+            Image(systemName: "bell.fill")
+                .font(.caption)
+                .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+        }
+    }
+
+    @ViewBuilder
+    private var occupancyBadge: some View {
+        if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+            OccupancyBadge(occupancy: occupancy)
+        }
+    }
+
+    private var countdown: some View {
+        CountdownView(
+            minutes: departure.arrivalDepartureMinutes,
+            isRealTime: status.isRealTime,
+            color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
+        )
     }
 
     private var accessibilityText: String {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -31,11 +31,12 @@ struct DepartureRowView: View {
     let onTap: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.obaFormatters) private var formatters
 
     private var dimmed: Bool { style != .normal }
 
     private var scheduledTimeText: String {
-        DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short)
+        formatters.timeFormatter.string(from: departure.scheduledDate)
     }
 
     var body: some View {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -81,8 +81,28 @@ struct DepartureRowView: View {
     }
 
     private var accessibilityText: String {
-        let fmt = OBALoc("stop_page.row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for a departure row: route, headsign, minutes, status.")
-        return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+        var clauses = [baseAccessibilityText]
+
+        if style == .missed {
+            clauses.append(OBALoc("stop_page.row.a11y_missed", value: "likely missed — departs sooner than your walk to the stop", comment: "VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves."))
+        }
+
+        if hasAlarm {
+            clauses.append(OBALoc("stop_page.row.a11y_alarm_set", value: "alarm set", comment: "VoiceOver suffix indicating a departure alarm is active"))
+        }
+
+        return clauses.joined(separator: ", ")
+    }
+
+    private var baseAccessibilityText: String {
+        switch style {
+        case .past:
+            let fmt = OBALoc("stop_page.row.a11y_past_fmt", value: "Route %@ to %@, departed %d minutes ago, %@", comment: "VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status.")
+            return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
+        case .normal, .missed:
+            let fmt = OBALoc("stop_page.row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for a departure row: route, headsign, minutes, status.")
+            return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+        }
     }
 }
 
@@ -126,6 +146,11 @@ extension View {
                 if actions.canAlarm {
                     Button(action: actions.onAlarmToggle) {
                         Label(actions.hasAlarm ? removeAlarmTitle : Strings.addAlarm, systemImage: "bell")
+                    }
+                }
+                if actions.canSchedule {
+                    Button(action: actions.onSchedule) {
+                        Label(Strings.schedules, systemImage: "calendar")
                     }
                 }
                 Button(action: actions.onBookmark) {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -116,6 +116,11 @@ struct DepartureRowActions {
     let onSchedule: () -> Void
     let onBookmark: () -> Void
     let onShowTrip: () -> Void
+    /// Lazily builds the long-press preview (a `TripViewController` embedded via a
+    /// representable). Built by the hosting VC so `Application`/UIKit stay out of
+    /// the view layer; `AnyView` is acceptable here because it lives inside the
+    /// context menu's lazily-evaluated preview closure, not the row structure.
+    let makePreview: () -> AnyView
 }
 
 extension View {
@@ -139,7 +144,7 @@ extension View {
                 }
                 .tint(.orange)
             }
-            .contextMenu {
+            .contextMenu(menuItems: {
                 Button(action: actions.onShowTrip) {
                     Label(OBALoc("stop_page.row.show_trip", value: "Show Trip Details", comment: "Context menu action opening the full trip screen"), systemImage: "bus")
                 }
@@ -156,6 +161,8 @@ extension View {
                 Button(action: actions.onBookmark) {
                     Label(Strings.addBookmark, systemImage: "bookmark")
                 }
-            }
+            }, preview: {
+                actions.makePreview()
+            })
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -18,7 +18,8 @@ private let removeAlarmTitle = OBALoc("stop_page.row.remove_alarm", value: "Remo
 struct DepartureRowView: View {
     enum Style {
         case normal
-        /// Upcoming but unreachable on foot: dim + strikethrough (§4.2).
+        /// Upcoming but unreachable on foot: rendered like a normal row;
+        /// only the VoiceOver label calls it out (§4.2).
         case missed
         /// Already departed: dim only (§4.2).
         case past
@@ -33,7 +34,7 @@ struct DepartureRowView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.obaFormatters) private var formatters
 
-    private var dimmed: Bool { style != .normal }
+    private var dimmed: Bool { style == .past }
 
     private var scheduledTimeText: String {
         formatters.timeFormatter.string(from: departure.scheduledDate)
@@ -106,7 +107,6 @@ struct DepartureRowView: View {
         Text(departure.tripHeadsign ?? departure.routeShortName)
             .font(.system(.body, weight: .bold))
             .lineLimit(2)
-            .strikethrough(style == .missed)
     }
 
     private var statusText: some View {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -65,6 +65,9 @@ struct DepartureRowView: View {
                             .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
                     }
                 }
+                if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+                    OccupancyBadge(occupancy: occupancy)
+                }
             }
             Spacer(minLength: 8)
             CountdownView(
@@ -83,6 +86,10 @@ struct DepartureRowView: View {
 
     private var accessibilityText: String {
         var clauses = [baseAccessibilityText]
+
+        if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+            clauses.append(OccupancyBadge.localizedDescription(occupancy))
+        }
 
         if style == .missed {
             clauses.append(OBALoc("stop_page.row.a11y_missed", value: "likely missed — departs sooner than your walk to the stop", comment: "VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves."))

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -1,0 +1,136 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// `Strings.removeAlarm` doesn't exist yet (only `Strings.addAlarm` does); this
+/// row needs both add/remove wording for the alarm toggle, so it's defined
+/// locally rather than added to the shared `Strings` catalog.
+private let removeAlarmTitle = OBALoc("stop_page.row.remove_alarm", value: "Remove Alarm", comment: "Swipe/context menu action that cancels an existing arrival alarm.")
+
+/// One departure row, used by chronological mode and (compact) by grouped
+/// expansion. Unary root HStack; all conditional content is interior so the
+/// List fast path holds.
+struct DepartureRowView: View {
+    enum Style {
+        case normal
+        /// Upcoming but unreachable on foot: dim + strikethrough (§4.2).
+        case missed
+        /// Already departed: dim only (§4.2).
+        case past
+    }
+
+    let departure: ArrivalDeparture
+    let status: DepartureStatus
+    let hasAlarm: Bool
+    var style: Style = .normal
+    let onTap: () -> Void
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var dimmed: Bool { style != .normal }
+
+    private var scheduledTimeText: String {
+        DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 13) {
+            RouteBadgeView(
+                routeShortName: departure.routeShortName,
+                routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+            )
+            VStack(alignment: .leading, spacing: 3) {
+                Text(departure.tripHeadsign ?? departure.routeShortName)
+                    .font(.system(.body, weight: .bold))
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                    .strikethrough(style == .missed)
+                HStack(spacing: 6) {
+                    Text(scheduledTimeText)
+                        .font(.footnote)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                    Text("·").foregroundStyle(.tertiary)
+                    Text(status.label)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color(uiColor: status.color))
+                    if hasAlarm {
+                        Image(systemName: "bell.fill")
+                            .font(.caption)
+                            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            CountdownView(
+                minutes: departure.arrivalDepartureMinutes,
+                isRealTime: status.isRealTime,
+                color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
+            )
+        }
+        .opacity(dimmed ? 0.55 : 1.0)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var accessibilityText: String {
+        let fmt = OBALoc("stop_page.row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for a departure row: route, headsign, minutes, status.")
+        return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+    }
+}
+
+/// Swipe + context-menu parity with today's `ArrivalDepartureItem`
+/// trailing actions (Alarm / Schedule / Save) and long-press menu.
+struct DepartureRowActions {
+    let canAlarm: Bool
+    let canSchedule: Bool
+    let hasAlarm: Bool
+    let onAlarmToggle: () -> Void
+    let onSchedule: () -> Void
+    let onBookmark: () -> Void
+    let onShowTrip: () -> Void
+}
+
+extension View {
+    func departureRowActions(_ actions: DepartureRowActions) -> some View {
+        self
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                if actions.canAlarm {
+                    Button(action: actions.onAlarmToggle) {
+                        Label(actions.hasAlarm ? removeAlarmTitle : Strings.addAlarm, systemImage: actions.hasAlarm ? "bell.slash" : "bell")
+                    }
+                    .tint(Color(uiColor: ThemeColors.shared.departureOnTime))
+                }
+                if actions.canSchedule {
+                    Button(action: actions.onSchedule) {
+                        Label(Strings.schedules, systemImage: "calendar")
+                    }
+                    .tint(.teal)
+                }
+                Button(action: actions.onBookmark) {
+                    Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+                .tint(.orange)
+            }
+            .contextMenu {
+                Button(action: actions.onShowTrip) {
+                    Label(OBALoc("stop_page.row.show_trip", value: "Show Trip Details", comment: "Context menu action opening the full trip screen"), systemImage: "bus")
+                }
+                if actions.canAlarm {
+                    Button(action: actions.onAlarmToggle) {
+                        Label(actions.hasAlarm ? removeAlarmTitle : Strings.addAlarm, systemImage: "bell")
+                    }
+                }
+                Button(action: actions.onBookmark) {
+                    Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+            }
+    }
+}

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -169,8 +169,8 @@ struct DepartureRowView: View {
     }
 }
 
-/// Swipe + context-menu parity with today's `ArrivalDepartureItem`
-/// trailing actions (Alarm / Schedule / Save) and long-press menu.
+/// Long-press context-menu parity with today's `ArrivalDepartureItem`
+/// menu actions (Alarm / Schedule / Save).
 struct DepartureRowActions {
     let canAlarm: Bool
     let canSchedule: Bool
@@ -189,24 +189,6 @@ struct DepartureRowActions {
 extension View {
     func departureRowActions(_ actions: DepartureRowActions) -> some View {
         self
-            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                if actions.canAlarm {
-                    Button(action: actions.onAlarmToggle) {
-                        Label(actions.hasAlarm ? removeAlarmTitle : Strings.addAlarm, systemImage: actions.hasAlarm ? "bell.slash" : "bell")
-                    }
-                    .tint(Color(uiColor: ThemeColors.shared.departureOnTime))
-                }
-                if actions.canSchedule {
-                    Button(action: actions.onSchedule) {
-                        Label(Strings.schedules, systemImage: "calendar")
-                    }
-                    .tint(.teal)
-                }
-                Button(action: actions.onBookmark) {
-                    Label(Strings.addBookmark, systemImage: "bookmark")
-                }
-                .tint(.orange)
-            }
             .contextMenu(menuItems: {
                 Button(action: actions.onShowTrip) {
                     Label(OBALoc("stop_page.row.show_trip", value: "Show Trip Details", comment: "Context menu action opening the full trip screen"), systemImage: "bus")

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -60,6 +60,7 @@ struct GroupedListView: View {
         let next = group.next
         let status = statusProvider(next)
         let routeColor = Color(uiColor: next.route.color ?? ThemeColors.shared.brand)
+        let alarm = alarmLookup(next)
 
         VStack(alignment: .leading, spacing: 10) {
             headerPrimaryRow(next: next, status: status, routeColor: routeColor)
@@ -72,6 +73,25 @@ struct GroupedListView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(groupAccessibilityLabel(group, status: status))
         .accessibilityAddTraits(.isButton)
+        // The combined element above (`children: .ignore`) swallows the alarm
+        // pill Button inside `headerChipsRow`, so VoiceOver can never reach it.
+        // `.accessibilityActions` is applied unconditionally (keeping this a
+        // single, uninterrupted modifier chain) but its @ContentBuilder body
+        // supports `if`, so the custom action itself only exists when the pill
+        // would actually be visible — mirroring `alarmPill(for:)`'s own condition.
+        .accessibilityActions {
+            if canAlarm(next) || alarm != nil {
+                Button(alarmActionName(for: alarm)) {
+                    onAlarmToggle(next)
+                }
+            }
+        }
+    }
+
+    private func alarmActionName(for alarm: Alarm?) -> String {
+        alarm != nil
+            ? OBALoc("stop_page.grouped.a11y_remove_alarm", value: "Remove alarm", comment: "VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure.")
+            : OBALoc("stop_page.grouped.a11y_set_alarm", value: "Set alarm", comment: "VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure.")
     }
 
     /// Badge, headsign, scheduled time + adherence, and the big countdown.
@@ -157,6 +177,10 @@ struct GroupedListView: View {
 
     @ViewBuilder
     private func expandedRows(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        // Same derivation as `cardHeader`'s routeColor, so the stripe painted
+        // on these rows via `listRowBackground` matches the header exactly and
+        // runs the full height of the expanded card (§4.3).
+        let routeColor = Color(uiColor: group.next.route.color ?? ThemeColors.shared.brand)
         ForEach(group.departures, id: \.id) { departure in
             let status = statusProvider(departure)
             HStack(spacing: 12) {
@@ -182,11 +206,13 @@ struct GroupedListView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture { onToggleTrip(departure) }
+            .listRowBackground(cardStripe(routeColor))
 
             // Accordion: the trip panel is an INSERTED SIBLING ROW keyed off the
             // open id — List animates the insert/remove (same pattern as Task 8).
             if openTripDepartureID == departure.id {
                 panelBuilder(departure)
+                    .listRowBackground(cardStripe(routeColor))
             }
         }
     }

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -76,7 +76,7 @@ struct GroupedListView: View {
             headerChipsRow(group)
         }
         .padding(.vertical, 4)
-        .listRowBackground(cardStripe(routeColor))
+        .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
         .contentShape(Rectangle())
         .onTapGesture { onToggleRoute(group.routeID) }
         .accessibilityElement(children: .ignore)
@@ -152,18 +152,6 @@ struct GroupedListView: View {
         }
     }
 
-    /// Route-color accent stripe on the card's left edge — the other place
-    /// route color appears in the departure list rows besides the route badge;
-    /// the trip panel separately uses it for the vehicle glyph and approach
-    /// timeline. Spec §4.3 still holds: route color never tints countdowns or
-    /// adherence text.
-    private func cardStripe(_ routeColor: Color) -> some View {
-        HStack(spacing: 0) {
-            routeColor.frame(width: 5)
-            Color(uiColor: .secondarySystemGroupedBackground)
-        }
-    }
-
     @ViewBuilder
     private func alarmPill(for departure: ArrivalDeparture) -> some View {
         let alarm = alarmLookup(departure)
@@ -189,10 +177,6 @@ struct GroupedListView: View {
 
     @ViewBuilder
     private func expandedRows(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
-        // Same derivation as `cardHeader`'s routeColor, so the stripe painted
-        // on these rows via `listRowBackground` matches the header exactly and
-        // runs the full height of the expanded card (§4.3).
-        let routeColor = Color(uiColor: group.next.route.color ?? ThemeColors.shared.brand)
         ForEach(group.departures, id: \.id) { departure in
             let status = statusProvider(departure)
             HStack(spacing: 12) {
@@ -217,7 +201,7 @@ struct GroupedListView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture { onToggleTrip(departure) }
-            .listRowBackground(cardStripe(routeColor))
+            .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
             // Make the whole expanded row a single VoiceOver activation target
             // that opens the trip panel, mirroring the card
             // header (`children: .ignore` + explicit label + `.isButton`). The
@@ -238,7 +222,7 @@ struct GroupedListView: View {
             // open id — List animates the insert/remove.
             if openTripDepartureID == departure.id {
                 panelBuilder(departure)
-                    .listRowBackground(cardStripe(routeColor))
+                    .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
             }
         }
     }

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -35,8 +35,8 @@ struct GroupedListView: View {
     let panelBuilder: (ArrivalDeparture) -> TripDetailPanelView
 
     /// The compact alarm circle in an expanded row. `@ScaledMetric` so the badge
-    /// grows with Dynamic Type (standing amendment) the same way the 48pt route
-    /// badge does inside `RouteBadgeView`.
+    /// grows with Dynamic Type the same way the 48pt route badge does inside
+    /// `RouteBadgeView`.
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
 
     @Environment(\.obaFormatters) private var formatters

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -32,7 +32,7 @@ struct GroupedListView: View {
     let onToggleRoute: (RouteID) -> Void
     let onToggleTrip: (ArrivalDeparture) -> Void
     let onAlarmToggle: (ArrivalDeparture) -> Void
-    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelView
 
     /// The compact alarm circle in an expanded row. `@ScaledMetric` so the badge
     /// grows with Dynamic Type (standing amendment) the same way the 48pt route
@@ -194,8 +194,7 @@ struct GroupedListView: View {
                             .foregroundStyle(Color(uiColor: status.color))
                     }
                     if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
-                        Text(String(describing: occupancy)) // Task 10 replaces with OccupancyStatusView reuse
-                            .font(.caption).foregroundStyle(.secondary)
+                        OccupancyBadge(occupancy: occupancy)
                     }
                 }
                 Spacer(minLength: 8)
@@ -207,6 +206,21 @@ struct GroupedListView: View {
             .contentShape(Rectangle())
             .onTapGesture { onToggleTrip(departure) }
             .listRowBackground(cardStripe(routeColor))
+            // Task 9 review: make the whole expanded row a single VoiceOver
+            // activation target that opens the trip panel, mirroring the card
+            // header (`children: .ignore` + explicit label + `.isButton`). The
+            // combined element swallows the inner alarm Button, so it's re-exposed
+            // as a custom action just like the header's alarm pill.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityActions {
+                if canAlarm(departure) || alarmLookup(departure) != nil {
+                    Button(alarmActionName(for: alarmLookup(departure))) {
+                        onAlarmToggle(departure)
+                    }
+                }
+            }
 
             // Accordion: the trip panel is an INSERTED SIBLING ROW keyed off the
             // open id — List animates the insert/remove (same pattern as Task 8).
@@ -231,6 +245,17 @@ struct GroupedListView: View {
             }
             .buttonStyle(.plain)
         }
+    }
+
+    /// Self-describing VoiceOver label for one expanded departure row: route,
+    /// headsign, minutes, live/scheduled status, and occupancy when present.
+    private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
+        let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
+        var label = String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+        if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+            label += ", " + OccupancyBadge.localizedDescription(occupancy)
+        }
+        return label
     }
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -1,0 +1,214 @@
+//
+//  GroupedListView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Grouped mode: one Section (= one inset-grouped card) per route, ordered by
+/// soonest departure (§4.9). Card header is the next departure; expansion
+/// lists every loaded departure; tapping one opens the shared trip panel.
+///
+/// Plain-value view: it never touches `StopViewModel`. Everything it needs
+/// arrives as `let` values or closures so `StopPageView` remains the only
+/// observer of the view model.
+struct GroupedListView: View {
+    let groups: [StopPageListBuilder.RouteGroup<ArrivalDeparture>]
+    let expandedRouteID: RouteID?
+    let openTripDepartureID: String?
+    let statusProvider: (ArrivalDeparture) -> DepartureStatus
+    let alarmLookup: (ArrivalDeparture) -> Alarm?
+    let alarmLeadTime: (Alarm) -> Int
+    /// Adaptation to the global alarm-gating constraint: the brief's alarm pill
+    /// and row icons ignore `canCreateAlarm(for:)`. This closure lets the view
+    /// hide the alarm affordance when a new alarm can't be created — while still
+    /// showing it for a departure that already has one, so it can be cancelled.
+    let canAlarm: (ArrivalDeparture) -> Bool
+    let onToggleRoute: (RouteID) -> Void
+    let onToggleTrip: (ArrivalDeparture) -> Void
+    let onAlarmToggle: (ArrivalDeparture) -> Void
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+
+    /// The compact alarm circle in an expanded row. `@ScaledMetric` so the badge
+    /// grows with Dynamic Type (standing amendment) the same way the 48pt route
+    /// badge does inside `RouteBadgeView`.
+    @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
+
+    var body: some View {
+        // One Section per route — the Section IS the card. Identity is the
+        // stable RouteID; the accordion toggle lives INSIDE the Section so the
+        // ForEach row stays a single top-level view.
+        ForEach(groups, id: \.routeID) { group in
+            Section {
+                cardHeader(group)
+                if expandedRouteID == group.routeID {
+                    expandedRows(group)
+                }
+            }
+        }
+    }
+
+    // MARK: - Card header (the route's next departure)
+
+    @ViewBuilder
+    private func cardHeader(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        let next = group.next
+        let status = statusProvider(next)
+        let routeColor = Color(uiColor: next.route.color ?? ThemeColors.shared.brand)
+
+        VStack(alignment: .leading, spacing: 10) {
+            headerPrimaryRow(next: next, status: status, routeColor: routeColor)
+            headerChipsRow(group)
+        }
+        .padding(.vertical, 4)
+        .listRowBackground(cardStripe(routeColor))
+        .contentShape(Rectangle())
+        .onTapGesture { onToggleRoute(group.routeID) }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(groupAccessibilityLabel(group, status: status))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Badge, headsign, scheduled time + adherence, and the big countdown.
+    private func headerPrimaryRow(next: ArrivalDeparture, status: DepartureStatus, routeColor: Color) -> some View {
+        HStack(alignment: .center, spacing: 13) {
+            RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(next.tripHeadsign ?? next.routeShortName)
+                    .font(.headline.weight(.heavy))
+                    .lineLimit(2)
+                HStack(spacing: 6) {
+                    Text(DateFormatter.localizedString(from: next.scheduledDate, dateStyle: .none, timeStyle: .short))
+                        .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                    Text("·").foregroundStyle(.tertiary)
+                    Text(status.label)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color(uiColor: status.color))
+                }
+            }
+            Spacer(minLength: 8)
+            CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+        }
+    }
+
+    /// Upcoming-trip chips (each tinted by its own departure's status), the
+    /// alarm pill, and the expand chevron. Empty chips render the §4.4 wording.
+    private func headerChipsRow(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        HStack(spacing: 8) {
+            if group.chips.isEmpty {
+                Text(OBALoc("stop_page.grouped.not_loaded", value: "later trips not loaded", comment: "Empty upcoming-chips state; must never imply no later trips exist (§4.4)"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(group.chips, id: \.id) { chip in
+                    let chipStatus = statusProvider(chip)
+                    Text("\(chip.arrivalDepartureMinutes)m")
+                        .font(.caption.weight(.heavy)).monospacedDigit()
+                        .foregroundStyle(Color(uiColor: chipStatus.color))
+                        .padding(.horizontal, 8).padding(.vertical, 3)
+                        .background(Color(uiColor: chipStatus.color).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            Spacer()
+            alarmPill(for: group.next)
+            Image(systemName: "chevron.down")
+                .font(.footnote.weight(.bold))
+                .foregroundStyle(.tertiary)
+                .rotationEffect(.degrees(expandedRouteID == group.routeID ? 180 : 0))
+        }
+    }
+
+    /// Route-color accent stripe on the card's left edge — the only other place
+    /// route color appears (§4.3).
+    private func cardStripe(_ routeColor: Color) -> some View {
+        HStack(spacing: 0) {
+            routeColor.frame(width: 5)
+            Color(uiColor: .secondarySystemGroupedBackground)
+        }
+    }
+
+    @ViewBuilder
+    private func alarmPill(for departure: ArrivalDeparture) -> some View {
+        let alarm = alarmLookup(departure)
+        if canAlarm(departure) || alarm != nil {
+            Button {
+                onAlarmToggle(departure)
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: alarm != nil ? "bell.fill" : "bell")
+                    Text(alarm.map { "\(alarmLeadTime($0))m" } ?? Strings.alarm)
+                        .monospacedDigit()
+                }
+                .font(.caption.weight(.heavy))
+                .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color(uiColor: .tertiarySystemFill), in: Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Expanded rows
+
+    @ViewBuilder
+    private func expandedRows(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        ForEach(group.departures, id: \.id) { departure in
+            let status = statusProvider(departure)
+            HStack(spacing: 12) {
+                alarmIcon(for: departure)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Text(DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short))
+                            .font(.subheadline.weight(.semibold)).monospacedDigit()
+                        Text("· \(status.label)")
+                            .font(.subheadline)
+                            .foregroundStyle(Color(uiColor: status.color))
+                    }
+                    if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+                        Text(String(describing: occupancy)) // Task 10 replaces with OccupancyStatusView reuse
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 8)
+                CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.bold)).foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(openTripDepartureID == departure.id ? 180 : 0))
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { onToggleTrip(departure) }
+
+            // Accordion: the trip panel is an INSERTED SIBLING ROW keyed off the
+            // open id — List animates the insert/remove (same pattern as Task 8).
+            if openTripDepartureID == departure.id {
+                panelBuilder(departure)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func alarmIcon(for departure: ArrivalDeparture) -> some View {
+        let alarm = alarmLookup(departure)
+        if canAlarm(departure) || alarm != nil {
+            Button { onAlarmToggle(departure) } label: {
+                Image(systemName: alarm != nil ? "bell.fill" : "bell")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
+                    .frame(width: alarmCircleSize, height: alarmCircleSize)
+                    .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                    .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: alarm != nil ? 0 : 1.5))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
+        let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
+        return String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+    }
+}

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -39,6 +39,15 @@ struct GroupedListView: View {
     /// badge does inside `RouteBadgeView`.
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
 
+    @Environment(\.obaFormatters) private var formatters
+
+    /// Whether this departure should show an alarm affordance: it can take a new
+    /// alarm, or it already has one that can be cancelled. Shared by the header
+    /// pill, the expanded-row icon, and both VoiceOver custom actions.
+    private func showsAlarmAffordance(for departure: ArrivalDeparture) -> Bool {
+        canAlarm(departure) || alarmLookup(departure) != nil
+    }
+
     var body: some View {
         // One Section per route — the Section IS the card. Identity is the
         // stable RouteID; the accordion toggle lives INSIDE the Section so the
@@ -80,7 +89,7 @@ struct GroupedListView: View {
         // supports `if`, so the custom action itself only exists when the pill
         // would actually be visible — mirroring `alarmPill(for:)`'s own condition.
         .accessibilityActions {
-            if canAlarm(next) || alarm != nil {
+            if showsAlarmAffordance(for: next) {
                 Button(alarmActionName(for: alarm)) {
                     onAlarmToggle(next)
                 }
@@ -103,7 +112,7 @@ struct GroupedListView: View {
                     .font(.headline.weight(.heavy))
                     .lineLimit(2)
                 HStack(spacing: 6) {
-                    Text(DateFormatter.localizedString(from: next.scheduledDate, dateStyle: .none, timeStyle: .short))
+                    Text(formatters.timeFormatter.string(from: next.scheduledDate))
                         .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
                     Text("·").foregroundStyle(.tertiary)
                     Text(status.label)
@@ -155,7 +164,7 @@ struct GroupedListView: View {
     @ViewBuilder
     private func alarmPill(for departure: ArrivalDeparture) -> some View {
         let alarm = alarmLookup(departure)
-        if canAlarm(departure) || alarm != nil {
+        if showsAlarmAffordance(for: departure) {
             Button {
                 onAlarmToggle(departure)
             } label: {
@@ -187,7 +196,7 @@ struct GroupedListView: View {
                 alarmIcon(for: departure)
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 4) {
-                        Text(DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short))
+                        Text(formatters.timeFormatter.string(from: departure.scheduledDate))
                             .font(.subheadline.weight(.semibold)).monospacedDigit()
                         Text("· \(status.label)")
                             .font(.subheadline)
@@ -215,7 +224,7 @@ struct GroupedListView: View {
             .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
             .accessibilityAddTraits(.isButton)
             .accessibilityActions {
-                if canAlarm(departure) || alarmLookup(departure) != nil {
+                if showsAlarmAffordance(for: departure) {
                     Button(alarmActionName(for: alarmLookup(departure))) {
                         onAlarmToggle(departure)
                     }
@@ -234,7 +243,7 @@ struct GroupedListView: View {
     @ViewBuilder
     private func alarmIcon(for departure: ArrivalDeparture) -> some View {
         let alarm = alarmLookup(departure)
-        if canAlarm(departure) || alarm != nil {
+        if showsAlarmAffordance(for: departure) {
             Button { onAlarmToggle(departure) } label: {
                 Image(systemName: alarm != nil ? "bell.fill" : "bell")
                     .font(.subheadline.weight(.semibold))

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -40,6 +40,12 @@ struct GroupedListView: View {
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
 
     @Environment(\.obaFormatters) private var formatters
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    /// At accessibility sizes the card layouts "stack" (the guide's committed
+    /// layout): badge + countdown become glance tokens on the first line and
+    /// everything else flows below at full width.
+    private var isAccessibilitySize: Bool { dynamicTypeSize.isAccessibilitySize }
 
     /// Whether this departure should show an alarm affordance: it can take a new
     /// alarm, or it already has one that can be cancelled. Shared by the header
@@ -104,48 +110,101 @@ struct GroupedListView: View {
     }
 
     /// Badge, headsign, scheduled time + adherence, and the big countdown.
+    /// At accessibility sizes the badge and countdown become glance tokens on
+    /// the first line, with the headsign and time/status stacked below.
     private func headerPrimaryRow(next: ArrivalDeparture, status: DepartureStatus, routeColor: Color) -> some View {
-        HStack(alignment: .center, spacing: 13) {
-            RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(next.tripHeadsign ?? next.routeShortName)
-                    .font(.headline.weight(.heavy))
-                    .lineLimit(2)
-                HStack(spacing: 6) {
-                    Text(formatters.timeFormatter.string(from: next.scheduledDate))
-                        .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
-                    Text("·").foregroundStyle(.tertiary)
-                    Text(status.label)
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(Color(uiColor: status.color))
+        VStack(alignment: .leading, spacing: 3) {
+            if isAccessibilitySize {
+                HStack(alignment: .center) {
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+                    Spacer(minLength: 8)
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                }
+                headsignText(next)
+                Text(formatters.timeFormatter.string(from: next.scheduledDate))
+                    .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                Text(status.label)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color(uiColor: status.color))
+            } else {
+                HStack(alignment: .center, spacing: 13) {
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+                    VStack(alignment: .leading, spacing: 3) {
+                        headsignText(next)
+                        HStack(spacing: 6) {
+                            Text(formatters.timeFormatter.string(from: next.scheduledDate))
+                                .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                            Text("·").foregroundStyle(.tertiary)
+                            Text(status.label)
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(Color(uiColor: status.color))
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
                 }
             }
-            Spacer(minLength: 8)
-            CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
         }
     }
 
+    /// Clamped to two lines at every size (the guide's committed "clamp + tap"
+    /// choice); expanding the card reveals rows that lead to the full name.
+    private func headsignText(_ next: ArrivalDeparture) -> some View {
+        Text(next.tripHeadsign ?? next.routeShortName)
+            .font(.headline.weight(.heavy))
+            .lineLimit(2)
+    }
+
     /// Upcoming-trip chips (each tinted by its own departure's status), the
-    /// alarm pill, and the expand chevron. Empty chips render the §4.4 wording.
+    /// alarm pill, and the expand chevron. At accessibility sizes the chips
+    /// wrap in a flow under a "Next departures" caption (their meaning is no
+    /// longer inferable from proximity alone) and the alarm pill + chevron
+    /// drop to their own full-width line.
+    @ViewBuilder
     private func headerChipsRow(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
-        HStack(spacing: 8) {
-            if !group.chips.isEmpty {
-                ForEach(group.chips, id: \.id) { chip in
-                    let chipStatus = statusProvider(chip)
-                    Text("\(chip.arrivalDepartureMinutes)m")
-                        .font(.caption.weight(.heavy)).monospacedDigit()
-                        .foregroundStyle(Color(uiColor: chipStatus.color))
-                        .padding(.horizontal, 8).padding(.vertical, 3)
-                        .background(Color(uiColor: chipStatus.color).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+        if isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 8) {
+                if !group.chips.isEmpty {
+                    Text(OBALoc("stop_page.grouped.next_departures", value: "Next departures", comment: "Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes."))
+                        .textCase(.uppercase)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.secondary)
+                    FlowLayout(hSpacing: 8, vSpacing: 8) {
+                        chips(group)
+                    }
+                }
+                HStack(spacing: 8) {
+                    alarmPill(for: group.next)
+                    Spacer()
+                    expandChevron(group)
                 }
             }
-            Spacer()
-            alarmPill(for: group.next)
-            Image(systemName: "chevron.down")
-                .font(.footnote.weight(.bold))
-                .foregroundStyle(.tertiary)
-                .rotationEffect(.degrees(expandedRouteID == group.routeID ? 180 : 0))
+        } else {
+            HStack(spacing: 8) {
+                chips(group)
+                Spacer()
+                alarmPill(for: group.next)
+                expandChevron(group)
+            }
         }
+    }
+
+    private func chips(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        ForEach(group.chips, id: \.id) { chip in
+            let chipStatus = statusProvider(chip)
+            Text("\(chip.arrivalDepartureMinutes)m")
+                .font(.caption.weight(.heavy)).monospacedDigit()
+                .foregroundStyle(Color(uiColor: chipStatus.color))
+                .padding(.horizontal, 8).padding(.vertical, 3)
+                .background(Color(uiColor: chipStatus.color).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private func expandChevron(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        Image(systemName: "chevron.down")
+            .font(.footnote.weight(.bold))
+            .foregroundStyle(.tertiary)
+            .rotationEffect(.degrees(expandedRouteID == group.routeID ? 180 : 0))
     }
 
     @ViewBuilder
@@ -175,25 +234,45 @@ struct GroupedListView: View {
     private func expandedRows(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
         ForEach(group.departures, id: \.id) { departure in
             let status = statusProvider(departure)
-            HStack(spacing: 12) {
-                alarmIcon(for: departure)
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 4) {
-                        Text(formatters.timeFormatter.string(from: departure.scheduledDate))
-                            .font(.subheadline.weight(.semibold)).monospacedDigit()
-                        Text("· \(status.label)")
-                            .font(.subheadline)
-                            .foregroundStyle(Color(uiColor: status.color))
+            // Unary root; the accessibility-size branch stacks the row the
+            // same way the departure rows do — glance tokens (alarm circle,
+            // countdown, chevron) on the first line, time + status below.
+            VStack(alignment: .leading, spacing: 4) {
+                if isAccessibilitySize {
+                    HStack(spacing: 12) {
+                        alarmIcon(for: departure)
+                        Spacer(minLength: 8)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        tripChevron(departure)
                     }
+                    Text(formatters.timeFormatter.string(from: departure.scheduledDate))
+                        .font(.subheadline.weight(.semibold)).monospacedDigit()
+                    Text(status.label)
+                        .font(.subheadline)
+                        .foregroundStyle(Color(uiColor: status.color))
                     if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
                         OccupancyBadge(occupancy: occupancy)
                     }
+                } else {
+                    HStack(spacing: 12) {
+                        alarmIcon(for: departure)
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text(formatters.timeFormatter.string(from: departure.scheduledDate))
+                                    .font(.subheadline.weight(.semibold)).monospacedDigit()
+                                Text("· \(status.label)")
+                                    .font(.subheadline)
+                                    .foregroundStyle(Color(uiColor: status.color))
+                            }
+                            if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+                                OccupancyBadge(occupancy: occupancy)
+                            }
+                        }
+                        Spacer(minLength: 8)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        tripChevron(departure)
+                    }
                 }
-                Spacer(minLength: 8)
-                CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
-                Image(systemName: "chevron.down")
-                    .font(.caption.weight(.bold)).foregroundStyle(.tertiary)
-                    .rotationEffect(.degrees(openTripDepartureID == departure.id ? 180 : 0))
             }
             .contentShape(Rectangle())
             .onTapGesture { onToggleTrip(departure) }
@@ -221,6 +300,12 @@ struct GroupedListView: View {
                     .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
             }
         }
+    }
+
+    private func tripChevron(_ departure: ArrivalDeparture) -> some View {
+        Image(systemName: "chevron.down")
+            .font(.caption.weight(.bold)).foregroundStyle(.tertiary)
+            .rotationEffect(.degrees(openTripDepartureID == departure.id ? 180 : 0))
     }
 
     @ViewBuilder

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -129,11 +129,7 @@ struct GroupedListView: View {
     /// alarm pill, and the expand chevron. Empty chips render the §4.4 wording.
     private func headerChipsRow(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
         HStack(spacing: 8) {
-            if group.chips.isEmpty {
-                Text(OBALoc("stop_page.grouped.not_loaded", value: "later trips not loaded", comment: "Empty upcoming-chips state; must never imply no later trips exist (§4.4)"))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-            } else {
+            if !group.chips.isEmpty {
                 ForEach(group.chips, id: \.id) { chip in
                     let chipStatus = statusProvider(chip)
                     Text("\(chip.arrivalDepartureMinutes)m")

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -152,8 +152,11 @@ struct GroupedListView: View {
         }
     }
 
-    /// Route-color accent stripe on the card's left edge — the only other place
-    /// route color appears (§4.3).
+    /// Route-color accent stripe on the card's left edge — the other place
+    /// route color appears in the departure list rows besides the route badge;
+    /// the trip panel separately uses it for the vehicle glyph and approach
+    /// timeline. Spec §4.3 still holds: route color never tints countdowns or
+    /// adherence text.
     private func cardStripe(_ routeColor: Color) -> some View {
         HStack(spacing: 0) {
             routeColor.frame(width: 5)
@@ -215,8 +218,8 @@ struct GroupedListView: View {
             .contentShape(Rectangle())
             .onTapGesture { onToggleTrip(departure) }
             .listRowBackground(cardStripe(routeColor))
-            // Task 9 review: make the whole expanded row a single VoiceOver
-            // activation target that opens the trip panel, mirroring the card
+            // Make the whole expanded row a single VoiceOver activation target
+            // that opens the trip panel, mirroring the card
             // header (`children: .ignore` + explicit label + `.isButton`). The
             // combined element swallows the inner alarm Button, so it's re-exposed
             // as a custom action just like the header's alarm pill.
@@ -232,7 +235,7 @@ struct GroupedListView: View {
             }
 
             // Accordion: the trip panel is an INSERTED SIBLING ROW keyed off the
-            // open id — List animates the insert/remove (same pattern as Task 8).
+            // open id — List animates the insert/remove.
             if openTripDepartureID == departure.id {
                 panelBuilder(departure)
                     .listRowBackground(cardStripe(routeColor))

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -88,6 +88,11 @@ struct GroupedListView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(groupAccessibilityLabel(group, status: status))
         .accessibilityAddTraits(.isButton)
+        // Disclosure state: the card header's activation toggles the list of
+        // departures beneath it, so announce which way it will go.
+        .accessibilityValue(expandedRouteID == group.routeID
+            ? OBALoc("stop_page.grouped.a11y_expanded", value: "expanded", comment: "VoiceOver value of a grouped route card whose departure list is showing.")
+            : OBALoc("stop_page.grouped.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of a grouped route card whose departure list is hidden."))
         // The combined element above (`children: .ignore`) swallows the alarm
         // pill Button inside `headerChipsRow`, so VoiceOver can never reach it.
         // `.accessibilityActions` is applied unconditionally (keeping this a

--- a/OBAKit/Stops/StopPage/DonationCardRepresentable.swift
+++ b/OBAKit/Stops/StopPage/DonationCardRepresentable.swift
@@ -1,0 +1,55 @@
+//
+//  DonationCardRepresentable.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Bridges the existing UIKit `DonationCell` into the SwiftUI Stop page so the
+/// inline donation request renders and behaves identically to the legacy screen.
+/// Task 12 reuses the cell rather than reimplementing the donation card.
+///
+/// All three affordances present VC-owned modals (the learn-more/donate flow and
+/// the dismiss action sheet), so their handlers are supplied by the hosting VC and
+/// routed through the `StopPageNavigationHandler`.
+struct DonationCardRepresentable: UIViewRepresentable {
+    /// "Donate Now" and "Learn More" both open the same donation modal, matching
+    /// `StopViewController.showDonationUI()`.
+    let onDonate: () -> Void
+    let onLearnMore: () -> Void
+    /// The close (×) button; presents the dismiss action sheet from the VC.
+    let onClose: () -> Void
+
+    func makeUIView(context: Context) -> DonationCell {
+        let cell = DonationCell(frame: .zero)
+        cell.apply(DonationContentConfiguration(makeItem()))
+        return cell
+    }
+
+    // The donation card's content is static; the closures route to stable VC
+    // methods, so there's nothing to reconcile on SwiftUI updates.
+    func updateUIView(_ uiView: DonationCell, context: Context) {}
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: DonationCell, context: Context) -> CGSize? {
+        let width = proposal.width ?? UIView.layoutFittingCompressedSize.width
+        let fitting = uiView.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        return CGSize(width: width, height: fitting.height)
+    }
+
+    private func makeItem() -> DonationListItem {
+        DonationListItem(
+            onSelectAction: { _ in onDonate() },
+            onLearnMoreAction: { _ in onLearnMore() },
+            onCloseAction: { _ in onClose() }
+        )
+    }
+}

--- a/OBAKit/Stops/StopPage/DonationCardRepresentable.swift
+++ b/OBAKit/Stops/StopPage/DonationCardRepresentable.swift
@@ -11,8 +11,8 @@ import SwiftUI
 import OBAKitCore
 
 /// Bridges the existing UIKit `DonationCell` into the SwiftUI Stop page so the
-/// inline donation request renders and behaves identically to the legacy screen.
-/// Task 12 reuses the cell rather than reimplementing the donation card.
+/// inline donation request renders and behaves identically to the legacy screen,
+/// reusing the cell rather than reimplementing the donation card.
 ///
 /// All three affordances present VC-owned modals (the learn-more/donate flow and
 /// the dismiss action sheet), so their handlers are supplied by the hosting VC and

--- a/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
+++ b/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
@@ -5,13 +5,14 @@
 //
 
 import Foundation
+import OBAKitCore
 
 /// Lead-time rules for departure alarms: user-adjustable within 1–15 minutes,
 /// but never scheduled at or past the departure itself.
 enum AlarmLeadTime {
     static let minimumMinutes = 1
     static let maximumMinutes = 15
-    static let defaultMinutes = 5
+    static let defaultMinutes = UserDataStoreDefaults.alarmLeadTimeMinutes
 
     /// Clamps a requested lead time into the valid range for a departure
     /// `minutesUntilDeparture` away, or nil when no valid lead time exists

--- a/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
+++ b/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
@@ -14,12 +14,17 @@ enum AlarmLeadTime {
     static let maximumMinutes = 15
     static let defaultMinutes = UserDataStoreDefaults.alarmLeadTimeMinutes
 
+    /// The largest lead time that still buzzes before a departure
+    /// `minutesUntilDeparture` away, capped at `maximumMinutes`.
+    static func ceiling(minutesUntilDeparture: Int) -> Int {
+        min(maximumMinutes, minutesUntilDeparture - 1)
+    }
+
     /// Clamps a requested lead time into the valid range for a departure
     /// `minutesUntilDeparture` away, or nil when no valid lead time exists
     /// (mirrors `StopViewModel.canCreateAlarm`'s `> 1` gate).
     static func clamped(_ requested: Int, minutesUntilDeparture: Int) -> Int? {
         guard minutesUntilDeparture > 1 else { return nil }
-        let ceiling = min(maximumMinutes, minutesUntilDeparture - 1)
-        return min(max(requested, minimumMinutes), ceiling)
+        return min(max(requested, minimumMinutes), ceiling(minutesUntilDeparture: minutesUntilDeparture))
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
+++ b/OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Lead-time rules for departure alarms: user-adjustable within 1–15 minutes,
+/// but never scheduled at or past the departure itself.
+enum AlarmLeadTime {
+    static let minimumMinutes = 1
+    static let maximumMinutes = 15
+    static let defaultMinutes = 5
+
+    /// Clamps a requested lead time into the valid range for a departure
+    /// `minutesUntilDeparture` away, or nil when no valid lead time exists
+    /// (mirrors `StopViewModel.canCreateAlarm`'s `> 1` gate).
+    static func clamped(_ requested: Int, minutesUntilDeparture: Int) -> Int? {
+        guard minutesUntilDeparture > 1 else { return nil }
+        let ceiling = min(maximumMinutes, minutesUntilDeparture - 1)
+        return min(max(requested, minimumMinutes), ceiling)
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -18,7 +18,7 @@ struct CountdownView: View {
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
             Text("\(minutes)m")
-                .font(.system(size: emphasized ? 27 : 17, weight: .heavy, design: .rounded))
+                .font(emphasized ? .system(.title, design: .rounded, weight: .heavy) : .system(.body, design: .rounded, weight: .heavy))
                 .monospacedDigit()
                 .foregroundStyle(color)
             RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 13 : 11)

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -19,7 +19,7 @@ struct CountdownView: View {
         // Top-aligned so the glyph floats at the number's top-right corner
         // like a superscript, per the comps — not baseline-aligned beside it.
         HStack(alignment: .top, spacing: 2) {
-            Text("\(minutes)m")
+            Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
                 .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
                 .monospacedDigit()
                 .foregroundStyle(color)

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The "{n}m" countdown with its real-time glyph. Color encodes adherence
+/// status, never route (§4.3).
+struct CountdownView: View {
+    let minutes: Int
+    let isRealTime: Bool
+    let color: Color
+    /// true = card-header size (grouped card / chrono row), false = compact.
+    var emphasized: Bool = true
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text("\(minutes)m")
+                .font(.system(size: emphasized ? 27 : 17, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(color)
+            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 13 : 11)
+        }
+        .accessibilityElement(children: .ignore)
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -16,12 +16,15 @@ struct CountdownView: View {
     var emphasized: Bool = true
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 4) {
+        // Top-aligned so the glyph floats at the number's top-right corner
+        // like a superscript, per the comps — not baseline-aligned beside it.
+        HStack(alignment: .top, spacing: 2) {
             Text("\(minutes)m")
-                .font(emphasized ? .system(.title, design: .rounded, weight: .heavy) : .system(.body, design: .rounded, weight: .heavy))
+                .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
                 .monospacedDigit()
                 .foregroundStyle(color)
-            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 13 : 11)
+            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
+                .padding(.top, 1)
         }
         .accessibilityElement(children: .ignore)
     }

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -26,6 +26,10 @@ struct CountdownView: View {
             RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
                 .padding(.top, 1)
         }
-        .accessibilityElement(children: .ignore)
+        // Hidden outright rather than an empty `children: .ignore` element:
+        // every consumer (departure rows, grouped cards) speaks the countdown
+        // in its own combined label, and a label-less element would otherwise
+        // be a silent VoiceOver stop wherever an ancestor doesn't swallow it.
+        .accessibilityHidden(true)
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
+++ b/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
@@ -42,9 +42,16 @@ struct DepartureStatus {
         }
     }
 
+    /// Adherence label shown when there's no real-time signal; deliberately
+    /// avoids claiming the bus is on time. Used by both the no-signal and the
+    /// unknown-status paths below.
+    private static var scheduleDataLabel: String {
+        OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+    }
+
     var label: String {
         guard isRealTime else {
-            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+            return Self.scheduleDataLabel
         }
         switch scheduleStatus {
         case .onTime:
@@ -56,7 +63,7 @@ struct DepartureStatus {
             let fmt = OBALoc("stop_page.status.early_fmt", value: "%d min early", comment: "Adherence label for an early departure. %d is minutes early.")
             return String(format: fmt, abs(deviationMinutes))
         default:
-            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+            return Self.scheduleDataLabel
         }
     }
 

--- a/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
+++ b/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+/// The single home of the Stop page's status visual language: countdowns,
+/// adherence labels, and the real-time hard gate. When `isRealTime == false`
+/// the UI must show a clock glyph, gray text, no occupancy, and never claim
+/// the trip is "on time" — a scheduled bus's punctuality is unknown.
+struct DepartureStatus {
+    let isRealTime: Bool
+    let scheduleStatus: ScheduleStatus
+    let deviationMinutes: Int
+
+    init(arrivalDeparture: ArrivalDeparture) {
+        self.init(
+            isRealTime: arrivalDeparture.predicted,
+            scheduleStatus: arrivalDeparture.scheduleStatus,
+            deviationMinutes: arrivalDeparture.deviationFromScheduleInMinutes
+        )
+    }
+
+    init(isRealTime: Bool, scheduleStatus: ScheduleStatus, deviationMinutes: Int) {
+        self.isRealTime = isRealTime
+        self.scheduleStatus = scheduleStatus
+        self.deviationMinutes = deviationMinutes
+    }
+
+    var showsOccupancy: Bool { isRealTime }
+
+    var color: UIColor {
+        guard isRealTime else { return .secondaryLabel }
+        switch scheduleStatus {
+        case .onTime: return ThemeColors.shared.departureOnTime
+        case .early: return ThemeColors.shared.departureEarly
+        case .delayed: return ThemeColors.shared.departureLate
+        default: return .secondaryLabel
+        }
+    }
+
+    var label: String {
+        guard isRealTime else {
+            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+        }
+        switch scheduleStatus {
+        case .onTime:
+            return OBALoc("stop_page.status.on_time", value: "on time", comment: "Adherence label for an on-time departure")
+        case .delayed:
+            let fmt = OBALoc("stop_page.status.late_fmt", value: "%d min late", comment: "Adherence label for a late departure. %d is minutes late.")
+            return String(format: fmt, abs(deviationMinutes))
+        case .early:
+            let fmt = OBALoc("stop_page.status.early_fmt", value: "%d min early", comment: "Adherence label for an early departure. %d is minutes early.")
+            return String(format: fmt, abs(deviationMinutes))
+        default:
+            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+        }
+    }
+
+    var accessibilityStatusDescription: String {
+        if isRealTime {
+            let fmt = OBALoc("stop_page.status.a11y_live_fmt", value: "live tracking, %@", comment: "VoiceOver status suffix for a live departure. %@ is the adherence label.")
+            return String(format: fmt, label)
+        }
+        return OBALoc("stop_page.status.a11y_scheduled", value: "scheduled time only, no live data", comment: "VoiceOver status suffix for a schedule-only departure")
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/OccupancyBadge.swift
+++ b/OBAKit/Stops/StopPage/Shared/OccupancyBadge.swift
@@ -1,0 +1,57 @@
+//
+//  OccupancyBadge.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Compact occupancy indicator for expanded departure rows.
+///
+/// The existing `OccupancyStatusView` is a reuse-oriented UIKit `UIView` whose
+/// `configure`/`prepareForReuse` lifecycle doesn't map onto a SwiftUI List row,
+/// so rather than wrap it in a `UIViewRepresentable` this is a lightweight
+/// text-plus-icon label that reuses the same `occupancy_status.*` localization
+/// keys — translations stay shared. Callers gate it on
+/// `DepartureStatus.showsOccupancy` (real-time only, §4.1).
+struct OccupancyBadge: View {
+    let occupancy: ArrivalDeparture.OccupancyStatus
+
+    var body: some View {
+        Label {
+            Text(Self.localizedDescription(occupancy))
+        } icon: {
+            Image(systemName: "person.fill")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    /// Human-readable occupancy string. Mirrors `OccupancyStatusView`'s mapping,
+    /// reusing the identical `occupancy_status.*` keys so both surfaces localize
+    /// from the same catalog entries.
+    static func localizedDescription(_ occupancy: ArrivalDeparture.OccupancyStatus) -> String {
+        switch occupancy {
+        case .empty:
+            return OBALoc("occupancy_status.empty", value: "Empty", comment: "Vehicle occupancy is zero")
+        case .manySeatsAvailable:
+            return OBALoc("occupancy_status.many_seats_available", value: "Many seats available", comment: "Vehicle occupancy is low")
+        case .fewSeatsAvailable:
+            return OBALoc("occupancy_status.few_seats_available", value: "Few seats available", comment: "Vehicle occupancy is medium")
+        case .standingRoomOnly:
+            return OBALoc("occupancy_status.standing_room_only", value: "Standing room only", comment: "Vehicle occupancy is high")
+        case .crushedStandingRoomOnly:
+            return OBALoc("occupancy_status.crushed_standing_room_only", value: "Crushed standing room only", comment: "Vehicle occupancy is very high")
+        case .full:
+            return OBALoc("occupancy_status.full", value: "Full", comment: "Vehicle occupancy is full")
+        case .notBoardable, .notAcceptingPassengers:
+            return OBALoc("occupancy_status.not_accepting_passengers", value: "Not accepting passengers", comment: "Vehicle is not accepting any passengers")
+        case .noDataAvailable, .unknown:
+            return OBALoc("occupancy_status.unknown", value: "Unknown", comment: "Vehicle occupancy status is unknown.")
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/OccupancyBadge.swift
+++ b/OBAKit/Stops/StopPage/Shared/OccupancyBadge.swift
@@ -10,30 +10,80 @@
 import SwiftUI
 import OBAKitCore
 
-/// Compact occupancy indicator for expanded departure rows.
+/// Compact occupancy indicator for departure rows in both chronological and
+/// grouped modes: a crowding-meter bars glyph plus a short label
+/// ("Many seats", "Some seats", …).
 ///
 /// The existing `OccupancyStatusView` is a reuse-oriented UIKit `UIView` whose
 /// `configure`/`prepareForReuse` lifecycle doesn't map onto a SwiftUI List row,
 /// so rather than wrap it in a `UIViewRepresentable` this is a lightweight
-/// text-plus-icon label that reuses the same `occupancy_status.*` localization
-/// keys — translations stay shared. Callers gate it on
-/// `DepartureStatus.showsOccupancy` (real-time only, §4.1).
+/// text-plus-icon label. Display text uses short `occupancy_status.short.*`
+/// strings sized for a one-line row; VoiceOver (via `localizedDescription`)
+/// keeps the full `occupancy_status.*` wording shared with
+/// `OccupancyStatusView`. Callers gate it on `DepartureStatus.showsOccupancy`
+/// (real-time only, §4.1).
 struct OccupancyBadge: View {
     let occupancy: ArrivalDeparture.OccupancyStatus
 
     var body: some View {
-        Label {
-            Text(Self.localizedDescription(occupancy))
-        } icon: {
-            Image(systemName: "person.fill")
+        HStack(spacing: 5) {
+            Image(systemName: "cellularbars", variableValue: Self.fillLevel(occupancy))
+            Text(Self.shortLabel(occupancy))
         }
-        .font(.caption)
+        .font(.caption.weight(.medium))
         .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Self.localizedDescription(occupancy))
+    }
+
+    /// How full the vehicle is, as the bars glyph's variable value: more filled
+    /// bars = more crowded. `cellularbars` has four segments, so levels are
+    /// quarter steps.
+    static func fillLevel(_ occupancy: ArrivalDeparture.OccupancyStatus) -> Double {
+        switch occupancy {
+        case .empty:
+            return 0.0
+        case .manySeatsAvailable:
+            return 0.25
+        case .fewSeatsAvailable:
+            return 0.5
+        case .standingRoomOnly:
+            return 0.75
+        case .crushedStandingRoomOnly, .full, .notBoardable, .notAcceptingPassengers:
+            return 1.0
+        case .noDataAvailable, .unknown:
+            return 0.0
+        }
+    }
+
+    /// Short display wording sized for a single row line. Deliberately separate
+    /// keys from the full `occupancy_status.*` strings, which stay untouched for
+    /// `OccupancyStatusView` and VoiceOver.
+    static func shortLabel(_ occupancy: ArrivalDeparture.OccupancyStatus) -> String {
+        switch occupancy {
+        case .empty:
+            return OBALoc("occupancy_status.short.empty", value: "Empty", comment: "Short occupancy label: vehicle is empty")
+        case .manySeatsAvailable:
+            return OBALoc("occupancy_status.short.many_seats", value: "Many seats", comment: "Short occupancy label: many seats available")
+        case .fewSeatsAvailable:
+            return OBALoc("occupancy_status.short.some_seats", value: "Some seats", comment: "Short occupancy label: few seats available")
+        case .standingRoomOnly:
+            return OBALoc("occupancy_status.short.standing_room", value: "Standing room", comment: "Short occupancy label: standing room only")
+        case .crushedStandingRoomOnly:
+            return OBALoc("occupancy_status.short.crowded", value: "Crowded", comment: "Short occupancy label: crushed standing room only")
+        case .full:
+            return OBALoc("occupancy_status.short.full", value: "Full", comment: "Short occupancy label: vehicle is full")
+        case .notBoardable, .notAcceptingPassengers:
+            return OBALoc("occupancy_status.short.not_boarding", value: "Not boarding", comment: "Short occupancy label: vehicle is not accepting passengers")
+        case .noDataAvailable, .unknown:
+            return OBALoc("occupancy_status.short.unknown", value: "Unknown", comment: "Short occupancy label: occupancy is unknown")
+        }
     }
 
     /// Human-readable occupancy string. Mirrors `OccupancyStatusView`'s mapping,
     /// reusing the identical `occupancy_status.*` keys so both surfaces localize
-    /// from the same catalog entries.
+    /// from the same catalog entries. Used for VoiceOver, where the full wording
+    /// is clearer than the short display label.
     static func localizedDescription(_ occupancy: ArrivalDeparture.OccupancyStatus) -> String {
         switch occupancy {
         case .empty:

--- a/OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift
+++ b/OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift
@@ -16,11 +16,12 @@ struct RealtimeGlyph: View {
     var size: CGFloat = 14
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
 
     var body: some View {
         // Unary root: one Image; the live/scheduled fork is symbol + modifier state.
         Image(systemName: isRealTime ? "dot.radiowaves.up.forward" : "clock")
-            .font(.system(size: size, weight: .semibold))
+            .font(.system(size: size * scale, weight: .semibold))
             .foregroundStyle(isRealTime ? color : Color(uiColor: .secondaryLabel))
             .symbolEffect(.variableColor.iterative, options: .repeating, isActive: isRealTime && !reduceMotion)
             .accessibilityHidden(true) // status is conveyed in the row's combined label

--- a/OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift
+++ b/OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The at-a-glance "is this tracked?" signal (§4.1): animated radiating waves
+/// for live trips, a static outline clock for schedule-only. Uses an SF Symbol
+/// variable-color effect so the system batches animation across the ~15
+/// instances a full list shows — never per-instance repeatForever loops.
+struct RealtimeGlyph: View {
+    let isRealTime: Bool
+    let color: Color
+    var size: CGFloat = 14
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        // Unary root: one Image; the live/scheduled fork is symbol + modifier state.
+        Image(systemName: isRealTime ? "dot.radiowaves.up.forward" : "clock")
+            .font(.system(size: size, weight: .semibold))
+            .foregroundStyle(isRealTime ? color : Color(uiColor: .secondaryLabel))
+            .symbolEffect(.variableColor.iterative, options: .repeating, isActive: isRealTime && !reduceMotion)
+            .accessibilityHidden(true) // status is conveyed in the row's combined label
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -6,10 +6,13 @@
 
 import SwiftUI
 
-/// Rounded-square route identity badge. One of only two places route color
-/// appears in the departure list rows (the other is the grouped card stripe);
-/// the trip panel separately uses it for the vehicle glyph and approach timeline.
-/// Spec §4.3 still holds: route color never tints countdowns or adherence text.
+/// Rounded-square route identity badge — the only place route color appears in
+/// the departure list rows; the trip panel separately uses it for the vehicle
+/// glyph and approach timeline. Spec §4.3 still holds: route color never tints
+/// countdowns or adherence text.
+///
+/// Rendered as a gradient of the route color with a glossy rim, plus the real
+/// Liquid Glass foreground treatment on OS versions that have it.
 struct RouteBadgeView: View {
     let routeShortName: String
     let routeColor: Color
@@ -18,6 +21,7 @@ struct RouteBadgeView: View {
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
 
     var body: some View {
+        let shape = RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous)
         Text(routeShortName)
             .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
             .monospacedDigit()
@@ -25,7 +29,35 @@ struct RouteBadgeView: View {
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .frame(width: size * scale, height: size * scale)
-            .background(routeColor, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .background(routeColor.gradient, in: shape)
+            // Glossy rim highlight — carries the glass feel on iOS 18–25 too.
+            .overlay {
+                shape.strokeBorder(
+                    LinearGradient(
+                        colors: [.white.opacity(0.5), .white.opacity(0.05)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ),
+                    lineWidth: 1
+                )
+            }
+            .modifier(BadgeGlassEffect(shape: shape))
+            .shadow(color: routeColor.opacity(0.3), radius: 3, y: 1)
             .accessibilityHidden(true) // route name is in the row's combined label
+    }
+}
+
+/// Applies the Liquid Glass foreground treatment over the badge's gradient on
+/// iOS 26+ (`.clear` so the route color stays saturated underneath); a no-op
+/// on earlier versions, where the gradient + rim highlight stand alone.
+private struct BadgeGlassEffect<S: Shape>: ViewModifier {
+    let shape: S
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(.clear, in: shape)
+        } else {
+            content
+        }
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -13,15 +13,17 @@ struct RouteBadgeView: View {
     let routeColor: Color
     var size: CGFloat = 44
 
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+
     var body: some View {
         Text(routeShortName)
-            .font(.system(size: routeShortName.count <= 2 ? 18 : 13, weight: .heavy))
+            .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
             .monospacedDigit()
             .foregroundStyle(.white)
             .minimumScaleFactor(0.6)
             .lineLimit(1)
-            .frame(width: size, height: size)
-            .background(routeColor, in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous))
+            .frame(width: size * scale, height: size * scale)
+            .background(routeColor, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
             .accessibilityHidden(true) // route name is in the row's combined label
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -6,8 +6,10 @@
 
 import SwiftUI
 
-/// Rounded-square route identity badge. The ONLY place (besides the grouped
-/// card stripe) that renders the route's brand color (§4.3).
+/// Rounded-square route identity badge. One of only two places route color
+/// appears in the departure list rows (the other is the grouped card stripe);
+/// the trip panel separately uses it for the vehicle glyph and approach timeline.
+/// Spec §4.3 still holds: route color never tints countdowns or adherence text.
 struct RouteBadgeView: View {
     let routeShortName: String
     let routeColor: Color

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Rounded-square route identity badge. The ONLY place (besides the grouped
+/// card stripe) that renders the route's brand color (§4.3).
+struct RouteBadgeView: View {
+    let routeShortName: String
+    let routeColor: Color
+    var size: CGFloat = 44
+
+    var body: some View {
+        Text(routeShortName)
+            .font(.system(size: routeShortName.count <= 2 ? 18 : 13, weight: .heavy))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size, height: size)
+            .background(routeColor, in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous))
+            .accessibilityHidden(true) // route name is in the row's combined label
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -10,9 +10,6 @@ import SwiftUI
 /// the departure list rows; the trip panel separately uses it for the vehicle
 /// glyph and approach timeline. Spec §4.3 still holds: route color never tints
 /// countdowns or adherence text.
-///
-/// Rendered as a gradient of the route color with a glossy rim, plus the real
-/// Liquid Glass foreground treatment on OS versions that have it.
 struct RouteBadgeView: View {
     let routeShortName: String
     let routeColor: Color
@@ -21,7 +18,6 @@ struct RouteBadgeView: View {
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
 
     var body: some View {
-        let shape = RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous)
         Text(routeShortName)
             .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
             .monospacedDigit()
@@ -29,35 +25,7 @@ struct RouteBadgeView: View {
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .frame(width: size * scale, height: size * scale)
-            .background(routeColor.gradient, in: shape)
-            // Glossy rim highlight — carries the glass feel on iOS 18–25 too.
-            .overlay {
-                shape.strokeBorder(
-                    LinearGradient(
-                        colors: [.white.opacity(0.5), .white.opacity(0.05)],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    ),
-                    lineWidth: 1
-                )
-            }
-            .modifier(BadgeGlassEffect(shape: shape))
-            .shadow(color: routeColor.opacity(0.3), radius: 3, y: 1)
+            .background(routeColor.gradient, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
             .accessibilityHidden(true) // route name is in the row's combined label
-    }
-}
-
-/// Applies the Liquid Glass foreground treatment over the badge's gradient on
-/// iOS 26+ (`.clear` so the route color stays saturated underneath); a no-op
-/// on earlier versions, where the gradient + rim highlight stand alone.
-private struct BadgeGlassEffect<S: Shape>: ViewModifier {
-    let shape: S
-
-    func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content.glassEffect(.clear, in: shape)
-        } else {
-            content
-        }
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift
@@ -62,7 +62,7 @@ enum StopPageListBuilder {
 
         var next: D { departures[0] }
         var upcoming: [D] { Array(departures.dropFirst()) }
-        /// The small status-tinted pills; empty renders "later trips not loaded" (§4.4).
+        /// The small status-tinted pills
         var chips: [D] { Array(departures.dropFirst().prefix(3)) }
     }
 

--- a/OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift
@@ -1,0 +1,85 @@
+//
+//  StopPageListBuilder.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The list-shape abstraction over `ArrivalDeparture` that the Stop page's
+/// pure transforms operate on; production code passes `ArrivalDeparture`,
+/// tests pass lightweight stubs (the real type only decodes from JSON).
+protocol DepartureListEntry {
+    var id: String { get }
+    var routeID: RouteID { get }
+    var arrivalDepartureMinutes: Int { get }
+    var temporalState: TemporalState { get }
+}
+
+extension ArrivalDeparture: DepartureListEntry {}
+
+/// Pure transforms shared by both Stop page list modes. Both modes are
+/// projections of the same filtered departure list (spec §3); callers apply
+/// `filter(preferences:)` for hidden routes before calling in.
+enum StopPageListBuilder {
+
+    // MARK: - Chronological
+
+    struct ChronologicalPartition<D: DepartureListEntry> {
+        /// Already departed. Rendered dimmed, no strikethrough (§4.2).
+        let past: [D]
+        /// Upcoming, but arriving sooner than the user can walk to the stop.
+        /// Rendered dimmed + struck-through (§4.2).
+        let missed: [D]
+        /// Catchable on foot: `arrivalDepartureMinutes >= walkMinutes` (§4.5).
+        let reachable: [D]
+    }
+
+    static func chronologicalPartition<D: DepartureListEntry>(_ departures: [D], walkMinutes: Int?) -> ChronologicalPartition<D> {
+        let sorted = departures.sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+        let past = sorted.filter { $0.temporalState == .past }
+        let upcoming = sorted.filter { $0.temporalState != .past }
+
+        guard let walkMinutes else {
+            return ChronologicalPartition(past: past, missed: [], reachable: upcoming)
+        }
+
+        let missed = upcoming.filter { $0.arrivalDepartureMinutes < walkMinutes }
+        let reachable = upcoming.filter { $0.arrivalDepartureMinutes >= walkMinutes }
+        return ChronologicalPartition(past: past, missed: missed, reachable: reachable)
+    }
+
+    // MARK: - Grouped ("By route")
+
+    struct RouteGroup<D: DepartureListEntry> {
+        let routeID: RouteID
+        /// Time-sorted; never empty. `[0]` is the card-header "next" departure.
+        let departures: [D]
+
+        var next: D { departures[0] }
+        var upcoming: [D] { Array(departures.dropFirst()) }
+        /// The small status-tinted pills; empty renders "later trips not loaded" (§4.4).
+        var chips: [D] { Array(departures.dropFirst().prefix(3)) }
+    }
+
+    /// Groups by route, preserving first-appearance order after the time sort,
+    /// so routes rank by their soonest departure (§4.9). Past departures are
+    /// excluded — grouped mode has no past block.
+    static func routeGroups<D: DepartureListEntry>(_ departures: [D]) -> [RouteGroup<D>] {
+        let sorted = departures
+            .filter { $0.temporalState != .past }
+            .sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+
+        var order: [RouteID] = []
+        var buckets: [RouteID: [D]] = [:]
+        for departure in sorted {
+            if buckets[departure.routeID] == nil { order.append(departure.routeID) }
+            buckets[departure.routeID, default: []].append(departure)
+        }
+        return order.map { RouteGroup(routeID: $0, departures: buckets[$0]!) }
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -22,7 +22,7 @@ struct WalkLineDivider: View {
             dash
             Label(text, systemImage: "figure.walk")
                 .font(.caption.weight(.heavy))
-                .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .foregroundStyle(.orange)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             dash
@@ -34,7 +34,7 @@ struct WalkLineDivider: View {
     private var dash: some View {
         Line()
             .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
-            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+            .foregroundStyle(.orange)
             .frame(height: 2)
             .frame(maxWidth: .infinity)
     }

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -21,7 +21,7 @@ struct WalkLineDivider: View {
         HStack(spacing: 10) {
             dash
             Label(text, systemImage: "figure.walk")
-                .font(.system(size: 12, weight: .heavy))
+                .font(.caption.weight(.heavy))
                 .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The dashed reachability divider in chronological mode: everything above is
+/// "just missed", everything below is catchable on foot (§4.5).
+struct WalkLineDivider: View {
+    let walkMinutes: Int
+
+    private var text: String {
+        let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
+        return String(format: fmt, walkMinutes)
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            dash
+            Label(text, systemImage: "figure.walk")
+                .font(.system(size: 12, weight: .heavy))
+                .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            dash
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(format: OBALoc("stop_page.walk_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute walk to the stop", comment: "VoiceOver description of the walk divider. %d is walk minutes."), walkMinutes))
+    }
+
+    private var dash: some View {
+        Line()
+            .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
+            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+            .frame(height: 2)
+            .frame(maxWidth: .infinity)
+    }
+
+    private struct Line: Shape {
+        func path(in rect: CGRect) -> Path {
+            var path = Path()
+            path.move(to: CGPoint(x: 0, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            return path
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -14,6 +14,9 @@ struct WalkLineDivider: View {
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
+    /// Matches the walk pill on the header card (§4.5).
+    private let lineColor = Color(uiColor: ThemeColors.shared.departureOnTime)
+
     private var text: String {
         let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
         return String(format: fmt, walkMinutes)
@@ -28,21 +31,25 @@ struct WalkLineDivider: View {
             if dynamicTypeSize.isAccessibilitySize {
                 Label(text, systemImage: "figure.walk")
                     .font(.caption.weight(.heavy))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(lineColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12, style: .continuous)
                             .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(lineColor)
                     )
             } else {
                 dash
                 Label(text, systemImage: "figure.walk")
                     .font(.caption.weight(.heavy))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(lineColor)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
+                    // The dashes are greedy (maxWidth: .infinity); without a
+                    // higher priority the HStack squeezes the label instead of
+                    // shortening the dashes.
+                    .layoutPriority(1)
                 dash
             }
         }
@@ -53,7 +60,7 @@ struct WalkLineDivider: View {
     private var dash: some View {
         Line()
             .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
-            .foregroundStyle(.orange)
+            .foregroundStyle(lineColor)
             .frame(height: 2)
             .frame(maxWidth: .infinity)
     }
@@ -65,5 +72,12 @@ struct WalkLineDivider: View {
             path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
             return path
         }
+    }
+}
+
+#Preview {
+    List {
+        WalkLineDivider(walkMinutes: 104)
+        WalkLineDivider(walkMinutes: 8)
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -12,20 +12,39 @@ import OBAKitCore
 struct WalkLineDivider: View {
     let walkMinutes: Int
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     private var text: String {
         let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
         return String(format: fmt, walkMinutes)
     }
 
     var body: some View {
+        // At accessibility sizes the flanking dashes go away — they'd squeeze
+        // the label into a sliver — and the label becomes a full-width dashed
+        // banner box that wraps at full size (minimum-scale-factor is not a
+        // Dynamic Type strategy; the text must grow, not the row squeeze it).
         HStack(spacing: 10) {
-            dash
-            Label(text, systemImage: "figure.walk")
-                .font(.caption.weight(.heavy))
-                .foregroundStyle(.orange)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-            dash
+            if dynamicTypeSize.isAccessibilitySize {
+                Label(text, systemImage: "figure.walk")
+                    .font(.caption.weight(.heavy))
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
+                            .foregroundStyle(.orange)
+                    )
+            } else {
+                dash
+                Label(text, systemImage: "figure.walk")
+                    .font(.caption.weight(.heavy))
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                dash
+            }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(String(format: OBALoc("stop_page.walk_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute walk to the stop", comment: "VoiceOver description of the walk divider. %d is walk minutes."), walkMinutes))

--- a/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
@@ -18,10 +18,13 @@ struct WalkTimeInfo: Equatable {
     /// Returns nil with no user location, an invalid speed, or when the user
     /// is effectively at the stop (<= 40 m, matching `WalkTimeView`).
     static func compute(from userLocation: CLLocation?, to stopLocation: CLLocation?, speedMetersPerSecond: Double) -> WalkTimeInfo? {
-        guard let userLocation, let stopLocation, speedMetersPerSecond > 0 else { return nil }
+        guard let userLocation, let stopLocation else { return nil }
         let distance = userLocation.distance(from: stopLocation)
-        guard distance > 40 else { return nil }
-        let seconds = distance / speedMetersPerSecond
+        // Suppress when effectively at the stop; the speed/velocity guard and the
+        // distance-over-velocity math both live in `WalkingDirections.travelTime`.
+        guard distance > 40,
+              let seconds = WalkingDirections.travelTime(from: userLocation, to: stopLocation, velocity: speedMetersPerSecond)
+        else { return nil }
         return WalkTimeInfo(walkMinutes: Int(ceil(seconds / 60.0)), distance: distance)
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+
+/// The single source of walk time on the Stop page (§4.5): the header chip
+/// and the chronological walk line must both read from the same instance.
+struct WalkTimeInfo: Equatable {
+    /// Rounded up — never promise a shorter walk than reality.
+    let walkMinutes: Int
+    let distance: CLLocationDistance
+
+    /// Straight-line walk estimate, matching `WalkingDirections.travelTime`.
+    /// Returns nil with no user location, an invalid speed, or when the user
+    /// is effectively at the stop (<= 40 m, matching `WalkTimeView`).
+    static func compute(from userLocation: CLLocation?, to stopLocation: CLLocation?, speedMetersPerSecond: Double) -> WalkTimeInfo? {
+        guard let userLocation, let stopLocation, speedMetersPerSecond > 0 else { return nil }
+        let distance = userLocation.distance(from: stopLocation)
+        guard distance > 40 else { return nil }
+        let seconds = distance / speedMetersPerSecond
+        return WalkTimeInfo(walkMinutes: Int(ceil(seconds / 60.0)), distance: distance)
+    }
+}

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -33,6 +33,8 @@ struct StopPageHeaderView: View {
     @State private var showsRoutes = false
     @State private var cardWidth: CGFloat = 0
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     /// Minimum card height; the card grows beyond it when the identity block
     /// needs more room (wrapped chips, Dynamic Type). Scales with Dynamic Type
     /// so the stop name has room at larger text sizes (standing amendment).
@@ -60,7 +62,9 @@ struct StopPageHeaderView: View {
             Text(stop.name)
                 .font(.title2.weight(.heavy))
                 .foregroundStyle(.white)
-                .lineLimit(2)
+                // Accessibility sizes get more lines so the full name still
+                // reads instead of clipping at the larger glyph sizes.
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 4 : 2)
             // Subtitle + chips flow together and wrap onto as many lines as
             // the routes need — chips are never compressed or dropped.
             FlowLayout(hSpacing: 4, vSpacing: 4) {
@@ -171,10 +175,11 @@ private struct HeaderStatusLine: View {
     }
 }
 
-/// Minimal leading-aligned wrapping layout for the subtitle + route chips:
-/// subviews flow left-to-right at their ideal sizes and break onto new lines
-/// as needed, so chips wrap instead of compressing or truncating.
-private struct FlowLayout: Layout {
+/// Minimal leading-aligned wrapping layout: subviews flow left-to-right at
+/// their ideal sizes and break onto new lines as needed, so chips wrap instead
+/// of compressing or truncating. Shared by the header's subtitle + route chips
+/// and the grouped card's upcoming-trip chips at accessibility sizes.
+struct FlowLayout: Layout {
     var hSpacing: CGFloat = 4
     var vSpacing: CGFloat = 4
 

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -8,12 +8,14 @@
 //
 
 import SwiftUI
-import MapKit
 import OBAKitCore
 
-/// The inset map-card header: snapshot background, stop identity, and the
-/// walk chip — the single visual source of walk time (§4.5). Tap toggles the
-/// routes-served line (parity with the old header).
+/// The full-bleed dark map header: an always-dark snapshot background under a
+/// dark scrim, with the identity block bottom-left in white — the "last
+/// updated" status line, stop name, the code/direction subtitle with inline
+/// route chips (wrapping onto as many lines as needed, never truncated), and
+/// the walk pill (the single visual source of walk time, §4.5). Tap toggles
+/// the full routes-served line (parity with the old header).
 ///
 /// A plain-value view: it never touches `StopViewModel`. The map snapshot is
 /// produced by a `snapshotLoader` closure supplied by the hosting VC, so the
@@ -23,69 +25,87 @@ import OBAKitCore
 struct StopPageHeaderView: View {
     let stop: Stop
     let walkTime: WalkTimeInfo?
+    /// The "Updated: …" line; empty hides it.
+    let statusText: String
     let snapshotLoader: (CGSize) async -> UIImage?
 
     @State private var snapshot: UIImage?
     @State private var showsRoutes = false
     @State private var cardWidth: CGFloat = 0
 
-    /// Grows the card with Dynamic Type so the stop name has room at larger
-    /// text sizes (standing amendment).
-    @ScaledMetric(relativeTo: .title2) private var cardHeight: CGFloat = 150
-
-    /// A single shared formatter; distances are formatted for display only.
-    private static let distanceFormatter = MKDistanceFormatter()
+    /// Minimum card height; the card grows beyond it when the identity block
+    /// needs more room (wrapped chips, Dynamic Type). Scales with Dynamic Type
+    /// so the stop name has room at larger text sizes (standing amendment).
+    @ScaledMetric(relativeTo: .title2) private var cardHeight: CGFloat = 170
 
     private var subtitle: String {
         Formatters.formattedCodeAndDirection(stop: stop)
     }
 
+    /// Sorted, de-duplicated route short names for the chips row. Mirrors
+    /// `Formatters.formattedRoutes`' filtering (some agencies omit short names).
+    private var routeChipNames: [String] {
+        var seen = Set<String>()
+        return stop.routes
+            .map(\.shortName)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            Group {
-                if let snapshot {
-                    Image(uiImage: snapshot).resizable().scaledToFill()
-                } else {
-                    Color(uiColor: .secondarySystemGroupedBackground)
-                }
+        VStack(alignment: .leading, spacing: 8) {
+            if !statusText.isEmpty {
+                HeaderStatusLine(statusText: statusText)
             }
-            LinearGradient(
-                colors: [
-                    Color(uiColor: .systemBackground).opacity(0.92),
-                    Color(uiColor: .systemBackground).opacity(0.4),
-                    .clear
-                ],
-                startPoint: .top, endPoint: .bottom
-            )
-            VStack(alignment: .leading, spacing: 4) {
-                Text(stop.name)
-                    .font(.title2.weight(.heavy))
-                    .lineLimit(2)
+            Text(stop.name)
+                .font(.title2.weight(.heavy))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+            // Subtitle + chips flow together and wrap onto as many lines as
+            // the routes need — chips are never compressed or dropped.
+            FlowLayout(hSpacing: 4, vSpacing: 4) {
                 Text(subtitle)
                     .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                if showsRoutes, let routes = Formatters.formattedRoutes(stop.routes) {
-                    Text(routes)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
+                    .foregroundStyle(.white.opacity(0.75))
+                    .padding(.trailing, 4)
+                ForEach(routeChipNames, id: \.self) { name in
+                    routeChip(name)
                 }
             }
-            .padding(16)
-        }
-        .frame(height: cardHeight)
-        .frame(maxWidth: .infinity)
-        .overlay(alignment: .bottomLeading) {
+            if showsRoutes, let routes = Formatters.formattedRoutes(stop.routes) {
+                Text(routes)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.75))
+                    .lineLimit(2)
+            }
             if let walkTime {
                 Label(walkChipText(walkTime), systemImage: "figure.walk")
                     .font(.footnote.weight(.heavy))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                     .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
-                    .padding(12)
             }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: cardHeight, alignment: .bottomLeading)
+        // The snapshot is a background so the identity block drives the card's
+        // height — it can grow past `cardHeight` instead of clipping content.
+        .background {
+            ZStack {
+                if let snapshot {
+                    Image(uiImage: snapshot).resizable().scaledToFill()
+                } else {
+                    Color.black
+                }
+                // Dark scrim so the white identity block reads over any map
+                // content, heaviest behind the text.
+                LinearGradient(
+                    colors: [.black.opacity(0.35), .black.opacity(0.45), .black.opacity(0.7)],
+                    startPoint: .top, endPoint: .bottom
+                )
+            }
+        }
+        .clipped()
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { showsRoutes.toggle() } }
         .onGeometryChange(for: CGFloat.self) { proxy in
@@ -103,13 +123,91 @@ struct StopPageHeaderView: View {
         .accessibilityElement(children: .combine)
     }
 
+    private func routeChip(_ name: String) -> some View {
+        Text(name)
+            .font(.caption2.weight(.bold))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+
     private func walkChipText(_ info: WalkTimeInfo) -> String {
-        let distance = Self.distanceFormatter.string(fromDistance: info.distance)
         let fmt = OBALoc(
-            "stop_page.walk_chip_fmt",
-            value: "%d min walk · %@",
-            comment: "Walk chip on the header card. %d minutes, %@ formatted distance."
+            "stop_page.walk_chip_minutes_fmt",
+            value: "%d min walk",
+            comment: "Walk chip on the header card. %d is the walk time in minutes."
         )
-        return String(format: fmt, info.walkMinutes, distance)
+        return String(format: fmt, info.walkMinutes)
     }
 }
+/// The "Updated: …" line atop the header's identity block, with a pulsing
+/// on-time dot. The pulse is gated on Reduce Motion (static when reduced),
+/// per the global constraints.
+private struct HeaderStatusLine: View {
+    let statusText: String
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .frame(width: 7, height: 7)
+                .opacity(reduceMotion ? 1 : (pulsing ? 1 : 0.35))
+            Text(statusText)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.85))
+        }
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
+    }
+}
+
+/// Minimal leading-aligned wrapping layout for the subtitle + route chips:
+/// subviews flow left-to-right at their ideal sizes and break onto new lines
+/// as needed, so chips wrap instead of compressing or truncating.
+private struct FlowLayout: Layout {
+    var hSpacing: CGFloat = 4
+    var vSpacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0, y: CGFloat = 0, lineHeight: CGFloat = 0, widest: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0 && x + size.width > maxWidth {
+                x = 0
+                y += lineHeight + vSpacing
+                lineHeight = 0
+            }
+            x += size.width + hSpacing
+            lineHeight = max(lineHeight, size.height)
+            widest = max(widest, x - hSpacing)
+        }
+        return CGSize(width: proposal.width ?? widest, height: y + lineHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, lineHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX && x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += lineHeight + vSpacing
+                lineHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: .unspecified)
+            x += size.width + hSpacing
+            lineHeight = max(lineHeight, size.height)
+        }
+    }
+}
+

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -279,4 +279,3 @@ struct FlowLayout: Layout {
         }
     }
 }
-

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -14,8 +14,8 @@ import OBAKitCore
 /// dark scrim, with the identity block bottom-left in white — the "last
 /// updated" status line, stop name, the code/direction subtitle with inline
 /// route chips (wrapping onto as many lines as needed, never truncated), and
-/// the walk pill (the single visual source of walk time, §4.5). Tap toggles
-/// the full routes-served line (parity with the old header).
+/// the walk pill (the single visual source of walk time, §4.5). Tapping the
+/// walk pill opens walking directions in an external maps app.
 ///
 /// A plain-value view: it never touches `StopViewModel`. The map snapshot is
 /// produced by a `snapshotLoader` closure supplied by the hosting VC, so the
@@ -28,9 +28,11 @@ struct StopPageHeaderView: View {
     /// The "Updated: …" line; empty hides it.
     let statusText: String
     let snapshotLoader: (CGSize) async -> UIImage?
+    /// Opens walking directions to the stop (VC-owned; disambiguates between
+    /// maps apps when more than one is available).
+    let onWalkingDirections: () -> Void
 
     @State private var snapshot: UIImage?
-    @State private var showsRoutes = false
     @State private var cardWidth: CGFloat = 0
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -56,38 +58,43 @@ struct StopPageHeaderView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if !statusText.isEmpty {
-                HeaderStatusLine(statusText: statusText)
-            }
-            Text(stop.name)
-                .font(.title2.weight(.heavy))
-                .foregroundStyle(.white)
-                // Accessibility sizes get more lines so the full name still
-                // reads instead of clipping at the larger glyph sizes.
-                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 4 : 2)
-            // Subtitle + chips flow together and wrap onto as many lines as
-            // the routes need — chips are never compressed or dropped.
-            FlowLayout(hSpacing: 4, vSpacing: 4) {
-                Text(subtitle)
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.white.opacity(0.75))
-                    .padding(.trailing, 4)
-                ForEach(routeChipNames, id: \.self) { name in
-                    routeChip(name)
+            VStack(alignment: .leading, spacing: 8) {
+                if !statusText.isEmpty {
+                    HeaderStatusLine(statusText: statusText)
+                }
+                Text(stop.name)
+                    .font(.title2.weight(.heavy))
+                    .foregroundStyle(.white)
+                    // Accessibility sizes get more lines so the full name still
+                    // reads instead of clipping at the larger glyph sizes.
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 4 : 2)
+                // Subtitle + chips flow together and wrap onto as many lines as
+                // the routes need — chips are never compressed or dropped.
+                FlowLayout(hSpacing: 4, vSpacing: 4) {
+                    Text(subtitle)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.75))
+                        .padding(.trailing, 4)
+                    ForEach(routeChipNames, id: \.self) { name in
+                        routeChip(name)
+                    }
                 }
             }
-            if showsRoutes, let routes = Formatters.formattedRoutes(stop.routes) {
-                Text(routes)
-                    .font(.caption)
-                    .foregroundStyle(.white.opacity(0.75))
-                    .lineLimit(2)
-            }
+            // One combined VoiceOver element for the identity text; the walk
+            // button below stays separate so it remains individually
+            // focusable and activatable.
+            .accessibilityElement(children: .combine)
             if let walkTime {
-                Label(walkChipText(walkTime), systemImage: "figure.walk")
-                    .font(.footnote.weight(.heavy))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 12).padding(.vertical, 6)
-                    .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+                Button(action: onWalkingDirections) {
+                    Label(walkChipText(walkTime), systemImage: "figure.walk")
+                        .font(.footnote.weight(.heavy))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 12).padding(.vertical, 6)
+                        .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+                        .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
             }
         }
         .padding(16)
@@ -113,8 +120,6 @@ struct StopPageHeaderView: View {
             }
         }
         .clipped()
-        .contentShape(Rectangle())
-        .onTapGesture { withAnimation { showsRoutes.toggle() } }
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.width
         } action: { newWidth in
@@ -127,11 +132,6 @@ struct StopPageHeaderView: View {
             guard cardWidth > 0, snapshot == nil else { return }
             snapshot = await snapshotLoader(CGSize(width: cardWidth, height: cardHeight))
         }
-        .accessibilityElement(children: .combine)
-        // The card is tappable (toggles the routes-served line), so VoiceOver
-        // must announce it as a button and explain what activation does.
-        .accessibilityAddTraits(.isButton)
-        .accessibilityHint(OBALoc("stop_page.header.a11y_hint", value: "Shows the routes served by this stop.", comment: "VoiceOver hint on the stop header card; activating it toggles the routes-served line."))
     }
 
     private func routeChip(_ name: String) -> some View {

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -97,7 +97,10 @@ struct StopPageHeaderView: View {
         .background {
             ZStack {
                 if let snapshot {
-                    Image(uiImage: snapshot).resizable().scaledToFill()
+                    Image(uiImage: snapshot)
+                        .resizable()
+                        .scaledToFill()
+                        .accessibilityHidden(true) // decorative map backdrop
                 } else {
                     Color.black
                 }
@@ -125,6 +128,10 @@ struct StopPageHeaderView: View {
             snapshot = await snapshotLoader(CGSize(width: cardWidth, height: cardHeight))
         }
         .accessibilityElement(children: .combine)
+        // The card is tappable (toggles the routes-served line), so VoiceOver
+        // must announce it as a button and explain what activation does.
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(OBALoc("stop_page.header.a11y_hint", value: "Shows the routes served by this stop.", comment: "VoiceOver hint on the stop header card; activating it toggles the routes-served line."))
     }
 
     private func routeChip(_ name: String) -> some View {

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -154,6 +154,63 @@ struct StopPageHeaderView: View {
         return String(format: fmt, info.walkMinutes)
     }
 }
+/// Skeleton stand-in for the header card, shown while `Stop` is still unknown
+/// (a stop opened by bare ID — Recents, deep links — has no model until the
+/// first fetch returns). Mirrors the real card's dark backdrop, minimum
+/// height, and bottom-leading identity block so the page opens with its full
+/// shape instead of decapitated.
+struct StopPageHeaderPlaceholderView: View {
+    @ScaledMetric(relativeTo: .title2) private var cardHeight: CGFloat = 170
+    @ScaledMetric(relativeTo: .title2) private var nameLineHeight: CGFloat = 22
+    @ScaledMetric(relativeTo: .footnote) private var chipLineHeight: CGFloat = 18
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            skeletonLine(width: 210, height: nameLineHeight)
+            HStack(spacing: 4) {
+                skeletonLine(width: 110, height: chipLineHeight)
+                ForEach(0..<3, id: \.self) { _ in
+                    skeletonLine(width: 30, height: chipLineHeight)
+                }
+            }
+        }
+        // Pulses the skeleton lines so the card reads as actively loading,
+        // not stalled. Static under Reduce Motion, per the global constraints.
+        .opacity(reduceMotion ? 1 : (pulsing ? 0.4 : 1))
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: cardHeight, alignment: .bottomLeading)
+        // A fixed dark gray rather than the real card's pre-snapshot black:
+        // in dark mode the page background is black, and a black card there
+        // has no visible edges — the skeleton lines just float in space.
+        .background {
+            ZStack {
+                Color(white: 0.14)
+                LinearGradient(
+                    colors: [.black.opacity(0.35), .black.opacity(0.45), .black.opacity(0.7)],
+                    startPoint: .top, endPoint: .bottom
+                )
+            }
+        }
+        .clipped()
+        .accessibilityHidden(true) // decorative; the loading row below announces progress
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
+    }
+
+    private func skeletonLine(width: CGFloat, height: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(Color.white.opacity(0.22))
+            .frame(width: width, height: height)
+    }
+}
+
 /// The "Updated: …" line atop the header's identity block, with a pulsing
 /// on-time dot. The pulse is gated on Reduce Motion (static when reduced),
 /// per the global constraints.

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -1,0 +1,115 @@
+//
+//  StopPageHeaderView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// The inset map-card header: snapshot background, stop identity, and the
+/// walk chip — the single visual source of walk time (§4.5). Tap toggles the
+/// routes-served line (parity with the old header).
+///
+/// A plain-value view: it never touches `StopViewModel`. The map snapshot is
+/// produced by a `snapshotLoader` closure supplied by the hosting VC, so the
+/// view stays UIKit-free. Per the standing amendment, the snapshot size is
+/// derived from the card's laid-out width (via `onGeometryChange`) rather than
+/// `UIScreen.main`.
+struct StopPageHeaderView: View {
+    let stop: Stop
+    let walkTime: WalkTimeInfo?
+    let snapshotLoader: (CGSize) async -> UIImage?
+
+    @State private var snapshot: UIImage?
+    @State private var showsRoutes = false
+    @State private var cardWidth: CGFloat = 0
+
+    /// Grows the card with Dynamic Type so the stop name has room at larger
+    /// text sizes (standing amendment).
+    @ScaledMetric(relativeTo: .title2) private var cardHeight: CGFloat = 150
+
+    /// A single shared formatter; distances are formatted for display only.
+    private static let distanceFormatter = MKDistanceFormatter()
+
+    private var subtitle: String {
+        Formatters.formattedCodeAndDirection(stop: stop)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Group {
+                if let snapshot {
+                    Image(uiImage: snapshot).resizable().scaledToFill()
+                } else {
+                    Color(uiColor: .secondarySystemGroupedBackground)
+                }
+            }
+            LinearGradient(
+                colors: [
+                    Color(uiColor: .systemBackground).opacity(0.92),
+                    Color(uiColor: .systemBackground).opacity(0.4),
+                    .clear
+                ],
+                startPoint: .top, endPoint: .bottom
+            )
+            VStack(alignment: .leading, spacing: 4) {
+                Text(stop.name)
+                    .font(.title2.weight(.heavy))
+                    .lineLimit(2)
+                Text(subtitle)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                if showsRoutes, let routes = Formatters.formattedRoutes(stop.routes) {
+                    Text(routes)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .padding(16)
+        }
+        .frame(height: cardHeight)
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .bottomLeading) {
+            if let walkTime {
+                Label(walkChipText(walkTime), systemImage: "figure.walk")
+                    .font(.footnote.weight(.heavy))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                    .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+                    .padding(12)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture { withAnimation { showsRoutes.toggle() } }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newWidth in
+            cardWidth = newWidth
+        }
+        .task(id: cardWidth) {
+            // MapSnapshotter needs concrete dimensions; commit to the laid-out
+            // card size once it's known. Keep the first snapshot on later
+            // width changes (scaledToFill adapts) rather than re-rendering.
+            guard cardWidth > 0, snapshot == nil else { return }
+            snapshot = await snapshotLoader(CGSize(width: cardWidth, height: cardHeight))
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func walkChipText(_ info: WalkTimeInfo) -> String {
+        let distance = Self.distanceFormatter.string(fromDistance: info.distance)
+        let fmt = OBALoc(
+            "stop_page.walk_chip_fmt",
+            value: "%d min walk · %@",
+            comment: "Walk chip on the header card. %d minutes, %@ formatted distance."
+        )
+        return String(format: fmt, info.walkMinutes, distance)
+    }
+}

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -130,9 +130,14 @@ struct StopPageView: View {
         viewModel.isLoading || (!hasLoadedArrivals && viewModel.operationError == nil && !viewModel.isBrokenBookmark)
     }
 
+    /// The departures both modes project. `filteringTerminalDuplicates()` collapses
+    /// the arrival/departure pair the API emits for a single vehicle visit at a
+    /// terminal or loop stop — without it the rider sees the same bus twice, with
+    /// two different countdowns (parity with `StopViewController`).
     private var filteredDepartures: [ArrivalDeparture] {
         let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
-        return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
+        let visible = viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
+        return visible.filteringTerminalDuplicates()
     }
 
     private var attributionText: String {
@@ -154,6 +159,13 @@ struct StopPageView: View {
         let departures = filteredDepartures
         let departureIDs = Set(departures.map(\.id))
         let routeIDs = Set(departures.map(\.routeID))
+        // Grouped mode drops past departures, so it can have nothing to render
+        // while `departures` is non-empty (the last bus of the evening has left).
+        // Deciding emptiness from the groups themselves — rather than from
+        // `departures` — keeps that case on the empty state instead of a void.
+        let isGrouped = viewModel.stopPreferences.sortType == .route
+        let routeGroups = isGrouped ? StopPageListBuilder.routeGroups(departures) : []
+        let listIsEmpty = isGrouped ? routeGroups.isEmpty : departures.isEmpty
 
         List {
             if let stop = viewModel.stop {
@@ -233,7 +245,7 @@ struct StopPageView: View {
                 }
             }
 
-            if departures.isEmpty {
+            if listIsEmpty {
                 if showsLoadingState {
                     Section {
                         StopPageLoadingRow()
@@ -241,8 +253,15 @@ struct StopPageView: View {
                 } else {
                     Section {
                         StopPageEmptyStateRow(
-                            errorText: viewModel.operationError?.localizedDescription,
-                            isFilteredEmpty: viewModel.isListFiltered && !(viewModel.stopArrivals?.arrivalsAndDepartures.isEmpty ?? true),
+                            isBrokenBookmark: viewModel.isBrokenBookmark,
+                            errorText: viewModel.operationErrorMessage,
+                            // Only when the route filter is what emptied the list.
+                            // Grouped mode can be empty while `departures` isn't
+                            // (every departure is in the past); that's a no-service
+                            // state, not a filtered-out one.
+                            isFilteredEmpty: viewModel.isListFiltered
+                                && departures.isEmpty
+                                && !(viewModel.stopArrivals?.arrivalsAndDepartures.isEmpty ?? true),
                             minutesAfter: viewModel.minutesAfter,
                             // With no header card above it (first fetch failed
                             // before the stop resolved), the row is the whole
@@ -255,7 +274,7 @@ struct StopPageView: View {
                         )
                     }
                 }
-            } else if viewModel.stopPreferences.sortType == .time {
+            } else if !isGrouped {
                 ChronologicalListView(
                     partition: StopPageListBuilder.chronologicalPartition(departures, walkMinutes: walkTime?.walkMinutes),
                     walkMinutes: walkTime?.walkMinutes,
@@ -274,7 +293,7 @@ struct StopPageView: View {
                 )
             } else {
                 GroupedListView(
-                    groups: StopPageListBuilder.routeGroups(departures),
+                    groups: routeGroups,
                     expandedRouteID: expandedRouteID,
                     openTripDepartureID: expandedDepartureID,
                     statusProvider: { DepartureStatus(arrivalDeparture: $0) },
@@ -334,17 +353,18 @@ struct StopPageView: View {
         }
     }
 
-    /// One-shot: an untouched stop (still on the default `.time` sort) opens in
-    /// the last mode the user picked anywhere in the app. A stop with a
-    /// persisted `.route` preference is left alone.
+    /// One-shot: a stop the user has never customized opens in the last mode they
+    /// picked anywhere in the app. A stop with saved preferences owns its sort
+    /// type and is left alone — including one deliberately set to Chronological,
+    /// which `stopPreferences.sortType` alone can't tell apart from the default.
     private func seedLastUsedModeIfNeeded() {
         guard !didSeedMode else { return }
         didSeedMode = true
-        guard viewModel.stopPreferences.sortType == .time,
+        guard !viewModel.hasCustomizedPreferences,
               let raw = userDefaults.string(forKey: Self.lastUsedStopSortKey),
               let seeded = StopSort(rawValue: raw)
         else { return }
-        viewModel.updateSortType(seeded)
+        viewModel.seedSortType(seeded)
     }
 
     /// Builds the shared trip-detail panel (§4.6) for an expanded departure.
@@ -752,9 +772,15 @@ struct StopPageLoadingRow: View {
 }
 
 /// The single empty-state row shown when there are no departures to list.
-/// Precedence: a network error (Retry) → everything filtered out (Show all
-/// routes) → genuinely no service in the window. §4.4 wording is exact.
+/// Precedence: a bookmark pointing at a stop that no longer exists → a network
+/// error (Retry) → everything filtered out (Show all routes) → genuinely no
+/// service in the window. §4.4 wording is exact.
 struct StopPageEmptyStateRow: View {
+    /// The stop behind a bookmark no longer resolves — almost always an agency
+    /// stop-ID realignment. Tells the user to recreate the bookmark rather than
+    /// leaving them to conclude the bus simply isn't running (parity with
+    /// `StopViewController.emptyData(for:)`).
+    var isBrokenBookmark: Bool = false
     let errorText: String?
     let isFilteredEmpty: Bool
     let minutesAfter: UInt
@@ -788,12 +814,16 @@ struct StopPageEmptyStateRow: View {
     }
 
     private var symbolName: String {
+        if isBrokenBookmark { return "bookmark.slash.fill" }
         if errorText != nil { return "exclamationmark.icloud" }
         if isFilteredEmpty { return "line.3.horizontal.decrease.circle" }
         return "clock.badge.xmark"
     }
 
     private var message: String {
+        if isBrokenBookmark {
+            return OBALoc("stop_controller.bad_bookmark_error_message", value: "This bookmark may not work anymore. Did your transit agency change something? Please delete and recreate the bookmark.", comment: "An error message displayed when a stop is shown by tapping on a bookmark—and the bookmark doesn't seem to point to a valid stop any longer. This problem will occur when a transit agency changes its stop IDs, perhaps as part of an annual transit system realignment.")
+        }
         if let errorText { return errorText }
         if isFilteredEmpty {
             return OBALoc("stop_page.empty.all_filtered", value: "All routes at this stop are filtered", comment: "Empty state shown when every route at the stop is hidden by the user's filter.")
@@ -803,6 +833,9 @@ struct StopPageEmptyStateRow: View {
     }
 
     private var actionTitle: String? {
+        // A broken bookmark has no retry: the stop ID itself is gone, so refetching
+        // it just fails again. The message tells the user to recreate the bookmark.
+        if isBrokenBookmark { return nil }
         if errorText != nil {
             return OBALoc("stop_page.empty.retry", value: "Retry", comment: "Button that retries loading departures after an error.")
         }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -102,6 +102,10 @@ struct StopPageView: View {
     /// read in `seedLastUsedModeIfNeeded()`, written in the toggle's `onChange`.
     private static let lastUsedStopSortKey = "OBALastUsedStopSort"
 
+    /// Leading/trailing inset shared by the page's full-width card rows
+    /// (header, survey, donation), matching the inset-grouped card margin.
+    private static let horizontalRowInset: CGFloat = 0
+
     private var filteredDepartures: [ArrivalDeparture] {
         let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
         return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
@@ -131,7 +135,7 @@ struct StopPageView: View {
             if let stop = viewModel.stop {
                 Section {
                     StopPageHeaderView(stop: stop, walkTime: walkTime, snapshotLoader: snapshotLoader)
-                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                        .listRowInsets(EdgeInsets(top: 0, leading: Self.horizontalRowInset, bottom: 0, trailing: Self.horizontalRowInset))
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                 }
@@ -154,7 +158,7 @@ struct StopPageView: View {
                             viewModel.launchExternalSurvey(survey, onFailure: navigation.showExternalSurveyError)
                         }
                     )
-                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                 }
@@ -171,7 +175,7 @@ struct StopPageView: View {
                         onLearnMore: navigation.showDonation,
                         onClose: { navigation.dismissDonation { donationHidden = true } }
                     )
-                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                 }
@@ -263,7 +267,13 @@ struct StopPageView: View {
                 onLoadMore: { Task { await viewModel.loadMoreDepartures() } }
             )
         }
-        .listStyle(.insetGrouped)
+        // `.plain` (rather than `.insetGrouped`) so sections have no horizontal
+        // card margin insetting them from the screen edges. That margin is
+        // separate from `listRowInsets` (which only pads inside a row's
+        // background), which is why zeroing the row insets alone left a gap.
+        // With `.plain`, rows whose `listRowInsets` leading/trailing are 0 sit
+        // flush with the screen edges.
+        .listStyle(.plain)
         .task { await viewModel.start() }
         .onAppear(perform: seedLastUsedModeIfNeeded)
         .onDisappear { viewModel.deactivate() }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -106,6 +106,23 @@ struct StopPageView: View {
     /// (header, survey, donation), matching the inset-grouped card margin.
     private static let horizontalRowInset: CGFloat = 0
 
+    /// `true` once any fetch has succeeded (errors don't clear `stopArrivals`).
+    /// Gates the chrome that means nothing before data exists — the mode
+    /// toggle, the donation card, and the Load-more/attribution footer — so
+    /// the first load reads as one deliberate loading page rather than empty
+    /// controls scattered around a spinner.
+    private var hasLoadedArrivals: Bool {
+        viewModel.stopArrivals != nil
+    }
+
+    /// `true` when the empty departures area should show the loading treatment
+    /// rather than an empty state: any in-flight fetch, plus the pre-`.task`
+    /// first frame (nothing fetched, no error yet) so the page never flashes
+    /// "No departures" before the first request has even started.
+    private var showsLoadingState: Bool {
+        viewModel.isLoading || (!hasLoadedArrivals && viewModel.operationError == nil && !viewModel.isBrokenBookmark)
+    }
+
     private var filteredDepartures: [ArrivalDeparture] {
         let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
         return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
@@ -139,6 +156,17 @@ struct StopPageView: View {
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                 }
+            } else if showsLoadingState {
+                // Loading only. A first fetch that fails leaves no header at
+                // all — a "loading" skeleton sitting above an error message
+                // reads as two contradictory states on one page; the centered
+                // error row below owns the screen instead.
+                Section {
+                    StopPageHeaderPlaceholderView()
+                        .listRowInsets(EdgeInsets(top: 0, leading: Self.horizontalRowInset, bottom: 0, trailing: Self.horizontalRowInset))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                }
             }
 
             if let survey = viewModel.currentSurvey {
@@ -164,7 +192,7 @@ struct StopPageView: View {
             // Gated on the view model's `shouldRequestDonations`; all three actions
             // present VC-owned modals via the navigation handler. Sits after the
             // survey and before service alerts, matching the legacy section order.
-            if viewModel.shouldRequestDonations && !donationHidden {
+            if hasLoadedArrivals && viewModel.shouldRequestDonations && !donationHidden {
                 Section {
                     DonationCardRepresentable(
                         onDonate: navigation.showDonation,
@@ -181,27 +209,27 @@ struct StopPageView: View {
                 ServiceAlertsSection(alerts: alerts, onSelect: navigation.showAlertDetail)
             }
 
-            Section {
-                StopPageModeToggle(mode: viewModel.stopPreferences.sortType) { newValue in
-                    withAnimation {
-                        // Switching modes collapses every open accordion (§4.6).
-                        expandedDepartureID = nil
-                        expandedRouteID = nil
-                        userDefaults.set(newValue.rawValue, forKey: Self.lastUsedStopSortKey)
-                        viewModel.updateSortType(newValue)
+            if hasLoadedArrivals {
+                Section {
+                    StopPageModeToggle(mode: viewModel.stopPreferences.sortType) { newValue in
+                        withAnimation {
+                            // Switching modes collapses every open accordion (§4.6).
+                            expandedDepartureID = nil
+                            expandedRouteID = nil
+                            userDefaults.set(newValue.rawValue, forKey: Self.lastUsedStopSortKey)
+                            viewModel.updateSortType(newValue)
+                        }
                     }
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
                 }
-                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
             }
 
             if departures.isEmpty {
-                if viewModel.isLoading {
+                if showsLoadingState {
                     Section {
-                        HStack { Spacer(); ProgressView(); Spacer() }
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
+                        StopPageLoadingRow()
                     }
                 } else {
                     Section {
@@ -209,6 +237,12 @@ struct StopPageView: View {
                             errorText: viewModel.operationError?.localizedDescription,
                             isFilteredEmpty: viewModel.isListFiltered && !(viewModel.stopArrivals?.arrivalsAndDepartures.isEmpty ?? true),
                             minutesAfter: viewModel.minutesAfter,
+                            // With no header card above it (first fetch failed
+                            // before the stop resolved), the row is the whole
+                            // page — center it vertically so it reads as a
+                            // designed full-screen state rather than content
+                            // stranded under the nav bar.
+                            fillsPage: viewModel.stop == nil,
                             onRetry: { Task { await viewModel.refresh() } },
                             onShowAllRoutes: { viewModel.isListFiltered = false }
                         )
@@ -258,11 +292,13 @@ struct StopPageView: View {
                 )
             }
 
-            StopPageFooterSection(
-                showLoadMore: !viewModel.isLoadMoreExhausted,
-                attribution: attributionText,
-                onLoadMore: { Task { await viewModel.loadMoreDepartures() } }
-            )
+            if hasLoadedArrivals {
+                StopPageFooterSection(
+                    showLoadMore: !viewModel.isLoadMoreExhausted,
+                    attribution: attributionText,
+                    onLoadMore: { Task { await viewModel.loadMoreDepartures() } }
+                )
+            }
         }
         // `.plain` (rather than `.insetGrouped`) so sections have no horizontal
         // card margin insetting them from the screen edges. That margin is
@@ -578,6 +614,37 @@ struct ServiceAlertsSection: View {
     }
 }
 
+#Preview("Initial loading") {
+    List {
+        Section {
+            StopPageHeaderPlaceholderView()
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+        }
+        Section {
+            StopPageLoadingRow()
+        }
+    }
+    .listStyle(.plain)
+}
+
+#Preview("First-load error") {
+    List {
+        Section {
+            StopPageEmptyStateRow(
+                errorText: "Expected to receive json data from the server, but we received nothing instead.",
+                isFilteredEmpty: false,
+                minutesAfter: 35,
+                fillsPage: true,
+                onRetry: {},
+                onShowAllRoutes: {}
+            )
+        }
+    }
+    .listStyle(.plain)
+}
+
 #Preview("AX5 adaptive controls") {
     ScrollView {
         VStack(spacing: 24) {
@@ -626,6 +693,26 @@ struct StopPageFooterSection: View {
     }
 }
 
+/// The loading treatment for an empty departures area — the first fetch and
+/// any empty-window refresh (auto-extension, Load more). A large spinner with
+/// a caption, so the in-progress state reads as deliberate rather than as a
+/// bare indicator floating in a blank page.
+struct StopPageLoadingRow: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+            Text(OBALoc("stop_page.loading_departures", value: "Loading departures…", comment: "Caption under the spinner shown while the stop page's departure list loads."))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 48)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+    }
+}
+
 /// The single empty-state row shown when there are no departures to list.
 /// Precedence: a network error (Retry) → everything filtered out (Show all
 /// routes) → genuinely no service in the window. §4.4 wording is exact.
@@ -633,6 +720,10 @@ struct StopPageEmptyStateRow: View {
     let errorText: String?
     let isFilteredEmpty: Bool
     let minutesAfter: UInt
+    /// `true` when the row is the page's only content (no header card above
+    /// it): the row claims most of the list's height so its message sits
+    /// centered on screen instead of stranded under the nav bar.
+    var fillsPage: Bool = false
     let onRetry: () -> Void
     let onShowAllRoutes: () -> Void
 
@@ -651,8 +742,9 @@ struct StopPageEmptyStateRow: View {
                     .buttonStyle(.bordered)
             }
         }
-        .frame(maxWidth: .infinity)
         .padding(.vertical, 28)
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, minHeight: fillsPage ? 420 : nil)
         .listRowBackground(Color.clear)
         .listRowSeparator(.hidden)
     }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -295,6 +295,7 @@ struct StopPageView: View {
             if hasLoadedArrivals {
                 StopPageFooterSection(
                     showLoadMore: !viewModel.isLoadMoreExhausted,
+                    isLoading: viewModel.isLoading,
                     attribution: attributionText,
                     onLoadMore: { Task { await viewModel.loadMoreDepartures() } }
                 )
@@ -663,9 +664,12 @@ struct ServiceAlertsSection: View {
 }
 
 /// The footer: "Load more" (hidden once auto-extend hits the 12 h cap) and the
-/// data-attribution line.
+/// data-attribution line. The button is a centered glass capsule echoing the
+/// mode toggle's backdrop, and swaps its plus glyph for a spinner while a
+/// refresh is in flight.
 struct StopPageFooterSection: View {
     let showLoadMore: Bool
+    let isLoading: Bool
     let attribution: String
     let onLoadMore: () -> Void
 
@@ -673,13 +677,34 @@ struct StopPageFooterSection: View {
         Section {
             if showLoadMore {
                 Button(action: onLoadMore) {
-                    Label(
-                        OBALoc("stop_page.load_more", value: "Load more", comment: "Extends the departure time window"),
-                        systemImage: "plus"
-                    )
-                    .font(.system(size: 14.5, weight: .bold))
-                    .frame(maxWidth: .infinity, minHeight: 44)
+                    HStack(spacing: 8) {
+                        // Fixed-size slot so the glyph→spinner swap doesn't
+                        // shift the text.
+                        ZStack {
+                            if isLoading {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "plus")
+                                    .font(.footnote.weight(.bold))
+                            }
+                        }
+                        .frame(width: 16, height: 16)
+                        Text(OBALoc("stop_page.load_more", value: "Load more", comment: "Extends the departure time window"))
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .foregroundStyle(isLoading ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.accentColor))
+                    .padding(.horizontal, 24)
+                    .frame(minHeight: 44)
+                    .modifier(GlassContainerBackground(usesCapsule: true))
+                    .contentShape(Capsule())
                 }
+                .buttonStyle(.plain)
+                .disabled(isLoading)
+                .frame(maxWidth: .infinity)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .padding(.vertical, 6)
             }
             if !attribution.isEmpty {
                 Text(attribution)

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -25,6 +25,9 @@ struct StopPageNavigationHandler {
     /// Region gate for the route-schedule affordances
     /// (`Region.supportsScheduleForRoute`); hides them where unsupported.
     let canScheduleForRoute: Bool
+    /// Opens walking directions to the stop in an external maps app (header
+    /// walk pill). Presents a choice sheet when more than one app is available.
+    let showWalkingDirections: () -> Void
     /// Pushes the alert-detail screen for a tapped service alert.
     let showAlertDetail: (ServiceAlert) -> Void
     /// Opens the bookmark editor: `nil` for a stop-level bookmark, an
@@ -151,7 +154,7 @@ struct StopPageView: View {
         List {
             if let stop = viewModel.stop {
                 Section {
-                    StopPageHeaderView(stop: stop, walkTime: walkTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader)
+                    StopPageHeaderView(stop: stop, walkTime: walkTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader, onWalkingDirections: navigation.showWalkingDirections)
                         .listRowInsets(EdgeInsets(top: 0, leading: Self.horizontalRowInset, bottom: 0, trailing: Self.horizontalRowInset))
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -16,15 +16,56 @@ import OBAKitCore
 struct StopPageView: View {
     @ObservedObject var viewModel: StopViewModel
 
+    @State private var expandedDepartureID: String?
+    @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
+
+    private var filteredDepartures: [ArrivalDeparture] {
+        let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
+        return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
+    }
+
     var body: some View {
         List {
-            Section {
-                Text(viewModel.stop?.name ?? "…")
-            }
+            ChronologicalListView(
+                partition: StopPageListBuilder.chronologicalPartition(filteredDepartures, walkMinutes: viewModel.walkTime?.walkMinutes),
+                walkMinutes: viewModel.walkTime?.walkMinutes,
+                showPast: !pastCollapsed,
+                expandedDepartureID: expandedDepartureID,
+                statusProvider: { DepartureStatus(arrivalDeparture: $0) },
+                alarmLookup: { viewModel.alarm(for: $0) },
+                actionsProvider: makeActions(for:),
+                onTogglePast: { withAnimation { pastCollapsed.toggle() } },
+                onToggleExpand: { departure in
+                    withAnimation(.snappy) {
+                        expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+                    }
+                },
+                panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+            )
         }
         .listStyle(.insetGrouped)
         .task { await viewModel.start() }
         .onDisappear { viewModel.deactivate() }
         .refreshable { await viewModel.refresh() }
+    }
+
+    private func makeActions(for departure: ArrivalDeparture) -> DepartureRowActions {
+        DepartureRowActions(
+            canAlarm: viewModel.canCreateAlarm(for: departure),
+            canSchedule: false,        // wired in Task 12 (region-gated)
+            hasAlarm: viewModel.alarm(for: departure) != nil,
+            onAlarmToggle: {
+                Task {
+                    if viewModel.alarm(for: departure) != nil {
+                        await viewModel.cancelAlarm(for: departure)
+                    } else {
+                        await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
+                    }
+                }
+            },
+            onSchedule: {},            // Task 12
+            onBookmark: {},            // Task 12
+            onShowTrip: {}             // Task 12
+        )
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -62,7 +62,7 @@ struct StopPageView: View {
                             expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
                         }
                     },
-                    panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+                    panelBuilder: makePanel(for:)
                 )
             } else {
                 GroupedListView(
@@ -93,7 +93,7 @@ struct StopPageView: View {
                             }
                         }
                     },
-                    panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+                    panelBuilder: makePanel(for:)
                 )
             }
         }
@@ -115,6 +115,28 @@ struct StopPageView: View {
               let seeded = StopSort(rawValue: raw)
         else { return }
         viewModel.updateSortType(seeded)
+    }
+
+    /// Builds the shared trip-detail panel (§4.6) for an expanded departure.
+    /// `StopPageView` is the only view that touches the VM, so the panel receives
+    /// plain values plus closures — the `approachLoader` closure wraps the cached,
+    /// live-only VM fetch; the alarm closures route through the single alarm index.
+    private func makePanel(for departure: ArrivalDeparture) -> TripDetailPanelView {
+        let status = DepartureStatus(arrivalDeparture: departure)
+        let alarm = viewModel.alarm(for: departure)
+        return TripDetailPanelView(
+            departure: departure,
+            status: status,
+            alarm: alarm,
+            alarmLeadTimeMinutes: alarm.map { viewModel.alarmLeadTimeMinutes($0) } ?? viewModel.defaultAlarmLeadTime,
+            canAlarm: viewModel.canCreateAlarm(for: departure),
+            approachLoader: { await viewModel.approachTripDetails(for: departure) },
+            onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
+            onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
+            onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
+            onSchedule: {},      // Task 12
+            onViewFullTrip: {}   // Task 12
+        )
     }
 
     private func makeActions(for departure: ArrivalDeparture) -> DepartureRowActions {

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -1,0 +1,30 @@
+//
+//  StopPageView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Root view of the redesigned Stop page. This is the ONLY view that observes
+/// `StopViewModel`; every subview receives plain values so the VM's frequent
+/// `@Published` churn (refresh + status timers) re-evaluates one shallow body.
+struct StopPageView: View {
+    @ObservedObject var viewModel: StopViewModel
+
+    var body: some View {
+        List {
+            Section {
+                Text(viewModel.stop?.name ?? "…")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .task { await viewModel.start() }
+        .onDisappear { viewModel.deactivate() }
+        .refreshable { await viewModel.refresh() }
+    }
+}

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -17,7 +17,14 @@ struct StopPageView: View {
     @ObservedObject var viewModel: StopViewModel
 
     @State private var expandedDepartureID: String?
+    @State private var expandedRouteID: RouteID?
+    @State private var didSeedMode = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
+
+    /// Global (not per-stop) "last mode the user picked" seed. A stop the user
+    /// has never customized opens in this mode; touched in exactly two places —
+    /// read in `seedLastUsedModeIfNeeded()`, written in the toggle's `onChange`.
+    private static let lastUsedStopSortKey = "OBALastUsedStopSort"
 
     private var filteredDepartures: [ArrivalDeparture] {
         let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
@@ -26,27 +33,88 @@ struct StopPageView: View {
 
     var body: some View {
         List {
-            ChronologicalListView(
-                partition: StopPageListBuilder.chronologicalPartition(filteredDepartures, walkMinutes: viewModel.walkTime?.walkMinutes),
-                walkMinutes: viewModel.walkTime?.walkMinutes,
-                showPast: !pastCollapsed,
-                expandedDepartureID: expandedDepartureID,
-                statusProvider: { DepartureStatus(arrivalDeparture: $0) },
-                alarmLookup: { viewModel.alarm(for: $0) },
-                actionsProvider: makeActions(for:),
-                onTogglePast: { withAnimation { pastCollapsed.toggle() } },
-                onToggleExpand: { departure in
-                    withAnimation(.snappy) {
-                        expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+            Section {
+                StopPageModeToggle(mode: viewModel.stopPreferences.sortType) { newValue in
+                    withAnimation {
+                        // Switching modes collapses every open accordion (§4.6).
+                        expandedDepartureID = nil
+                        expandedRouteID = nil
+                        UserDefaults.standard.set(newValue.rawValue, forKey: Self.lastUsedStopSortKey)
+                        viewModel.updateSortType(newValue)
                     }
-                },
-                panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
-            )
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+            }
+
+            if viewModel.stopPreferences.sortType == .time {
+                ChronologicalListView(
+                    partition: StopPageListBuilder.chronologicalPartition(filteredDepartures, walkMinutes: viewModel.walkTime?.walkMinutes),
+                    walkMinutes: viewModel.walkTime?.walkMinutes,
+                    showPast: !pastCollapsed,
+                    expandedDepartureID: expandedDepartureID,
+                    statusProvider: { DepartureStatus(arrivalDeparture: $0) },
+                    alarmLookup: { viewModel.alarm(for: $0) },
+                    actionsProvider: makeActions(for:),
+                    onTogglePast: { withAnimation { pastCollapsed.toggle() } },
+                    onToggleExpand: { departure in
+                        withAnimation(.snappy) {
+                            expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+                        }
+                    },
+                    panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+                )
+            } else {
+                GroupedListView(
+                    groups: StopPageListBuilder.routeGroups(filteredDepartures),
+                    expandedRouteID: expandedRouteID,
+                    openTripDepartureID: expandedDepartureID,
+                    statusProvider: { DepartureStatus(arrivalDeparture: $0) },
+                    alarmLookup: { viewModel.alarm(for: $0) },
+                    alarmLeadTime: { viewModel.alarmLeadTimeMinutes($0) },
+                    canAlarm: { viewModel.canCreateAlarm(for: $0) },
+                    onToggleRoute: { routeID in
+                        withAnimation(.snappy) {
+                            expandedRouteID = expandedRouteID == routeID ? nil : routeID
+                            expandedDepartureID = nil
+                        }
+                    },
+                    onToggleTrip: { departure in
+                        withAnimation(.snappy) {
+                            expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+                        }
+                    },
+                    onAlarmToggle: { departure in
+                        Task {
+                            if viewModel.alarm(for: departure) != nil {
+                                await viewModel.cancelAlarm(for: departure)
+                            } else {
+                                await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
+                            }
+                        }
+                    },
+                    panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+                )
+            }
         }
         .listStyle(.insetGrouped)
         .task { await viewModel.start() }
+        .onAppear(perform: seedLastUsedModeIfNeeded)
         .onDisappear { viewModel.deactivate() }
         .refreshable { await viewModel.refresh() }
+    }
+
+    /// One-shot: an untouched stop (still on the default `.time` sort) opens in
+    /// the last mode the user picked anywhere in the app. A stop with a
+    /// persisted `.route` preference is left alone.
+    private func seedLastUsedModeIfNeeded() {
+        guard !didSeedMode else { return }
+        didSeedMode = true
+        guard viewModel.stopPreferences.sortType == .time,
+              let raw = UserDefaults.standard.string(forKey: Self.lastUsedStopSortKey),
+              let seeded = StopSort(rawValue: raw)
+        else { return }
+        viewModel.updateSortType(seeded)
     }
 
     private func makeActions(for departure: ArrivalDeparture) -> DepartureRowActions {
@@ -67,5 +135,23 @@ struct StopPageView: View {
             onBookmark: {},            // Task 12
             onShowTrip: {}             // Task 12
         )
+    }
+}
+
+/// The segmented Chronological / By route switch shown above the departure list.
+/// Factored into its own `View` (per the SwiftUI structure guidance and the
+/// Task 9 interface) so `StopPageView` stays a thin composition — the mode
+/// change side effects (collapse accordions, persist) live in the caller's
+/// `onChange`.
+struct StopPageModeToggle: View {
+    let mode: StopSort
+    let onChange: (StopSort) -> Void
+
+    var body: some View {
+        Picker("", selection: Binding(get: { mode }, set: onChange)) {
+            Text(OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list")).tag(StopSort.time)
+            Text(OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route")).tag(StopSort.route)
+        }
+        .pickerStyle(.segmented)
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -391,8 +391,9 @@ struct LiveStatusRow: View {
 /// Honors the legacy `stopViewShowsServiceAlerts` preference (same UserDefaults
 /// key, default collapsed): tapping the header toggles and persists it, matching
 /// the legacy screen's collapsible section. When collapsed it shows a single
-/// "N service alerts" summary row that expands for the visit; when expanded and
-/// there are more than two alerts, it shows the first two plus a "Show all N"
+/// "N service alerts" summary row that expands and persists the preference, same
+/// as the header toggle; when expanded and there are more than two alerts, it
+/// shows the first two plus a "Show all N"
 /// row.
 struct ServiceAlertsSection: View {
     let alerts: [ServiceAlert]

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -319,6 +319,7 @@ struct StopPageView: View {
             // approach timeline while it stays open (scheduled→live flips and
             // failed first fetches retry on the next refresh).
             refreshToken: viewModel.lastUpdated,
+            cachedTripDetails: viewModel.cachedApproachTripDetails(for: departure),
             approachLoader: { await viewModel.approachTripDetails(for: departure) },
             onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -306,6 +306,10 @@ struct StopPageView: View {
             alarm: alarm,
             alarmLeadTimeMinutes: alarm.map { viewModel.alarmLeadTimeMinutes($0) } ?? viewModel.defaultAlarmLeadTime,
             canAlarm: viewModel.canCreateAlarm(for: departure),
+            // Bumps on every successful refresh so the panel re-fetches its
+            // approach timeline while it stays open (scheduled→live flips and
+            // failed first fetches retry on the next refresh).
+            refreshToken: viewModel.lastUpdated,
             approachLoader: { await viewModel.approachTripDetails(for: departure) },
             onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
@@ -390,25 +394,58 @@ struct LiveStatusRow: View {
 
 /// Service alerts affecting this stop. Each row pushes the existing alert-detail
 /// screen via the hosting VC's `onSelect` callback.
+///
+/// Honors the legacy `stopViewShowsServiceAlerts` preference (same UserDefaults
+/// key, default collapsed): tapping the header toggles and persists it, matching
+/// the legacy screen's collapsible section. When collapsed it shows a single
+/// "N service alerts" summary row that expands for the visit; when expanded and
+/// there are more than two alerts, it shows the first two plus a "Show all N"
+/// row.
 struct ServiceAlertsSection: View {
     let alerts: [ServiceAlert]
     let onSelect: (ServiceAlert) -> Void
 
+    /// Legacy persisted preference; read/written through the app-group suite that
+    /// `StopPageRootView` installs via `.defaultAppStorage`. Default `false`
+    /// (collapsed) mirrors `StopViewController`, which registers no default for
+    /// this key.
+    @AppStorage("stopViewShowsServiceAlerts") private var showsServiceAlerts = false
+
+    /// Per-visit "show all" expansion for the >2 case (not persisted).
+    @State private var showAllAlerts = false
+
+    private var visibleAlerts: [ServiceAlert] {
+        showAllAlerts ? alerts : Array(alerts.prefix(2))
+    }
+
     var body: some View {
         Section {
-            ForEach(alerts) { alert in
+            if showsServiceAlerts {
+                ForEach(visibleAlerts) { alert in
+                    alertRow(alert)
+                }
+                if alerts.count > 2 && !showAllAlerts {
+                    Button {
+                        withAnimation { showAllAlerts = true }
+                    } label: {
+                        Text(String(format: OBALoc("stop_page.service_alerts.show_all_fmt", value: "Show all %d alerts", comment: "Row that expands the service alerts section to show every alert. %d is the total number of alerts."), alerts.count))
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            } else {
                 Button {
-                    onSelect(alert)
+                    withAnimation { showsServiceAlerts = true }
                 } label: {
                     HStack(spacing: 10) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
-                        Text(alert.title(forLocale: .current) ?? OBALoc("stop_page.service_alert_fallback", value: "Service alert", comment: "Fallback title for a service alert that has no summary text."))
+                        Text(String(format: OBALoc("stop_page.service_alerts.summary_fmt", value: "%d service alerts", comment: "Collapsed summary row for the service alerts section. %d is the number of alerts."), alerts.count))
                             .font(.subheadline)
                             .foregroundStyle(.primary)
-                            .lineLimit(2)
                         Spacer(minLength: 0)
-                        Image(systemName: "chevron.right")
+                        Image(systemName: "chevron.down")
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.tertiary)
                     }
@@ -416,8 +453,43 @@ struct ServiceAlertsSection: View {
                 .buttonStyle(.plain)
             }
         } header: {
-            Text(Strings.serviceAlerts)
+            Button {
+                withAnimation {
+                    showsServiceAlerts.toggle()
+                    if !showsServiceAlerts { showAllAlerts = false }
+                }
+            } label: {
+                HStack {
+                    Text(Strings.serviceAlerts)
+                    Spacer()
+                    Image(systemName: showsServiceAlerts ? "chevron.up" : "chevron.down")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
+    }
+
+    private func alertRow(_ alert: ServiceAlert) -> some View {
+        Button {
+            onSelect(alert)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(alert.title(forLocale: .current) ?? OBALoc("stop_page.service_alert_fallback", value: "Service alert", comment: "Fallback title for a service alert that has no summary text."))
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -197,6 +197,7 @@ struct StopPageView: View {
                 }
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
             }
 
             if departures.isEmpty {
@@ -345,21 +346,69 @@ struct StopPageView: View {
     }
 }
 
-/// The segmented Chronological / By route switch shown above the departure list.
+/// The Chronological / By route switch shown above the departure list.
 /// Factored into its own `View` (per the SwiftUI structure guidance and the
 /// Task 9 interface) so `StopPageView` stays a thin composition — the mode
 /// change side effects (collapse accordions, persist) live in the caller's
 /// `onChange`.
+///
+/// A custom capsule control rather than a segmented `Picker`: taller segments,
+/// narrower footprint, and a Liquid Glass backdrop on iOS 26+ (an
+/// ultra-thin-material capsule stands in on earlier versions). The selected
+/// pill slides between segments via `matchedGeometryEffect`; the caller's
+/// `withAnimation` drives it.
 struct StopPageModeToggle: View {
     let mode: StopSort
     let onChange: (StopSort) -> Void
 
+    @Namespace private var selectionNamespace
+
     var body: some View {
-        Picker("", selection: Binding(get: { mode }, set: onChange)) {
-            Text(OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list")).tag(StopSort.time)
-            Text(OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route")).tag(StopSort.route)
+        HStack(spacing: 2) {
+            segment(.time, title: OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list"))
+            segment(.route, title: OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route"))
         }
-        .pickerStyle(.segmented)
+        .padding(3)
+        .modifier(GlassCapsuleBackground())
+        .frame(maxWidth: 300)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
+    }
+
+    private func segment(_ value: StopSort, title: String) -> some View {
+        Button {
+            if mode != value { onChange(value) }
+        } label: {
+            Text(title)
+                .font(.subheadline.weight(mode == value ? .bold : .semibold))
+                .foregroundStyle(mode == value ? Color.primary : Color.secondary)
+                .frame(maxWidth: .infinity, minHeight: 38)
+                .background {
+                    if mode == value {
+                        Capsule()
+                            .fill(Color(uiColor: .systemBackground))
+                            .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
+                            .matchedGeometryEffect(id: "selectedSegment", in: selectionNamespace)
+                    }
+                }
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(mode == value ? [.isButton, .isSelected] : [.isButton])
+    }
+}
+
+/// The toggle's backdrop: real Liquid Glass on iOS 26+, an ultra-thin-material
+/// capsule with a hairline rim on earlier versions.
+private struct GlassCapsuleBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(.regular, in: Capsule())
+        } else {
+            content
+                .background(.ultraThinMaterial, in: Capsule())
+                .overlay(Capsule().strokeBorder(Color(uiColor: .separator).opacity(0.5), lineWidth: 0.5))
+        }
     }
 }
 
@@ -396,16 +445,16 @@ struct LiveStatusRow: View {
     }
 }
 
-/// Service alerts affecting this stop. Each row pushes the existing alert-detail
-/// screen via the hosting VC's `onSelect` callback.
+/// Service alerts affecting this stop, rendered as one self-contained,
+/// orange-tinted card: a header row (gradient warning badge, title, count pill,
+/// rotating chevron) that toggles expansion, with the alert rows inside the
+/// card when expanded. Each alert row pushes the existing alert-detail screen
+/// via the hosting VC's `onSelect` callback.
 ///
 /// Honors the legacy `stopViewShowsServiceAlerts` preference (same UserDefaults
 /// key, default collapsed): tapping the header toggles and persists it, matching
-/// the legacy screen's collapsible section. When collapsed it shows a single
-/// "N service alerts" summary row that expands and persists the preference, same
-/// as the header toggle; when expanded and there are more than two alerts, it
-/// shows the first two plus a "Show all N"
-/// row.
+/// the legacy screen's collapsible section. When expanded and there are more
+/// than two alerts, it shows the first two plus a "Show all N" row.
 struct ServiceAlertsSection: View {
     let alerts: [ServiceAlert]
     let onSelect: (ServiceAlert) -> Void
@@ -423,60 +472,91 @@ struct ServiceAlertsSection: View {
         showAllAlerts ? alerts : Array(alerts.prefix(2))
     }
 
+    private var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+    }
+
     var body: some View {
         Section {
-            if showsServiceAlerts {
-                ForEach(visibleAlerts) { alert in
-                    alertRow(alert)
-                }
-                if alerts.count > 2 && !showAllAlerts {
-                    Button {
-                        withAnimation { showAllAlerts = true }
-                    } label: {
-                        Text(String(format: OBALoc("stop_page.service_alerts.show_all_fmt", value: "Show all %d alerts", comment: "Row that expands the service alerts section to show every alert. %d is the total number of alerts."), alerts.count))
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.primary)
+            VStack(spacing: 0) {
+                headerRow
+                if showsServiceAlerts {
+                    ForEach(visibleAlerts) { alert in
+                        Divider().padding(.leading, 14)
+                        alertRow(alert)
                     }
-                    .buttonStyle(.plain)
-                }
-            } else {
-                Button {
-                    withAnimation { showsServiceAlerts = true }
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text(alerts.count == 1
-                            ? OBALoc("stop_page.service_alerts.summary_one", value: "1 service alert", comment: "Collapsed summary row for the service alerts section when exactly one alert applies.")
-                            : String(format: OBALoc("stop_page.service_alerts.summary_fmt", value: "%d service alerts", comment: "Collapsed summary row for the service alerts section. %d is the number of alerts."), alerts.count))
-                            .font(.subheadline)
-                            .foregroundStyle(.primary)
-                        Spacer(minLength: 0)
-                        Image(systemName: "chevron.down")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.tertiary)
+                    if alerts.count > 2 && !showAllAlerts {
+                        Divider().padding(.leading, 14)
+                        showAllRow
                     }
                 }
-                .buttonStyle(.plain)
             }
-        } header: {
-            Button {
-                withAnimation {
-                    showsServiceAlerts.toggle()
-                    if !showsServiceAlerts { showAllAlerts = false }
-                }
-            } label: {
-                HStack {
-                    Text(Strings.serviceAlerts)
-                    Spacer()
-                    Image(systemName: showsServiceAlerts ? "chevron.up" : "chevron.down")
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
+            .background(cardShape.fill(Color.orange.opacity(0.08)))
+            .overlay(cardShape.strokeBorder(Color.orange.opacity(0.22), lineWidth: 1))
+            .clipShape(cardShape)
+            .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
         }
+    }
+
+    /// Always-visible card header; tapping toggles (and persists) expansion.
+    private var headerRow: some View {
+        Button {
+            withAnimation(.snappy) {
+                showsServiceAlerts.toggle()
+                if !showsServiceAlerts { showAllAlerts = false }
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 30, height: 30)
+                    .background(Color.orange.gradient, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                Text(Strings.serviceAlerts)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text("\(alerts.count)")
+                    .font(.caption.weight(.heavy))
+                    .monospacedDigit()
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(Color.orange, in: Capsule())
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.down")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(showsServiceAlerts ? 180 : 0))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(headerAccessibilityLabel)
+    }
+
+    private var showAllRow: some View {
+        Button {
+            withAnimation { showAllAlerts = true }
+        } label: {
+            Text(String(format: OBALoc("stop_page.service_alerts.show_all_fmt", value: "Show all %d alerts", comment: "Row that expands the service alerts section to show every alert. %d is the total number of alerts."), alerts.count))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var headerAccessibilityLabel: String {
+        alerts.count == 1
+            ? OBALoc("stop_page.service_alerts.summary_one", value: "1 service alert", comment: "Collapsed summary row for the service alerts section when exactly one alert applies.")
+            : String(format: OBALoc("stop_page.service_alerts.summary_fmt", value: "%d service alerts", comment: "Collapsed summary row for the service alerts section. %d is the number of alerts."), alerts.count)
     }
 
     private func alertRow(_ alert: ServiceAlert) -> some View {
@@ -484,17 +564,19 @@ struct ServiceAlertsSection: View {
             onSelect(alert)
         } label: {
             HStack(spacing: 10) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
                 Text(alert.title(forLocale: .current) ?? OBALoc("stop_page.service_alert_fallback", value: "Service alert", comment: "Fallback title for a service alert that has no summary text."))
                     .font(.subheadline)
                     .foregroundStyle(.primary)
                     .lineLimit(2)
+                    .multilineTextAlignment(.leading)
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -134,15 +134,11 @@ struct StopPageView: View {
         List {
             if let stop = viewModel.stop {
                 Section {
-                    StopPageHeaderView(stop: stop, walkTime: walkTime, snapshotLoader: snapshotLoader)
+                    StopPageHeaderView(stop: stop, walkTime: walkTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader)
                         .listRowInsets(EdgeInsets(top: 0, leading: Self.horizontalRowInset, bottom: 0, trailing: Self.horizontalRowInset))
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                 }
-            }
-
-            if !viewModel.statusText.isEmpty {
-                LiveStatusRow(statusText: viewModel.statusText)
             }
 
             if let survey = viewModel.currentSurvey {
@@ -195,7 +191,7 @@ struct StopPageView: View {
                         viewModel.updateSortType(newValue)
                     }
                 }
-                .listRowInsets(EdgeInsets())
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
             }
@@ -353,10 +349,10 @@ struct StopPageView: View {
 /// `onChange`.
 ///
 /// A custom capsule control rather than a segmented `Picker`: taller segments,
-/// narrower footprint, and a Liquid Glass backdrop on iOS 26+ (an
-/// ultra-thin-material capsule stands in on earlier versions). The selected
-/// pill slides between segments via `matchedGeometryEffect`; the caller's
-/// `withAnimation` drives it.
+/// full row width (the row carries the list's standard horizontal insets), and
+/// a Liquid Glass backdrop on iOS 26+ (an ultra-thin-material capsule stands
+/// in on earlier versions). The selected pill slides between segments via
+/// `matchedGeometryEffect`; the caller's `withAnimation` drives it.
 struct StopPageModeToggle: View {
     let mode: StopSort
     let onChange: (StopSort) -> Void
@@ -365,21 +361,21 @@ struct StopPageModeToggle: View {
 
     var body: some View {
         HStack(spacing: 2) {
-            segment(.time, title: OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list"))
-            segment(.route, title: OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route"))
+            segment(.time, title: OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list"), systemImage: "list.bullet")
+            segment(.route, title: OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route"), systemImage: "square.grid.2x2")
         }
         .padding(3)
         .modifier(GlassCapsuleBackground())
-        .frame(maxWidth: 300)
         .frame(maxWidth: .infinity)
         .padding(.vertical, 4)
     }
 
-    private func segment(_ value: StopSort, title: String) -> some View {
+    private func segment(_ value: StopSort, title: String, systemImage: String) -> some View {
         Button {
             if mode != value { onChange(value) }
         } label: {
-            Text(title)
+            Label(title, systemImage: systemImage)
+                .labelStyle(.titleAndIcon)
                 .font(.subheadline.weight(mode == value ? .bold : .semibold))
                 .foregroundStyle(mode == value ? Color.primary : Color.secondary)
                 .frame(maxWidth: .infinity, minHeight: 38)
@@ -409,39 +405,6 @@ private struct GlassCapsuleBackground: ViewModifier {
                 .background(.ultraThinMaterial, in: Capsule())
                 .overlay(Capsule().strokeBorder(Color(uiColor: .separator).opacity(0.5), lineWidth: 0.5))
         }
-    }
-}
-
-/// The out-of-card "Updated N min ago" line with a pulsing on-time dot. The dot
-/// pulse is gated on Reduce Motion (static when reduced), per the global
-/// constraints.
-struct LiveStatusRow: View {
-    let statusText: String
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var pulsing = false
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(Color(uiColor: ThemeColors.shared.departureOnTime))
-                .frame(width: 7, height: 7)
-                .opacity(reduceMotion ? 1 : (pulsing ? 1 : 0.35))
-            Text(statusText)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-            Spacer(minLength: 0)
-        }
-        .listRowInsets(EdgeInsets(top: 2, leading: 20, bottom: 2, trailing: 20))
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .onAppear {
-            guard !reduceMotion else { return }
-            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                pulsing = true
-            }
-        }
-        .accessibilityElement(children: .combine)
     }
 }
 

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -364,7 +364,9 @@ struct StopPageView: View {
             approachLoader: { await viewModel.approachTripDetails(for: departure) },
             onSetAlarm: { navigation.showAlarmPicker(departure) },
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
-            onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
+            // Change re-presents the same alarm picker bulletin as create; the
+            // controller's alarmCreated callback replaces the existing alarm.
+            onChangeAlarm: { navigation.showAlarmPicker(departure) },
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },
             onViewFullTrip: { navigation.showTrip(departure) }
@@ -662,8 +664,7 @@ struct ServiceAlertsSection: View {
             AlarmControlView(
                 alarmIsSet: true,
                 leadTimeMinutes: 5,
-                maxLeadTime: 10,
-                onSet: {}, onCancel: {}, onChange: { _ in }
+                onSet: {}, onCancel: {}, onChange: {}
             )
         }
         .padding()

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -33,6 +33,10 @@ struct StopPageNavigationHandler {
     /// Opens the bookmark editor: `nil` for a stop-level bookmark, an
     /// `ArrivalDeparture` for a trip-level bookmark (row swipe/menu).
     let showBookmarkEditor: (ArrivalDeparture?) -> Void
+    /// Presents the alarm lead-time picker bulletin for a departure (the trip
+    /// panel's Set-an-alarm button), reusing `AlarmBuilder` from the legacy
+    /// stop screen.
+    let showAlarmPicker: (ArrivalDeparture) -> Void
     /// Shows the "couldn't open survey" alert when an external survey link fails.
     let showExternalSurveyError: () -> Void
     /// Presents the donation learn-more/donate modal.
@@ -358,7 +362,7 @@ struct StopPageView: View {
             refreshToken: viewModel.lastUpdated,
             cachedTripDetails: viewModel.cachedApproachTripDetails(for: departure),
             approachLoader: { await viewModel.approachTripDetails(for: departure) },
-            onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
+            onSetAlarm: { navigation.showAlarmPicker(departure) },
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
             onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
             onSchedule: { navigation.showScheduleForRoute(departure) },

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -358,14 +358,23 @@ struct StopPageModeToggle: View {
     let onChange: (StopSort) -> Void
 
     @Namespace private var selectionNamespace
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    /// At accessibility sizes the two segments stack as full-width rows (the
+    /// guide's layout) instead of splitting one line — each label gets the
+    /// whole row's width, so neither truncates.
+    private var isAccessibilitySize: Bool { dynamicTypeSize.isAccessibilitySize }
 
     var body: some View {
-        HStack(spacing: 2) {
+        let layout = isAccessibilitySize
+            ? AnyLayout(VStackLayout(spacing: 2))
+            : AnyLayout(HStackLayout(spacing: 2))
+        layout {
             segment(.time, title: OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list"), systemImage: "list.bullet")
             segment(.route, title: OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route"), systemImage: "square.grid.2x2")
         }
         .padding(3)
-        .modifier(GlassCapsuleBackground())
+        .modifier(GlassContainerBackground(usesCapsule: !isAccessibilitySize))
         .frame(maxWidth: .infinity)
         .padding(.vertical, 4)
     }
@@ -381,29 +390,44 @@ struct StopPageModeToggle: View {
                 .frame(maxWidth: .infinity, minHeight: 38)
                 .background {
                     if mode == value {
-                        Capsule()
+                        selectionShape
                             .fill(Color(uiColor: .systemBackground))
                             .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
                             .matchedGeometryEffect(id: "selectedSegment", in: selectionNamespace)
                     }
                 }
-                .contentShape(Capsule())
+                .contentShape(selectionShape)
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(mode == value ? [.isButton, .isSelected] : [.isButton])
     }
+
+    /// Capsule segments inside the capsule container; rounded rectangles when
+    /// the segments stack (a capsule around a multi-line label reads poorly).
+    private var selectionShape: AnyShape {
+        isAccessibilitySize
+            ? AnyShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            : AnyShape(Capsule())
+    }
 }
 
 /// The toggle's backdrop: real Liquid Glass on iOS 26+, an ultra-thin-material
-/// capsule with a hairline rim on earlier versions.
-private struct GlassCapsuleBackground: ViewModifier {
+/// shape with a hairline rim on earlier versions. Capsule by default; a
+/// rounded rectangle when the segments stack at accessibility sizes.
+private struct GlassContainerBackground: ViewModifier {
+    let usesCapsule: Bool
+
+    private var shape: AnyShape {
+        usesCapsule ? AnyShape(Capsule()) : AnyShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
+    }
+
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
-            content.glassEffect(.regular, in: Capsule())
+            content.glassEffect(.regular, in: shape)
         } else {
             content
-                .background(.ultraThinMaterial, in: Capsule())
-                .overlay(Capsule().strokeBorder(Color(uiColor: .separator).opacity(0.5), lineWidth: 0.5))
+                .background(.ultraThinMaterial, in: shape)
+                .overlay(shape.stroke(Color(uiColor: .separator).opacity(0.5), lineWidth: 0.5))
         }
     }
 }
@@ -430,6 +454,9 @@ struct ServiceAlertsSection: View {
 
     /// Per-visit "show all" expansion for the >2 case (not persisted).
     @State private var showAllAlerts = false
+
+    /// The warning badge scales with Dynamic Type so its glyph never clips.
+    @ScaledMetric(relativeTo: .subheadline) private var warningBadgeSize: CGFloat = 30
 
     private var visibleAlerts: [ServiceAlert] {
         showAllAlerts ? alerts : Array(alerts.prefix(2))
@@ -475,7 +502,7 @@ struct ServiceAlertsSection: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(.white)
-                    .frame(width: 30, height: 30)
+                    .frame(width: warningBadgeSize, height: warningBadgeSize)
                     .background(Color.orange.gradient, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                 Text(Strings.serviceAlerts)
                     .font(.subheadline.weight(.semibold))
@@ -543,6 +570,23 @@ struct ServiceAlertsSection: View {
         }
         .buttonStyle(.plain)
     }
+}
+
+#Preview("AX5 adaptive controls") {
+    ScrollView {
+        VStack(spacing: 24) {
+            StopPageModeToggle(mode: .time) { _ in }
+            WalkLineDivider(walkMinutes: 4)
+            AlarmControlView(
+                alarmIsSet: true,
+                leadTimeMinutes: 5,
+                maxLeadTime: 10,
+                onSet: {}, onCancel: {}, onChange: { _ in }
+            )
+        }
+        .padding()
+    }
+    .environment(\.dynamicTypeSize, .accessibility5)
 }
 
 /// The footer: "Load more" (hidden once auto-extend hits the 12 h cap) and the

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -362,6 +362,7 @@ struct StopPageView: View {
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
             onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
             onSchedule: { navigation.showScheduleForRoute(departure) },
+            onBookmark: { navigation.showBookmarkEditor(departure) },
             onViewFullTrip: { navigation.showTrip(departure) }
         )
     }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -10,6 +10,37 @@
 import SwiftUI
 import OBAKitCore
 
+/// Everything that navigates away from — or presents a modal over — the Stop
+/// page, implemented by the hosting `StopPageViewController` so the SwiftUI layer
+/// stays router-free and holds no `Application` reference of its own.
+struct StopPageNavigationHandler {
+    /// Pushes the full trip screen for a departure (row context menu, trip panel).
+    let showTrip: (ArrivalDeparture) -> Void
+    /// Presents the whole-stop schedule (nav-bar Schedules button).
+    let showScheduleForStop: () -> Void
+    /// Presents the schedule for a specific departure's route (row swipe/menu and
+    /// trip panel). Mirrors the legacy row `Schedule` action, which is
+    /// route-scoped rather than stop-scoped.
+    let showScheduleForRoute: (ArrivalDeparture) -> Void
+    /// Region gate for the route-schedule affordances
+    /// (`Region.supportsScheduleForRoute`); hides them where unsupported.
+    let canScheduleForRoute: Bool
+    /// Pushes the alert-detail screen for a tapped service alert.
+    let showAlertDetail: (ServiceAlert) -> Void
+    /// Opens the bookmark editor: `nil` for a stop-level bookmark, an
+    /// `ArrivalDeparture` for a trip-level bookmark (row swipe/menu).
+    let showBookmarkEditor: (ArrivalDeparture?) -> Void
+    /// Shows the "couldn't open survey" alert when an external survey link fails.
+    let showExternalSurveyError: () -> Void
+    /// Presents the donation learn-more/donate modal.
+    let showDonation: () -> Void
+    /// Presents the donation dismiss action sheet; invokes the completion when the
+    /// user actually hides the card (dismiss or remind-later, not cancel).
+    let dismissDonation: (@escaping () -> Void) -> Void
+    /// Lazily builds the row long-press trip preview as an `AnyView`.
+    let makeTripPreview: (ArrivalDeparture) -> AnyView
+}
+
 /// Thin hosting wrapper for `StopPageView`. Its only job is to apply
 /// `.defaultAppStorage` so the page's `@AppStorage` reads and writes the
 /// app-group suite (matching the legacy screen + view model) rather than
@@ -19,14 +50,14 @@ struct StopPageRootView: View {
     let viewModel: StopViewModel
     let userDefaults: UserDefaults
     let snapshotLoader: (CGSize) async -> UIImage?
-    let onSelectAlert: (ServiceAlert) -> Void
+    let navigation: StopPageNavigationHandler
 
     var body: some View {
         StopPageView(
             viewModel: viewModel,
             userDefaults: userDefaults,
             snapshotLoader: snapshotLoader,
-            onSelectAlert: onSelectAlert
+            navigation: navigation
         )
         .defaultAppStorage(userDefaults)
     }
@@ -48,12 +79,17 @@ struct StopPageView: View {
     /// hosting VC so this view stays UIKit-free.
     let snapshotLoader: (CGSize) async -> UIImage?
 
-    /// Pushes the alert-detail screen. Owned by the hosting VC (`viewRouter`).
-    let onSelectAlert: (ServiceAlert) -> Void
+    /// Everything that leaves the page or presents a VC-owned modal. Supplied by
+    /// the hosting VC so this view stays router-free.
+    let navigation: StopPageNavigationHandler
 
     @State private var expandedDepartureID: String?
     @State private var expandedRouteID: RouteID?
     @State private var didSeedMode = false
+    /// Set when the user explicitly dismisses the donation card, so it disappears
+    /// immediately instead of waiting for the next view-model refresh to re-read
+    /// `shouldRequestDonations`.
+    @State private var donationHidden = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     /// Global (not per-stop) "last mode the user picked" seed. A stop the user
@@ -109,7 +145,9 @@ struct StopPageView: View {
                             Task { await viewModel.submitHeroAnswer(answer, stopLocation: viewModel.stop?.coordinate) }
                         },
                         onDismiss: { viewModel.dismissCurrentSurvey() },
-                        onOpenExternalSurvey: { viewModel.launchExternalSurvey(survey) }
+                        onOpenExternalSurvey: {
+                            viewModel.launchExternalSurvey(survey, onFailure: navigation.showExternalSurveyError)
+                        }
                     )
                     .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                     .listRowBackground(Color.clear)
@@ -117,13 +155,25 @@ struct StopPageView: View {
                 }
             }
 
-            // Donations are deferred to the parity task (Task 12): the inline
-            // request is a UIKit `DonationListItem` gated on
-            // `application.donationsManager.shouldRequestDonations`, whose tap
-            // handlers present VC-owned modals. It is intentionally not dropped.
+            // Inline donation request (parity with the legacy UIKit `DonationListItem`).
+            // Gated on the view model's `shouldRequestDonations`; all three actions
+            // present VC-owned modals via the navigation handler. Sits after the
+            // survey and before service alerts, matching the legacy section order.
+            if viewModel.shouldRequestDonations && !donationHidden {
+                Section {
+                    DonationCardRepresentable(
+                        onDonate: navigation.showDonation,
+                        onLearnMore: navigation.showDonation,
+                        onClose: { navigation.dismissDonation { donationHidden = true } }
+                    )
+                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                }
+            }
 
             if let alerts = viewModel.stopArrivals?.serviceAlerts, !alerts.isEmpty {
-                ServiceAlertsSection(alerts: alerts, onSelect: onSelectAlert)
+                ServiceAlertsSection(alerts: alerts, onSelect: navigation.showAlertDetail)
             }
 
             Section {
@@ -260,15 +310,15 @@ struct StopPageView: View {
             onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
             onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
             onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
-            onSchedule: {},      // Task 12
-            onViewFullTrip: {}   // Task 12
+            onSchedule: { navigation.showScheduleForRoute(departure) },
+            onViewFullTrip: { navigation.showTrip(departure) }
         )
     }
 
     private func makeActions(for departure: ArrivalDeparture) -> DepartureRowActions {
         DepartureRowActions(
             canAlarm: viewModel.canCreateAlarm(for: departure),
-            canSchedule: false,        // wired in Task 12 (region-gated)
+            canSchedule: navigation.canScheduleForRoute,
             hasAlarm: viewModel.alarm(for: departure) != nil,
             onAlarmToggle: {
                 Task {
@@ -279,9 +329,10 @@ struct StopPageView: View {
                     }
                 }
             },
-            onSchedule: {},            // Task 12
-            onBookmark: {},            // Task 12
-            onShowTrip: {}             // Task 12
+            onSchedule: { navigation.showScheduleForRoute(departure) },
+            onBookmark: { navigation.showBookmarkEditor(departure) },
+            onShowTrip: { navigation.showTrip(departure) },
+            makePreview: { navigation.makeTripPreview(departure) }
         )
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -293,7 +293,11 @@ struct StopPageView: View {
                         }
                     },
                     onAlarmToggle: { departure in
-                        Task { await viewModel.toggleAlarm(for: departure) }
+                        if viewModel.alarm(for: departure) != nil {
+                            Task { await viewModel.cancelAlarm(for: departure) }
+                        } else {
+                            navigation.showAlarmPicker(departure)
+                        }
                     },
                     panelBuilder: makePanel(for:)
                 )

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -51,6 +51,10 @@ struct StopPageRootView: View {
     let userDefaults: UserDefaults
     let snapshotLoader: (CGSize) async -> UIImage?
     let navigation: StopPageNavigationHandler
+    /// The app's shared `Formatters`, injected so the departure views format
+    /// times through the same instance as the rest of the app instead of
+    /// spinning up ad-hoc `DateFormatter`s.
+    let formatters: Formatters
 
     var body: some View {
         StopPageView(
@@ -60,6 +64,7 @@ struct StopPageRootView: View {
             navigation: navigation
         )
         .defaultAppStorage(userDefaults)
+        .environment(\.obaFormatters, formatters)
     }
 }
 
@@ -246,13 +251,7 @@ struct StopPageView: View {
                         }
                     },
                     onAlarmToggle: { departure in
-                        Task {
-                            if viewModel.alarm(for: departure) != nil {
-                                await viewModel.cancelAlarm(for: departure)
-                            } else {
-                                await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
-                            }
-                        }
+                        Task { await viewModel.toggleAlarm(for: departure) }
                     },
                     panelBuilder: makePanel(for:)
                 )
@@ -325,13 +324,7 @@ struct StopPageView: View {
             canSchedule: navigation.canScheduleForRoute,
             hasAlarm: viewModel.alarm(for: departure) != nil,
             onAlarmToggle: {
-                Task {
-                    if viewModel.alarm(for: departure) != nil {
-                        await viewModel.cancelAlarm(for: departure)
-                    } else {
-                        await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
-                    }
-                }
+                Task { await viewModel.toggleAlarm(for: departure) }
             },
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },
@@ -441,7 +434,9 @@ struct ServiceAlertsSection: View {
                     HStack(spacing: 10) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
-                        Text(String(format: OBALoc("stop_page.service_alerts.summary_fmt", value: "%d service alerts", comment: "Collapsed summary row for the service alerts section. %d is the number of alerts."), alerts.count))
+                        Text(alerts.count == 1
+                            ? OBALoc("stop_page.service_alerts.summary_one", value: "1 service alert", comment: "Collapsed summary row for the service alerts section when exactly one alert applies.")
+                            : String(format: OBALoc("stop_page.service_alerts.summary_fmt", value: "%d service alerts", comment: "Collapsed summary row for the service alerts section. %d is the number of alerts."), alerts.count))
                             .font(.subheadline)
                             .foregroundStyle(.primary)
                         Spacer(minLength: 0)

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -526,6 +526,11 @@ struct ServiceAlertsSection: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(headerAccessibilityLabel)
+        // Disclosure state, so VoiceOver users know whether activating will
+        // reveal or hide the alert rows.
+        .accessibilityValue(showsServiceAlerts
+            ? OBALoc("stop_page.service_alerts.a11y_expanded", value: "expanded", comment: "VoiceOver value of the service-alerts card header when the alert list is showing.")
+            : OBALoc("stop_page.service_alerts.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of the service-alerts card header when the alert list is hidden."))
     }
 
     private var showAllRow: some View {
@@ -563,6 +568,7 @@ struct ServiceAlertsSection: View {
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true) // decorative; the alert title labels the button
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 11)
@@ -635,6 +641,7 @@ struct StopPageEmptyStateRow: View {
             Image(systemName: symbolName)
                 .font(.largeTitle)
                 .foregroundStyle(.secondary)
+                .accessibilityHidden(true) // decorative; the message text carries the meaning
             Text(message)
                 .font(.callout)
                 .multilineTextAlignment(.center)

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -391,6 +391,7 @@ struct StopPageView: View {
             // Change re-presents the same alarm picker bulletin as create; the
             // controller's alarmCreated callback replaces the existing alarm.
             onChangeAlarm: { navigation.showAlarmPicker(departure) },
+            canSchedule: navigation.canScheduleForRoute,
             onSchedule: { navigation.showScheduleForRoute(departure) },
             onBookmark: { navigation.showBookmarkEditor(departure) },
             onViewFullTrip: { navigation.showTrip(departure) }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -10,11 +10,46 @@
 import SwiftUI
 import OBAKitCore
 
+/// Thin hosting wrapper for `StopPageView`. Its only job is to apply
+/// `.defaultAppStorage` so the page's `@AppStorage` reads and writes the
+/// app-group suite (matching the legacy screen + view model) rather than
+/// `UserDefaults.standard`. It deliberately does NOT observe `StopViewModel` —
+/// `StopPageView` remains the sole observer.
+struct StopPageRootView: View {
+    let viewModel: StopViewModel
+    let userDefaults: UserDefaults
+    let snapshotLoader: (CGSize) async -> UIImage?
+    let onSelectAlert: (ServiceAlert) -> Void
+
+    var body: some View {
+        StopPageView(
+            viewModel: viewModel,
+            userDefaults: userDefaults,
+            snapshotLoader: snapshotLoader,
+            onSelectAlert: onSelectAlert
+        )
+        .defaultAppStorage(userDefaults)
+    }
+}
+
 /// Root view of the redesigned Stop page. This is the ONLY view that observes
 /// `StopViewModel`; every subview receives plain values so the VM's frequent
 /// `@Published` churn (refresh + status timers) re-evaluates one shallow body.
 struct StopPageView: View {
     @ObservedObject var viewModel: StopViewModel
+
+    /// The app-group suite (injected from the hosting VC). Used for the
+    /// "last used sort" seed/write so the SwiftUI page shares the same store as
+    /// the legacy screen; `@AppStorage` picks up the same suite via
+    /// `.defaultAppStorage` applied by `StopPageRootView`.
+    let userDefaults: UserDefaults
+
+    /// Produces the header map snapshot at a concrete size. Supplied by the
+    /// hosting VC so this view stays UIKit-free.
+    let snapshotLoader: (CGSize) async -> UIImage?
+
+    /// Pushes the alert-detail screen. Owned by the hosting VC (`viewRouter`).
+    let onSelectAlert: (ServiceAlert) -> Void
 
     @State private var expandedDepartureID: String?
     @State private var expandedRouteID: RouteID?
@@ -31,15 +66,73 @@ struct StopPageView: View {
         return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
     }
 
+    private var attributionText: String {
+        guard let stop = viewModel.stop else { return "" }
+        let agencies = Formatters.formattedAgenciesForRoutes(stop.routes)
+        guard !agencies.isEmpty else { return "" }
+        let fmt = OBALoc(
+            "stop_controller.data_attribution_format",
+            value: "Data provided by %@",
+            comment: "A string listing the data providers (agencies) for this stop's data. It contains one or more providers separated by commas. e.g. Data provided by King County Metro, Sound Transit"
+        )
+        return String(format: fmt, agencies)
+    }
+
     var body: some View {
+        // Hoist the single computed walk value so the header chip, the
+        // chronological partition, and the divider all read one snapshot of it.
+        let walkTime = viewModel.walkTime
+        let departures = filteredDepartures
+        let departureIDs = Set(departures.map(\.id))
+        let routeIDs = Set(departures.map(\.routeID))
+
         List {
+            if let stop = viewModel.stop {
+                Section {
+                    StopPageHeaderView(stop: stop, walkTime: walkTime, snapshotLoader: snapshotLoader)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                }
+            }
+
+            if !viewModel.statusText.isEmpty {
+                LiveStatusRow(statusText: viewModel.statusText)
+            }
+
+            if let survey = viewModel.currentSurvey {
+                Section {
+                    SurveyCardRepresentable(
+                        survey: survey,
+                        stopID: viewModel.stopID,
+                        onNext: { answer in
+                            Task { await viewModel.submitHeroAnswer(answer, stopLocation: viewModel.stop?.coordinate) }
+                        },
+                        onDismiss: { viewModel.dismissCurrentSurvey() },
+                        onOpenExternalSurvey: { viewModel.launchExternalSurvey(survey) }
+                    )
+                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                }
+            }
+
+            // Donations are deferred to the parity task (Task 12): the inline
+            // request is a UIKit `DonationListItem` gated on
+            // `application.donationsManager.shouldRequestDonations`, whose tap
+            // handlers present VC-owned modals. It is intentionally not dropped.
+
+            if let alerts = viewModel.stopArrivals?.serviceAlerts, !alerts.isEmpty {
+                ServiceAlertsSection(alerts: alerts, onSelect: onSelectAlert)
+            }
+
             Section {
                 StopPageModeToggle(mode: viewModel.stopPreferences.sortType) { newValue in
                     withAnimation {
                         // Switching modes collapses every open accordion (§4.6).
                         expandedDepartureID = nil
                         expandedRouteID = nil
-                        UserDefaults.standard.set(newValue.rawValue, forKey: Self.lastUsedStopSortKey)
+                        userDefaults.set(newValue.rawValue, forKey: Self.lastUsedStopSortKey)
                         viewModel.updateSortType(newValue)
                     }
                 }
@@ -47,10 +140,28 @@ struct StopPageView: View {
                 .listRowBackground(Color.clear)
             }
 
-            if viewModel.stopPreferences.sortType == .time {
+            if departures.isEmpty {
+                if viewModel.isLoading {
+                    Section {
+                        HStack { Spacer(); ProgressView(); Spacer() }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    }
+                } else {
+                    Section {
+                        StopPageEmptyStateRow(
+                            errorText: viewModel.operationError?.localizedDescription,
+                            isFilteredEmpty: viewModel.isListFiltered && !(viewModel.stopArrivals?.arrivalsAndDepartures.isEmpty ?? true),
+                            minutesAfter: viewModel.minutesAfter,
+                            onRetry: { Task { await viewModel.refresh() } },
+                            onShowAllRoutes: { viewModel.isListFiltered = false }
+                        )
+                    }
+                }
+            } else if viewModel.stopPreferences.sortType == .time {
                 ChronologicalListView(
-                    partition: StopPageListBuilder.chronologicalPartition(filteredDepartures, walkMinutes: viewModel.walkTime?.walkMinutes),
-                    walkMinutes: viewModel.walkTime?.walkMinutes,
+                    partition: StopPageListBuilder.chronologicalPartition(departures, walkMinutes: walkTime?.walkMinutes),
+                    walkMinutes: walkTime?.walkMinutes,
                     showPast: !pastCollapsed,
                     expandedDepartureID: expandedDepartureID,
                     statusProvider: { DepartureStatus(arrivalDeparture: $0) },
@@ -66,7 +177,7 @@ struct StopPageView: View {
                 )
             } else {
                 GroupedListView(
-                    groups: StopPageListBuilder.routeGroups(filteredDepartures),
+                    groups: StopPageListBuilder.routeGroups(departures),
                     expandedRouteID: expandedRouteID,
                     openTripDepartureID: expandedDepartureID,
                     statusProvider: { DepartureStatus(arrivalDeparture: $0) },
@@ -96,12 +207,27 @@ struct StopPageView: View {
                     panelBuilder: makePanel(for:)
                 )
             }
+
+            StopPageFooterSection(
+                showLoadMore: !viewModel.isLoadMoreExhausted,
+                attribution: attributionText,
+                onLoadMore: { Task { await viewModel.loadMoreDepartures() } }
+            )
         }
         .listStyle(.insetGrouped)
         .task { await viewModel.start() }
         .onAppear(perform: seedLastUsedModeIfNeeded)
         .onDisappear { viewModel.deactivate() }
         .refreshable { await viewModel.refresh() }
+        // Reconcile the open accordions against the live feed: when a refresh
+        // drops the expanded departure (or its whole route) from the list,
+        // clear the stale expansion so no orphaned panel lingers.
+        .onChange(of: departureIDs) { _, ids in
+            if let id = expandedDepartureID, !ids.contains(id) { expandedDepartureID = nil }
+        }
+        .onChange(of: routeIDs) { _, ids in
+            if let rid = expandedRouteID, !ids.contains(rid) { expandedRouteID = nil }
+        }
     }
 
     /// One-shot: an untouched stop (still on the default `.time` sort) opens in
@@ -111,7 +237,7 @@ struct StopPageView: View {
         guard !didSeedMode else { return }
         didSeedMode = true
         guard viewModel.stopPreferences.sortType == .time,
-              let raw = UserDefaults.standard.string(forKey: Self.lastUsedStopSortKey),
+              let raw = userDefaults.string(forKey: Self.lastUsedStopSortKey),
               let seeded = StopSort(rawValue: raw)
         else { return }
         viewModel.updateSortType(seeded)
@@ -175,5 +301,166 @@ struct StopPageModeToggle: View {
             Text(OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route")).tag(StopSort.route)
         }
         .pickerStyle(.segmented)
+    }
+}
+
+/// The out-of-card "Updated N min ago" line with a pulsing on-time dot. The dot
+/// pulse is gated on Reduce Motion (static when reduced), per the global
+/// constraints.
+struct LiveStatusRow: View {
+    let statusText: String
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .frame(width: 7, height: 7)
+                .opacity(reduceMotion ? 1 : (pulsing ? 1 : 0.35))
+            Text(statusText)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .listRowInsets(EdgeInsets(top: 2, leading: 20, bottom: 2, trailing: 20))
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Service alerts affecting this stop. Each row pushes the existing alert-detail
+/// screen via the hosting VC's `onSelect` callback.
+struct ServiceAlertsSection: View {
+    let alerts: [ServiceAlert]
+    let onSelect: (ServiceAlert) -> Void
+
+    var body: some View {
+        Section {
+            ForEach(alerts) { alert in
+                Button {
+                    onSelect(alert)
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text(alert.title(forLocale: .current) ?? OBALoc("stop_page.service_alert_fallback", value: "Service alert", comment: "Fallback title for a service alert that has no summary text."))
+                            .font(.subheadline)
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        } header: {
+            Text(Strings.serviceAlerts)
+        }
+    }
+}
+
+/// The footer: "Load more" (hidden once auto-extend hits the 12 h cap) and the
+/// data-attribution line.
+struct StopPageFooterSection: View {
+    let showLoadMore: Bool
+    let attribution: String
+    let onLoadMore: () -> Void
+
+    var body: some View {
+        Section {
+            if showLoadMore {
+                Button(action: onLoadMore) {
+                    Label(
+                        OBALoc("stop_page.load_more", value: "Load more", comment: "Extends the departure time window"),
+                        systemImage: "plus"
+                    )
+                    .font(.system(size: 14.5, weight: .bold))
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                }
+            }
+            if !attribution.isEmpty {
+                Text(attribution)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+        }
+    }
+}
+
+/// The single empty-state row shown when there are no departures to list.
+/// Precedence: a network error (Retry) → everything filtered out (Show all
+/// routes) → genuinely no service in the window. §4.4 wording is exact.
+struct StopPageEmptyStateRow: View {
+    let errorText: String?
+    let isFilteredEmpty: Bool
+    let minutesAfter: UInt
+    let onRetry: () -> Void
+    let onShowAllRoutes: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: symbolName)
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            if let actionTitle {
+                Button(actionTitle, action: action)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 28)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+    }
+
+    private var symbolName: String {
+        if errorText != nil { return "exclamationmark.icloud" }
+        if isFilteredEmpty { return "line.3.horizontal.decrease.circle" }
+        return "clock.badge.xmark"
+    }
+
+    private var message: String {
+        if let errorText { return errorText }
+        if isFilteredEmpty {
+            return OBALoc("stop_page.empty.all_filtered", value: "All routes at this stop are filtered", comment: "Empty state shown when every route at the stop is hidden by the user's filter.")
+        }
+        let fmt = OBALoc("stop_page.empty.no_departures_fmt", value: "No departures in the next %d minutes", comment: "Empty state shown when the stop has no upcoming departures within the loaded time window. %d is the number of minutes.")
+        return String(format: fmt, minutesAfter)
+    }
+
+    private var actionTitle: String? {
+        if errorText != nil {
+            return OBALoc("stop_page.empty.retry", value: "Retry", comment: "Button that retries loading departures after an error.")
+        }
+        if isFilteredEmpty {
+            return OBALoc("stop_page.empty.show_all_routes", value: "Show all routes", comment: "Button that clears the route filter so all routes are shown.")
+        }
+        return nil
+    }
+
+    private func action() {
+        if errorText != nil {
+            onRetry()
+        } else if isFilteredEmpty {
+            onShowAllRoutes()
+        }
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -1,0 +1,56 @@
+//
+//  StopPageViewController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import SwiftUI
+import OBAKitCore
+
+/// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
+/// (nav bar items, menus) and keeps parity entry points (`Previewable` etc.)
+/// working while `FeatureFlags.useNewStopPageKey` is enabled.
+class StopPageViewController: UIHostingController<StopPageView>, AppContext {
+    let application: Application
+    let viewModel: StopViewModel
+
+    var bookmarkContext: Bookmark? {
+        get { viewModel.bookmarkContext }
+        set { viewModel.bookmarkContext = newValue }
+    }
+
+    var transferContext: TransferContext? {
+        get { viewModel.transferContext }
+        set { viewModel.transferContext = newValue }
+    }
+
+    convenience init(application: Application, stop: Stop) {
+        self.init(application: application, stopID: stop.id, stop: stop)
+    }
+
+    convenience init(application: Application, stopID: StopID) {
+        self.init(application: application, stopID: stopID, stop: nil)
+    }
+
+    private init(application: Application, stopID: StopID, stop: Stop?) {
+        self.application = application
+        self.viewModel = StopViewModel(application: application, stopID: stopID, stop: stop)
+        super.init(rootView: StopPageView(viewModel: viewModel))
+        hidesBottomBarWhenPushed = false
+    }
+
+    @available(*, unavailable)
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+        navigationItem.largeTitleDisplayMode = .never
+    }
+}

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -277,10 +277,17 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
 
     /// Presents the same lead-time picker bulletin as
     /// `StopViewController.addAlarm(arrivalDeparture:)`; `AlarmBuilder` owns the
-    /// picker UI and the create request.
+    /// picker UI and the create request. Also serves the Change flow: when the
+    /// departure already has an alarm, the picker opens pre-selected to its
+    /// current lead time and the created alarm replaces the old one.
     private func showAlarmPicker(for arrivalDeparture: ArrivalDeparture) {
         alarmBuilderDeparture = arrivalDeparture
-        alarmBuilder = AlarmBuilder(arrivalDeparture: arrivalDeparture, application: application, delegate: self)
+        let existingAlarm = viewModel.alarm(for: arrivalDeparture)
+        alarmBuilder = AlarmBuilder(
+            arrivalDeparture: arrivalDeparture,
+            application: application,
+            initialMinutes: existingAlarm.map { viewModel.alarmLeadTimeMinutes($0) },
+            delegate: self)
         alarmBuilder?.showBulletin(above: self)
     }
 
@@ -290,7 +297,10 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
 
     func alarmBuilder(_ alarmBuilder: AlarmBuilder, alarmCreated alarm: Alarm) {
         if let departure = alarmBuilderDeparture {
-            viewModel.registerAlarm(alarm, for: departure)
+            // `replaceAlarm` indexes the new alarm synchronously and no-ops the
+            // delete when the departure had no prior alarm, so it serves both
+            // the create and change flows.
+            Task { await viewModel.replaceAlarm(with: alarm, for: departure) }
         } else {
             viewModel.recordAlarmCreated(alarm)
         }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -262,7 +262,16 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         return await withCheckedContinuation { continuation in
             let snapshotter = MapSnapshotter(size: size, stopIconFactory: factory)
             snapshotter.snapshot(stop: stop, traitCollection: traits) { image in
-                continuation.resume(returning: image)
+                // `MapSnapshotter`'s internal `MKMapSnapshotter.start` completion is
+                // `[weak self]`, so the wrapper must outlive the async render or the
+                // completion early-returns and this continuation never resumes —
+                // leaving the header permanently blank. The legacy `StopHeaderView`
+                // avoids this by retaining the snapshotter in a stored property; here
+                // there's no `self` to hold it, so extend its lifetime through the
+                // callback explicitly.
+                withExtendedLifetime(snapshotter) {
+                    continuation.resume(returning: image)
+                }
             }
         }
     }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -152,16 +152,15 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
 
     // MARK: - Combine Bindings
 
-    /// Rebuilds the nav-bar chrome (title + right bar items) whenever the state
-    /// the menus read changes. Mirrors `StopViewController.bindViewModel()`'s
-    /// `configureTabBarButtons()` calls.
+    /// Rebuilds the nav-bar chrome (right bar items) whenever the state the
+    /// menus read changes. Mirrors `StopViewController.bindViewModel()`'s
+    /// `configureTabBarButtons()` calls. No nav-bar title: the header card
+    /// carries the stop identity.
     private func bindChrome() {
         viewModel.$stop
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] stop in
-                guard let self else { return }
-                self.title = stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
-                self.configureBarButtons()
+            .sink { [weak self] _ in
+                self?.configureBarButtons()
             }
             .store(in: &cancellables)
 
@@ -272,7 +271,10 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     private func loadSnapshot(size: CGSize) async -> UIImage? {
         guard let stop = viewModel.stop, size.width > 0, size.height > 0 else { return nil }
         let factory = application.stopIconFactory
-        let traits = traitCollection
+        // The header design is always-dark (white identity text over a dark
+        // scrim), so render the map snapshot in dark style regardless of the
+        // system appearance.
+        let traits = traitCollection.modifyingTraits { $0.userInterfaceStyle = .dark }
         return await withCheckedContinuation { continuation in
             let snapshotter = MapSnapshotter(size: size, stopIconFactory: factory)
             snapshotter.snapshot(stop: stop, traitCollection: traits) { image in

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -9,6 +9,7 @@
 
 import UIKit
 import SwiftUI
+import Combine
 import OBAKitCore
 
 /// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
@@ -17,6 +18,7 @@ import OBAKitCore
 class StopPageViewController: UIHostingController<StopPageView>, AppContext {
     let application: Application
     let viewModel: StopViewModel
+    private var cancellables = Set<AnyCancellable>()
 
     var bookmarkContext: Bookmark? {
         get { viewModel.bookmarkContext }
@@ -50,7 +52,12 @@ class StopPageViewController: UIHostingController<StopPageView>, AppContext {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = viewModel.stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+        viewModel.$stop
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] stop in
+                self?.title = stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+            }
+            .store(in: &cancellables)
         navigationItem.largeTitleDisplayMode = .never
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -115,6 +115,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showScheduleForStop: {},
         showScheduleForRoute: { _ in },
         canScheduleForRoute: false,
+        showWalkingDirections: {},
         showAlertDetail: { _ in },
         showBookmarkEditor: { _ in },
         showExternalSurveyError: {},
@@ -132,6 +133,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             showScheduleForStop: { [weak self] in self?.showScheduleForStop() },
             showScheduleForRoute: { [weak self] departure in self?.showScheduleForRoute(for: departure) },
             canScheduleForRoute: application.currentRegion?.supportsScheduleForRoute ?? true,
+            showWalkingDirections: { [weak self] in self?.showWalkingDirections() },
             showAlertDetail: { [weak self] alert in
                 guard let self else { return }
                 self.application.viewRouter.navigateTo(alert: alert, from: self)
@@ -485,6 +487,56 @@ private extension StopPageViewController {
         let stopPreferencesView = StopPreferencesWrappedView(stop, initialHiddenRoutes: hiddenRoutes, delegate: self)
             .environment(\.coreApplication, application)
         present(UIHostingController(rootView: stopPreferencesView), animated: true)
+    }
+
+    /// Opens walking directions to the stop from the header's walk pill. Reuses
+    /// the `locationMenu()` availability logic: Apple Maps always, Google Maps
+    /// only when installed. One available app opens directly; more than one
+    /// presents an action sheet to disambiguate.
+    func showWalkingDirections() {
+        guard let coordinate = viewModel.stop?.coordinate else { return }
+
+        var options: [(title: String, url: URL)] = []
+
+        if let appleMapsURL = AppInterop.appleMapsWalkingDirectionsURL(coordinate: coordinate) {
+            options.append((
+                OBALoc("stops_controller.walking_directions_apple", value: "Walking Directions (Apple Maps)", comment: "Button that launches Apple's maps.app with walking directions to this stop"),
+                appleMapsURL
+            ))
+        }
+
+        #if !targetEnvironment(simulator)
+        if let googleMapsURL = AppInterop.googleMapsWalkingDirectionsURL(coordinate: coordinate), googleMapsAvailable {
+            options.append((
+                OBALoc("stops_controller.walking_directions_google", value: "Walking Directions (Google Maps)", comment: "Button that launches Google Maps with walking directions to this stop"),
+                googleMapsURL
+            ))
+        }
+        #endif
+
+        guard let first = options.first else { return }
+
+        if options.count == 1 {
+            application.open(first.url, options: [:], completionHandler: nil)
+            return
+        }
+
+        let sheet = UIAlertController(
+            title: OBALoc("stops_controller.walking_directions", value: "Walking Directions", comment: "Button that launches a maps app with walking directions to this stop"),
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+        for option in options {
+            sheet.addAction(UIAlertAction(title: option.title, style: .default) { [weak self] _ in
+                self?.application.open(option.url, options: [:], completionHandler: nil)
+            })
+        }
+        sheet.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
+        if let popover = sheet.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(origin: view.center, size: .zero)
+        }
+        present(sheet, animated: true)
     }
 
     func showReportProblem() {

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -25,6 +25,7 @@ import OBAKitCore
 /// layer stays router-free and holds no `Application` reference.
 class StopPageViewController: UIHostingController<StopPageRootView>,
     AppContext,
+    AlarmBuilderDelegate,
     BookmarkEditorDelegate,
     StopPreferencesViewDelegate,
     Previewable {
@@ -118,6 +119,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showWalkingDirections: {},
         showAlertDetail: { _ in },
         showBookmarkEditor: { _ in },
+        showAlarmPicker: { _ in },
         showExternalSurveyError: {},
         showDonation: {},
         dismissDonation: { _ in },
@@ -139,6 +141,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
                 self.application.viewRouter.navigateTo(alert: alert, from: self)
             },
             showBookmarkEditor: { [weak self] departure in self?.showBookmarkEditor(for: departure) },
+            showAlarmPicker: { [weak self] departure in self?.showAlarmPicker(for: departure) },
             showExternalSurveyError: { [weak self] in self?.showExternalSurveyError() },
             showDonation: { [weak self] in self?.showDonationUI() },
             dismissDonation: { [weak self] onHide in self?.showDonationDismissUI(onHide: onHide) },
@@ -263,6 +266,44 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         present(alert, animated: true)
         // Reset so a later already-denied attempt re-fires the binding.
         viewModel.clearAlarmPermissionDenied()
+    }
+
+    // MARK: - Alarm Picker
+
+    private var alarmBuilder: AlarmBuilder?
+    /// The departure the open bulletin is for, so `alarmCreated` can index the
+    /// alarm under it (the delegate callback doesn't carry the departure).
+    private var alarmBuilderDeparture: ArrivalDeparture?
+
+    /// Presents the same lead-time picker bulletin as
+    /// `StopViewController.addAlarm(arrivalDeparture:)`; `AlarmBuilder` owns the
+    /// picker UI and the create request.
+    private func showAlarmPicker(for arrivalDeparture: ArrivalDeparture) {
+        alarmBuilderDeparture = arrivalDeparture
+        alarmBuilder = AlarmBuilder(arrivalDeparture: arrivalDeparture, application: application, delegate: self)
+        alarmBuilder?.showBulletin(above: self)
+    }
+
+    func alarmBuilderStartedRequest(_ alarmBuilder: AlarmBuilder) {
+        ProgressHUD.show()
+    }
+
+    func alarmBuilder(_ alarmBuilder: AlarmBuilder, alarmCreated alarm: Alarm) {
+        if let departure = alarmBuilderDeparture {
+            viewModel.registerAlarm(alarm, for: departure)
+        } else {
+            viewModel.recordAlarmCreated(alarm)
+        }
+
+        let message = OBALoc("stop_controller.alarm_created_message", value: "Alarm created", comment: "A message that appears when a user's alarm is created.")
+        ProgressHUD.showSuccessAndDismiss(message: message)
+    }
+
+    func alarmBuilder(_ alarmBuilder: AlarmBuilder, error: Error) {
+        ProgressHUD.dismiss()
+        Task { @MainActor in
+            await AlertPresenter.show(error: error, presentingController: self)
+        }
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -33,11 +33,18 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     let viewModel: StopViewModel
     private var cancellables = Set<AnyCancellable>()
 
-    /// Right bar-button items, rebuilt whenever the stop, its preferences, its
-    /// arrivals, or the filter flag change (Combine sinks in `bindChrome()`).
-    private var moreMenuButton: UIBarButtonItem?
-    private var filterMenuButton: UIBarButtonItem?
-    private var schedulesButton: UIBarButtonItem?
+    #if !targetEnvironment(simulator)
+    /// `application.canOpenURL` is an XPC round-trip and Google Maps can't be
+    /// installed or removed within a screen's lifetime, so resolve availability
+    /// once instead of on every ~15s chrome rebuild. Evaluated lazily on the
+    /// first `locationMenu()` build, by which point `viewModel.stop` is set.
+    private lazy var googleMapsAvailable: Bool = {
+        guard let coordinate = viewModel.stop?.coordinate,
+              let url = AppInterop.googleMapsWalkingDirectionsURL(coordinate: coordinate)
+        else { return false }
+        return application.canOpenURL(url)
+    }()
+    #endif
 
     var bookmarkContext: Bookmark? {
         get { viewModel.bookmarkContext }
@@ -67,7 +74,8 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             viewModel: viewModel,
             userDefaults: application.userDefaults,
             snapshotLoader: { _ in nil },
-            navigation: Self.placeholderNavigation
+            navigation: Self.placeholderNavigation,
+            formatters: application.formatters
         ))
 
         rootView = StopPageRootView(
@@ -77,7 +85,8 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
                 guard let self else { return nil }
                 return await self.loadSnapshot(size: size)
             },
-            navigation: makeNavigationHandler()
+            navigation: makeNavigationHandler(),
+            formatters: application.formatters
         )
 
         hidesBottomBarWhenPushed = false
@@ -161,7 +170,12 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             .sink { [weak self] _ in self?.configureBarButtons() }
             .store(in: &cancellables)
 
+        // The only chrome that reads `stopArrivals` is the File menu's service-alerts
+        // action (enabled iff alerts exist). Collapse the ~15s refresh churn to that
+        // one bit so the menus aren't rebuilt on every otherwise-identical emission.
         viewModel.$stopArrivals
+            .map { ($0?.serviceAlerts ?? []).isEmpty }
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.configureBarButtons() }
             .store(in: &cancellables)
@@ -320,10 +334,6 @@ private extension StopPageViewController {
         schedulesBtn.accessibilityLabel = Strings.schedules
 
         navigationItem.rightBarButtonItems = [moreMenuButton, filterMenuButton, schedulesBtn]
-
-        self.moreMenuButton = moreMenuButton
-        self.filterMenuButton = filterMenuButton
-        self.schedulesButton = schedulesBtn
     }
 
     /// The "More" pulldown: File / Location / Help. No Sort submenu (the toggle
@@ -404,7 +414,7 @@ private extension StopPageViewController {
             #if !targetEnvironment(simulator)
             // Display Google Maps app link, only if Google Maps is installed.
             if let googleMapsURL = AppInterop.googleMapsWalkingDirectionsURL(coordinate: stop.coordinate),
-               self.application.canOpenURL(googleMapsURL) {
+               self.googleMapsAvailable {
                 let googleMaps = UIAction(title: OBALoc("stops_controller.walking_directions_google", value: "Walking Directions (Google Maps)", comment: "Button that launches Google Maps with walking directions to this stop")) { [unowned self] _ in
                     self.application.open(googleMapsURL, options: [:], completionHandler: nil)
                 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -752,6 +752,14 @@ private extension StopPageViewController {
 
         alertController.addAction(title: Strings.cancel, style: .cancel, handler: nil)
 
+        // An unanchored action sheet is a hard crash on iPad. The donation card has no
+        // stable UIKit source view (it lives inside the SwiftUI list), so anchor to the
+        // middle of the page, as `showWalkingDirections()` does.
+        if let popover = alertController.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(origin: view.center, size: .zero)
+        }
+
         present(alertController, animated: true)
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -13,16 +13,31 @@ import Combine
 import OBAKitCore
 
 /// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
-/// (nav bar items, menus) and keeps parity entry points (`Previewable` etc.)
-/// working while `FeatureFlags.useNewStopPageKey` is enabled.
+/// (nav bar items, menus) and keeps parity entry points (`Previewable`,
+/// navigation-out modals) working while `FeatureFlags.useNewStopPageKey` is
+/// enabled.
 ///
 /// The root view is `StopPageRootView`, a thin wrapper that applies
 /// `.defaultAppStorage(application.userDefaults)` so the page's `@AppStorage`
-/// shares the app-group suite with the legacy screen.
-class StopPageViewController: UIHostingController<StopPageRootView>, AppContext {
+/// shares the app-group suite with the legacy screen. Everything that leaves the
+/// page — trip/schedule/alert/bookmark navigation, the donation and survey
+/// modals — is routed here through `StopPageNavigationHandler`, so the SwiftUI
+/// layer stays router-free and holds no `Application` reference.
+class StopPageViewController: UIHostingController<StopPageRootView>,
+    AppContext,
+    BookmarkEditorDelegate,
+    StopPreferencesViewDelegate,
+    Previewable {
+
     let application: Application
     let viewModel: StopViewModel
     private var cancellables = Set<AnyCancellable>()
+
+    /// Right bar-button items, rebuilt whenever the stop, its preferences, its
+    /// arrivals, or the filter flag change (Combine sinks in `bindChrome()`).
+    private var moreMenuButton: UIBarButtonItem?
+    private var filterMenuButton: UIBarButtonItem?
+    private var schedulesButton: UIBarButtonItem?
 
     var bookmarkContext: Bookmark? {
         get { viewModel.bookmarkContext }
@@ -47,12 +62,12 @@ class StopPageViewController: UIHostingController<StopPageRootView>, AppContext 
         self.viewModel = StopViewModel(application: application, stopID: stopID, stop: stop)
 
         // Seed with placeholder closures; `self` isn't available until super.init
-        // returns, so the real closures (which capture `self`) are installed below.
+        // returns, so the real handler (which captures `self`) is installed below.
         super.init(rootView: StopPageRootView(
             viewModel: viewModel,
             userDefaults: application.userDefaults,
             snapshotLoader: { _ in nil },
-            onSelectAlert: { _ in }
+            navigation: Self.placeholderNavigation
         ))
 
         rootView = StopPageRootView(
@@ -62,10 +77,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>, AppContext 
                 guard let self else { return nil }
                 return await self.loadSnapshot(size: size)
             },
-            onSelectAlert: { [weak self] alert in
-                guard let self else { return }
-                self.application.viewRouter.navigateTo(alert: alert, from: self)
-            }
+            navigation: makeNavigationHandler()
         )
 
         hidesBottomBarWhenPushed = false
@@ -78,14 +90,110 @@ class StopPageViewController: UIHostingController<StopPageRootView>, AppContext 
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationItem.largeTitleDisplayMode = .never
+        configureBarButtons()
+        bindChrome()
+        bindSurveyPresentation()
+    }
+
+    // MARK: - Navigation Handler
+
+    /// A fully no-op handler used only to satisfy the required `rootView` before
+    /// `self` is available; replaced immediately with `makeNavigationHandler()`.
+    private static let placeholderNavigation = StopPageNavigationHandler(
+        showTrip: { _ in },
+        showScheduleForStop: {},
+        showScheduleForRoute: { _ in },
+        canScheduleForRoute: false,
+        showAlertDetail: { _ in },
+        showBookmarkEditor: { _ in },
+        showExternalSurveyError: {},
+        showDonation: {},
+        dismissDonation: { _ in },
+        makeTripPreview: { _ in AnyView(EmptyView()) }
+    )
+
+    private func makeNavigationHandler() -> StopPageNavigationHandler {
+        StopPageNavigationHandler(
+            showTrip: { [weak self] departure in
+                guard let self else { return }
+                self.application.viewRouter.navigateTo(arrivalDeparture: departure, from: self)
+            },
+            showScheduleForStop: { [weak self] in self?.showScheduleForStop() },
+            showScheduleForRoute: { [weak self] departure in self?.showScheduleForRoute(for: departure) },
+            canScheduleForRoute: application.currentRegion?.supportsScheduleForRoute ?? true,
+            showAlertDetail: { [weak self] alert in
+                guard let self else { return }
+                self.application.viewRouter.navigateTo(alert: alert, from: self)
+            },
+            showBookmarkEditor: { [weak self] departure in self?.showBookmarkEditor(for: departure) },
+            showExternalSurveyError: { [weak self] in self?.showExternalSurveyError() },
+            showDonation: { [weak self] in self?.showDonationUI() },
+            dismissDonation: { [weak self] onHide in self?.showDonationDismissUI(onHide: onHide) },
+            makeTripPreview: { [weak self] departure in
+                guard let self else { return AnyView(EmptyView()) }
+                return AnyView(
+                    TripViewControllerPreview(departure: departure, application: self.application)
+                        .frame(width: 320, height: 400)
+                )
+            }
+        )
+    }
+
+    // MARK: - Combine Bindings
+
+    /// Rebuilds the nav-bar chrome (title + right bar items) whenever the state
+    /// the menus read changes. Mirrors `StopViewController.bindViewModel()`'s
+    /// `configureTabBarButtons()` calls.
+    private func bindChrome() {
         viewModel.$stop
             .receive(on: DispatchQueue.main)
             .sink { [weak self] stop in
-                self?.title = stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+                guard let self else { return }
+                self.title = stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+                self.configureBarButtons()
             }
             .store(in: &cancellables)
-        navigationItem.largeTitleDisplayMode = .never
+
+        viewModel.$stopPreferences
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.configureBarButtons() }
+            .store(in: &cancellables)
+
+        viewModel.$stopArrivals
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.configureBarButtons() }
+            .store(in: &cancellables)
+
+        viewModel.$isListFiltered
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.configureBarButtons() }
+            .store(in: &cancellables)
     }
+
+    /// Presents the multi-question survey screen and the hero-submission error
+    /// alert, driven by the view model's publishers (ported from
+    /// `StopViewController.bindSurveysSink()`).
+    private func bindSurveyPresentation() {
+        viewModel.presentFullSurvey
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] payload in
+                self?.showFullSurvey(payload.survey, heroResponseID: payload.heroResponseID)
+            }
+            .store(in: &cancellables)
+
+        viewModel.surveySubmissionError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                guard let self else { return }
+                Task { @MainActor in
+                    await AlertPresenter.show(error: error, presentingController: self)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Snapshot
 
     /// Bridges the callback-based `MapSnapshotter` into async/await for the
     /// SwiftUI header. Mirrors `StopHeaderView`'s configuration (stop
@@ -101,4 +209,343 @@ class StopPageViewController: UIHostingController<StopPageRootView>, AppContext 
             }
         }
     }
+
+    // MARK: - Previewable
+
+    private var inPreviewMode = false
+
+    func enterPreviewMode() {
+        inPreviewMode = true
+        configureBarButtons()
+    }
+
+    func exitPreviewMode() {
+        inPreviewMode = false
+        configureBarButtons()
+    }
+}
+
+// MARK: - Nav Bar Items & Menus
+
+private extension StopPageViewController {
+    /// Ported from `StopViewController.configureTabBarButtons()`, minus the Sort
+    /// menu — the SwiftUI mode toggle supersedes it (spec decision).
+    func configureBarButtons() {
+        // A peek preview shows a bare, non-interactive glance (no chrome).
+        guard !inPreviewMode else {
+            navigationItem.rightBarButtonItems = nil
+            return
+        }
+
+        let filterButtonImage: UIImage?
+        let filterButtonTitle: String
+
+        if viewModel.stopPreferences.hasHiddenRoutes && viewModel.isListFiltered {
+            filterButtonTitle = "FILTER (ON)"
+            filterButtonImage = UIImage(systemName: "line.3.horizontal.decrease.circle.fill")
+        } else {
+            filterButtonTitle = "FILTER (OFF)"
+            filterButtonImage = UIImage(systemName: "line.3.horizontal.decrease.circle")
+        }
+
+        let filterMenuButton = UIBarButtonItem(title: filterButtonTitle, image: filterButtonImage, menu: filterMenu())
+        let moreMenuButton = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "ellipsis.circle"), menu: pulldownMenu())
+        let schedulesBtn = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(showScheduleForStop))
+        schedulesBtn.accessibilityLabel = Strings.schedules
+
+        navigationItem.rightBarButtonItems = [moreMenuButton, filterMenuButton, schedulesBtn]
+
+        self.moreMenuButton = moreMenuButton
+        self.filterMenuButton = filterMenuButton
+        self.schedulesButton = schedulesBtn
+    }
+
+    /// The "More" pulldown: File / Location / Help. No Sort submenu (the toggle
+    /// supersedes it).
+    func pulldownMenu() -> UIMenu {
+        UIMenu(children: [fileMenu(), locationMenu(), helpMenu()])
+    }
+
+    func filterMenu() -> UIMenu {
+        let allRoutesTitle = OBALoc("stops_controller.filter.all_routes", value: "All Routes", comment: "A menu item on a Stop page that toggles the visible list of transit vehicles from a filtered list to all of the list items. e.g. a stop serves routes 1, 2, and 3. The user has filtered the stop to only show route 3. Chooosing this item will show 1, 2, and 3 again.")
+        let filteredRoutesTitle = OBALoc("stops_controller.filter.filtered_routes", value: "Filtered Routes", comment: "A menu item on a Stop page that toggles the visible list of transit vehicles from a list of all items to a filtered list. e.g. a stop serves routes 1, 2, and 3. The user wants to only view route 3. Choosing this item would show that subset of routes.")
+
+        let showAll = UIAction(title: allRoutesTitle) { [unowned self] _ in
+            if self.viewModel.isListFiltered {
+                self.viewModel.isListFiltered = false
+            }
+        }
+
+        let showFiltered = UIAction(title: filteredRoutesTitle) { [unowned self] _ in
+            self.viewModel.isListFiltered = true
+            self.filter()
+        }
+
+        guard let stop = viewModel.stop else {
+            return UIMenu(children: [showAll, showFiltered])
+        }
+
+        var children = [showAll]
+
+        if stop.routes.count > 1 {
+            if viewModel.isListFiltered && viewModel.stopPreferences.hasHiddenRoutes {
+                showFiltered.image = UIImage(systemName: "checkmark")
+            } else {
+                showAll.image = UIImage(systemName: "checkmark")
+            }
+
+            children.append(showFiltered)
+        }
+
+        return UIMenu(children: children)
+    }
+
+    func fileMenu() -> UIMenu {
+        let bookmarkAction = UIAction(title: Strings.addBookmark, image: UIImage(systemName: "bookmark")) { [unowned self] _ in
+            self.showBookmarkEditor(for: nil)
+        }
+
+        let alertsAction = UIAction(title: Strings.serviceAlerts, image: UIImage(systemName: "exclamationmark.circle")) { [unowned self] _ in
+            let controller = ServiceAlertListController(application: self.application, serviceAlerts: self.viewModel.stopArrivals?.serviceAlerts ?? [])
+            self.application.viewRouter.navigate(to: controller, from: self)
+        }
+
+        // Disable the alerts action if there are no service alerts.
+        if (viewModel.stopArrivals?.serviceAlerts ?? []).isEmpty {
+            alertsAction.attributes = .disabled
+        }
+
+        return UIMenu(title: "File", options: .displayInline, children: [bookmarkAction, alertsAction])
+    }
+
+    func locationMenu() -> UIMenu {
+        let nearbyAction = UIAction(title: OBALoc("stops_controller.nearby_stops", value: "Nearby Stops", comment: "Title of the row that will show stops that are near this one."), image: UIImage(systemName: "location")) { [unowned self] _ in
+            guard let coordinate = self.viewModel.stop?.coordinate else { return }
+            let nearbyController = NearbyStopsViewController(coordinate: coordinate, application: self.application)
+            self.application.viewRouter.navigate(to: nearbyController, from: self)
+        }
+
+        var walkingDirectionActions: [UIMenuElement] = []
+
+        if let stop = viewModel.stop {
+            if let appleMapsURL = AppInterop.appleMapsWalkingDirectionsURL(coordinate: stop.coordinate) {
+                let appleMaps = UIAction(title: OBALoc("stops_controller.walking_directions_apple", value: "Walking Directions (Apple Maps)", comment: "Button that launches Apple's maps.app with walking directions to this stop")) { [unowned self] _ in
+                    self.application.open(appleMapsURL, options: [:], completionHandler: nil)
+                }
+                walkingDirectionActions.append(appleMaps)
+            }
+
+            #if !targetEnvironment(simulator)
+            // Display Google Maps app link, only if Google Maps is installed.
+            if let googleMapsURL = AppInterop.googleMapsWalkingDirectionsURL(coordinate: stop.coordinate),
+               self.application.canOpenURL(googleMapsURL) {
+                let googleMaps = UIAction(title: OBALoc("stops_controller.walking_directions_google", value: "Walking Directions (Google Maps)", comment: "Button that launches Google Maps with walking directions to this stop")) { [unowned self] _ in
+                    self.application.open(googleMapsURL, options: [:], completionHandler: nil)
+                }
+                walkingDirectionActions.append(googleMaps)
+            }
+            #endif
+        }
+
+        let walkingDirectionsElement: UIMenuElement
+        let walkingDirectionsTitle = OBALoc("stops_controller.walking_directions", value: "Walking Directions", comment: "Button that launches a maps app with walking directions to this stop")
+        let walkingDirectionsImage = UIImage(systemName: "figure.walk")
+
+        // Show a disabled walking directions button if there are no Walking Directions apps available.
+        if walkingDirectionActions.isEmpty {
+            walkingDirectionsElement = UIAction(title: walkingDirectionsTitle, image: walkingDirectionsImage, attributes: .disabled) { _ in /* noop */ }
+        } else {
+            walkingDirectionsElement = UIMenu(title: walkingDirectionsTitle, image: walkingDirectionsImage, children: walkingDirectionActions)
+        }
+
+        return UIMenu(title: "Location", options: .displayInline, children: [nearbyAction, walkingDirectionsElement])
+    }
+
+    func helpMenu() -> UIMenu {
+        let reportButton = UIAction(title: OBALoc("stops_controller.report_problem", value: "Report a Problem", comment: "Button that launches the 'Report Problem' UI."), image: UIImage(systemName: "exclamationmark.bubble")) { [unowned self] _ in
+            self.showReportProblem()
+        }
+
+        return UIMenu(title: "Help", options: .displayInline, children: [reportButton])
+    }
+}
+
+// MARK: - Navigation Out (ported presentation flows)
+
+private extension StopPageViewController {
+    @objc func showScheduleForStop() {
+        let scheduleVC = ScheduleForStopViewController(stopID: viewModel.stopID, application: application)
+        present(scheduleVC, animated: true)
+    }
+
+    func showScheduleForRoute(for arrivalDeparture: ArrivalDeparture) {
+        let scheduleVC = ScheduleForRouteViewController(routeID: arrivalDeparture.routeID, application: application)
+        present(scheduleVC, animated: true)
+    }
+
+    /// Opens the bookmark editor. `nil` starts the stop-level "Add Bookmark"
+    /// workflow; a departure jumps straight into editing a trip bookmark. Ports
+    /// `StopViewController.addBookmark(sender:)` and `addBookmark(arrivalDeparture:)`.
+    func showBookmarkEditor(for arrivalDeparture: ArrivalDeparture?) {
+        if let arrivalDeparture {
+            let bookmarkController = EditBookmarkViewController(application: application, arrivalDeparture: arrivalDeparture, bookmark: nil, delegate: self)
+            let navigation = UINavigationController(rootViewController: bookmarkController)
+            application.viewRouter.present(navigation, from: self)
+        } else {
+            guard let stop = viewModel.stop else { return }
+            let bookmarkController = AddBookmarkViewController(application: application, stop: stop, preloadedArrivals: viewModel.stopArrivals?.arrivalsAndDepartures, delegate: self)
+            let navigation = application.viewRouter.buildNavigation(controller: bookmarkController)
+            application.viewRouter.present(navigation, from: self, isModal: true)
+        }
+    }
+
+    /// Route Filter workflow. Presents the SwiftUI `StopPreferencesWrappedView` in
+    /// a `UIHostingController` (ported from `StopViewController.filter()`).
+    func filter() {
+        guard let stop = viewModel.stop else { return }
+
+        let hiddenRoutes = Set(viewModel.stopPreferences.hiddenRoutes)
+        let stopPreferencesView = StopPreferencesWrappedView(stop, initialHiddenRoutes: hiddenRoutes, delegate: self)
+            .environment(\.coreApplication, application)
+        present(UIHostingController(rootView: stopPreferencesView), animated: true)
+    }
+
+    func showReportProblem() {
+        guard let stop = viewModel.stop else { return }
+
+        let reportProblemController = ReportProblemViewController(application: application, stop: stop)
+        let navigation = application.viewRouter.buildNavigation(controller: reportProblemController)
+        application.viewRouter.present(navigation, from: self, isModal: true)
+    }
+
+    // MARK: - Surveys
+
+    func showFullSurvey(_ survey: Survey, heroResponseID: String? = nil) {
+        let surveyVC = SurveyViewController(
+            survey: survey,
+            surveyService: application.surveyService,
+            stop: viewModel.stop,
+            stopID: viewModel.stopID,
+            stopLocation: viewModel.stop?.coordinate,
+            heroResponseID: heroResponseID
+        )
+        let nav = UINavigationController(rootViewController: surveyVC)
+        present(nav, animated: true)
+    }
+
+    func showExternalSurveyError() {
+        let alert = UIAlertController(
+            title: OBALoc("stop_controller.external_survey_error.title", value: "Can't Open Survey", comment: "Title shown when an external survey link cannot be opened"),
+            message: OBALoc("stop_controller.external_survey_error.message", value: "This survey link couldn't be opened. Please try again later.", comment: "Message shown when an external survey link cannot be opened"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.ok, style: .default))
+        present(alert, animated: true)
+    }
+
+    // MARK: - Donations
+
+    func showDonationUI() {
+        guard
+            application.donationsManager.donationsEnabled,
+            let donationModel = application.donationsManager.buildObservableDonationModel()
+        else {
+            return
+        }
+
+        let learnMoreView = DonationLearnMoreView()
+            .environmentObject(donationModel)
+            .environmentObject(AnalyticsModel(application.analytics))
+
+        present(UIHostingController(rootView: learnMoreView), animated: true)
+    }
+
+    /// Presents the "please don't dismiss" action sheet. `onHide` is invoked only
+    /// when the user actually hides the card (dismiss or remind-later), so the
+    /// SwiftUI page can drop the donation section immediately. Ports
+    /// `StopViewController.showDonationDismissUI()` (whose `refresh()` re-render is
+    /// replaced by the `onHide` callback).
+    func showDonationDismissUI(onHide: @escaping () -> Void) {
+        let alertController = UIAlertController(
+            title: OBALoc(
+                "donations.donations_dismiss_alert.title",
+                value: "Please don't dismiss this request",
+                comment: "Title of the alert that appears when the user chooses to dismiss the donations request UI on a stop page"
+            ),
+            message: OBALoc(
+                "donations.donations_dismiss_alert.message",
+                value: "OneBusAway is a volunteer-run organization with almost no funding. We need your help to keep this app running.",
+                comment: "Body of the alert that appears when the user chooses to dismiss the donations request UI on a stop page"
+            ),
+            preferredStyle: .actionSheet
+        )
+
+        alertController.addAction(
+            title: OBALoc(
+                "donations.donations_dismiss_alert.button_dismiss",
+                value: "I Don't Want to Help Right Now",
+                comment: "Dismiss button on the alert"
+            ),
+            style: .destructive
+        ) { [weak self] _ in
+            self?.application.donationsManager.dismissDonationsRequests()
+            onHide()
+        }
+
+        alertController.addAction(
+            title: OBALoc(
+                "donations.donations_dismiss_alert.button_remind_later",
+                value: "Remind Me Later",
+                comment: "A button that prompts the system to remind them to donate later."
+            ),
+            style: .default
+        ) { [weak self] _ in
+            self?.application.donationsManager.remindUserLater()
+            onHide()
+        }
+
+        alertController.addAction(title: Strings.cancel, style: .cancel, handler: nil)
+
+        present(alertController, animated: true)
+    }
+}
+
+// MARK: - BookmarkEditorDelegate
+
+extension StopPageViewController {
+    func bookmarkEditorCancelled(_ viewController: UIViewController) {
+        viewController.dismiss(animated: true, completion: nil)
+    }
+
+    func bookmarkEditor(_ viewController: UIViewController, editedBookmark bookmark: Bookmark, isNewBookmark: Bool) {
+        viewController.dismiss(animated: true) {
+            let msg = isNewBookmark
+                ? OBALoc("stops_controller.created_new_bookmark", value: "Added Bookmark", comment: "Message displayed when a new bookmark is created.")
+                : OBALoc("stops_controller.updated_bookmark", value: "Updated Bookmark", comment: "Message displayed an existing bookmark is updated.")
+            ProgressHUD.showSuccessAndDismiss(message: msg, dismissAfter: 1.0)
+        }
+    }
+}
+
+// MARK: - StopPreferencesViewDelegate
+
+extension StopPageViewController {
+    func stopPreferences(stopID: StopID, updated stopPreferences: StopPreferences) {
+        viewModel.updateStopPreferences(stopPreferences)
+    }
+}
+
+// MARK: - Trip Preview
+
+/// Lazily-built UIKit preview for row long-presses; the `TripViewController` is
+/// constructed only when SwiftUI actually presents the context-menu preview.
+struct TripViewControllerPreview: UIViewControllerRepresentable {
+    let departure: ArrivalDeparture
+    let application: Application
+
+    func makeUIViewController(context: Context) -> TripViewController {
+        TripViewController(application: application, arrivalDeparture: departure)
+    }
+
+    func updateUIViewController(_ uiViewController: TripViewController, context: Context) {}
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -94,6 +94,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         configureBarButtons()
         bindChrome()
         bindSurveyPresentation()
+        bindAlarmFeedback()
     }
 
     // MARK: - Navigation Handler
@@ -191,6 +192,62 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
                 }
             }
             .store(in: &cancellables)
+    }
+
+    /// Surfaces alarm-flow failures the SwiftUI page can't present itself: the
+    /// standard error alert for a failed create/cancel, and a Settings-guidance
+    /// alert when notification permission is already denied.
+    private func bindAlarmFeedback() {
+        viewModel.$alarmError
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                guard let self else { return }
+                Task { @MainActor in
+                    await AlertPresenter.show(error: error, presentingController: self)
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$alarmPermissionDenied
+            .dropFirst()
+            .filter { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.presentAlarmPermissionDeniedAlert()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func presentAlarmPermissionDeniedAlert() {
+        let alert = UIAlertController(
+            title: OBALoc(
+                "stop_page.alarm_permission_denied.title",
+                value: "Notifications Are Off",
+                comment: "Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings."
+            ),
+            message: OBALoc(
+                "stop_page.alarm_permission_denied.message",
+                value: "To get departure alarms, allow notifications for OneBusAway in Settings.",
+                comment: "Body of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings."
+            ),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(
+            title: OBALoc(
+                "stop_page.alarm_permission_denied.open_settings",
+                value: "Open Settings",
+                comment: "Button that opens the system Settings app so the user can enable notifications."
+            ),
+            style: .default
+        ) { [weak self] _ in
+            guard let self, let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            self.application.open(url, options: [:], completionHandler: nil)
+        })
+        present(alert, animated: true)
+        // Reset so a later already-denied attempt re-fires the binding.
+        viewModel.clearAlarmPermissionDenied()
     }
 
     // MARK: - Snapshot

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -27,12 +27,21 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     AppContext,
     AlarmBuilderDelegate,
     BookmarkEditorDelegate,
+    Idleable,
     StopPreferencesViewDelegate,
     Previewable {
 
     let application: Application
     let viewModel: StopViewModel
     private var cancellables = Set<AnyCancellable>()
+
+    public var idleTimerFailsafe: Timer?
+
+    private lazy var dataLoadFeedbackGenerator = DataLoadFeedbackGenerator(application: application)
+
+    /// Gates the one-shot success haptic to the first arrivals load, matching
+    /// `StopViewController.bindArrivalsSink()`; later refreshes are silent.
+    private var firstLoad = true
 
     #if !targetEnvironment(simulator)
     /// `application.canOpenURL` is an XPC round-trip and Google Maps can't be
@@ -103,8 +112,34 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         navigationItem.largeTitleDisplayMode = .never
         configureBarButtons()
         bindChrome()
+        bindArrivalsFeedback()
         bindSurveyPresentation()
         bindAlarmFeedback()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        disableIdleTimer()
+        beginUserActivity()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        enableIdleTimer()
+    }
+
+    // MARK: - NSUserActivity
+
+    /// Publishes this stop's `NSUserActivity` for Handoff, Siri and Spotlight.
+    /// Ports `StopViewController.beginUserActivity()`; called on appearance and
+    /// whenever the stop resolves.
+    private func beginUserActivity() {
+        guard let stop = viewModel.stop,
+              let region = application.regionsService.currentRegion,
+              let userActivityBuilder = application.userActivityBuilder
+        else { return }
+
+        self.userActivity = userActivityBuilder.userActivity(for: stop, region: region)
     }
 
     // MARK: - Navigation Handler
@@ -166,6 +201,7 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.configureBarButtons()
+                self?.beginUserActivity()
             }
             .store(in: &cancellables)
 
@@ -187,6 +223,29 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         viewModel.$isListFiltered
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.configureBarButtons() }
+            .store(in: &cancellables)
+    }
+
+    /// Haptic feedback for data loads, ported from `StopViewController`: a
+    /// success tap on the first arrivals load and an error buzz whenever a fetch
+    /// fails. The SwiftUI layer owns no `Application`, so this stays here.
+    private func bindArrivalsFeedback() {
+        viewModel.$stopArrivals
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self, firstLoad else { return }
+                firstLoad = false
+                dataLoadFeedbackGenerator.dataLoad(.success)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$operationError
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.dataLoadFeedbackGenerator.dataLoad(.failed)
+            }
             .store(in: &cancellables)
     }
 
@@ -281,6 +340,13 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
     /// departure already has an alarm, the picker opens pre-selected to its
     /// current lead time and the created alarm replaces the old one.
     private func showAlarmPicker(for arrivalDeparture: ArrivalDeparture) {
+        // The SwiftUI alarm affordances are gated on `canCreateAlarm`, but that
+        // gate is only re-evaluated on the ~15s refresh — a departure can slip
+        // inside the one-minute floor while the row (or an open trip panel) still
+        // offers the button. Re-check here so the picker never opens with no
+        // selectable lead time.
+        guard viewModel.canCreateAlarm(for: arrivalDeparture) else { return }
+
         alarmBuilderDeparture = arrivalDeparture
         let existingAlarm = viewModel.alarm(for: arrivalDeparture)
         alarmBuilder = AlarmBuilder(

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -319,19 +319,18 @@ private extension StopPageViewController {
             return
         }
 
-        let filterButtonImage: UIImage?
-        let filterButtonTitle: String
+        // The titles double as the VoiceOver labels for these image-only bar
+        // buttons, so they must be localized, human-readable strings — the
+        // filter's on/off state rides in `accessibilityValue` rather than
+        // being baked into the label.
+        let filterIsOn = viewModel.stopPreferences.hasHiddenRoutes && viewModel.isListFiltered
+        let filterButtonImage = UIImage(systemName: filterIsOn ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
 
-        if viewModel.stopPreferences.hasHiddenRoutes && viewModel.isListFiltered {
-            filterButtonTitle = "FILTER (ON)"
-            filterButtonImage = UIImage(systemName: "line.3.horizontal.decrease.circle.fill")
-        } else {
-            filterButtonTitle = "FILTER (OFF)"
-            filterButtonImage = UIImage(systemName: "line.3.horizontal.decrease.circle")
-        }
-
-        let filterMenuButton = UIBarButtonItem(title: filterButtonTitle, image: filterButtonImage, menu: filterMenu())
-        let moreMenuButton = UIBarButtonItem(title: "MORE", image: UIImage(systemName: "ellipsis.circle"), menu: pulldownMenu())
+        let filterMenuButton = UIBarButtonItem(title: Strings.filter, image: filterButtonImage, menu: filterMenu())
+        filterMenuButton.accessibilityValue = filterIsOn
+            ? OBALoc("stop_page.filter.a11y_on", value: "on", comment: "VoiceOver value of the route-filter bar button when the filter is active.")
+            : OBALoc("stop_page.filter.a11y_off", value: "off", comment: "VoiceOver value of the route-filter bar button when the filter is inactive.")
+        let moreMenuButton = UIBarButtonItem(title: Strings.more, image: UIImage(systemName: "ellipsis.circle"), menu: pulldownMenu())
         let schedulesBtn = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(showScheduleForStop))
         schedulesBtn.accessibilityLabel = Strings.schedules
 

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -15,7 +15,11 @@ import OBAKitCore
 /// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
 /// (nav bar items, menus) and keeps parity entry points (`Previewable` etc.)
 /// working while `FeatureFlags.useNewStopPageKey` is enabled.
-class StopPageViewController: UIHostingController<StopPageView>, AppContext {
+///
+/// The root view is `StopPageRootView`, a thin wrapper that applies
+/// `.defaultAppStorage(application.userDefaults)` so the page's `@AppStorage`
+/// shares the app-group suite with the legacy screen.
+class StopPageViewController: UIHostingController<StopPageRootView>, AppContext {
     let application: Application
     let viewModel: StopViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -41,7 +45,29 @@ class StopPageViewController: UIHostingController<StopPageView>, AppContext {
     private init(application: Application, stopID: StopID, stop: Stop?) {
         self.application = application
         self.viewModel = StopViewModel(application: application, stopID: stopID, stop: stop)
-        super.init(rootView: StopPageView(viewModel: viewModel))
+
+        // Seed with placeholder closures; `self` isn't available until super.init
+        // returns, so the real closures (which capture `self`) are installed below.
+        super.init(rootView: StopPageRootView(
+            viewModel: viewModel,
+            userDefaults: application.userDefaults,
+            snapshotLoader: { _ in nil },
+            onSelectAlert: { _ in }
+        ))
+
+        rootView = StopPageRootView(
+            viewModel: viewModel,
+            userDefaults: application.userDefaults,
+            snapshotLoader: { [weak self] size in
+                guard let self else { return nil }
+                return await self.loadSnapshot(size: size)
+            },
+            onSelectAlert: { [weak self] alert in
+                guard let self else { return }
+                self.application.viewRouter.navigateTo(alert: alert, from: self)
+            }
+        )
+
         hidesBottomBarWhenPushed = false
     }
 
@@ -59,5 +85,20 @@ class StopPageViewController: UIHostingController<StopPageView>, AppContext {
             }
             .store(in: &cancellables)
         navigationItem.largeTitleDisplayMode = .never
+    }
+
+    /// Bridges the callback-based `MapSnapshotter` into async/await for the
+    /// SwiftUI header. Mirrors `StopHeaderView`'s configuration (stop
+    /// annotation, zoom, muted map) from `StopHeaderController.swift`.
+    private func loadSnapshot(size: CGSize) async -> UIImage? {
+        guard let stop = viewModel.stop, size.width > 0, size.height > 0 else { return nil }
+        let factory = application.stopIconFactory
+        let traits = traitCollection
+        return await withCheckedContinuation { continuation in
+            let snapshotter = MapSnapshotter(size: size, stopIconFactory: factory)
+            snapshotter.snapshot(stop: stop, traitCollection: traits) { image in
+                continuation.resume(returning: image)
+            }
+        }
     }
 }

--- a/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
+++ b/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
@@ -1,0 +1,70 @@
+//
+//  SurveyCardRepresentable.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Bridges the existing UIKit `SurveyCell` into the SwiftUI Stop page so the
+/// inline hero survey renders and behaves identically to the legacy screen.
+/// Task 11 reuses the cell rather than reimplementing survey interaction.
+///
+/// Full-survey presentation (multi-question surveys) and submission-error alerts
+/// are driven by the view model's Combine publishers; wiring the hosting VC to
+/// present them is Task 12 (navigation out of the page).
+struct SurveyCardRepresentable: UIViewRepresentable {
+    let survey: Survey
+    let stopID: String
+    let onNext: (String) -> Void
+    let onDismiss: () -> Void
+    let onOpenExternalSurvey: () -> Void
+
+    func makeUIView(context: Context) -> SurveyCell {
+        let cell = SurveyCell(frame: .zero)
+        context.coordinator.apply(to: cell, from: self)
+        return cell
+    }
+
+    func updateUIView(_ uiView: SurveyCell, context: Context) {
+        // Re-apply only when the survey identity changes so the cell keeps its
+        // in-progress selection across unrelated SwiftUI updates.
+        if context.coordinator.appliedSurveyID != survey.id {
+            context.coordinator.apply(to: uiView, from: self)
+        }
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: SurveyCell, context: Context) -> CGSize? {
+        let width = proposal.width ?? UIView.layoutFittingCompressedSize.width
+        let fitting = uiView.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        return CGSize(width: width, height: fitting.height)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var appliedSurveyID: Int?
+
+        func apply(to cell: SurveyCell, from view: SurveyCardRepresentable) {
+            let item = SurveyStopListItem(
+                survey: view.survey,
+                stopID: view.stopID,
+                selectedOption: nil,
+                onNext: view.onNext,
+                onDismiss: view.onDismiss,
+                onSelectionChanged: { _ in },
+                onOpenExternalSurvey: view.onOpenExternalSurvey
+            )
+            cell.apply(SurveyContentConfiguration(item))
+            appliedSurveyID = view.survey.id
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
+++ b/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
@@ -11,12 +11,12 @@ import SwiftUI
 import OBAKitCore
 
 /// Bridges the existing UIKit `SurveyCell` into the SwiftUI Stop page so the
-/// inline hero survey renders and behaves identically to the legacy screen.
-/// Task 11 reuses the cell rather than reimplementing survey interaction.
+/// inline hero survey renders and behaves identically to the legacy screen,
+/// reusing the cell rather than reimplementing survey interaction.
 ///
 /// Full-survey presentation (multi-question surveys) and submission-error alerts
-/// are driven by the view model's Combine publishers; wiring the hosting VC to
-/// present them is Task 12 (navigation out of the page).
+/// are driven by the view model's Combine publishers and presented by
+/// `StopPageViewController.bindSurveyPresentation()`.
 struct SurveyCardRepresentable: UIViewRepresentable {
     let survey: Survey
     let stopID: String

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -1,0 +1,91 @@
+//
+//  AlarmControlView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The trip panel's alarm block: a single "Set an alarm" button by default;
+/// once set, an info row with Change (inline stepper) and Cancel.
+///
+/// Text uses Dynamic Type text styles; the fixed bell-circle dimension scales
+/// with `@ScaledMetric` (standing amendment 1).
+struct AlarmControlView: View {
+    let alarmIsSet: Bool
+    let leadTimeMinutes: Int
+    let maxLeadTime: Int   // min(15, minutesUntilDeparture - 1)
+    let onSet: () -> Void
+    let onCancel: () -> Void
+    let onChange: (Int) -> Void
+
+    @State private var editing = false
+    @State private var pendingMinutes: Int = AlarmLeadTime.defaultMinutes
+
+    /// The bell circle grows with Dynamic Type the way the grouped alarm badge
+    /// does (standing amendment 1).
+    @ScaledMetric(relativeTo: .body) private var bellCircleSize: CGFloat = 32
+
+    private var onTimeColor: Color { Color(uiColor: ThemeColors.shared.departureOnTime) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if !alarmIsSet {
+                Button(action: onSet) {
+                    Label(OBALoc("stop_page.alarm.set", value: "Set an alarm", comment: "Primary alarm button in the trip panel"), systemImage: "bell")
+                        .font(.subheadline.weight(.heavy))
+                        .frame(maxWidth: .infinity, minHeight: 46)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(onTimeColor)
+            } else {
+                HStack(spacing: 10) {
+                    Image(systemName: "bell.fill")
+                        .foregroundStyle(onTimeColor)
+                        .frame(width: bellCircleSize, height: bellCircleSize)
+                        .background(onTimeColor.opacity(0.14), in: Circle())
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(OBALoc("stop_page.alarm.set_title", value: "Alarm set", comment: "Title of the set-alarm info row"))
+                            .font(.subheadline.weight(.bold))
+                        Text(String(format: OBALoc("stop_page.alarm.buzz_fmt", value: "Buzz %d min before it arrives", comment: "Subtitle of the set-alarm info row. %d is lead-time minutes."), leadTimeMinutes))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if !editing {
+                        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Reveals the alarm lead-time stepper")) {
+                            pendingMinutes = leadTimeMinutes
+                            editing = true
+                        }
+                        .buttonStyle(.bordered)
+                        Button(Strings.cancel, role: .destructive, action: onCancel)
+                            .buttonStyle(.bordered)
+                    }
+                }
+                if editing {
+                    HStack {
+                        Text(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Stepper(value: $pendingMinutes, in: AlarmLeadTime.minimumMinutes...max(AlarmLeadTime.minimumMinutes, maxLeadTime)) {
+                            Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
+                        }
+                        .fixedSize()
+                        Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
+                            editing = false
+                            onChange(pendingMinutes)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(onTimeColor)
+                    }
+                    .padding(.top, 10)
+                }
+            }
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -11,20 +11,17 @@ import SwiftUI
 import OBAKitCore
 
 /// The trip panel's alarm block: a single "Set an alarm" button by default;
-/// once set, an info row with Change (inline stepper) and Cancel.
+/// once set, an info row with Change and Cancel. Change re-presents the same
+/// alarm-time-picker bulletin used to create the alarm.
 ///
 /// Text uses Dynamic Type text styles; the fixed bell-circle dimension scales
 /// with Dynamic Type via `@ScaledMetric`.
 struct AlarmControlView: View {
     let alarmIsSet: Bool
     let leadTimeMinutes: Int
-    let maxLeadTime: Int   // min(15, minutesUntilDeparture - 1)
     let onSet: () -> Void
     let onCancel: () -> Void
-    let onChange: (Int) -> Void
-
-    @State private var editing = false
-    @State private var pendingMinutes: Int = AlarmLeadTime.defaultMinutes
+    let onChange: () -> Void
 
     /// The bell circle grows with Dynamic Type the way the grouped alarm badge
     /// does: fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
@@ -65,11 +62,11 @@ struct AlarmControlView: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if !editing && !isAccessibilitySize {
+                    if !isAccessibilitySize {
                         changeCancelButtons
                     }
                 }
-                if !editing && isAccessibilitySize {
+                if isAccessibilitySize {
                     // Side by side below the label when both fit; at the
                     // largest sizes each becomes its own full-width row.
                     ViewThatFits(in: .horizontal) {
@@ -84,9 +81,6 @@ struct AlarmControlView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, 10)
                 }
-                if editing {
-                    editingControls
-                }
             }
         }
     }
@@ -95,54 +89,9 @@ struct AlarmControlView: View {
     /// (accessibility-size) placements.
     @ViewBuilder
     private var changeCancelButtons: some View {
-        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Reveals the alarm lead-time stepper")) {
-            pendingMinutes = leadTimeMinutes
-            editing = true
-        }
-        .buttonStyle(.bordered)
+        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Re-presents the alarm time picker for an existing alarm"), action: onChange)
+            .buttonStyle(.bordered)
         Button(Strings.cancel, role: .destructive, action: onCancel)
             .buttonStyle(.bordered)
-    }
-
-    /// The lead-time stepper row. At accessibility sizes the label sits above
-    /// the stepper + Done controls instead of sharing their line.
-    @ViewBuilder
-    private var editingControls: some View {
-        let label = Text(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
-            .font(.footnote.weight(.semibold))
-            .foregroundStyle(.secondary)
-        let controls = HStack {
-            Stepper(value: $pendingMinutes, in: AlarmLeadTime.minimumMinutes...max(AlarmLeadTime.minimumMinutes, maxLeadTime)) {
-                Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
-            }
-            .fixedSize()
-            // The visible "Minutes before" caption is a separate Text, so the
-            // stepper's own label would otherwise be just "5m" — restate the
-            // label and speak the value in full.
-            .accessibilityLabel(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
-            .accessibilityValue(String(format: OBALoc("stop_page.alarm.a11y_minutes_fmt", value: "%d minutes", comment: "VoiceOver value of the alarm lead-time stepper. %d is the number of minutes."), pendingMinutes))
-            Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
-                editing = false
-                onChange(pendingMinutes)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(onTimeColor)
-        }
-
-        if isAccessibilitySize {
-            VStack(alignment: .leading, spacing: 8) {
-                label
-                controls
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 10)
-        } else {
-            HStack {
-                label
-                Spacer()
-                controls
-            }
-            .padding(.top, 10)
-        }
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -30,7 +30,14 @@ struct AlarmControlView: View {
     /// does: fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
     @ScaledMetric(relativeTo: .body) private var bellCircleSize: CGFloat = 32
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     private var onTimeColor: Color { Color(uiColor: ThemeColors.shared.departureOnTime) }
+
+    /// At accessibility sizes the alarm block stacks (the guide's committed
+    /// layout): Change/Cancel drop below the label instead of competing with
+    /// it for one line's width.
+    private var isAccessibilitySize: Bool { dynamicTypeSize.isAccessibilitySize }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,36 +63,79 @@ struct AlarmControlView: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if !editing {
-                        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Reveals the alarm lead-time stepper")) {
-                            pendingMinutes = leadTimeMinutes
-                            editing = true
-                        }
-                        .buttonStyle(.bordered)
-                        Button(Strings.cancel, role: .destructive, action: onCancel)
-                            .buttonStyle(.bordered)
+                    if !editing && !isAccessibilitySize {
+                        changeCancelButtons
                     }
                 }
-                if editing {
-                    HStack {
-                        Text(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
-                            .font(.footnote.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Stepper(value: $pendingMinutes, in: AlarmLeadTime.minimumMinutes...max(AlarmLeadTime.minimumMinutes, maxLeadTime)) {
-                            Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
+                if !editing && isAccessibilitySize {
+                    // Side by side below the label when both fit; at the
+                    // largest sizes each becomes its own full-width row.
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 10) {
+                            changeCancelButtons
                         }
-                        .fixedSize()
-                        Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
-                            editing = false
-                            onChange(pendingMinutes)
+                        VStack(spacing: 10) {
+                            changeCancelButtons
                         }
-                        .buttonStyle(.borderedProminent)
-                        .tint(onTimeColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, 10)
                 }
+                if editing {
+                    editingControls
+                }
             }
+        }
+    }
+
+    /// Change + Cancel, shared by the inline (default) and stacked
+    /// (accessibility-size) placements.
+    @ViewBuilder
+    private var changeCancelButtons: some View {
+        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Reveals the alarm lead-time stepper")) {
+            pendingMinutes = leadTimeMinutes
+            editing = true
+        }
+        .buttonStyle(.bordered)
+        Button(Strings.cancel, role: .destructive, action: onCancel)
+            .buttonStyle(.bordered)
+    }
+
+    /// The lead-time stepper row. At accessibility sizes the label sits above
+    /// the stepper + Done controls instead of sharing their line.
+    @ViewBuilder
+    private var editingControls: some View {
+        let label = Text(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(.secondary)
+        let controls = HStack {
+            Stepper(value: $pendingMinutes, in: AlarmLeadTime.minimumMinutes...max(AlarmLeadTime.minimumMinutes, maxLeadTime)) {
+                Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
+            }
+            .fixedSize()
+            Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
+                editing = false
+                onChange(pendingMinutes)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(onTimeColor)
+        }
+
+        if isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 8) {
+                label
+                controls
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 10)
+        } else {
+            HStack {
+                label
+                Spacer()
+                controls
+            }
+            .padding(.top, 10)
         }
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -55,6 +55,7 @@ struct AlarmControlView: View {
                         .foregroundStyle(onTimeColor)
                         .frame(width: bellCircleSize, height: bellCircleSize)
                         .background(onTimeColor.opacity(0.14), in: Circle())
+                        .accessibilityHidden(true) // decorative; the "Alarm set" text carries the meaning
                     VStack(alignment: .leading, spacing: 1) {
                         Text(OBALoc("stop_page.alarm.set_title", value: "Alarm set", comment: "Title of the set-alarm info row"))
                             .font(.subheadline.weight(.bold))
@@ -114,6 +115,11 @@ struct AlarmControlView: View {
                 Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
             }
             .fixedSize()
+            // The visible "Minutes before" caption is a separate Text, so the
+            // stepper's own label would otherwise be just "5m" — restate the
+            // label and speak the value in full.
+            .accessibilityLabel(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
+            .accessibilityValue(String(format: OBALoc("stop_page.alarm.a11y_minutes_fmt", value: "%d minutes", comment: "VoiceOver value of the alarm lead-time stepper. %d is the number of minutes."), pendingMinutes))
             Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
                 editing = false
                 onChange(pendingMinutes)

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -44,11 +44,12 @@ struct AlarmControlView: View {
             if !alarmIsSet {
                 Button(action: onSet) {
                     Label(OBALoc("stop_page.alarm.set", value: "Set an alarm", comment: "Primary alarm button in the trip panel"), systemImage: "bell")
-                        .font(.subheadline.weight(.heavy))
                         .frame(maxWidth: .infinity, minHeight: 46)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(onTimeColor)
+                .tint(Color(uiColor: ThemeColors.shared.brand))
+                .foregroundStyle(.white)
+                .font(.body.weight(.semibold))
             } else {
                 HStack(spacing: 10) {
                     Image(systemName: "bell.fill")

--- a/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
@@ -14,7 +14,7 @@ import OBAKitCore
 /// once set, an info row with Change (inline stepper) and Cancel.
 ///
 /// Text uses Dynamic Type text styles; the fixed bell-circle dimension scales
-/// with `@ScaledMetric` (standing amendment 1).
+/// with Dynamic Type via `@ScaledMetric`.
 struct AlarmControlView: View {
     let alarmIsSet: Bool
     let leadTimeMinutes: Int
@@ -27,7 +27,7 @@ struct AlarmControlView: View {
     @State private var pendingMinutes: Int = AlarmLeadTime.defaultMinutes
 
     /// The bell circle grows with Dynamic Type the way the grouped alarm badge
-    /// does (standing amendment 1).
+    /// does: fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
     @ScaledMetric(relativeTo: .body) private var bellCircleSize: CGFloat = 32
 
     private var onTimeColor: Color { Color(uiColor: ThemeColors.shared.departureOnTime) }

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
@@ -1,0 +1,51 @@
+//
+//  ApproachSlice.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Abstraction over `TripStopTime` so the windowing logic is testable with
+/// stubs (the real type only decodes from JSON).
+protocol ApproachTimelineStop {
+    var stopID: StopID { get }
+    var stopName: String { get }
+}
+
+/// The trip panel's approach window: the user's stop plus up to 4 upstream
+/// stops, with the vehicle's position resolved from `closestStopID` — the
+/// same field the Trip screen uses (`TripStopListItem`).
+struct ApproachSlice<S: ApproachTimelineStop> {
+    let stops: [S]
+    let vehicleIndex: Int?
+
+    static func make(stopTimes: [S], userStopID: StopID, closestStopID: StopID?) -> ApproachSlice? {
+        guard let userIndex = stopTimes.firstIndex(where: { $0.stopID == userStopID }) else { return nil }
+
+        if let closestStopID,
+           let vehicleAbsolute = stopTimes.firstIndex(where: { $0.stopID == closestStopID }),
+           vehicleAbsolute > userIndex {
+            return nil // vehicle already past the user's stop
+        }
+
+        let start = max(0, userIndex - 4)
+        let window = Array(stopTimes[start...userIndex])
+        let vehicleIndex = closestStopID.flatMap { closest in
+            window.firstIndex(where: { $0.stopID == closest })
+        }
+        return ApproachSlice(stops: window, vehicleIndex: vehicleIndex)
+    }
+}
+
+/// Adapts the real REST model to the timeline windowing logic. `stopName`
+/// reads through the resolved `stop` reference — the same access
+/// `TripStopListItem`/`TripStopViewModel` use (`stopTime.stop.name`), which
+/// is populated by `loadReferences` before the trip panel ever renders.
+extension TripStopTime: ApproachTimelineStop {
+    var stopName: String { stop.name }
+}

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
@@ -20,25 +20,38 @@ protocol ApproachTimelineStop {
 /// The trip panel's approach window: the user's stop plus up to 4 upstream
 /// stops, with the vehicle's position resolved from `closestStopID` — the
 /// same field the Trip screen uses (`TripStopListItem`).
+///
+/// When the vehicle is further back than the window, its stop is pinned to
+/// the top of the slice and the stops between it and the final 3 upstream
+/// stops are elided; `skippedStopCount` says how many were dropped so the
+/// timeline can render a gap marker.
 struct ApproachSlice<S: ApproachTimelineStop> {
     let stops: [S]
     let vehicleIndex: Int?
+    /// Stops elided between `stops[0]` (the vehicle's stop) and `stops[1]`.
+    /// Zero when the window is contiguous.
+    let skippedStopCount: Int
 
     static func make(stopTimes: [S], userStopID: StopID, closestStopID: StopID?) -> ApproachSlice? {
         guard let userIndex = stopTimes.firstIndex(where: { $0.stopID == userStopID }) else { return nil }
 
-        if let closestStopID,
-           let vehicleAbsolute = stopTimes.firstIndex(where: { $0.stopID == closestStopID }),
-           vehicleAbsolute > userIndex {
+        let vehicleAbsolute = closestStopID.flatMap { closest in
+            stopTimes.firstIndex(where: { $0.stopID == closest })
+        }
+        if let vehicleAbsolute, vehicleAbsolute > userIndex {
             return nil // vehicle already past the user's stop
         }
 
         let start = max(0, userIndex - 4)
-        let window = Array(stopTimes[start...userIndex])
-        let vehicleIndex = closestStopID.flatMap { closest in
-            window.firstIndex(where: { $0.stopID == closest })
+        if let vehicleAbsolute, vehicleAbsolute < start {
+            // Vehicle is beyond the window: pin its stop on top, keep the 3
+            // stops nearest the user, and elide everything in between.
+            let window = [stopTimes[vehicleAbsolute]] + Array(stopTimes[(userIndex - 3)...userIndex])
+            return ApproachSlice(stops: window, vehicleIndex: 0, skippedStopCount: userIndex - 4 - vehicleAbsolute)
         }
-        return ApproachSlice(stops: window, vehicleIndex: vehicleIndex)
+
+        let window = Array(stopTimes[start...userIndex])
+        return ApproachSlice(stops: window, vehicleIndex: vehicleAbsolute.map { $0 - start }, skippedStopCount: 0)
     }
 }
 

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
@@ -32,14 +32,22 @@ struct ApproachSlice<S: ApproachTimelineStop> {
     /// Zero when the window is contiguous.
     let skippedStopCount: Int
 
-    static func make(stopTimes: [S], userStopID: StopID, closestStopID: StopID?) -> ApproachSlice? {
-        guard let userIndex = stopTimes.firstIndex(where: { $0.stopID == userStopID }) else { return nil }
+    /// - Parameter userStopSequence: The departure's position in the trip's stop
+    ///   times. A loop route visits the same stop at more than one sequence, so
+    ///   the stop ID alone can't say which visit this departure is for.
+    static func make(stopTimes: [S], userStopID: StopID, userStopSequence: Int? = nil, closestStopID: StopID?) -> ApproachSlice? {
+        guard let userIndex = userIndex(in: stopTimes, stopID: userStopID, stopSequence: userStopSequence) else { return nil }
 
-        let vehicleAbsolute = closestStopID.flatMap { closest in
-            stopTimes.firstIndex(where: { $0.stopID == closest })
-        }
-        if let vehicleAbsolute, vehicleAbsolute > userIndex {
-            return nil // vehicle already past the user's stop
+        var vehicleAbsolute: Int?
+        if let closest = closestStopID, stopTimes.contains(where: { $0.stopID == closest }) {
+            // The vehicle's closest stop can also appear more than once on a loop.
+            // The occurrence that matters is the last one at or before the user's
+            // stop — the leg the vehicle is on now. If every occurrence is
+            // downstream of the user's stop, the vehicle has already been through.
+            guard let index = stopTimes[...userIndex].lastIndex(where: { $0.stopID == closest }) else {
+                return nil // vehicle already past the user's stop
+            }
+            vehicleAbsolute = index
         }
 
         let start = max(0, userIndex - 4)
@@ -52,6 +60,17 @@ struct ApproachSlice<S: ApproachTimelineStop> {
 
         let window = Array(stopTimes[start...userIndex])
         return ApproachSlice(stops: window, vehicleIndex: vehicleAbsolute.map { $0 - start }, skippedStopCount: 0)
+    }
+
+    /// Resolves the departure's own visit to the user's stop. `stopSequence`
+    /// indexes the trip's stop times, so it picks out the right occurrence when a
+    /// loop route calls at the stop more than once; the stop-ID search is the
+    /// fallback for callers (and feeds) that don't supply one.
+    private static func userIndex(in stopTimes: [S], stopID: StopID, stopSequence: Int?) -> Int? {
+        if let stopSequence, stopTimes.indices.contains(stopSequence), stopTimes[stopSequence].stopID == stopID {
+            return stopSequence
+        }
+        return stopTimes.firstIndex(where: { $0.stopID == stopID })
     }
 }
 

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -1,0 +1,67 @@
+//
+//  ApproachTimelineView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Vertical line-and-dot approach timeline: upstream stops leading to the
+/// user's stop with a "bus here" marker at the vehicle's position. Live
+/// trips only (§4.1). Stops at/behind the bus are gray, stops between bus
+/// and user use the route color.
+///
+/// Dot sizes scale with Dynamic Type via `@ScaledMetric`; labels use text
+/// styles (standing amendment 1).
+struct ApproachTimelineView: View {
+    struct Row: Identifiable {
+        let id: String       // stopID
+        let name: String
+        let isUserStop: Bool
+        let isVehicleHere: Bool
+        let isPassed: Bool   // at or behind the vehicle
+    }
+
+    let rows: [Row]
+    let minutesAway: Int
+    let routeColor: Color
+
+    @ScaledMetric(relativeTo: .body) private var userDotSize: CGFloat = 12
+    @ScaledMetric(relativeTo: .body) private var stopDotSize: CGFloat = 9
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(rows) { row in
+                HStack(spacing: 12) {
+                    Circle()
+                        .strokeBorder(row.isPassed ? Color(uiColor: .quaternaryLabel) : routeColor, lineWidth: 2.5)
+                        .background(Circle().fill(row.isUserStop ? routeColor : Color.clear))
+                        .frame(width: row.isUserStop ? userDotSize : stopDotSize,
+                               height: row.isUserStop ? userDotSize : stopDotSize)
+                    Text(row.name)
+                        .font(.subheadline.weight(row.isUserStop ? .heavy : .medium))
+                        .foregroundStyle(row.isUserStop ? .primary : (row.isPassed ? Color(uiColor: .tertiaryLabel) : .secondary))
+                        .lineLimit(1)
+                    if row.isUserStop {
+                        Text(OBALoc("stop_page.timeline.your_stop", value: "· your stop", comment: "Marker on the user's stop in the approach timeline"))
+                            .font(.caption.weight(.bold)).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if row.isVehicleHere {
+                        Label(String(format: OBALoc("stop_page.timeline.bus_here_fmt", value: "bus here · %dm away", comment: "Vehicle-position pill. %d is minutes to the user's stop."), minutesAway), systemImage: "bus")
+                            .font(.caption2.weight(.heavy)).monospacedDigit()
+                            .foregroundStyle(routeColor)
+                            .padding(.horizontal, 8).padding(.vertical, 3)
+                            .background(routeColor.opacity(0.14), in: Capsule())
+                    }
+                }
+                .frame(minHeight: 30)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -11,14 +11,15 @@ import SwiftUI
 import OBAKitCore
 
 /// Vertical line-and-dot approach timeline: upstream stops leading to the
-/// user's stop with a "bus here" marker at the vehicle's position. Live
+/// user's stop with a bus-glyph dot marking the vehicle's position. Live
 /// trips only (§4.1).
 ///
 /// Per the comp: a continuous connector line runs through the dots — gray
 /// above the bus's position, route-colored from the bus down to the user's
 /// stop. Stops strictly behind the bus are small filled gray dots with dimmed
-/// names; the bus's stop and everything between it and the user are outlined
-/// route-color dots; the user's stop is a larger filled route-color dot.
+/// names; the vehicle's stop is a filled route-color dot containing the bus
+/// glyph; stops between it and the user are outlined route-color dots; the
+/// user's stop is a larger filled route-color dot.
 ///
 /// Dot sizes and line width scale with Dynamic Type via `@ScaledMetric`;
 /// labels use text styles.
@@ -34,9 +35,12 @@ struct ApproachTimelineView: View {
     let rows: [Row]
     let minutesAway: Int
     let routeColor: Color
+    /// Drives the glyph inside the vehicle-position dot (bus, light rail, …).
+    let routeType: Route.RouteType
 
     @ScaledMetric(relativeTo: .body) private var userDotSize: CGFloat = 14
     @ScaledMetric(relativeTo: .body) private var stopDotSize: CGFloat = 10
+    @ScaledMetric(relativeTo: .body) private var busDotSize: CGFloat = 22
     @ScaledMetric(relativeTo: .body) private var lineWidth: CGFloat = 2.5
 
     var body: some View {
@@ -53,13 +57,6 @@ struct ApproachTimelineView: View {
                             .font(.caption.weight(.bold)).foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if row.isVehicleHere {
-                        Label(String(format: OBALoc("stop_page.timeline.bus_here_fmt", value: "bus here · %dm away", comment: "Vehicle-position pill. %d is minutes to the user's stop."), minutesAway), systemImage: "bus.fill")
-                            .font(.caption2.weight(.heavy)).monospacedDigit()
-                            .foregroundStyle(routeColor)
-                            .padding(.horizontal, 8).padding(.vertical, 3)
-                            .background(routeColor.opacity(0.14), in: Capsule())
-                    }
                 }
                 .frame(minHeight: 32)
             }
@@ -95,12 +92,26 @@ struct ApproachTimelineView: View {
             }
             dot(for: row)
         }
-        .frame(width: userDotSize)
+        .frame(width: busDotSize)
     }
 
     @ViewBuilder
     private func dot(for row: Row) -> some View {
-        if row.isUserStop {
+        if row.isVehicleHere {
+            // The vehicle's position: the mode-appropriate transport glyph
+            // rides inside the dot itself rather than in a trailing pill.
+            Circle()
+                .fill(routeColor)
+                .frame(width: busDotSize, height: busDotSize)
+                .overlay {
+                    Image(uiImage: Icons.transportIcon(from: routeType))
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(.white)
+                        .frame(width: busDotSize * 0.55, height: busDotSize * 0.55)
+                }
+                .accessibilityLabel(String(format: OBALoc("stop_page.timeline.vehicle_here_fmt", value: "vehicle here · %dm away", comment: "Vehicle-position marker. %d is minutes to the user's stop."), minutesAway))
+        } else if row.isUserStop {
             Circle()
                 .fill(routeColor)
                 .frame(width: userDotSize, height: userDotSize)

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -37,6 +37,10 @@ struct ApproachTimelineView: View {
     let routeColor: Color
     /// Drives the glyph inside the vehicle-position dot (bus, light rail, …).
     let routeType: Route.RouteType
+    /// Stops elided between the vehicle's row (`rows[0]`) and `rows[1]` when
+    /// the vehicle is further back than the window (§4.1). When > 0, a
+    /// zig-zag gap row labeled with the count renders between them.
+    let skippedStopCount: Int
 
     @ScaledMetric(relativeTo: .body) private var userDotSize: CGFloat = 14
     @ScaledMetric(relativeTo: .body) private var stopDotSize: CGFloat = 10
@@ -59,9 +63,36 @@ struct ApproachTimelineView: View {
                     Spacer()
                 }
                 .frame(minHeight: 32)
+
+                if index == 0 && skippedStopCount > 0 {
+                    gapRow
+                }
             }
         }
         .accessibilityElement(children: .combine)
+    }
+
+    /// The elision marker between the vehicle's stop and the stops nearest
+    /// the user: a zig-zag continuation of the connector line with the
+    /// skipped-stop count alongside.
+    private var gapRow: some View {
+        HStack(spacing: 12) {
+            ZigZagLine()
+                .stroke(routeColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+                .frame(width: busDotSize)
+            Text(skippedStopsLabel)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(minHeight: 32)
+    }
+
+    private var skippedStopsLabel: String {
+        if skippedStopCount == 1 {
+            return OBALoc("stop_page.timeline.skipped_stop_one", value: "1 stop", comment: "Gap marker in the approach timeline when a single stop is elided between the vehicle and the stops shown")
+        }
+        return String(format: OBALoc("stop_page.timeline.skipped_stops_fmt", value: "%d stops", comment: "Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown."), skippedStopCount)
     }
 
     /// "Behind the bus" for styling: `isPassed` marks at-or-behind, but the
@@ -127,5 +158,21 @@ struct ApproachTimelineView: View {
                 .background(Circle().fill(Color(uiColor: .secondarySystemGroupedBackground)))
                 .frame(width: stopDotSize, height: stopDotSize)
         }
+    }
+}
+
+/// Vertical zig-zag connector segment for the timeline's gap row: enters at
+/// the top center and exits at the bottom center so it lines up with the
+/// straight connector halves above and below.
+private struct ZigZagLine: Shape {
+    func path(in rect: CGRect) -> Path {
+        let amplitude = min(rect.width / 2, 5)
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.midX - amplitude, y: rect.minY + rect.height * 0.3))
+        path.addLine(to: CGPoint(x: rect.midX + amplitude, y: rect.minY + rect.height * 0.55))
+        path.addLine(to: CGPoint(x: rect.midX - amplitude, y: rect.minY + rect.height * 0.8))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        return path
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -16,7 +16,7 @@ import OBAKitCore
 /// and user use the route color.
 ///
 /// Dot sizes scale with Dynamic Type via `@ScaledMetric`; labels use text
-/// styles (standing amendment 1).
+/// styles. Fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
 struct ApproachTimelineView: View {
     struct Row: Identifiable {
         let id: String       // stopID

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -12,11 +12,16 @@ import OBAKitCore
 
 /// Vertical line-and-dot approach timeline: upstream stops leading to the
 /// user's stop with a "bus here" marker at the vehicle's position. Live
-/// trips only (§4.1). Stops at/behind the bus are gray, stops between bus
-/// and user use the route color.
+/// trips only (§4.1).
 ///
-/// Dot sizes scale with Dynamic Type via `@ScaledMetric`; labels use text
-/// styles. Fixed dimensions scale with Dynamic Type via `@ScaledMetric`.
+/// Per the comp: a continuous connector line runs through the dots — gray
+/// above the bus's position, route-colored from the bus down to the user's
+/// stop. Stops strictly behind the bus are small filled gray dots with dimmed
+/// names; the bus's stop and everything between it and the user are outlined
+/// route-color dots; the user's stop is a larger filled route-color dot.
+///
+/// Dot sizes and line width scale with Dynamic Type via `@ScaledMetric`;
+/// labels use text styles.
 struct ApproachTimelineView: View {
     struct Row: Identifiable {
         let id: String       // stopID
@@ -30,21 +35,18 @@ struct ApproachTimelineView: View {
     let minutesAway: Int
     let routeColor: Color
 
-    @ScaledMetric(relativeTo: .body) private var userDotSize: CGFloat = 12
-    @ScaledMetric(relativeTo: .body) private var stopDotSize: CGFloat = 9
+    @ScaledMetric(relativeTo: .body) private var userDotSize: CGFloat = 14
+    @ScaledMetric(relativeTo: .body) private var stopDotSize: CGFloat = 10
+    @ScaledMetric(relativeTo: .body) private var lineWidth: CGFloat = 2.5
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(rows) { row in
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                 HStack(spacing: 12) {
-                    Circle()
-                        .strokeBorder(row.isPassed ? Color(uiColor: .quaternaryLabel) : routeColor, lineWidth: 2.5)
-                        .background(Circle().fill(row.isUserStop ? routeColor : Color.clear))
-                        .frame(width: row.isUserStop ? userDotSize : stopDotSize,
-                               height: row.isUserStop ? userDotSize : stopDotSize)
+                    connectorColumn(index: index, row: row)
                     Text(row.name)
                         .font(.subheadline.weight(row.isUserStop ? .heavy : .medium))
-                        .foregroundStyle(row.isUserStop ? .primary : (row.isPassed ? Color(uiColor: .tertiaryLabel) : .secondary))
+                        .foregroundStyle(row.isUserStop ? .primary : (isBehindBus(row) ? Color(uiColor: .tertiaryLabel) : .secondary))
                         .lineLimit(1)
                     if row.isUserStop {
                         Text(OBALoc("stop_page.timeline.your_stop", value: "· your stop", comment: "Marker on the user's stop in the approach timeline"))
@@ -52,16 +54,67 @@ struct ApproachTimelineView: View {
                     }
                     Spacer()
                     if row.isVehicleHere {
-                        Label(String(format: OBALoc("stop_page.timeline.bus_here_fmt", value: "bus here · %dm away", comment: "Vehicle-position pill. %d is minutes to the user's stop."), minutesAway), systemImage: "bus")
+                        Label(String(format: OBALoc("stop_page.timeline.bus_here_fmt", value: "bus here · %dm away", comment: "Vehicle-position pill. %d is minutes to the user's stop."), minutesAway), systemImage: "bus.fill")
                             .font(.caption2.weight(.heavy)).monospacedDigit()
                             .foregroundStyle(routeColor)
                             .padding(.horizontal, 8).padding(.vertical, 3)
                             .background(routeColor.opacity(0.14), in: Capsule())
                     }
                 }
-                .frame(minHeight: 30)
+                .frame(minHeight: 32)
             }
         }
         .accessibilityElement(children: .combine)
+    }
+
+    /// "Behind the bus" for styling: `isPassed` marks at-or-behind, but the
+    /// bus's own row renders active (colored dot, undimmed name) per the comp.
+    private func isBehindBus(_ row: Row) -> Bool {
+        row.isPassed && !row.isVehicleHere
+    }
+
+    /// Color of the connector segment hanging BELOW the row at `index` (down
+    /// to the next row): gray while still behind the bus, route color from the
+    /// bus's stop onward.
+    private func segmentColor(fromRowAt index: Int) -> Color {
+        isBehindBus(rows[index]) ? Color(uiColor: .systemGray4) : routeColor
+    }
+
+    /// The dot with its two connector half-segments behind it. The top half
+    /// continues the segment from the previous row; the bottom half starts
+    /// this row's own segment; first/last rows leave their outer half clear.
+    private func connectorColumn(index: Int, row: Row) -> some View {
+        ZStack {
+            VStack(spacing: 0) {
+                (index > 0 ? segmentColor(fromRowAt: index - 1) : Color.clear)
+                    .frame(width: lineWidth)
+                    .frame(maxHeight: .infinity)
+                (index < rows.count - 1 ? segmentColor(fromRowAt: index) : Color.clear)
+                    .frame(width: lineWidth)
+                    .frame(maxHeight: .infinity)
+            }
+            dot(for: row)
+        }
+        .frame(width: userDotSize)
+    }
+
+    @ViewBuilder
+    private func dot(for row: Row) -> some View {
+        if row.isUserStop {
+            Circle()
+                .fill(routeColor)
+                .frame(width: userDotSize, height: userDotSize)
+        } else if isBehindBus(row) {
+            Circle()
+                .fill(Color(uiColor: .systemGray3))
+                .frame(width: stopDotSize, height: stopDotSize)
+        } else {
+            // Opaque interior so the connector line doesn't show through the
+            // open ring.
+            Circle()
+                .strokeBorder(routeColor, lineWidth: lineWidth)
+                .background(Circle().fill(Color(uiColor: .secondarySystemGroupedBackground)))
+                .frame(width: stopDotSize, height: stopDotSize)
+        }
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
@@ -25,7 +25,10 @@ import OBAKitCore
 /// labels use text styles.
 struct ApproachTimelineView: View {
     struct Row: Identifiable {
-        let id: String       // stopID
+        /// Position-qualified, not the bare stop ID: a loop route can put the same
+        /// stop in the window twice, and duplicate `ForEach` identities collapse
+        /// the rows.
+        let id: String
         let name: String
         let isUserStop: Bool
         let isVehicleHere: Bool

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -35,6 +35,9 @@ struct TripDetailPanelView: View {
     let onSetAlarm: () -> Void
     let onCancelAlarm: () -> Void
     let onChangeAlarm: () -> Void
+    /// Region gate (`Region.supportsScheduleForRoute`), matching the row actions:
+    /// where route schedules aren't supported, the panel must not offer the flow.
+    let canSchedule: Bool
     let onSchedule: () -> Void
     let onBookmark: () -> Void
     let onViewFullTrip: () -> Void
@@ -86,12 +89,17 @@ struct TripDetailPanelView: View {
                 )
             }
 
-            TripPanelActionsRow(onSchedule: onSchedule, onBookmark: onBookmark, onViewFullTrip: onViewFullTrip)
+            TripPanelActionsRow(canSchedule: canSchedule, onSchedule: onSchedule, onBookmark: onBookmark, onViewFullTrip: onViewFullTrip)
         }
         .padding(.vertical, 6)
         .task(id: FetchKey(departureID: departure.id, refreshToken: refreshToken)) {
             guard status.isRealTime else { return }
             let details = await approachLoader()
+            // A refresh (or a collapse) restarts this task, but the superseded fetch
+            // can still land afterwards. Its result belongs to a request nobody is
+            // waiting on any more — writing it would clobber the live one, or mark
+            // the timeline unavailable while the current fetch is still in flight.
+            guard !Task.isCancelled else { return }
             // The skeleton pre-allocates the timeline's slot, so the first
             // result usually swaps in near the same height; animate the small
             // residual adjustment. Refetches swap data in place at the same
@@ -229,6 +237,7 @@ private struct ScheduledOnlyNotice: View {
 /// accessibility sizes the buttons stack so each is a full-width tap target
 /// (the guide's committed layout).
 private struct TripPanelActionsRow: View {
+    let canSchedule: Bool
     let onSchedule: () -> Void
     let onBookmark: () -> Void
     let onViewFullTrip: () -> Void
@@ -244,8 +253,10 @@ private struct TripPanelActionsRow: View {
                 Button(action: onBookmark) {
                     Label(Strings.addBookmark, systemImage: "bookmark")
                 }
-                Button(action: onSchedule) {
-                    Label(Strings.schedules, systemImage: "calendar")
+                if canSchedule {
+                    Button(action: onSchedule) {
+                        Label(Strings.schedules, systemImage: "calendar")
+                    }
                 }
             } label: {
                 Label(Strings.more, systemImage: "ellipsis.circle")

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -15,9 +15,8 @@ import OBAKitCore
 /// honesty notice), approach timeline, alarm control, and actions.
 ///
 /// The pure-value header sections (`TripPanelStatusStrip`, `ScheduledOnlyNotice`,
-/// `TripPanelActionsRow`) are factored into their own `View` types so the
-/// once-per-open `tripDetails` state change only re-renders the timeline
-/// section, not the whole panel.
+/// `TripPanelActionsRow`) are factored into their own `View` types so SwiftUI can
+/// skip re-diffing them when only `tripDetails` changes.
 struct TripDetailPanelView: View {
     let departure: ArrivalDeparture
     let status: DepartureStatus
@@ -169,7 +168,7 @@ private struct ScheduledOnlyNotice: View {
     }
 }
 
-/// Schedule + full-trip actions. No-op callbacks until Task 12 wires them.
+/// Schedule + full-trip actions, wired to ViewRouter navigation by the hosting page.
 private struct TripPanelActionsRow: View {
     let onSchedule: () -> Void
     let onViewFullTrip: () -> Void

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -119,7 +119,8 @@ struct TripDetailPanelView: View {
             ApproachTimelineView(
                 rows: timelineRows(slice),
                 minutesAway: departure.arrivalDepartureMinutes,
-                routeColor: routeColor
+                routeColor: routeColor,
+                routeType: departure.route.routeType
             )
         } else if !timelineUnavailable {
             ApproachTimelineSkeleton()

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -24,6 +24,9 @@ struct TripDetailPanelView: View {
     let alarm: Alarm?
     let alarmLeadTimeMinutes: Int
     let canAlarm: Bool
+    /// Changes on each successful stop refresh so the open panel re-fetches its
+    /// approach timeline instead of freezing on the first load.
+    let refreshToken: Date?
     let approachLoader: () async -> TripDetails?
     let onSetAlarm: () -> Void
     let onCancelAlarm: () -> Void
@@ -33,6 +36,14 @@ struct TripDetailPanelView: View {
 
     @State private var tripDetails: TripDetails?
     @State private var timelineLoading = false
+
+    /// Identity for the timeline `.task`: a change in either the departure or the
+    /// refresh token re-runs the fetch. Keeping the token in the key is what lets
+    /// an open panel refresh (and lets a nil first fetch retry).
+    private struct FetchKey: Hashable {
+        let departureID: String
+        let refreshToken: Date?
+    }
 
     private var routeColor: Color {
         Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
@@ -66,11 +77,16 @@ struct TripDetailPanelView: View {
             TripPanelActionsRow(onSchedule: onSchedule, onViewFullTrip: onViewFullTrip)
         }
         .padding(.vertical, 6)
-        .task(id: departure.id) {
-            guard status.isRealTime, tripDetails == nil else { return }
-            timelineLoading = true
-            tripDetails = await approachLoader()
+        .task(id: FetchKey(departureID: departure.id, refreshToken: refreshToken)) {
+            guard status.isRealTime else { return }
+            // Show the spinner only on the first load; on a token-driven refetch
+            // keep the previous timeline on screen to avoid flicker.
+            if tripDetails == nil { timelineLoading = true }
+            let details = await approachLoader()
             timelineLoading = false
+            // Only swap when the refetch returns data; a nil result (fetch failed
+            // or no live timeline) leaves the previously shown timeline in place.
+            if let details { tripDetails = details }
         }
     }
 

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -223,12 +223,19 @@ private struct ScheduledOnlyNotice: View {
 }
 
 /// Schedule + full-trip actions, wired to ViewRouter navigation by the hosting page.
+/// Half-width side-by-side by default; at accessibility sizes the buttons stack
+/// so each is a full-width tap target (the guide's committed layout).
 private struct TripPanelActionsRow: View {
     let onSchedule: () -> Void
     let onViewFullTrip: () -> Void
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     var body: some View {
-        HStack(spacing: 10) {
+        let layout = dynamicTypeSize.isAccessibilitySize
+            ? AnyLayout(VStackLayout(spacing: 10))
+            : AnyLayout(HStackLayout(spacing: 10))
+        layout {
             Button(action: onSchedule) {
                 Label(Strings.schedules, systemImage: "calendar")
                     .frame(maxWidth: .infinity, minHeight: 40)

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -134,6 +134,7 @@ struct TripDetailPanelView: View {
         return ApproachSlice.make(
             stopTimes: stopTimes,
             userStopID: departure.stopID,
+            userStopSequence: departure.stopSequence,
             closestStopID: departure.tripStatus?.closestStopID
         )
     }
@@ -141,7 +142,7 @@ struct TripDetailPanelView: View {
     private func timelineRows(_ slice: ApproachSlice<TripStopTime>) -> [ApproachTimelineView.Row] {
         slice.stops.enumerated().map { index, stopTime in
             ApproachTimelineView.Row(
-                id: stopTime.stopID,
+                id: "\(index)-\(stopTime.stopID)",
                 name: stopTime.stopName,
                 isUserStop: index == slice.stops.count - 1,
                 isVehicleHere: slice.vehicleIndex == index,

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -1,0 +1,175 @@
+//
+//  TripDetailPanelView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The shared "second tap" panel (§4.6), rendered as an inserted row beneath
+/// its departure in either mode: live-vehicle strip (or the scheduled-only
+/// honesty notice), approach timeline, alarm control, and actions.
+///
+/// The pure-value header sections (`TripPanelStatusStrip`, `ScheduledOnlyNotice`,
+/// `TripPanelActionsRow`) are factored into their own `View` types so the
+/// once-per-open `tripDetails` state change only re-renders the timeline
+/// section, not the whole panel.
+struct TripDetailPanelView: View {
+    let departure: ArrivalDeparture
+    let status: DepartureStatus
+    let alarm: Alarm?
+    let alarmLeadTimeMinutes: Int
+    let canAlarm: Bool
+    let approachLoader: () async -> TripDetails?
+    let onSetAlarm: () -> Void
+    let onCancelAlarm: () -> Void
+    let onChangeAlarm: (Int) -> Void
+    let onSchedule: () -> Void
+    let onViewFullTrip: () -> Void
+
+    @State private var tripDetails: TripDetails?
+    @State private var timelineLoading = false
+
+    private var routeColor: Color {
+        Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TripPanelStatusStrip(
+                isRealTime: status.isRealTime,
+                vehicleID: departure.vehicleID,
+                routeColor: routeColor
+            )
+
+            if status.isRealTime {
+                liveApproachSection
+            } else {
+                ScheduledOnlyNotice()
+            }
+
+            if canAlarm {
+                AlarmControlView(
+                    alarmIsSet: alarm != nil,
+                    leadTimeMinutes: alarmLeadTimeMinutes,
+                    maxLeadTime: min(AlarmLeadTime.maximumMinutes, departure.arrivalDepartureMinutes - 1),
+                    onSet: onSetAlarm,
+                    onCancel: onCancelAlarm,
+                    onChange: onChangeAlarm
+                )
+            }
+
+            TripPanelActionsRow(onSchedule: onSchedule, onViewFullTrip: onViewFullTrip)
+        }
+        .padding(.vertical, 6)
+        .task(id: departure.id) {
+            guard status.isRealTime, tripDetails == nil else { return }
+            timelineLoading = true
+            tripDetails = await approachLoader()
+            timelineLoading = false
+        }
+    }
+
+    /// Timeline (or its loading spinner). Kept in the parent because it reads the
+    /// `tripDetails`/`timelineLoading` state; a fetch failure or a vehicle that's
+    /// already past the window renders nothing (silently omitted, §4.1).
+    @ViewBuilder
+    private var liveApproachSection: some View {
+        if let slice = approachSlice {
+            ApproachTimelineView(
+                rows: timelineRows(slice),
+                minutesAway: departure.arrivalDepartureMinutes,
+                routeColor: routeColor
+            )
+        } else if timelineLoading {
+            ProgressView().frame(maxWidth: .infinity)
+        }
+    }
+
+    private var approachSlice: ApproachSlice<TripStopTime>? {
+        guard let stopTimes = tripDetails?.stopTimes else { return nil }
+        return ApproachSlice.make(
+            stopTimes: stopTimes,
+            userStopID: departure.stopID,
+            closestStopID: departure.tripStatus?.closestStopID
+        )
+    }
+
+    private func timelineRows(_ slice: ApproachSlice<TripStopTime>) -> [ApproachTimelineView.Row] {
+        slice.stops.enumerated().map { index, stopTime in
+            ApproachTimelineView.Row(
+                id: stopTime.stopID,
+                name: stopTime.stopName,
+                isUserStop: index == slice.stops.count - 1,
+                isVehicleHere: slice.vehicleIndex == index,
+                isPassed: slice.vehicleIndex.map { index <= $0 } ?? false
+            )
+        }
+    }
+}
+
+/// Live-vehicle strip, or the schedule-only strip when there's no real-time
+/// position (§4.1). Pure values so it never re-renders on the panel's timeline
+/// fetch.
+private struct TripPanelStatusStrip: View {
+    let isRealTime: Bool
+    let vehicleID: String?
+    let routeColor: Color
+
+    var body: some View {
+        HStack(spacing: 8) {
+            RealtimeGlyph(isRealTime: isRealTime, color: routeColor, size: 15)
+            if isRealTime {
+                Text(String(format: OBALoc("stop_page.panel.live_vehicle_fmt", value: "Live · vehicle %@", comment: "Trip panel live strip. %@ is the vehicle id."), vehicleID ?? "—"))
+                    .font(.footnote.weight(.bold))
+            } else {
+                Text(OBALoc("stop_page.panel.scheduled_strip", value: "Scheduled · no live position yet", comment: "Trip panel strip for schedule-only trips"))
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// The schedule-only honesty notice (§4.1/§4.4): shown instead of the approach
+/// timeline when the trip has no live signal, and never alongside occupancy.
+private struct ScheduledOnlyNotice: View {
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(OBALoc("stop_page.panel.scheduled_title", value: "Scheduled time only", comment: "Title of the schedule-only notice"))
+                    .font(.footnote.weight(.bold))
+                Text(OBALoc("stop_page.panel.scheduled_body", value: "No live signal from this bus yet — this is when it's supposed to arrive. It may run early, late, or not at all.", comment: "Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4)"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: "calendar").foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// Schedule + full-trip actions. No-op callbacks until Task 12 wires them.
+private struct TripPanelActionsRow: View {
+    let onSchedule: () -> Void
+    let onViewFullTrip: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: onSchedule) {
+                Label(Strings.schedules, systemImage: "calendar")
+                    .frame(maxWidth: .infinity, minHeight: 40)
+            }
+            .buttonStyle(.bordered)
+            Button(action: onViewFullTrip) {
+                Label(OBALoc("stop_page.panel.full_trip", value: "View full trip", comment: "Opens the full trip screen"), systemImage: "bus")
+                    .frame(maxWidth: .infinity, minHeight: 40)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -34,7 +34,7 @@ struct TripDetailPanelView: View {
     let approachLoader: () async -> TripDetails?
     let onSetAlarm: () -> Void
     let onCancelAlarm: () -> Void
-    let onChangeAlarm: (Int) -> Void
+    let onChangeAlarm: () -> Void
     let onSchedule: () -> Void
     let onBookmark: () -> Void
     let onViewFullTrip: () -> Void
@@ -80,7 +80,6 @@ struct TripDetailPanelView: View {
                 AlarmControlView(
                     alarmIsSet: alarm != nil,
                     leadTimeMinutes: alarmLeadTimeMinutes,
-                    maxLeadTime: AlarmLeadTime.ceiling(minutesUntilDeparture: departure.arrivalDepartureMinutes),
                     onSet: onSetAlarm,
                     onCancel: onCancelAlarm,
                     onChange: onChangeAlarm

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -67,7 +67,7 @@ struct TripDetailPanelView: View {
                 AlarmControlView(
                     alarmIsSet: alarm != nil,
                     leadTimeMinutes: alarmLeadTimeMinutes,
-                    maxLeadTime: min(AlarmLeadTime.maximumMinutes, departure.arrivalDepartureMinutes - 1),
+                    maxLeadTime: AlarmLeadTime.ceiling(minutesUntilDeparture: departure.arrivalDepartureMinutes),
                     onSet: onSetAlarm,
                     onCancel: onCancelAlarm,
                     onChange: onChangeAlarm

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -62,11 +62,12 @@ struct TripDetailPanelView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            TripPanelStatusStrip(
-                isRealTime: status.isRealTime,
-                vehicleID: departure.vehicleID,
-                routeColor: routeColor
-            )
+            if status.isRealTime {
+                TripPanelStatusStrip(
+                    vehicleID: departure.vehicleID,
+                    routeColor: routeColor
+                )
+            }
 
             if status.isRealTime {
                 liveApproachSection
@@ -191,21 +192,14 @@ private struct ApproachTimelineSkeleton: View {
 /// position (§4.1). Pure values so it never re-renders on the panel's timeline
 /// fetch.
 private struct TripPanelStatusStrip: View {
-    let isRealTime: Bool
     let vehicleID: String?
     let routeColor: Color
 
     var body: some View {
         HStack(spacing: 8) {
-            RealtimeGlyph(isRealTime: isRealTime, color: routeColor, size: 15)
-            if isRealTime {
-                Text(String(format: OBALoc("stop_page.panel.live_vehicle_fmt", value: "Live · vehicle %@", comment: "Trip panel live strip. %@ is the vehicle id."), vehicleID ?? "—"))
-                    .font(.footnote.weight(.bold))
-            } else {
-                Text(OBALoc("stop_page.panel.scheduled_strip", value: "Scheduled · no live position yet", comment: "Trip panel strip for schedule-only trips"))
-                    .font(.footnote.weight(.bold))
-                    .foregroundStyle(.secondary)
-            }
+            RealtimeGlyph(isRealTime: true, color: routeColor, size: 15)
+            Text(String(format: OBALoc("stop_page.panel.live_vehicle_fmt", value: "Live · vehicle %@", comment: "Trip panel live strip. %@ is the vehicle id."), vehicleID ?? "—"))
+                .font(.footnote.weight(.bold))
         }
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -239,12 +239,14 @@ private struct TripPanelActionsRow: View {
                 Label(Strings.schedules, systemImage: "calendar")
                     .frame(maxWidth: .infinity, minHeight: 40)
             }
-            .buttonStyle(.bordered)
             Button(action: onViewFullTrip) {
-                Label(OBALoc("stop_page.panel.full_trip", value: "View full trip", comment: "Opens the full trip screen"), systemImage: "bus")
+                Label(OBALoc("stop_page.panel.full_trip", value: "View full trip", comment: "Opens the full trip screen"), systemImage: "point.bottomleft.forward.to.point.topright.scurvepath")
                     .frame(maxWidth: .infinity, minHeight: 40)
             }
-            .buttonStyle(.bordered)
         }
+        .buttonStyle(.borderedProminent)
+        .tint(Color(uiColor: ThemeColors.shared.brand))
+        .foregroundStyle(.white)
+        .font(.body.weight(.semibold))
     }
 }

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -36,6 +36,7 @@ struct TripDetailPanelView: View {
     let onCancelAlarm: () -> Void
     let onChangeAlarm: (Int) -> Void
     let onSchedule: () -> Void
+    let onBookmark: () -> Void
     let onViewFullTrip: () -> Void
 
     @State private var tripDetails: TripDetails?
@@ -86,7 +87,7 @@ struct TripDetailPanelView: View {
                 )
             }
 
-            TripPanelActionsRow(onSchedule: onSchedule, onViewFullTrip: onViewFullTrip)
+            TripPanelActionsRow(onSchedule: onSchedule, onBookmark: onBookmark, onViewFullTrip: onViewFullTrip)
         }
         .padding(.vertical, 6)
         .task(id: FetchKey(departureID: departure.id, refreshToken: refreshToken)) {
@@ -222,11 +223,13 @@ private struct ScheduledOnlyNotice: View {
     }
 }
 
-/// Schedule + full-trip actions, wired to ViewRouter navigation by the hosting page.
-/// Half-width side-by-side by default; at accessibility sizes the buttons stack
-/// so each is a full-width tap target (the guide's committed layout).
+/// More menu (Add Bookmark / Schedules) + full-trip action, wired to ViewRouter
+/// navigation by the hosting page. Half-width side-by-side by default; at
+/// accessibility sizes the buttons stack so each is a full-width tap target
+/// (the guide's committed layout).
 private struct TripPanelActionsRow: View {
     let onSchedule: () -> Void
+    let onBookmark: () -> Void
     let onViewFullTrip: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -236,8 +239,15 @@ private struct TripPanelActionsRow: View {
             ? AnyLayout(VStackLayout(spacing: 10))
             : AnyLayout(HStackLayout(spacing: 10))
         layout {
-            Button(action: onSchedule) {
-                Label(Strings.schedules, systemImage: "calendar")
+            Menu {
+                Button(action: onBookmark) {
+                    Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+                Button(action: onSchedule) {
+                    Label(Strings.schedules, systemImage: "calendar")
+                }
+            } label: {
+                Label(Strings.more, systemImage: "ellipsis.circle")
                     .frame(maxWidth: .infinity, minHeight: 40)
             }
             Button(action: onViewFullTrip) {

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -26,6 +26,11 @@ struct TripDetailPanelView: View {
     /// Changes on each successful stop refresh so the open panel re-fetches its
     /// approach timeline instead of freezing on the first load.
     let refreshToken: Date?
+    /// Warm-cache seed, read synchronously from the VM when the panel is built.
+    /// With it, the timeline is on screen at full size the frame the accordion
+    /// row is inserted, so the insert animation targets the correct final
+    /// height instead of the row popping when the async fetch lands.
+    let cachedTripDetails: TripDetails?
     let approachLoader: () async -> TripDetails?
     let onSetAlarm: () -> Void
     let onCancelAlarm: () -> Void
@@ -35,6 +40,10 @@ struct TripDetailPanelView: View {
 
     @State private var tripDetails: TripDetails?
     @State private var timelineLoading = false
+
+    /// What the timeline renders: the async fetch result once it lands, else
+    /// the synchronous warm-cache seed.
+    private var resolvedTripDetails: TripDetails? { tripDetails ?? cachedTripDetails }
 
     /// Identity for the timeline `.task`: a change in either the departure or the
     /// refresh token re-runs the fetch. Keeping the token in the key is what lets
@@ -78,14 +87,22 @@ struct TripDetailPanelView: View {
         .padding(.vertical, 6)
         .task(id: FetchKey(departureID: departure.id, refreshToken: refreshToken)) {
             guard status.isRealTime else { return }
-            // Show the spinner only on the first load; on a token-driven refetch
-            // keep the previous timeline on screen to avoid flicker.
-            if tripDetails == nil { timelineLoading = true }
+            // Show the spinner only when there's no timeline to show; with a
+            // warm-cache seed or on a token-driven refetch keep the current
+            // timeline on screen to avoid flicker.
+            if resolvedTripDetails == nil {
+                withAnimation(.snappy) { timelineLoading = true }
+            }
             let details = await approachLoader()
-            timelineLoading = false
-            // Only swap when the refetch returns data; a nil result (fetch failed
-            // or no live timeline) leaves the previously shown timeline in place.
-            if let details { tripDetails = details }
+            // The first content to arrive after the row is already on screen
+            // changes the row's height, so animate the growth; refetches swap
+            // data in place at the same height and stay non-animated. A nil
+            // result (fetch failed or no live timeline) leaves the previously
+            // shown timeline in place.
+            withAnimation(resolvedTripDetails == nil ? .snappy : nil) {
+                timelineLoading = false
+                if let details { tripDetails = details }
+            }
         }
     }
 
@@ -106,7 +123,7 @@ struct TripDetailPanelView: View {
     }
 
     private var approachSlice: ApproachSlice<TripStopTime>? {
-        guard let stopTimes = tripDetails?.stopTimes else { return nil }
+        guard let stopTimes = resolvedTripDetails?.stopTimes else { return nil }
         return ApproachSlice.make(
             stopTimes: stopTimes,
             userStopID: departure.stopID,

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -121,7 +121,8 @@ struct TripDetailPanelView: View {
                 rows: timelineRows(slice),
                 minutesAway: departure.arrivalDepartureMinutes,
                 routeColor: routeColor,
-                routeType: departure.route.routeType
+                routeType: departure.route.routeType,
+                skippedStopCount: slice.skippedStopCount
             )
         } else if !timelineUnavailable {
             ApproachTimelineSkeleton()

--- a/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+++ b/OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
@@ -39,7 +39,10 @@ struct TripDetailPanelView: View {
     let onViewFullTrip: () -> Void
 
     @State private var tripDetails: TripDetails?
-    @State private var timelineLoading = false
+    /// Set when the fetch completes with nothing to show (failed, or the
+    /// vehicle is past the approach window) so the pre-allocated skeleton
+    /// collapses instead of pulsing forever.
+    @State private var timelineUnavailable = false
 
     /// What the timeline renders: the async fetch result once it lands, else
     /// the synchronous warm-cache seed.
@@ -87,28 +90,29 @@ struct TripDetailPanelView: View {
         .padding(.vertical, 6)
         .task(id: FetchKey(departureID: departure.id, refreshToken: refreshToken)) {
             guard status.isRealTime else { return }
-            // Show the spinner only when there's no timeline to show; with a
-            // warm-cache seed or on a token-driven refetch keep the current
-            // timeline on screen to avoid flicker.
-            if resolvedTripDetails == nil {
-                withAnimation(.snappy) { timelineLoading = true }
-            }
             let details = await approachLoader()
-            // The first content to arrive after the row is already on screen
-            // changes the row's height, so animate the growth; refetches swap
-            // data in place at the same height and stay non-animated. A nil
-            // result (fetch failed or no live timeline) leaves the previously
-            // shown timeline in place.
+            // The skeleton pre-allocates the timeline's slot, so the first
+            // result usually swaps in near the same height; animate the small
+            // residual adjustment. Refetches swap data in place at the same
+            // height and stay non-animated. A nil result while a timeline is
+            // showing leaves it in place; nil with only the skeleton showing
+            // collapses the slot (§4.1 silently omits the timeline).
             withAnimation(resolvedTripDetails == nil ? .snappy : nil) {
-                timelineLoading = false
-                if let details { tripDetails = details }
+                if let details {
+                    tripDetails = details
+                } else if resolvedTripDetails == nil {
+                    timelineUnavailable = true
+                }
             }
         }
     }
 
-    /// Timeline (or its loading spinner). Kept in the parent because it reads the
-    /// `tripDetails`/`timelineLoading` state; a fetch failure or a vehicle that's
-    /// already past the window renders nothing (silently omitted, §4.1).
+    /// Timeline (or its fixed-height skeleton). The skeleton renders from the
+    /// panel's very first frame so a real-time panel opens with the timeline's
+    /// space already allocated instead of popping taller when the async fetch
+    /// lands. Kept in the parent because it reads the panel's state; a fetch
+    /// failure or a vehicle that's already past the window collapses to
+    /// nothing (silently omitted, §4.1).
     @ViewBuilder
     private var liveApproachSection: some View {
         if let slice = approachSlice {
@@ -117,8 +121,8 @@ struct TripDetailPanelView: View {
                 minutesAway: departure.arrivalDepartureMinutes,
                 routeColor: routeColor
             )
-        } else if timelineLoading {
-            ProgressView().frame(maxWidth: .infinity)
+        } else if !timelineUnavailable {
+            ApproachTimelineSkeleton()
         }
     }
 
@@ -141,6 +145,44 @@ struct TripDetailPanelView: View {
                 isPassed: slice.vehicleIndex.map { index <= $0 } ?? false
             )
         }
+    }
+}
+
+/// Placeholder occupying the approach timeline's slot while the fetch is in
+/// flight. Fixed at 150pt so the accordion insert animation targets (roughly)
+/// the panel's final height instead of the row popping when the timeline
+/// lands. The pulse is gated on Reduce Motion, matching `LiveStatusRow`.
+private struct ApproachTimelineSkeleton: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsing = false
+
+    /// Deterministic per-row bar widths, echoing the varied stop-name lengths
+    /// of the real timeline.
+    private static let barWidths: [CGFloat] = [150, 120, 165, 130, 180]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ForEach(Array(Self.barWidths.enumerated()), id: \.offset) { _, width in
+                HStack(spacing: 12) {
+                    Circle()
+                        .fill(Color(uiColor: .tertiarySystemFill))
+                        .frame(width: 10, height: 10)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(uiColor: .tertiarySystemFill))
+                        .frame(width: width, height: 12)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 150, alignment: .top)
+        .opacity(reduceMotion ? 1 : (pulsing ? 0.45 : 1))
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+                pulsing = true
+            }
+        }
+        .accessibilityHidden(true)
     }
 }
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -767,14 +767,8 @@
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Display test alerts";
 
-/* Settings > Alerts section > 10-minute alarm lead time option */
-"settings_controller.alerts_section.lead_time_10min" = "10 min";
-
-/* Settings > Alerts section > 2-minute alarm lead time option */
-"settings_controller.alerts_section.lead_time_2min" = "2 min";
-
-/* Settings > Alerts section > 5-minute alarm lead time option */
-"settings_controller.alerts_section.lead_time_5min" = "5 min";
+/* Lead-time segment label. %d is minutes. */
+"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Agency Alerts";
@@ -982,6 +976,12 @@
 
 /* Fallback title for a service alert that has no summary text. */
 "stop_page.service_alert_fallback" = "Service alert";
+
+/* Collapsed summary row for the service alerts section. %d is the number of alerts. */
+"stop_page.service_alerts.summary_fmt" = "%d service alerts";
+
+/* Collapsed summary row for the service alerts section when exactly one alert applies. */
+"stop_page.service_alerts.summary_one" = "1 service alert";
 
 /* VoiceOver status suffix for a live departure. %@ is the adherence label. */
 "stop_page.status.a11y_live_fmt" = "live tracking, %@";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -761,8 +761,20 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibility";
 
+/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
+"settings_controller.alerts_section.default_alarm_lead_time" = "Default alarm lead time";
+
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Display test alerts";
+
+/* Settings > Alerts section > 10-minute alarm lead time option */
+"settings_controller.alerts_section.lead_time_10min" = "10 min";
+
+/* Settings > Alerts section > 2-minute alarm lead time option */
+"settings_controller.alerts_section.lead_time_2min" = "2 min";
+
+/* Settings > Alerts section > 5-minute alarm lead time option */
+"settings_controller.alerts_section.lead_time_5min" = "5 min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Agency Alerts";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1001,6 +1001,12 @@
 /* Vehicle-position pill. %d is minutes to the user's stop. */
 "stop_page.timeline.bus_here_fmt" = "bus here · %dm away";
 
+/* Gap marker in the approach timeline when a single stop is elided between the vehicle and the stops shown */
+"stop_page.timeline.skipped_stop_one" = "1 stop";
+
+/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. */
+"stop_page.timeline.skipped_stops_fmt" = "%d stops";
+
 /* Marker on the user's stop in the approach timeline */
 "stop_page.timeline.your_stop" = "· your stop";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -920,9 +920,6 @@
 /* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
 "stop_page.grouped.expanded_row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
 
-/* Empty upcoming-chips state; must never imply no later trips exist (§4.4) */
-"stop_page.grouped.not_loaded" = "later trips not loaded";
-
 /* Extends the departure time window */
 "stop_page.load_more" = "Load more";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -794,6 +794,9 @@
 /* Settings > Experimental section > Footer indicating changes apply on relaunch */
 "settings_controller.experimental_section.map_panel.footer" = "Restart the app to apply.";
 
+/* Settings > Experimental section > New stop page toggle */
+"settings_controller.experimental_section.new_stop_page" = "Use new stop page";
+
 /* Settings > Experimental section title */
 "settings_controller.experimental_section.title" = "Experimental";
 
@@ -880,6 +883,138 @@
 
 /* Button to reveal departures that leave before the rider's transfer arrival. Parameter is the count of hidden departures. */
 "stop_controller.transfer_show_earlier_departures_fmt" = "Show %d earlier departures";
+
+/* Subtitle of the set-alarm info row. %d is lead-time minutes. */
+"stop_page.alarm.buzz_fmt" = "Buzz %d min before it arrives";
+
+/* Reveals the alarm lead-time stepper */
+"stop_page.alarm.change" = "Change";
+
+/* Commits the lead-time change */
+"stop_page.alarm.done" = "Done";
+
+/* Stepper label */
+"stop_page.alarm.minutes_before" = "Minutes before";
+
+/* Primary alarm button in the trip panel */
+"stop_page.alarm.set" = "Set an alarm";
+
+/* Title of the set-alarm info row */
+"stop_page.alarm.set_title" = "Alarm set";
+
+/* Empty state shown when every route at the stop is hidden by the user's filter. */
+"stop_page.empty.all_filtered" = "All routes at this stop are filtered";
+
+/* Empty state shown when the stop has no upcoming departures within the loaded time window. %d is the number of minutes. */
+"stop_page.empty.no_departures_fmt" = "No departures in the next %d minutes";
+
+/* Button that retries loading departures after an error. */
+"stop_page.empty.retry" = "Retry";
+
+/* Button that clears the route filter so all routes are shown. */
+"stop_page.empty.show_all_routes" = "Show all routes";
+
+/* VoiceOver label for a grouped route card */
+"stop_page.grouped.a11y_fmt" = "Route %1$@ to %2$@, next departure in %3$d minutes, %4$@. %5$d more departures loaded.";
+
+/* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
+"stop_page.grouped.a11y_remove_alarm" = "Remove alarm";
+
+/* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
+"stop_page.grouped.a11y_set_alarm" = "Set alarm";
+
+/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
+"stop_page.grouped.expanded_row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
+
+/* Empty upcoming-chips state; must never imply no later trips exist (§4.4) */
+"stop_page.grouped.not_loaded" = "later trips not loaded";
+
+/* Extends the departure time window */
+"stop_page.load_more" = "Load more";
+
+/* Stop page mode toggle: grouped by route */
+"stop_page.mode.by_route" = "By route";
+
+/* Stop page mode toggle: flat time-sorted list */
+"stop_page.mode.chronological" = "Chronological";
+
+/* Opens the full trip screen */
+"stop_page.panel.full_trip" = "View full trip";
+
+/* Trip panel live strip. %@ is the vehicle id. */
+"stop_page.panel.live_vehicle_fmt" = "Live · vehicle %@";
+
+/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
+"stop_page.panel.scheduled_body" = "No live signal from this bus yet — this is when it's supposed to arrive. It may run early, late, or not at all.";
+
+/* Trip panel strip for schedule-only trips */
+"stop_page.panel.scheduled_strip" = "Scheduled · no live position yet";
+
+/* Title of the schedule-only notice */
+"stop_page.panel.scheduled_title" = "Scheduled time only";
+
+/* Button revealing recently departed trips. %d is the count. */
+"stop_page.past_toggle_fmt" = "Past · %d";
+
+/* Button hiding recently departed trips */
+"stop_page.past_toggle_hide" = "Hide past";
+
+/* VoiceOver suffix indicating a departure alarm is active */
+"stop_page.row.a11y_alarm_set" = "alarm set";
+
+/* VoiceOver label for a departure row: route, headsign, minutes, status. */
+"stop_page.row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
+
+/* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
+"stop_page.row.a11y_missed" = "likely missed — departs sooner than your walk to the stop";
+
+/* VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status. */
+"stop_page.row.a11y_past_fmt" = "Route %1$@ to %2$@, departed %3$d minutes ago, %4$@";
+
+/* Swipe/context menu action that cancels an existing arrival alarm. */
+"stop_page.row.remove_alarm" = "Remove Alarm";
+
+/* Context menu action opening the full trip screen */
+"stop_page.row.show_trip" = "Show Trip Details";
+
+/* Chronological list section header */
+"stop_page.section.arrivals_departures" = "Arrivals & Departures";
+
+/* Fallback title for a service alert that has no summary text. */
+"stop_page.service_alert_fallback" = "Service alert";
+
+/* VoiceOver status suffix for a live departure. %@ is the adherence label. */
+"stop_page.status.a11y_live_fmt" = "live tracking, %@";
+
+/* VoiceOver status suffix for a schedule-only departure */
+"stop_page.status.a11y_scheduled" = "scheduled time only, no live data";
+
+/* Adherence label for an early departure. %d is minutes early. */
+"stop_page.status.early_fmt" = "%d min early";
+
+/* Adherence label for a late departure. %d is minutes late. */
+"stop_page.status.late_fmt" = "%d min late";
+
+/* Adherence label for an on-time departure */
+"stop_page.status.on_time" = "on time";
+
+/* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
+"stop_page.status.schedule_data" = "schedule data";
+
+/* Vehicle-position pill. %d is minutes to the user's stop. */
+"stop_page.timeline.bus_here_fmt" = "bus here · %dm away";
+
+/* Marker on the user's stop in the approach timeline */
+"stop_page.timeline.your_stop" = "· your stop";
+
+/* Walk chip on the header card. %d minutes, %@ formatted distance. */
+"stop_page.walk_chip_fmt" = "%1$d min walk · %2$@";
+
+/* VoiceOver description of the walk divider. %d is walk minutes. */
+"stop_page.walk_divider_a11y_fmt" = "Departures above this point leave sooner than your %d minute walk to the stop";
+
+/* Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes. */
+"stop_page.walk_divider_fmt" = "%d MIN WALK — CATCH BELOW";
 
 /* Title of the Sorting section */
 "stop_preferences_controller.sorting_section.header_title" = "Sort By";

--- a/OBAKit/Theme/Icons.swift
+++ b/OBAKit/Theme/Icons.swift
@@ -259,6 +259,51 @@ class Icons: NSObject {
         imageNamed("walkTransport")
     }
 
+    // MARK: - Squircle icon
+
+    private static var iconCache = [Route.RouteType: UIImage]()
+    public static var squircleIconSize: CGFloat = 40
+
+    /// The transport glyph in white over a brand-color gradient squircle,
+    /// echoing the stop page's `RouteBadgeView` treatment.
+    public static func squircleTransportIcon(for routeType: Route.RouteType) -> UIImage {
+        if let cached = iconCache[routeType] { return cached }
+
+        let rect = CGRect(x: 0, y: 0, width: squircleIconSize, height: squircleIconSize)
+        let image = UIGraphicsImageRenderer(bounds: rect).image { context in
+            let brand = ThemeColors.shared.brand
+            UIBezierPath(roundedRect: rect, cornerRadius: squircleIconSize * 0.28).addClip()
+
+            let colors = [
+                brand.blended(with: .white, amount: 0.18).cgColor,
+                brand.blended(with: .black, amount: 0.12).cgColor
+            ]
+            if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: colors as CFArray, locations: [0, 1]) {
+                context.cgContext.drawLinearGradient(
+                    gradient,
+                    start: CGPoint(x: rect.midX, y: rect.minY),
+                    end: CGPoint(x: rect.midX, y: rect.maxY),
+                    options: [])
+            } else {
+                brand.setFill()
+                context.fill(rect)
+            }
+
+            let glyph = Icons.transportIcon(from: routeType).withTintColor(.white, renderingMode: .alwaysOriginal)
+            let maxGlyphExtent = squircleIconSize * 0.55
+            let scale = min(maxGlyphExtent / glyph.size.width, maxGlyphExtent / glyph.size.height)
+            let glyphSize = CGSize(width: glyph.size.width * scale, height: glyph.size.height * scale)
+            glyph.draw(in: CGRect(
+                x: rect.midX - glyphSize.width / 2.0,
+                y: rect.midY - glyphSize.height / 2.0,
+                width: glyphSize.width,
+                height: glyphSize.height))
+        }.withRenderingMode(.alwaysOriginal)
+
+        iconCache[routeType] = image
+        return image
+    }
+
     // MARK: - Private Helpers
 
     /// This applies the configuration used for generating tab bar icons.

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -356,7 +356,13 @@ class TripFloatingPanelController: UIViewController,
         }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = self.application.viewRouter.makeStopController(stopID: tripStop.stop.id)
+            // Committing the preview pushes this exact controller, so it has to be
+            // built the same way `onSelectTripStop` builds it — with the transfer
+            // context, which also decides whether the stop opens on the legacy screen.
+            let stopVC = self.application.viewRouter.makeStopController(
+                stop: tripStop.stop,
+                transferContext: self.buildTransferContext(for: tripStop)
+            )
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -356,7 +356,7 @@ class TripFloatingPanelController: UIViewController,
         }
 
         let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
-            let stopVC = StopViewController(application: self.application, stopID: tripStop.stop.id)
+            let stopVC = self.application.viewRouter.makeStopController(stopID: tripStop.stop.id)
             self.currentPreviewingViewController = stopVC
             return stopVC
         }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -89,6 +89,17 @@ class StopViewModel: ObservableObject {
     /// so auto-extension is exhausted (capped at 12 h).
     @Published private(set) var isLoadMoreExhausted = false
 
+    /// Alarms owned by this stop's departures, keyed by `ArrivalDeparture.id`.
+    /// All four alarm entry points (swipe, pill, row icon, trip panel) read and
+    /// write through this single index (§4.7).
+    @Published private(set) var alarmsByDepartureID: [String: Alarm] = [:]
+
+    /// Non-nil after an alarm create/cancel fails; consumer shows a toast/alert.
+    @Published private(set) var alarmError: Error?
+
+    /// Cache for trip-panel approach timelines, invalidated on each refresh.
+    private var approachCache: [String: TripDetails] = [:]
+
     // MARK: - Init Context
 
     /// Optional bookmark that opened this stop view.
@@ -217,6 +228,8 @@ class StopViewModel: ObservableObject {
             self.stop = stop
         }
         stopArrivals = arrivals
+        approachCache.removeAll()
+        rebuildAlarmIndex()
         recomputeCurrentSurvey()
     }
 
@@ -481,5 +494,121 @@ class StopViewModel: ObservableObject {
             return
         }
         statusText = String(format: Strings.updatedAtFormat, application.formatters.timeAgoInWords(date: lastUpdated))
+    }
+
+    // MARK: - Stop Page: Walk Time
+
+    /// Walk time from the user's current location to this stop; the single
+    /// source for the header chip and the chronological walk line (§4.5).
+    var walkTime: WalkTimeInfo? {
+        WalkTimeInfo.compute(
+            from: application.locationService.currentLocation,
+            to: stop?.location,
+            speedMetersPerSecond: application.userDataStore.walkingSpeedMetersPerSecond
+        )
+    }
+
+    // MARK: - Stop Page: Alarms
+
+    var defaultAlarmLeadTime: Int {
+        application.userDataStore.defaultAlarmLeadTimeMinutes
+    }
+
+    func alarm(for arrivalDeparture: ArrivalDeparture) -> Alarm? {
+        alarmsByDepartureID[arrivalDeparture.id]
+    }
+
+    /// Minutes-before-departure for a persisted alarm, derived from its dates.
+    func alarmLeadTimeMinutes(_ alarm: Alarm) -> Int {
+        guard let tripDate = alarm.tripDate, let alarmDate = alarm.alarmDate else {
+            return AlarmLeadTime.defaultMinutes
+        }
+        return max(AlarmLeadTime.minimumMinutes, Int(round(tripDate.timeIntervalSince(alarmDate) / 60.0)))
+    }
+
+    func setAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
+        guard
+            canCreateAlarm(for: arrivalDeparture),
+            let obacoService = application.obacoService,
+            let pushService = application.pushService,
+            let region = application.currentRegion,
+            let minutes = AlarmLeadTime.clamped(leadTimeMinutes, minutesUntilDeparture: arrivalDeparture.arrivalDepartureMinutes)
+        else { return }
+
+        do {
+            let userPushID = await pushService.pushID()
+            let alarm = try await obacoService.postAlarm(minutesBefore: minutes, arrivalDeparture: arrivalDeparture, userPushID: userPushID)
+            alarm.deepLink = ArrivalDepartureDeepLink(arrivalDeparture: arrivalDeparture, regionID: region.regionIdentifier)
+            alarm.set(tripDate: arrivalDeparture.arrivalDepartureDate, alarmOffset: minutes)
+            application.userDataStore.add(alarm: alarm)
+            alarmsByDepartureID[arrivalDeparture.id] = alarm
+            alarmError = nil
+        } catch {
+            alarmError = error
+        }
+    }
+
+    func cancelAlarm(for arrivalDeparture: ArrivalDeparture) async {
+        guard let alarm = alarm(for: arrivalDeparture) else { return }
+        // Optimistic removal; restore on failure.
+        alarmsByDepartureID[arrivalDeparture.id] = nil
+        do {
+            if let obacoService = application.obacoService {
+                try await obacoService.deleteAlarm(url: alarm.url)
+            }
+            application.userDataStore.delete(alarm: alarm)
+            alarmError = nil
+        } catch {
+            alarmsByDepartureID[arrivalDeparture.id] = alarm
+            alarmError = error
+        }
+    }
+
+    /// Obaco has no update endpoint: change = delete + re-post.
+    func changeAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
+        await cancelAlarm(for: arrivalDeparture)
+        guard alarmError == nil else { return }
+        await setAlarm(for: arrivalDeparture, leadTimeMinutes: leadTimeMinutes)
+    }
+
+    /// Rebuilds the departure-id → alarm index by matching each persisted
+    /// alarm's deep link against the current departures. Called after each
+    /// successful fetch so expired/foreign alarms fall out naturally.
+    private func rebuildAlarmIndex() {
+        guard let region = application.currentRegion,
+              let departures = stopArrivals?.arrivalsAndDepartures
+        else {
+            alarmsByDepartureID = [:]
+            return
+        }
+        application.userDataStore.deleteExpiredAlarms()
+        var index: [String: Alarm] = [:]
+        for departure in departures {
+            let candidate = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
+            if let match = application.userDataStore.alarms.first(where: { $0.deepLink == candidate }) {
+                index[departure.id] = match
+            }
+        }
+        alarmsByDepartureID = index
+    }
+
+    // MARK: - Stop Page: Approach Timeline
+
+    /// Trip details backing the trip panel's approach timeline. Fetched on
+    /// panel open, cached until the next refresh, live trips only (§4.1).
+    func approachTripDetails(for arrivalDeparture: ArrivalDeparture) async -> TripDetails? {
+        guard arrivalDeparture.predicted, let apiService = application.apiService else { return nil }
+        if let cached = approachCache[arrivalDeparture.tripID] { return cached }
+        do {
+            let details = try await apiService.getTrip(
+                tripID: arrivalDeparture.tripID,
+                vehicleID: arrivalDeparture.vehicleID,
+                serviceDate: arrivalDeparture.serviceDate
+            ).entry
+            approachCache[arrivalDeparture.tripID] = details
+            return details
+        } catch {
+            return nil // panel silently omits the timeline on failure
+        }
     }
 }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -80,6 +80,19 @@ class StopViewModel: ObservableObject {
     /// Non-nil when a network error occurred.
     @Published private(set) var operationError: Error?
 
+    /// User-facing copy for `operationError`. Run through `ErrorClassifier` so a
+    /// raw decoding/URL error becomes region-named, actionable text instead of a
+    /// developer-facing Foundation string — the same pass `StopViewController`
+    /// applies at display time. `operationError` stays raw for logging.
+    var operationErrorMessage: String? {
+        guard let operationError else { return nil }
+        return ErrorClassifier.classify(
+            operationError,
+            regionName: application.currentRegionName,
+            isCellularDataRestricted: application.isCellularDataRestricted
+        ).localizedDescription
+    }
+
     /// `true` when a bookmark's stop ID no longer resolves.
     @Published private(set) var isBrokenBookmark = false
 
@@ -395,6 +408,23 @@ class StopViewModel: ObservableObject {
         updateStopPreferences(prefs)
     }
 
+    /// `true` when the user has never saved preferences for this stop, so the
+    /// page may seed its sort mode from the app-wide last-used mode. A stop whose
+    /// preferences were saved — including one deliberately set back to
+    /// Chronological — owns its sort type and must not be re-seeded.
+    var hasCustomizedPreferences: Bool {
+        guard let region = application.currentRegion else { return false }
+        return application.stopPreferencesDataStore.hasPreferences(stopID: stopID, region: region)
+    }
+
+    /// Applies a sort type for display only. Unlike `updateSortType`, this does
+    /// not persist, so an untouched stop keeps tracking the app-wide last-used
+    /// mode instead of freezing at whatever it happened to be on first view.
+    func seedSortType(_ sortType: StopSort) {
+        guard stopPreferences.sortType != sortType else { return }
+        stopPreferences.sortType = sortType
+    }
+
     /// Saves alarm creation to the user data store.
     func recordAlarmCreated(_ alarm: Alarm) {
         application.userDataStore.add(alarm: alarm)
@@ -683,14 +713,42 @@ class StopViewModel: ObservableObject {
         application.userDataStore.deleteExpiredAlarms()
         // Re-read the pruned set once, out of the loop (another decode per access).
         let alarms = application.userDataStore.alarms
+        var alarmsByVisit: [AlarmVisitIdentity: Alarm] = [:]
+        for alarm in alarms {
+            guard let deepLink = alarm.deepLink else { continue }
+            alarmsByVisit[AlarmVisitIdentity(deepLink)] = alarm
+        }
+
         var index: [String: Alarm] = [:]
         for departure in departures {
             let candidate = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
-            if let match = alarms.first(where: { $0.deepLink == candidate }) {
+            if let match = alarmsByVisit[AlarmVisitIdentity(candidate)] {
                 index[departure.id] = match
             }
         }
         alarmsByDepartureID = index
+    }
+
+    /// The trip visit an alarm was armed on. Deliberately narrower than
+    /// `ArrivalDepartureDeepLink`'s own equality, which also compares `vehicleID`
+    /// and `title`: both change the moment a scheduled trip goes real-time and the
+    /// feed assigns it a coach, which would drop a live alarm out of the index —
+    /// flipping the row back to "Set an alarm" and letting the rider arm a second,
+    /// uncancellable alarm on the same departure.
+    private struct AlarmVisitIdentity: Hashable {
+        let regionID: Int
+        let stopID: StopID
+        let tripID: TripIdentifier
+        let serviceDate: Date
+        let stopSequence: Int
+
+        init(_ deepLink: ArrivalDepartureDeepLink) {
+            self.regionID = deepLink.regionID
+            self.stopID = deepLink.stopID
+            self.tripID = deepLink.tripID
+            self.serviceDate = deepLink.serviceDate
+            self.stopSequence = deepLink.stopSequence
+        }
     }
 
     // MARK: - Stop Page: Approach Timeline

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -629,11 +629,13 @@ class StopViewModel: ObservableObject {
         // Optimistic removal; restore on failure.
         alarmsByDepartureID[arrivalDeparture.id] = nil
         do {
-            if let obacoService = application.obacoService {
-                try await obacoService.deleteAlarm(url: alarm.url)
-            } else {
-                Logger.error("Cancelled alarm locally but obacoService is unavailable; server alarm \(alarm.url) may still fire")
+            guard let obacoService = application.obacoService else {
+                // The alarm lives on the server and will still fire. Deleting only
+                // the local copy would leave the rider with a notification they can
+                // no longer see or cancel, so fail loudly instead.
+                throw AlarmCancellationError.serviceUnavailable
             }
+            try await obacoService.deleteAlarm(url: alarm.url)
             application.userDataStore.delete(alarm: alarm)
             // A refresh that landed mid-await could have re-inserted this entry
             // (rebuildAlarmIndex ran while the persisted alarm was still present);
@@ -644,6 +646,21 @@ class StopViewModel: ObservableObject {
             Logger.error("Alarm cancel failed for \(arrivalDeparture.id): \(error)")
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = error
+        }
+    }
+
+    /// Why an alarm couldn't be cancelled. Surfaced through `alarmError`, which the
+    /// hosting controller presents.
+    enum AlarmCancellationError: LocalizedError {
+        /// No Obaco service for the current region, so the server alarm can't be deleted.
+        case serviceUnavailable
+
+        var errorDescription: String? {
+            OBALoc(
+                "stop_page.alarm_cancel_unavailable",
+                value: "This alarm couldn't be cancelled because the alarm service isn't available right now. Please try again later.",
+                comment: "Error shown when a departure alarm can't be cancelled because the region's alarm service is unreachable."
+            )
         }
     }
 
@@ -758,7 +775,7 @@ class StopViewModel: ObservableObject {
     /// inserted, which resizes the panel without animation; this accessor lets
     /// the panel seed a warm timeline at full size on the frame it's built.
     func cachedApproachTripDetails(for arrivalDeparture: ArrivalDeparture) -> TripDetails? {
-        approachCache[arrivalDeparture.tripID]
+        approachCache[approachCacheKey(for: arrivalDeparture)]
     }
 
     /// Trip details backing the trip panel's approach timeline. Fetched on
@@ -772,10 +789,17 @@ class StopViewModel: ObservableObject {
                 vehicleID: arrivalDeparture.vehicleID,
                 serviceDate: arrivalDeparture.serviceDate
             ).entry
-            approachCache[arrivalDeparture.tripID] = details
+            approachCache[approachCacheKey(for: arrivalDeparture)] = details
             return details
         } catch {
             return nil // panel silently omits the timeline on failure
         }
+    }
+
+    /// The full identity of the `getTrip` request, so two instances of the same trip
+    /// — a different vehicle, or the same run on the next service day — don't share
+    /// a cache entry and render each other's timeline.
+    private func approachCacheKey(for arrivalDeparture: ArrivalDeparture) -> String {
+        "\(arrivalDeparture.tripID)|\(arrivalDeparture.vehicleID ?? "")|\(arrivalDeparture.serviceDate.timeIntervalSince1970)"
     }
 }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -564,10 +564,13 @@ class StopViewModel: ObservableObject {
         }
     }
 
-    /// Obaco has no update endpoint: change = delete + re-post.
+    /// Obaco has no update endpoint: change = delete + re-post. Proceeds only
+    /// when the old alarm is actually gone (a failed delete rolls it back into
+    /// the index), so a stale `alarmError` from an earlier operation can't
+    /// block the change.
     func changeAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
         await cancelAlarm(for: arrivalDeparture)
-        guard alarmError == nil else { return }
+        guard alarm(for: arrivalDeparture) == nil else { return }
         await setAlarm(for: arrivalDeparture, leadTimeMinutes: leadTimeMinutes)
     }
 

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -400,6 +400,14 @@ class StopViewModel: ObservableObject {
         application.userDataStore.add(alarm: alarm)
     }
 
+    /// Records an alarm created outside the view model (the `AlarmBuilder`
+    /// bulletin flow) and indexes it under its departure so open trip panels
+    /// flip to "Alarm set" immediately instead of waiting for the next refresh.
+    func registerAlarm(_ alarm: Alarm, for arrivalDeparture: ArrivalDeparture) {
+        recordAlarmCreated(alarm)
+        alarmsByDepartureID[arrivalDeparture.id] = alarm
+    }
+
     /// Returns whether an alarm can be created for the given arrival/departure.
     func canCreateAlarm(for arrivalDeparture: ArrivalDeparture) -> Bool {
         guard

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -633,14 +633,34 @@ class StopViewModel: ObservableObject {
         alarmPermissionDenied = false
     }
 
-    /// Obaco has no update endpoint: change = delete + re-post. Proceeds only
-    /// when the old alarm is actually gone (a failed delete rolls it back into
-    /// the index), so a stale `alarmError` from an earlier operation can't
-    /// block the change.
-    func changeAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
-        await cancelAlarm(for: arrivalDeparture)
-        guard alarm(for: arrivalDeparture) == nil else { return }
-        await setAlarm(for: arrivalDeparture, leadTimeMinutes: leadTimeMinutes)
+    /// Replaces the departure's existing alarm with one created outside the
+    /// view model — the trip panel's Change flow re-presents the `AlarmBuilder`
+    /// bulletin, which posts a brand-new alarm (Obaco has no update endpoint).
+    /// The new alarm is indexed and persisted immediately so the panel never
+    /// flips back to "Set an alarm"; the old alarm is then deleted.
+    func replaceAlarm(with newAlarm: Alarm, for arrivalDeparture: ArrivalDeparture) async {
+        let oldAlarm = alarm(for: arrivalDeparture)
+        registerAlarm(newAlarm, for: arrivalDeparture)
+
+        guard let oldAlarm, oldAlarm.url != newAlarm.url else { return }
+
+        if let obacoService = application.obacoService {
+            do {
+                try await obacoService.deleteAlarm(url: oldAlarm.url)
+            } catch {
+                // The new alarm stands either way; the undeleted server alarm
+                // may buzz once more but expires with the trip.
+                Logger.error("Failed to delete replaced alarm \(oldAlarm.url) from the server: \(error)")
+            }
+        } else {
+            Logger.error("Replaced alarm locally but obacoService is unavailable; server alarm \(oldAlarm.url) may still fire")
+        }
+
+        // Drop the old alarm from the persisted store even if the server
+        // delete failed: it shares the new alarm's deep link, and a leftover
+        // copy would win the next `rebuildAlarmIndex()` and resurrect the old
+        // lead time in the UI.
+        application.userDataStore.delete(alarm: oldAlarm)
     }
 
     /// Rebuilds the departure-id → alarm index by matching each persisted

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -577,7 +577,7 @@ class StopViewModel: ObservableObject {
             let alarm = try await obacoService.postAlarm(minutesBefore: minutes, arrivalDeparture: arrivalDeparture, userPushID: userPushID)
             alarm.deepLink = ArrivalDepartureDeepLink(arrivalDeparture: arrivalDeparture, regionID: region.regionIdentifier)
             alarm.set(tripDate: arrivalDeparture.arrivalDepartureDate, alarmOffset: minutes)
-            application.userDataStore.add(alarm: alarm)
+            recordAlarmCreated(alarm)
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = nil
         } catch {
@@ -602,6 +602,15 @@ class StopViewModel: ObservableObject {
         } catch {
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = error
+        }
+    }
+
+    /// Toggle entry point shared by all four alarm surfaces (§4.7).
+    func toggleAlarm(for arrivalDeparture: ArrivalDeparture) async {
+        if alarm(for: arrivalDeparture) != nil {
+            await cancelAlarm(for: arrivalDeparture)
+        } else {
+            await setAlarm(for: arrivalDeparture, leadTimeMinutes: defaultAlarmLeadTime)
         }
     }
 
@@ -632,9 +641,15 @@ class StopViewModel: ObservableObject {
             alarmsByDepartureID = [:]
             return
         }
+        // Fast path: `alarms` JSON-decodes the persisted store on every access.
+        // With nothing persisted there's no expiry to run and no match to make,
+        // so bail before touching `deleteExpiredAlarms()`.
+        guard !application.userDataStore.alarms.isEmpty else {
+            alarmsByDepartureID = [:]
+            return
+        }
         application.userDataStore.deleteExpiredAlarms()
-        // Hoisted out of the loop: `alarms` JSON-decodes the persisted store on
-        // every access, so reading it once per rebuild instead of per departure.
+        // Re-read the pruned set once, out of the loop (another decode per access).
         let alarms = application.userDataStore.alarms
         var index: [String: Alarm] = [:]
         for departure in departures {

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -10,6 +10,7 @@
 import Foundation
 import Combine
 import CoreLocation
+import UserNotifications
 import OBAKitCore
 
 /// Shared ViewModel for the stop arrivals/departures screen.
@@ -105,6 +106,16 @@ class StopViewModel: ObservableObject {
 
     /// Non-nil after an alarm create/cancel fails; consumer shows a toast/alert.
     @Published private(set) var alarmError: Error?
+
+    /// Set `true` when the user attempts to create an alarm but notification
+    /// permission is already `.denied`; the consumer presents Settings guidance
+    /// and then calls `clearAlarmPermissionDenied()`.
+    @Published private(set) var alarmPermissionDenied = false
+
+    /// Departure ids with an in-flight `setAlarm`, so a double-tap can't create a
+    /// duplicate alarm while the first create is suspended (MainActor-serialized,
+    /// so a plain `Set` needs no further synchronization).
+    private var alarmSetsInFlight: Set<String> = []
 
     /// Cache for trip-panel approach timelines, invalidated on each refresh.
     private var approachCache: [String: TripDetails] = [:]
@@ -538,11 +549,28 @@ class StopViewModel: ObservableObject {
     func setAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
         guard
             canCreateAlarm(for: arrivalDeparture),
+            !alarmSetsInFlight.contains(arrivalDeparture.id),
             let obacoService = application.obacoService,
             let pushService = application.pushService,
             let region = application.currentRegion,
             let minutes = AlarmLeadTime.clamped(leadTimeMinutes, minutesUntilDeparture: arrivalDeparture.arrivalDepartureMinutes)
         else { return }
+
+        // Reserve this departure before the first `await` so a double-tap can't
+        // slip a second create through while the permission/network work is
+        // suspended. The check-then-insert is atomic on the MainActor.
+        alarmSetsInFlight.insert(arrivalDeparture.id)
+        defer { alarmSetsInFlight.remove(arrivalDeparture.id) }
+
+        // Already-denied notification permission is a dead end for departure
+        // alarms: pushID() can't yield a deliverable id. Surface Settings
+        // guidance instead. (.notDetermined falls through so pushID() triggers
+        // the first-time system prompt.)
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        if settings.authorizationStatus == .denied {
+            alarmPermissionDenied = true
+            return
+        }
 
         do {
             let userPushID = await pushService.pushID()
@@ -566,11 +594,22 @@ class StopViewModel: ObservableObject {
                 try await obacoService.deleteAlarm(url: alarm.url)
             }
             application.userDataStore.delete(alarm: alarm)
+            // A refresh that landed mid-await could have re-inserted this entry
+            // (rebuildAlarmIndex ran while the persisted alarm was still present);
+            // re-assert the removal now that the alarm is actually deleted.
+            alarmsByDepartureID[arrivalDeparture.id] = nil
             alarmError = nil
         } catch {
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = error
         }
+    }
+
+    /// Resets the permission-denied flag after the consumer has presented its
+    /// Settings-guidance alert, so a later already-denied attempt re-fires the
+    /// binding.
+    func clearAlarmPermissionDenied() {
+        alarmPermissionDenied = false
     }
 
     /// Obaco has no update endpoint: change = delete + re-post. Proceeds only
@@ -594,10 +633,13 @@ class StopViewModel: ObservableObject {
             return
         }
         application.userDataStore.deleteExpiredAlarms()
+        // Hoisted out of the loop: `alarms` JSON-decodes the persisted store on
+        // every access, so reading it once per rebuild instead of per departure.
+        let alarms = application.userDataStore.alarms
         var index: [String: Alarm] = [:]
         for departure in departures {
             let candidate = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
-            if let match = application.userDataStore.alarms.first(where: { $0.deepLink == candidate }) {
+            if let match = alarms.first(where: { $0.deepLink == candidate }) {
                 index[departure.id] = match
             }
         }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -31,6 +31,15 @@ class StopViewModel: ObservableObject {
     /// sink is the sole driver of survey-row reloads.
     @Published private(set) var currentSurvey: Survey?
 
+    /// Whether the inline donation-request card should be offered on this stop.
+    /// Mirrors `DonationsManager.shouldRequestDonations`; read by the SwiftUI Stop
+    /// page, which has no `Application` reference of its own. Not `@Published` — the
+    /// page re-reads it on the view model's routine refresh churn, and the explicit
+    /// dismiss path hides the card immediately via local view state.
+    var shouldRequestDonations: Bool {
+        application.donationsManager.shouldRequestDonations
+    }
+
     /// Emits when the inline hero answer succeeds but the survey has remaining
     /// questions. Consumers present the full survey screen with the supplied
     /// `heroResponseID` so the hero isn't re-submitted on retry.

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -667,11 +667,19 @@ class StopViewModel: ObservableObject {
 
     // MARK: - Stop Page: Approach Timeline
 
+    /// Synchronous read of the approach-details cache. The async
+    /// `approachTripDetails` path always resolves after the accordion row is
+    /// inserted, which resizes the panel without animation; this accessor lets
+    /// the panel seed a warm timeline at full size on the frame it's built.
+    func cachedApproachTripDetails(for arrivalDeparture: ArrivalDeparture) -> TripDetails? {
+        approachCache[arrivalDeparture.tripID]
+    }
+
     /// Trip details backing the trip panel's approach timeline. Fetched on
     /// panel open, cached until the next refresh, live trips only (§4.1).
     func approachTripDetails(for arrivalDeparture: ArrivalDeparture) async -> TripDetails? {
         guard arrivalDeparture.predicted, let apiService = application.apiService else { return nil }
-        if let cached = approachCache[arrivalDeparture.tripID] { return cached }
+        if let cached = cachedApproachTripDetails(for: arrivalDeparture) { return cached }
         do {
             let details = try await apiService.getTrip(
                 tripID: arrivalDeparture.tripID,

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -581,6 +581,7 @@ class StopViewModel: ObservableObject {
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = nil
         } catch {
+            Logger.error("Alarm create failed for \(arrivalDeparture.id): \(error)")
             alarmError = error
         }
     }
@@ -592,6 +593,8 @@ class StopViewModel: ObservableObject {
         do {
             if let obacoService = application.obacoService {
                 try await obacoService.deleteAlarm(url: alarm.url)
+            } else {
+                Logger.error("Cancelled alarm locally but obacoService is unavailable; server alarm \(alarm.url) may still fire")
             }
             application.userDataStore.delete(alarm: alarm)
             // A refresh that landed mid-await could have re-inserted this entry
@@ -600,6 +603,7 @@ class StopViewModel: ObservableObject {
             alarmsByDepartureID[arrivalDeparture.id] = nil
             alarmError = nil
         } catch {
+            Logger.error("Alarm cancel failed for \(arrivalDeparture.id): \(error)")
             alarmsByDepartureID[arrivalDeparture.id] = alarm
             alarmError = error
         }

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -86,25 +86,39 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
 
     public func navigateTo(stop: Stop, from fromController: UIViewController, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) {
         guard shouldNavigate(from: fromController, to: .stop(stop)) else { return }
-        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
-            let stopController = StopPageViewController(application: application, stop: stop)
-            stopController.bookmarkContext = bookmark
-            stopController.transferContext = transferContext
-            navigate(to: stopController, from: fromController)
-        } else {
-            let stopController = StopViewController(application: application, stop: stop)
-            stopController.bookmarkContext = bookmark
-            stopController.transferContext = transferContext
-            navigate(to: stopController, from: fromController)
-        }
+        navigate(to: makeStopController(stop: stop, bookmark: bookmark, transferContext: transferContext), from: fromController)
     }
 
     public func navigateTo(stopID: StopID, from fromController: UIViewController) {
         guard shouldNavigate(from: fromController, to: .stopID(stopID)) else { return }
+        navigate(to: makeStopController(stopID: stopID), from: fromController)
+    }
+
+    /// Builds the Stop screen honoring the new-stop-page feature flag. All stop
+    /// navigation and long-press previews must construct the controller through
+    /// these factories so the flag governs every path.
+    public func makeStopController(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) -> UIViewController {
         if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
-            navigate(to: StopPageViewController(application: application, stopID: stopID), from: fromController)
+            let stopController = StopPageViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            return stopController
         } else {
-            navigate(to: StopViewController(application: application, stopID: stopID), from: fromController)
+            let stopController = StopViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            return stopController
+        }
+    }
+
+    /// Builds the Stop screen honoring the new-stop-page feature flag. All stop
+    /// navigation and long-press previews must construct the controller through
+    /// these factories so the flag governs every path.
+    public func makeStopController(stopID: StopID) -> UIViewController {
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+            return StopPageViewController(application: application, stopID: stopID)
+        } else {
+            return StopViewController(application: application, stopID: stopID)
         }
     }
 

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -98,7 +98,8 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     /// navigation and long-press previews must construct the controller through
     /// these factories so the flag governs every path.
     public func makeStopController(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) -> UIViewController {
-        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+        // TransferContext UX (arrival-relative filtering, transfer banner) is not yet built on the new stop page — route transfers to the legacy screen until it is.
+        if transferContext == nil, FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
             let stopController = StopPageViewController(application: application, stop: stop)
             stopController.bookmarkContext = bookmark
             stopController.transferContext = transferContext

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -99,22 +99,17 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     /// these factories so the flag governs every path.
     public func makeStopController(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) -> UIViewController {
         // TransferContext UX (arrival-relative filtering, transfer banner) is not yet built on the new stop page — route transfers to the legacy screen until it is.
+        let stopController: StopContextConfigurable
         if transferContext == nil, FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
-            let stopController = StopPageViewController(application: application, stop: stop)
-            stopController.bookmarkContext = bookmark
-            stopController.transferContext = transferContext
-            return stopController
+            stopController = StopPageViewController(application: application, stop: stop)
         } else {
-            let stopController = StopViewController(application: application, stop: stop)
-            stopController.bookmarkContext = bookmark
-            stopController.transferContext = transferContext
-            return stopController
+            stopController = StopViewController(application: application, stop: stop)
         }
+        stopController.bookmarkContext = bookmark
+        stopController.transferContext = transferContext
+        return stopController
     }
 
-    /// Builds the Stop screen honoring the new-stop-page feature flag. All stop
-    /// navigation and long-press previews must construct the controller through
-    /// these factories so the flag governs every path.
     public func makeStopController(stopID: StopID) -> UIViewController {
         if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
             return StopPageViewController(application: application, stopID: stopID)
@@ -196,3 +191,15 @@ extension ViewRouter: RoutePickerDelegate {
         navigation.pushViewController(currentTripController, animated: true)
     }
 }
+
+// MARK: - Stop controller factory seam
+
+/// The shared context both Stop-screen controllers expose, so `makeStopController`
+/// can set it once regardless of which the feature flag selects.
+protocol StopContextConfigurable: UIViewController {
+    var bookmarkContext: Bookmark? { get set }
+    var transferContext: TransferContext? { get set }
+}
+
+extension StopViewController: StopContextConfigurable {}
+extension StopPageViewController: StopContextConfigurable {}

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -86,16 +86,26 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
 
     public func navigateTo(stop: Stop, from fromController: UIViewController, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) {
         guard shouldNavigate(from: fromController, to: .stop(stop)) else { return }
-        let stopController = StopViewController(application: application, stop: stop)
-        stopController.bookmarkContext = bookmark
-        stopController.transferContext = transferContext
-        navigate(to: stopController, from: fromController)
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+            let stopController = StopPageViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            navigate(to: stopController, from: fromController)
+        } else {
+            let stopController = StopViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            navigate(to: stopController, from: fromController)
+        }
     }
 
     public func navigateTo(stopID: StopID, from fromController: UIViewController) {
         guard shouldNavigate(from: fromController, to: .stopID(stopID)) else { return }
-        let stopController = StopViewController(application: application, stopID: stopID)
-        navigate(to: stopController, from: fromController)
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+            navigate(to: StopPageViewController(application: application, stopID: stopID), from: fromController)
+        } else {
+            navigate(to: StopViewController(application: application, stopID: stopID), from: fromController)
+        }
     }
 
     public func navigateTo(arrivalDeparture: ArrivalDeparture, from fromController: UIViewController) {

--- a/OBAKitCore/Extensions/UIKitExtensions.swift
+++ b/OBAKitCore/Extensions/UIKitExtensions.swift
@@ -232,6 +232,20 @@ public extension UIColor {
             alpha: alpha
         )
     }
+
+    /// Linear blend toward `other` in RGB space; `amount` is clamped to 0...1.
+    func blended(with other: UIColor, amount: CGFloat) -> UIColor {
+        var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
+        var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
+        getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        other.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        let t = max(0, min(1, amount))
+        return UIColor(
+            red: r1 + (r2 - r1) * t,
+            green: g1 + (g2 - g1) * t,
+            blue: b1 + (b2 - b1) * t,
+            alpha: a1)
+    }
 }
 
 // MARK: - UICollectionView

--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -196,9 +196,12 @@ public class ArrivalDeparture: NSObject, Identifiable, Decodable, HasReferences 
 
     // MARK: - Helpers/Names
 
-    /// Provides an ID for this arrival departure consisting of its Stop, Trip, and Route IDs.
+    /// Provides an ID for this arrival departure consisting of its Stop, Trip, and Route IDs,
+    /// plus the service date and stop sequence. The latter two disambiguate the same trip
+    /// serving this stop more than once: loop routes visit a stop at multiple sequences, and
+    /// trips can repeat across consecutive service dates.
     public var id: String {
-        return "stop=\(stopID),trip=\(tripID),route=\(routeID),status=\(arrivalDepartureStatus)"
+        return "stop=\(stopID),trip=\(tripID),route=\(routeID),serviceDate=\(serviceDate.timeIntervalSince1970),sequence=\(stopSequence),status=\(arrivalDepartureStatus)"
     }
 
     /// Provides the best available trip headsign.

--- a/OBAKitCore/Models/REST/StopArrivals.swift
+++ b/OBAKitCore/Models/REST/StopArrivals.swift
@@ -67,7 +67,10 @@ public class StopArrivals: NSObject, Identifiable, Decodable, HasReferences {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        arrivalsAndDepartures = try container.decode([ArrivalDeparture].self, forKey: .arrivalsAndDepartures)
+        // Some real-time feeds briefly assign two vehicles to one trip, which makes the
+        // server emit two entries for a single trip visit. Collapse those at ingestion so
+        // every consumer sees one entry per visit (see `filteringDuplicateVehicleReports`).
+        arrivalsAndDepartures = try container.decode([ArrivalDeparture].self, forKey: .arrivalsAndDepartures).filteringDuplicateVehicleReports()
         nearbyStopIDs = try container.decode([StopID].self, forKey: .nearbyStopIDs)
         situationIDs = try container.decode([String].self, forKey: .situationIDs)
         stopID = try container.decode(StopID.self, forKey: .stopID)

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -10,6 +10,8 @@
 import Foundation
 import MapKit
 
+// swiftlint:disable file_length
+
 @objc(OBASelectedTab) public enum SelectedTab: Int {
     case map, recentStops, bookmarks, vehicles, settings
 }
@@ -297,6 +299,12 @@ public protocol UserDataStore: NSObjectProtocol {
     /// The source of the walking speed value (manual preset or HealthKit).
     var walkingSpeedSource: WalkingSpeedSource { get set }
 
+    // MARK: - Alarm Lead Time
+
+    /// The user's preferred alarm lead time in minutes for one-tap alarms on
+    /// the Stop page. Adjustable per-alarm afterward. Defaults to 5.
+    var defaultAlarmLeadTimeMinutes: Int { get set }
+
 }
 
 // MARK: - Survey Tracking Data Models
@@ -371,6 +379,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let alwaysShowSurveysOnStops = "UserDataStore.alwaysShowSurveysOnStops"
         static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
+        static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
     }
 
     public init(userDefaults: UserDefaults) {
@@ -379,7 +388,8 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         self.userDefaults.register(defaults: [
             UserDefaultsKeys.debugMode: false,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
-            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue,
+            UserDefaultsKeys.defaultAlarmLeadTimeMinutes: 5
         ])
     }
 
@@ -1054,6 +1064,17 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.walkingSpeedSource)
+        }
+    }
+
+    // MARK: - Alarm Lead Time
+
+    public var defaultAlarmLeadTimeMinutes: Int {
+        get {
+            userDefaults.integer(forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes)
         }
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -348,6 +348,16 @@ public protocol StopPreferencesStore: NSObjectProtocol {
     /// - Parameter stopID: The ID of the `Stop` for which `StopPreferences` will be retrieved.
     /// - Parameter region: The `Region` in which `stop` exists.
     func preferences(stopID: StopID, region: Region) -> StopPreferences
+
+    /// `true` when preferences have been explicitly saved for this `Stop`.
+    ///
+    /// `preferences(stopID:region:)` always returns a value, so its result can't
+    /// distinguish "the user chose the defaults" from "the user never chose
+    /// anything" — callers that need that distinction (e.g. seeding a stop with a
+    /// last-used sort mode only when it is untouched) ask here instead.
+    /// - Parameter stopID: The ID of the `Stop` to check.
+    /// - Parameter region: The `Region` in which `stop` exists.
+    func hasPreferences(stopID: StopID, region: Region) -> Bool
 }
 
 // MARK: - UserDataStore Defaults
@@ -943,6 +953,10 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         let prefs = stopPreferences
         let key = stopPreferencesKey(id: stopID, region: region)
         return prefs[key] ?? StopPreferences()
+    }
+
+    public func hasPreferences(stopID: StopID, region: Region) -> Bool {
+        stopPreferences[stopPreferencesKey(id: stopID, region: region)] != nil
     }
 
     private func stopPreferencesKey(id: String, region: Region) -> String {

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -350,6 +350,16 @@ public protocol StopPreferencesStore: NSObjectProtocol {
     func preferences(stopID: StopID, region: Region) -> StopPreferences
 }
 
+// MARK: - UserDataStore Defaults
+
+/// Canonical defaults for `UserDefaultsStore` configuration. Shared with OBAKit's UI
+/// so registered defaults and UI defaults remain synchronized.
+public enum UserDataStoreDefaults {
+    /// Default lead time in minutes for one-tap alarms on the Stop page.
+    /// Referenced by OBAKit's `AlarmLeadTime.defaultMinutes`.
+    public static let alarmLeadTimeMinutes = 5
+}
+
 // MARK: - UserDefaultsStore
 
 @objc(OBAUserDefaultsStore)
@@ -389,7 +399,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             UserDefaultsKeys.debugMode: false,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
             UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue,
-            UserDefaultsKeys.defaultAlarmLeadTimeMinutes: 5
+            UserDefaultsKeys.defaultAlarmLeadTimeMinutes: UserDataStoreDefaults.alarmLeadTimeMinutes
         ])
     }
 

--- a/OBAKitCore/Models/ViewModels/ArrivalDeparture+Deduplication.swift
+++ b/OBAKitCore/Models/ViewModels/ArrivalDeparture+Deduplication.swift
@@ -24,6 +24,40 @@ private struct VisitIdentity: Hashable {
 
 extension Sequence where Element == ArrivalDeparture {
 
+    /// Collapses entries that describe the same arrival/departure — identical `id`
+    /// (stop, trip, route, service date, stop sequence, and arrival/departure status) —
+    /// into a single entry, keeping the most recently updated report.
+    ///
+    /// Real-time feeds occasionally assign two vehicles to one trip (e.g. an AVL ghost
+    /// alongside the actual coach), and the server then emits one entry per vehicle for
+    /// the same trip visit. Riders should only ever see one row per visit, and duplicate
+    /// `id`s also break identity-keyed UI downstream (SwiftUI `ForEach`, alarm indexes),
+    /// so this runs at ingestion when `StopArrivals` is decoded.
+    ///
+    /// Unlike `filteringTerminalDuplicates()`, entries that differ in stop sequence or
+    /// arrival/departure status are never merged, so loop-route double visits and
+    /// terminal arrival/departure pairs pass through untouched.
+    ///
+    /// - Returns: A filtered array preserving the original order, with each duplicate's
+    ///   first-occurrence position retained.
+    public func filteringDuplicateVehicleReports() -> [ArrivalDeparture] {
+        var seen = [String: Int]()
+        var result: [ArrivalDeparture] = []
+
+        for arrDep in self {
+            if let existingIndex = seen[arrDep.id] {
+                if arrDep.lastUpdated > result[existingIndex].lastUpdated {
+                    result[existingIndex] = arrDep
+                }
+            } else {
+                seen[arrDep.id] = result.count
+                result.append(arrDep)
+            }
+        }
+
+        return result
+    }
+
     /// Filters out visually duplicate arrival/departure entries that occur at terminal or loop stops.
     ///
     /// At terminal stops, the OBA API returns two separate `ArrivalDeparture` objects for the

--- a/OBAKitCore/Network/APIService/APIService+GetData.swift
+++ b/OBAKitCore/Network/APIService/APIService+GetData.swift
@@ -46,7 +46,12 @@ extension APIService {
         // If you request a valid endpoint, but provide it with a bogus piece of
         // data (e.g. a non-existent Stop ID), it should return a 404 error to you.
         // Instead, it gives a 200 and a blank body.
-        if httpResponse.expectedContentLength == 0 && httpResponse.statusCode == 200 {
+        //
+        // Only GETs are covered by this: for a DELETE, an empty body is the expected
+        // shape of *success* (the sidecar's alarm and live activity endpoints answer
+        // with a bare 204, and older deployments with a bare 200), so applying the
+        // heuristic there reported every successful delete as a missing resource.
+        if request.httpMethod == "GET" && httpResponse.expectedContentLength == 0 && httpResponse.statusCode == 200 {
             logger.error("Failed network request for \(request.description, privacy: .public): 404 not found.")
             throw APIError.requestNotFound(httpResponse)
         }

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -141,7 +141,7 @@ public actor ObacoAPIService: @preconcurrency APIService {
         // just never arrives. Flagging the alarm at registration tells the server to route
         // this one push through the sandbox instead. (The alarm fires minutes later, from
         // a job, so the flag has to be persisted server-side rather than sent at push time.)
-        params["development"] = "1"
+        params["apns_sandbox"] = "1"
         #endif
 
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -133,6 +133,17 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let vehicleID = vehicleID {
             params["vehicle_id"] = vehicleID
         }
+
+        #if DEBUG
+        // A debug build is provisioned with the development APNs entitlement, so the
+        // token APNs issues us is only valid against the APNs sandbox host. The server
+        // pushes to production APNs by config, which rejects a sandbox token — the alarm
+        // just never arrives. Flagging the alarm at registration tells the server to route
+        // this one push through the sandbox instead. (The alarm fires minutes later, from
+        // a job, so the flag has to be persisted server-side rather than sent at push time.)
+        params["development"] = "1"
+        #endif
+
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 
         let (data, _) = try await data(for: urlRequest as URLRequest)

--- a/OBAKitCore/Orchestration/FeatureFlags.swift
+++ b/OBAKitCore/Orchestration/FeatureFlags.swift
@@ -15,4 +15,15 @@ public enum FeatureFlags {
     /// Gates the SwiftUI map panel experience (full-screen map + floating
     /// sheet) over the classic UIKit tab bar.
     public static let useMapPanelExperienceKey = "OBAUseMapPanelExperience"
+
+    /// Gates the redesigned SwiftUI Stop page over the classic
+    /// `StopViewController`. Enabled by default; the Settings > Experimental
+    /// toggle writes an explicit value.
+    public static let useNewStopPageKey = "OBAUseNewStopPage"
+
+    /// Resolves the new-stop-page flag, defaulting to enabled when the user
+    /// has never touched the toggle.
+    public static func isNewStopPageEnabled(userDefaults: UserDefaults) -> Bool {
+        userDefaults.object(forKey: useNewStopPageKey) as? Bool ?? true
+    }
 }

--- a/OBAKitCore/SwiftUI/Environment/OBAFormattersKey.swift
+++ b/OBAKitCore/SwiftUI/Environment/OBAFormattersKey.swift
@@ -12,7 +12,7 @@ private struct OBAFormattersKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    var obaFormatters: Formatters {
+    public var obaFormatters: Formatters {
         get { self[OBAFormattersKey.self] }
         set { self[OBAFormattersKey.self] = newValue }
     }

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -121,8 +121,8 @@ class MockDataLoader: NSObject, URLDataLoader {
         return nil
     }
 
-    func mock(data: Data, matcher: @escaping MockDataLoaderMatcher) {
-        let urlResponse = buildURLResponse(URL: URL(string: "https://mockdataloader.example.com")!, statusCode: 200)
+    func mock(data: Data, statusCode: Int = 200, matcher: @escaping MockDataLoaderMatcher) {
+        let urlResponse = buildURLResponse(URL: URL(string: "https://mockdataloader.example.com")!, statusCode: statusCode, contentLength: data.count)
         let mockResponse = MockDataResponse(data: data, urlResponse: urlResponse, error: nil, matcher: matcher)
         mock(response: mockResponse)
     }
@@ -132,7 +132,7 @@ class MockDataLoader: NSObject, URLDataLoader {
     }
 
     func mock(url: URL, with data: Data) {
-        let urlResponse = buildURLResponse(URL: url, statusCode: 200)
+        let urlResponse = buildURLResponse(URL: url, statusCode: 200, contentLength: data.count)
         let mockResponse = MockDataResponse(data: data, urlResponse: urlResponse, error: nil) {
             let requestURL = $0.url!
             return requestURL.host == url.host && requestURL.path == url.path
@@ -163,8 +163,19 @@ class MockDataLoader: NSObject, URLDataLoader {
 
     // MARK: - URL Response
 
-    func buildURLResponse(URL: URL, statusCode: Int) -> HTTPURLResponse {
-        return HTTPURLResponse(url: URL, statusCode: statusCode, httpVersion: "2", headerFields: ["Content-Type": "application/json"])!
+    /// - parameter contentLength: Populates `Content-Length`, and therefore
+    /// `HTTPURLResponse.expectedContentLength`. Omitting it leaves the header off and
+    /// `expectedContentLength` at `NSURLResponseUnknownLength`, which no real server does —
+    /// pass the mocked body's `count` so response-length checks in `APIService` see what
+    /// they'd see in production.
+    func buildURLResponse(URL: URL, statusCode: Int, contentLength: Int? = nil) -> HTTPURLResponse {
+        var headerFields = ["Content-Type": "application/json"]
+
+        if let contentLength {
+            headerFields["Content-Length"] = String(contentLength)
+        }
+
+        return HTTPURLResponse(url: URL, statusCode: statusCode, httpVersion: "2", headerFields: headerFields)!
     }
 
     // MARK: - Description

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -17,6 +17,13 @@ import CoreLocation
 
 class AlarmModelOperationTests: OBATestCase {
 
+    /// Captures the body of the request the service actually put on the wire. Single
+    /// request per test, written before the mock returns and read after the `await`
+    /// resumes, so there's no concurrent access in practice.
+    private final class RequestCapture: @unchecked Sendable {
+        nonisolated(unsafe) var body: String?
+    }
+
     func testSuccessfulAlarmCreation() async throws {
         let data = Fixtures.loadData(file: "create_alarm.json")
         let arrivalDeparture = try Fixtures.loadRESTAPIPayload(type: ArrivalDeparture.self, fileName: "arrival-and-departure-for-stop-1_11420.json")
@@ -26,6 +33,33 @@ class AlarmModelOperationTests: OBATestCase {
 
         let alarm = try await obacoService.postAlarm(minutesBefore: 1, arrivalDeparture: arrivalDeparture, userPushID: "123")
         XCTAssertEqual(alarm.url.absoluteString, "https://alerts.example.com/regions/1/alarms/1234567890")
+    }
+
+    /// A debug build is provisioned with the development APNs entitlement, so the token
+    /// APNs issues it is a sandbox token. The server pushes to production APNs by config,
+    /// which rejects that token — the alarm silently never arrives. Registration therefore
+    /// flags the alarm, and the server pushes it through the APNs sandbox instead.
+    ///
+    /// The test suite only ever builds in Debug, so `#if DEBUG` is always true here; this
+    /// pins the flag's presence and wire format, not the compile-time condition itself.
+    func testAlarmCreationFlagsDevelopmentBuilds() async throws {
+        let data = Fixtures.loadData(file: "create_alarm.json")
+        let arrivalDeparture = try Fixtures.loadRESTAPIPayload(type: ArrivalDeparture.self, fileName: "arrival-and-departure-for-stop-1_11420.json")
+
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: data) { request in
+            guard request.httpMethod == "POST", request.url?.path.hasSuffix("/alarms") ?? false else {
+                return false
+            }
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            return true
+        }
+
+        _ = try await obacoService.postAlarm(minutesBefore: 1, arrivalDeparture: arrivalDeparture, userPushID: "123")
+
+        let body = try XCTUnwrap(capture.body, "Expected postAlarm to send a form-encoded body")
+        XCTAssertTrue(body.contains("development=1"), "Expected a debug build to flag the alarm for the APNs sandbox. Body: \(body)")
     }
 
     /// The sidecar answers a successful `DELETE` with an empty `204`.

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -59,7 +59,7 @@ class AlarmModelOperationTests: OBATestCase {
         _ = try await obacoService.postAlarm(minutesBefore: 1, arrivalDeparture: arrivalDeparture, userPushID: "123")
 
         let body = try XCTUnwrap(capture.body, "Expected postAlarm to send a form-encoded body")
-        XCTAssertTrue(body.contains("development=1"), "Expected a debug build to flag the alarm for the APNs sandbox. Body: \(body)")
+        XCTAssertTrue(body.contains("apns_sandbox=1"), "Expected a debug build to flag the alarm for the APNs sandbox. Body: \(body)")
     }
 
     /// The sidecar answers a successful `DELETE` with an empty `204`.

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -28,12 +28,31 @@ class AlarmModelOperationTests: OBATestCase {
         XCTAssertEqual(alarm.url.absoluteString, "https://alerts.example.com/regions/1/alarms/1234567890")
     }
 
+    /// The sidecar answers a successful `DELETE` with an empty `204`.
     func testSuccessfulAlarmDeletion() async throws {
         let alarm = try Fixtures.loadAlarm()
         XCTAssertNotNil(alarm)
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
-        dataLoader.mock(data: Data()) { (request) -> Bool in
+        dataLoader.mock(data: Data(), statusCode: 204) { (request) -> Bool in
+            request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
+            request.httpMethod == "DELETE"
+        }
+
+        let (_, response) = try await obacoService.deleteAlarm(url: alarm.url)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
+        XCTAssertEqual(httpResponse.statusCode, 204)
+    }
+
+    /// Sidecars predating the switch to `204` answer a successful `DELETE` with an empty
+    /// `200`. `APIService.data(for:)` reads an empty-bodied `200` as a disguised 404 — a
+    /// workaround for the REST API's handling of bogus IDs — which turned every successful
+    /// alarm cancel into a `requestNotFound` failure. That heuristic must not apply here.
+    func testSuccessfulAlarmDeletionWithEmpty200() async throws {
+        let alarm = try Fixtures.loadAlarm()
+
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 200) { (request) -> Bool in
             request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
             request.httpMethod == "DELETE"
         }
@@ -41,5 +60,26 @@ class AlarmModelOperationTests: OBATestCase {
         let (_, response) = try await obacoService.deleteAlarm(url: alarm.url)
         let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
         XCTAssertEqual(httpResponse.statusCode, 200)
+    }
+
+    /// A genuine 404 — the alarm is already gone — must still surface as `requestNotFound`.
+    func testAlarmDeletionWith404() async throws {
+        let alarm = try Fixtures.loadAlarm()
+
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 404) { (request) -> Bool in
+            request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
+            request.httpMethod == "DELETE"
+        }
+
+        do {
+            _ = try await obacoService.deleteAlarm(url: alarm.url)
+            XCTFail("Expected deleteAlarm to throw APIError.requestNotFound")
+        } catch let error as APIError {
+            guard case .requestNotFound = error else {
+                XCTFail("Expected APIError.requestNotFound, got \(error)")
+                return
+            }
+        }
     }
 }

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopArrivalsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopArrivalsModelOperationTests.swift
@@ -20,6 +20,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
     let campusParkwayStopID = "1_10914"
     let galerStopID = "1_11370"
     let rvtdStopID = "1739_d1e8e68e-83f8-487f-baf5-f465fe70fc84.json"
+    let duplicatesStopID = "1_10914_duplicates"
 
     private func makeUrlString(stopID: StopID) -> String {
         "https://www.example.com/api/where/arrivals-and-departures-for-stop/\(stopID).json"
@@ -43,6 +44,11 @@ class StopArrivalsModelOperationTests: OBATestCase {
         dataLoader.mock(
             URLString: makeUrlString(stopID: rvtdStopID),
             with: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1739-rvtd.json")
+        )
+
+        dataLoader.mock(
+            URLString: makeUrlString(stopID: duplicatesStopID),
+            with: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_10914-duplicates.json")
         )
     }
 
@@ -121,6 +127,30 @@ class StopArrivalsModelOperationTests: OBATestCase {
         expect(tripStatus.activeTrip.id) == "1_40984840"
 
         expect(arrDep.vehicleID) == "1_4559"
+    }
+
+    /// Real-time feeds occasionally assign two vehicles to the same trip, which makes the
+    /// server emit two `arrivalAndDeparture` entries for one trip visit (identical stop,
+    /// trip, route, service date, and stop sequence — i.e. identical `ArrivalDeparture.id`).
+    /// Ingestion must collapse these to a single entry, keeping the most recent report.
+    func testLoading_duplicateTripVisits_collapsedToFreshestReport() async throws {
+        let arrivals = try await restService.getArrivalsAndDeparturesForStop(id: duplicatesStopID, minutesBefore: 5, minutesAfter: 30).entry
+
+        // The fixture contains three entries: trip 1_40984902 reported twice
+        // (stale vehicle 1_4559, then fresh vehicle 1_8109999) and trip 1_40984903 once.
+        expect(arrivals.arrivalsAndDepartures.count) == 2
+
+        let ids = arrivals.arrivalsAndDepartures.map(\.id)
+        expect(Set(ids).count) == ids.count
+
+        // The duplicated trip keeps its original (first-occurrence) position, but is
+        // represented by the report with the newer lastUpdateTime.
+        let deduped = try XCTUnwrap(arrivals.arrivalsAndDepartures.first)
+        expect(deduped.tripID) == "1_40984902"
+        expect(deduped.vehicleID) == "1_8109999"
+        expect(deduped.occupancyStatus) == .empty
+
+        expect(arrivals.arrivalsAndDepartures.last?.tripID) == "1_40984903"
     }
 
     func testLoading_rogueValley() async throws {

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -307,4 +307,16 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(WalkingSpeed.validRange.upperBound))
     }
 
+    // MARK: - Default Alarm Lead Time
+
+    func test_defaultAlarmLeadTime_defaultValueAndRoundTrip() {
+        expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes) == 5
+
+        userDefaultsStore.defaultAlarmLeadTimeMinutes = 10
+        expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes) == 10
+
+        let newStore = UserDefaultsStore(userDefaults: userDefaults)
+        expect(newStore.defaultAlarmLeadTimeMinutes) == 10
+    }
+
 }

--- a/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
+++ b/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import OBAKit
+
+final class AlarmLeadTimeTests: XCTestCase {
+    func test_requestWithinRange_passesThrough() {
+        XCTAssertEqual(AlarmLeadTime.clamped(5, minutesUntilDeparture: 20), 5)
+    }
+
+    func test_clampsToMaximum15() {
+        XCTAssertEqual(AlarmLeadTime.clamped(30, minutesUntilDeparture: 60), 15)
+    }
+
+    func test_clampsToMinimum1() {
+        XCTAssertEqual(AlarmLeadTime.clamped(0, minutesUntilDeparture: 20), 1)
+    }
+
+    func test_cappedBelowMinutesUntilDeparture() {
+        // A buzz can't be scheduled for a moment that's already passed.
+        XCTAssertEqual(AlarmLeadTime.clamped(10, minutesUntilDeparture: 4), 3)
+    }
+
+    func test_departureTooSoon_returnsNil() {
+        // Matches StopViewModel.canCreateAlarm: requires arrivalDepartureMinutes > 1.
+        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 1))
+        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 0))
+    }
+}

--- a/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
+++ b/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
@@ -26,12 +26,14 @@ final class ApproachSliceTests: XCTestCase {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "d")
         XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
         XCTAssertEqual(slice?.vehicleIndex, 1) // "d" within the slice
+        XCTAssertEqual(slice?.skippedStopCount, 0)
     }
 
     func test_shortTrip_usesAllAvailableUpstream() {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "user"]), userStopID: "user", closestStopID: "a")
         XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "user"])
         XCTAssertEqual(slice?.vehicleIndex, 0)
+        XCTAssertEqual(slice?.skippedStopCount, 0)
     }
 
     func test_vehiclePastUserStop_returnsNil() {
@@ -40,11 +42,31 @@ final class ApproachSliceTests: XCTestCase {
         XCTAssertNil(slice)
     }
 
-    func test_vehicleOutsideWindow_hasNilVehicleIndex() {
-        // Vehicle is upstream but further back than the 4-stop window.
+    func test_vehicleBeyondWindow_pinsVehicleStopAndElidesGap() {
+        // Vehicle is upstream but further back than the 4-stop window: its
+        // stop pins to the top, "b"/"c" are elided, the 3 stops nearest the
+        // user remain.
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "a")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "d", "e", "f", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+        XCTAssertEqual(slice?.skippedStopCount, 2)
+    }
+
+    func test_vehicleAtWindowEdge_hasNoGap() {
+        // Vehicle exactly 4 stops upstream sits at the top of the contiguous
+        // window; nothing is elided.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "c")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+        XCTAssertEqual(slice?.skippedStopCount, 0)
+    }
+
+    func test_unknownClosestStop_hasNilVehicleIndex() {
+        // closestStopID not on this trip at all: show the window, no bus dot.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "zzz")
         XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
         XCTAssertNil(slice?.vehicleIndex)
+        XCTAssertEqual(slice?.skippedStopCount, 0)
     }
 
     func test_userStopMissing_returnsNil() {
@@ -55,5 +77,6 @@ final class ApproachSliceTests: XCTestCase {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "user"]), userStopID: "user", closestStopID: nil)
         XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
         XCTAssertNil(slice?.vehicleIndex)
+        XCTAssertEqual(slice?.skippedStopCount, 0)
     }
 }

--- a/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
+++ b/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
@@ -1,0 +1,59 @@
+//
+//  ApproachSliceTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+import OBAKitCore
+
+private struct StubStop: ApproachTimelineStop {
+    let stopID: StopID
+    let stopName: String
+}
+
+private func stops(_ ids: [String]) -> [StubStop] {
+    ids.map { StubStop(stopID: $0, stopName: "Stop \($0)") }
+}
+
+final class ApproachSliceTests: XCTestCase {
+
+    func test_takesFourUpstreamStopsPlusUserStop() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "d")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 1) // "d" within the slice
+    }
+
+    func test_shortTrip_usesAllAvailableUpstream() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "user"]), userStopID: "user", closestStopID: "a")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+    }
+
+    func test_vehiclePastUserStop_returnsNil() {
+        // Vehicle beyond the user's stop: timeline is meaningless, drop it.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "user", "b"]), userStopID: "user", closestStopID: "b")
+        XCTAssertNil(slice)
+    }
+
+    func test_vehicleOutsideWindow_hasNilVehicleIndex() {
+        // Vehicle is upstream but further back than the 4-stop window.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "a")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
+        XCTAssertNil(slice?.vehicleIndex)
+    }
+
+    func test_userStopMissing_returnsNil() {
+        XCTAssertNil(ApproachSlice.make(stopTimes: stops(["a", "b"]), userStopID: "user", closestStopID: "a"))
+    }
+
+    func test_nilClosestStop_stillShowsStops() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "user"]), userStopID: "user", closestStopID: nil)
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
+        XCTAssertNil(slice?.vehicleIndex)
+    }
+}

--- a/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
+++ b/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
@@ -73,6 +73,60 @@ final class ApproachSliceTests: XCTestCase {
         XCTAssertNil(ApproachSlice.make(stopTimes: stops(["a", "b"]), userStopID: "user", closestStopID: "a"))
     }
 
+    // MARK: - Loop routes
+
+    func test_loopRoute_windowsAroundTheDeparturesOwnVisit() {
+        // "user" is visited twice (indices 1 and 5). The departure is for the
+        // second visit, and the vehicle is between the two — so the window must
+        // lead up to index 5, not collapse onto the first visit.
+        let slice = ApproachSlice.make(
+            stopTimes: stops(["a", "user", "b", "c", "d", "user", "e"]),
+            userStopID: "user",
+            userStopSequence: 5,
+            closestStopID: "c"
+        )
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["user", "b", "c", "d", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 2) // "c"
+        XCTAssertEqual(slice?.skippedStopCount, 0)
+    }
+
+    func test_loopRoute_vehicleStopRevisited_usesOccurrenceBeforeUserStop() {
+        // The vehicle's closest stop ("a") also appears downstream of the user's
+        // stop. The upstream occurrence is the leg the vehicle is actually on.
+        let slice = ApproachSlice.make(
+            stopTimes: stops(["a", "b", "user", "a", "c"]),
+            userStopID: "user",
+            userStopSequence: 2,
+            closestStopID: "a"
+        )
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+    }
+
+    func test_loopRoute_vehiclePastTheDeparturesVisit_returnsNil() {
+        // Every occurrence of the vehicle's stop is downstream of this visit.
+        let slice = ApproachSlice.make(
+            stopTimes: stops(["a", "user", "b", "user", "c"]),
+            userStopID: "user",
+            userStopSequence: 1,
+            closestStopID: "b"
+        )
+        XCTAssertNil(slice)
+    }
+
+    func test_staleStopSequence_fallsBackToStopIDSearch() {
+        // A sequence that doesn't point at the user's stop (out of range, or a
+        // feed that numbers sequences differently) falls back to the first match.
+        let slice = ApproachSlice.make(
+            stopTimes: stops(["a", "b", "user"]),
+            userStopID: "user",
+            userStopSequence: 99,
+            closestStopID: "a"
+        )
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+    }
+
     func test_nilClosestStop_stillShowsStops() {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "user"]), userStopID: "user", closestStopID: nil)
         XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])

--- a/OBAKitTests/Stops/StopPage/DepartureStatusBridgeTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusBridgeTests.swift
@@ -1,0 +1,75 @@
+//
+//  DepartureStatusBridgeTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+/// Bridge tests over `DepartureStatus(arrivalDeparture:)` driven by real REST
+/// fixtures rather than the hand-built values in `DepartureStatusTests`. They
+/// verify the init forwards `predicted`/`scheduleStatus` correctly and that the
+/// derived color and label stay consistent with the model's `scheduleStatus`.
+final class DepartureStatusBridgeTests: XCTestCase {
+
+    /// A live `ArrivalDeparture` (`predicted == true`) bridges to a real-time
+    /// status: occupancy is shown and the color/label follow its `scheduleStatus`.
+    func test_realtimeArrivalDeparture_isRealTimeWithConsistentColorAndLabel() throws {
+        let arrivalDeparture = try Fixtures.loadRESTAPIPayload(
+            type: ArrivalDeparture.self,
+            fileName: "arrival-and-departure-for-stop-1_11420.json"
+        )
+        // Guard the fixture's real-time premise so a fixture change can't silently
+        // reduce this to a scheduled-only case.
+        XCTAssertTrue(arrivalDeparture.predicted)
+
+        let status = DepartureStatus(arrivalDeparture: arrivalDeparture)
+        XCTAssertTrue(status.isRealTime)
+        XCTAssertTrue(status.showsOccupancy)
+        assertColorAndLabelConsistent(status, with: arrivalDeparture.scheduleStatus)
+    }
+
+    /// A schedule-only `ArrivalDeparture` (`predicted == false`) bridges to the
+    /// honesty state: no occupancy, gray, and the "schedule data" label that
+    /// deliberately never claims the bus is "on time" (§4.1).
+    func test_scheduledOnlyArrivalDeparture_isNotRealTimeWithScheduleDataLabel() throws {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals_and_departures_for_stop_1_10020_no_realtime.json"
+        )
+        let arrivalDeparture = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        // Every entry in this fixture has `predicted == false`.
+        XCTAssertFalse(arrivalDeparture.predicted)
+
+        let status = DepartureStatus(arrivalDeparture: arrivalDeparture)
+        XCTAssertFalse(status.isRealTime)
+        XCTAssertFalse(status.showsOccupancy)
+        XCTAssertEqual(status.label, "schedule data")
+        XCTAssertNotEqual(status.label, "on time")
+        XCTAssertEqual(status.color, UIColor.secondaryLabel)
+    }
+
+    /// Asserts the real-time status' derived color and label agree with whatever
+    /// `scheduleStatus` the model computed for the fixture.
+    private func assertColorAndLabelConsistent(_ status: DepartureStatus, with scheduleStatus: ScheduleStatus) {
+        switch scheduleStatus {
+        case .onTime:
+            XCTAssertEqual(status.color, ThemeColors.shared.departureOnTime)
+            XCTAssertEqual(status.label, "on time")
+        case .early:
+            XCTAssertEqual(status.color, ThemeColors.shared.departureEarly)
+            XCTAssertTrue(status.label.contains("early"))
+        case .delayed:
+            XCTAssertEqual(status.color, ThemeColors.shared.departureLate)
+            XCTAssertTrue(status.label.contains("late"))
+        case .unknown:
+            XCTAssertEqual(status.color, UIColor.secondaryLabel)
+            XCTAssertEqual(status.label, "schedule data")
+        }
+    }
+}

--- a/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+final class DepartureStatusTests: XCTestCase {
+
+    func test_scheduledOnly_isGrayWithScheduleDataLabel() {
+        let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
+        XCTAssertEqual(status.color, UIColor.secondaryLabel)
+        XCTAssertEqual(status.label, "schedule data")
+        XCTAssertFalse(status.showsOccupancy)
+    }
+
+    func test_scheduledOnly_neverClaimsOnTime_evenWithZeroDeviation() {
+        // §4.1: a scheduled bus is NOT "on time" — we have no idea if it's on time.
+        let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
+        XCTAssertNotEqual(status.label, "on time")
+    }
+
+    func test_onTime_isGreen() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureOnTime)
+        XCTAssertEqual(status.label, "on time")
+        XCTAssertTrue(status.showsOccupancy)
+    }
+
+    func test_late_isBlue_withMinuteCount() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .delayed, deviationMinutes: 4)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureLate)
+        XCTAssertEqual(status.label, "4 min late")
+    }
+
+    func test_early_isRed_withMinuteCount() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .early, deviationMinutes: -3)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureEarly)
+        XCTAssertEqual(status.label, "3 min early")
+    }
+}

--- a/OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift
+++ b/OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift
@@ -1,0 +1,34 @@
+//
+//  FeatureFlagsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+import XCTest
+@testable import OBAKitCore
+
+final class FeatureFlagsTests: XCTestCase {
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "FeatureFlagsTests")!
+        defaults.removePersistentDomain(forName: "FeatureFlagsTests")
+    }
+
+    func test_newStopPage_defaultsToEnabled() {
+        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+
+    func test_newStopPage_respectsExplicitFalse() {
+        defaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
+        XCTAssertFalse(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+
+    func test_newStopPage_respectsExplicitTrue() {
+        defaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
+        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+}

--- a/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
@@ -83,10 +83,4 @@ final class StopPageListBuilderTests: XCTestCase {
         XCTAssertEqual(groups[0].chips.map(\.id), ["d1", "d2", "d3"])
         XCTAssertEqual(groups[0].upcoming.count, 5)
     }
-
-    func test_groups_singleDeparture_hasEmptyChips() {
-        // Renders as "later trips not loaded" (§4.4) — builder just returns empty.
-        let groups = StopPageListBuilder.routeGroups([dep("only", route: "24", mins: 8)])
-        XCTAssertTrue(groups[0].chips.isEmpty)
-    }
 }

--- a/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+private struct StubDeparture: DepartureListEntry {
+    let id: String
+    let routeID: RouteID
+    let arrivalDepartureMinutes: Int
+    var temporalState: TemporalState {
+        arrivalDepartureMinutes < 0 ? .past : (arrivalDepartureMinutes == 0 ? .present : .future)
+    }
+}
+
+private func dep(_ id: String, route: String, mins: Int) -> StubDeparture {
+    StubDeparture(id: id, routeID: route, arrivalDepartureMinutes: mins)
+}
+
+final class StopPageListBuilderTests: XCTestCase {
+
+    // MARK: - Chronological partition
+
+    func test_partition_splitsAtWalkThreshold() {
+        let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5), dep("c", route: "62", mins: 7)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
+        XCTAssertEqual(p.missed.map(\.id), ["a"])       // 1 < 4: can't reach on foot
+        XCTAssertEqual(p.reachable.map(\.id), ["b", "c"]) // 5 and 7 >= 4 (§4.5: catchable iff mins >= walk)
+        XCTAssertTrue(p.past.isEmpty)
+    }
+
+    func test_partition_boundaryIsCatchable() {
+        // minutesAway == walkMinutes is catchable (§4.5: >=)
+        let p = StopPageListBuilder.chronologicalPartition([dep("x", route: "5", mins: 4)], walkMinutes: 4)
+        XCTAssertEqual(p.reachable.map(\.id), ["x"])
+        XCTAssertTrue(p.missed.isEmpty)
+    }
+
+    func test_partition_nilWalk_hasNoMissedBucket() {
+        let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
+        XCTAssertTrue(p.missed.isEmpty)
+        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+    }
+
+    func test_partition_pastIsSeparateFromMissed() {
+        // §4.2: past (already departed) and missed (can't walk there in time) are distinct.
+        let deps = [dep("gone", route: "24", mins: -3), dep("miss", route: "H", mins: 1), dep("ok", route: "5", mins: 9)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
+        XCTAssertEqual(p.past.map(\.id), ["gone"])
+        XCTAssertEqual(p.missed.map(\.id), ["miss"])
+        XCTAssertEqual(p.reachable.map(\.id), ["ok"])
+    }
+
+    func test_partition_sortsByMinutes() {
+        let deps = [dep("b", route: "1", mins: 9), dep("a", route: "2", mins: 5)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
+        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+    }
+
+    // MARK: - Route groups
+
+    func test_groups_orderedBySoonestDeparture_notRouteName() {
+        // §4.9: route with a bus in 1m outranks a route whose next is 5m.
+        let deps = [
+            dep("z5", route: "5", mins: 5), dep("h1", route: "H Line", mins: 1),
+            dep("h2", route: "H Line", mins: 12), dep("z5b", route: "5", mins: 30)
+        ]
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups.map(\.routeID), ["H Line", "5"])
+        XCTAssertEqual(groups[0].departures.map(\.id), ["h1", "h2"])
+        XCTAssertEqual(groups[0].next.id, "h1")
+    }
+
+    func test_groups_excludePastDepartures() {
+        let deps = [dep("gone", route: "5", mins: -2), dep("soon", route: "5", mins: 6)]
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].departures.map(\.id), ["soon"])
+    }
+
+    func test_groups_chips_areAtMostThree_afterNext() {
+        let deps = (0..<6).map { dep("d\($0)", route: "40", mins: 5 + $0 * 5) }
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups[0].chips.map(\.id), ["d1", "d2", "d3"])
+        XCTAssertEqual(groups[0].upcoming.count, 5)
+    }
+
+    func test_groups_singleDeparture_hasEmptyChips() {
+        // Renders as "later trips not loaded" (§4.4) — builder just returns empty.
+        let groups = StopPageListBuilder.routeGroups([dep("only", route: "24", mins: 8)])
+        XCTAssertTrue(groups[0].chips.isEmpty)
+    }
+}

--- a/OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift
+++ b/OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import CoreLocation
+@testable import OBAKit
+
+final class WalkTimeInfoTests: XCTestCase {
+    // ~111m per 0.001 degree latitude at the equator; use real CLLocations.
+    private let stopLocation = CLLocation(latitude: 47.6097, longitude: -122.3331)
+
+    func test_computesMinutesRoundedUp() {
+        // ~500m at 1.25 m/s = 400s = 6.67 min -> 7 min
+        let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
+        let info = WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25)
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info!.walkMinutes, 7)
+    }
+
+    func test_nilWhenUserLocationMissing() {
+        XCTAssertNil(WalkTimeInfo.compute(from: nil, to: stopLocation, speedMetersPerSecond: 1.25))
+    }
+
+    func test_nilWhenVeryClose() {
+        // <= 40m: suppress, matching today's WalkTimeView behavior.
+        let user = CLLocation(latitude: 47.60972, longitude: -122.3331)
+        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25))
+    }
+
+    func test_nilWhenSpeedInvalid() {
+        let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
+        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 0))
+    }
+}

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -39,12 +39,13 @@ class StopViewModelTests: OBATestCase {
     private func createApplication(
         dataLoader: MockDataLoader,
         analytics: AnalyticsMock,
-        surveyHitCounter: SurveyHitCounter? = nil
+        surveyHitCounter: SurveyHitCounter? = nil,
+        arrivalsFixture: String = "arrivals_and_departures_empty.json"
     ) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
-        stubArrivalsAndDepartures(dataLoader: dataLoader)
+        stubArrivalsAndDepartures(dataLoader: dataLoader, fixture: arrivalsFixture)
         if let surveyHitCounter {
             stubSurveys(dataLoader: dataLoader, counter: surveyHitCounter)
         } else {
@@ -75,10 +76,10 @@ class StopViewModelTests: OBATestCase {
         return Application(config: config)
     }
 
-    /// Stubs every `arrivals-and-departures-for-stop` call with an empty-arrivals payload.
+    /// Stubs every `arrivals-and-departures-for-stop` call with the given fixture.
     /// The matcher is path-based, so the same stub serves every minutesAfter value the VM walks through.
-    private func stubArrivalsAndDepartures(dataLoader: MockDataLoader) {
-        let data = Fixtures.loadData(file: "arrivals_and_departures_empty.json")
+    private func stubArrivalsAndDepartures(dataLoader: MockDataLoader, fixture: String = "arrivals_and_departures_empty.json") {
+        let data = Fixtures.loadData(file: fixture)
         dataLoader.mock(data: data) { request in
             request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
         }
@@ -708,5 +709,46 @@ class StopViewModelTests: OBATestCase {
         expect(alarm.alarmDate).to(beNil())
 
         expect(viewModel.alarmLeadTimeMinutes(alarm)) == AlarmLeadTime.defaultMinutes
+    }
+
+    // MARK: - Approach Cache (trip panel)
+
+    /// The synchronous cache accessor backs the trip panel's "render at full
+    /// size on insert" behavior: nil before the async fetch has populated the
+    /// cache, identical to the fetched details afterwards, and nil again after
+    /// a refresh invalidates the cache.
+    @MainActor
+    func test_cachedApproachTripDetails_warmAfterFetch_invalidatedByRefresh() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            analytics: AnalyticsMock(),
+            arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json"
+        )
+
+        // Stub the trip-details endpoint behind `approachTripDetails`.
+        let tripData = Fixtures.loadData(file: "trip_details_1_18196913.json")
+        dataLoader.mock(data: tripData) { request in
+            request.url?.path.contains("/api/where/trip-details/") ?? false
+        }
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        let departure = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures.first)
+        expect(departure.predicted).to(beTrue())
+
+        // Cold: nothing cached until the async path has run.
+        expect(viewModel.cachedApproachTripDetails(for: departure)).to(beNil())
+
+        let fetched = await viewModel.approachTripDetails(for: departure)
+        expect(fetched).toNot(beNil())
+
+        // Warm: the sync accessor returns the exact cached instance.
+        expect(viewModel.cachedApproachTripDetails(for: departure)).to(beIdenticalTo(fetched))
+
+        // Refresh clears the cache, so the accessor goes cold again.
+        await viewModel.refresh()
+        expect(viewModel.cachedApproachTripDetails(for: departure)).to(beNil())
     }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -677,4 +677,36 @@ class StopViewModelTests: OBATestCase {
         let plainController = app.viewRouter.makeStopController(stop: stop, transferContext: nil)
         expect(plainController).to(beAKindOf(StopPageViewController.self))
     }
+
+    // MARK: - Alarm Lead Time
+
+    /// `alarmLeadTimeMinutes` derives the displayed lead time from the alarm's
+    /// `tripDate`/`alarmDate` spread, not from any stored minutes field.
+    @MainActor
+    func test_alarmLeadTimeMinutes_derivesFromDates() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+
+        let alarm = try Fixtures.loadAlarm()
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 600), alarmOffset: 8)
+
+        expect(viewModel.alarmLeadTimeMinutes(alarm)) == 8
+    }
+
+    /// With no `tripDate`/`alarmDate` to measure, the lead time falls back to the
+    /// default rather than surfacing a bogus value.
+    @MainActor
+    func test_alarmLeadTimeMinutes_fallsBackToDefaultOnNilDates() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+
+        // A freshly decoded alarm has nil `tripDate`/`alarmDate` until `set(...)`.
+        let alarm = try Fixtures.loadAlarm()
+        expect(alarm.tripDate).to(beNil())
+        expect(alarm.alarmDate).to(beNil())
+
+        expect(viewModel.alarmLeadTimeMinutes(alarm)) == AlarmLeadTime.defaultMinutes
+    }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -653,4 +653,28 @@ class StopViewModelTests: OBATestCase {
         // OR heroSubmitInFlight) prevents a duplicate emission.
         expect(presented.count) == 1
     }
+
+    // MARK: - Router transfer fallback (final-review FIX 1)
+
+    /// A transfer (non-nil `TransferContext`) must always resolve to the legacy
+    /// `StopViewController`, even with the new-stop-page flag ON (its default),
+    /// because the transfer UX isn't built on the new page yet. A plain open with
+    /// the flag ON resolves to the new `StopPageViewController`.
+    @MainActor
+    func test_makeStopController_transferContext_fallsBackToLegacyScreen() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        // The new-stop-page flag defaults to ON when unset.
+        expect(FeatureFlags.isNewStopPageEnabled(userDefaults: app.userDefaults)).to(beTrue())
+
+        let stop = try XCTUnwrap(try Fixtures.loadSomeStops().first)
+
+        let transfer = TransferContext(arrivalTime: Date(), fromRouteShortName: "1", fromTripHeadsign: "Downtown")
+        let transferController = app.viewRouter.makeStopController(stop: stop, transferContext: transfer)
+        expect(transferController).to(beAKindOf(StopViewController.self))
+
+        let plainController = app.viewRouter.makeStopController(stop: stop, transferContext: nil)
+        expect(plainController).to(beAKindOf(StopPageViewController.self))
+    }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -36,16 +36,28 @@ class StopViewModelTests: OBATestCase {
 
     /// Builds an `Application` whose REST API service routes through the supplied `MockDataLoader`.
     /// Locks the current region to Puget Sound so the API base URL is deterministic.
+    ///
+    /// Pass `bundledRegionsFixture: "regions-puget-sound-no-sidecar.json"` for a Puget
+    /// Sound with no `sidecarBaseURL`, which leaves `application.obacoService` nil —
+    /// the configuration the alarm paths have to survive.
     private func createApplication(
         dataLoader: MockDataLoader,
         analytics: AnalyticsMock,
         surveyHitCounter: SurveyHitCounter? = nil,
-        arrivalsFixture: String = "arrivals_and_departures_empty.json"
+        arrivalsFixture: String = "arrivals_and_departures_empty.json",
+        arrivalsData: Data? = nil,
+        bundledRegionsFixture: String? = nil
     ) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
-        stubArrivalsAndDepartures(dataLoader: dataLoader, fixture: arrivalsFixture)
+        if let arrivalsData {
+            dataLoader.mock(data: arrivalsData) { request in
+                request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            }
+        } else {
+            stubArrivalsAndDepartures(dataLoader: dataLoader, fixture: arrivalsFixture)
+        }
         if let surveyHitCounter {
             stubSurveys(dataLoader: dataLoader, counter: surveyHitCounter)
         } else {
@@ -67,13 +79,29 @@ class StopViewModelTests: OBATestCase {
             analytics: analytics,
             queue: queue,
             locationService: locationService,
-            bundledRegionsFilePath: bundledRegionsPath,
+            bundledRegionsFilePath: bundledRegionsFixture.map { Fixtures.path(to: $0) } ?? bundledRegionsPath,
             regionsAPIPath: regionsAPIPath,
             dataLoader: dataLoader,
             fixedRegionName: Fixtures.pugetSoundRegion.name
         )
 
         return Application(config: config)
+    }
+
+    /// `RegionsService` prefers the on-disk regions file over the bundled one, and a
+    /// prior run in the same simulator can leave a copy that *does* have a sidecar URL.
+    /// Wipe it so a no-sidecar bundled fixture actually reaches `currentRegion`.
+    private func removeStoredRegionsFile() {
+        guard let appSupport = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else { return }
+
+        try? FileManager.default.removeItem(
+            at: appSupport.appendingPathComponent("Regions/default-regions.json")
+        )
     }
 
     /// Stubs every `arrivals-and-departures-for-stop` call with the given fixture.
@@ -750,5 +778,108 @@ class StopViewModelTests: OBATestCase {
         // Refresh clears the cache, so the accessor goes cold again.
         await viewModel.refresh()
         expect(viewModel.cachedApproachTripDetails(for: departure)).to(beNil())
+    }
+
+    /// The approach fetch varies by trip *instance* — `getTrip` takes tripID,
+    /// vehicleID and serviceDate — so the cache has to key on all three. Keyed on
+    /// tripID alone, the same trip running on two service days shares one entry and
+    /// the panel renders the other day's timeline.
+    @MainActor
+    func test_approachCache_sameTripDifferentServiceDate_doesNotCollide() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            analytics: AnalyticsMock(),
+            arrivalsData: try arrivalsWithSameTripOnTwoServiceDays()
+        )
+
+        let tripData = Fixtures.loadData(file: "trip_details_1_18196913.json")
+        dataLoader.mock(data: tripData) { request in
+            request.url?.path.contains("/api/where/trip-details/") ?? false
+        }
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        let departures = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures)
+        let today = try XCTUnwrap(departures.first { $0.vehicleID == "1_7028" })
+        let tomorrow = try XCTUnwrap(departures.first { $0.vehicleID == "1_9999" })
+
+        // Same trip, different instance: only the service date and vehicle differ.
+        expect(today.tripID) == tomorrow.tripID
+        expect(today.serviceDate).toNot(equal(tomorrow.serviceDate))
+
+        // Warm the cache for one instance.
+        let fetched = await viewModel.approachTripDetails(for: today)
+        expect(fetched).toNot(beNil())
+        expect(viewModel.cachedApproachTripDetails(for: today)).toNot(beNil())
+
+        // The other instance is a different request and must not read that entry.
+        expect(viewModel.cachedApproachTripDetails(for: tomorrow)).to(beNil())
+    }
+
+    /// The arrivals fixture with its first departure duplicated onto the next service
+    /// day (new vehicle, same trip), so the two entries differ only in the fields the
+    /// approach cache key has to account for.
+    private func arrivalsWithSameTripOnTwoServiceDays() throws -> Data {
+        let raw = Fixtures.loadData(file: "arrivals_and_departures_for_stop_1_10020.json")
+        var payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        var data = try XCTUnwrap(payload["data"] as? [String: Any])
+        var entry = try XCTUnwrap(data["entry"] as? [String: Any])
+        var arrDeps = try XCTUnwrap(entry["arrivalsAndDepartures"] as? [[String: Any]])
+
+        var nextDay = try XCTUnwrap(arrDeps.first)
+        let serviceDate = try XCTUnwrap(nextDay["serviceDate"] as? Int)
+        nextDay["serviceDate"] = serviceDate + 86_400_000 // ms
+        nextDay["vehicleId"] = "1_9999"
+        arrDeps.append(nextDay)
+
+        entry["arrivalsAndDepartures"] = arrDeps
+        data["entry"] = entry
+        payload["data"] = data
+        return try JSONSerialization.data(withJSONObject: payload)
+    }
+
+    // MARK: - Alarm Cancellation
+
+    /// Cancelling with no Obaco service must not report success: the server alarm is
+    /// still armed and will still fire, so dropping the local copy would leave the
+    /// rider with a buzzing alarm they can no longer see or cancel.
+    @MainActor
+    func test_cancelAlarm_withoutObacoService_keepsAlarmAndSurfacesError() async throws {
+        removeStoredRegionsFile()
+
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            analytics: AnalyticsMock(),
+            arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json",
+            bundledRegionsFixture: "regions-puget-sound-no-sidecar.json"
+        )
+
+        // Precondition: no sidecar URL means no Obaco service to delete against.
+        expect(app.obacoService).to(beNil())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        let departure = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures.first)
+        let region = try XCTUnwrap(app.currentRegion)
+
+        let alarm = try Fixtures.loadAlarm()
+        alarm.deepLink = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
+        // A trip in the future, so `deleteExpiredAlarms()` doesn't prune it out from under us.
+        alarm.set(tripDate: Date(timeIntervalSinceNow: 900), alarmOffset: 5)
+        app.userDataStore.add(alarm: alarm)
+
+        // The index is rebuilt from the persisted store on each successful fetch.
+        await viewModel.refresh()
+        expect(viewModel.alarm(for: departure)).toNot(beNil())
+
+        await viewModel.cancelAlarm(for: departure)
+
+        expect(viewModel.alarmError).toNot(beNil())
+        expect(viewModel.alarm(for: departure)).toNot(beNil())
+        expect(app.userDataStore.alarms).toNot(beEmpty())
     }
 }

--- a/OBAKitTests/fixtures/arrivals-and-departures-for-stop-1_10914-duplicates.json
+++ b/OBAKitTests/fixtures/arrivals-and-departures-for-stop-1_10914-duplicates.json
@@ -1,0 +1,663 @@
+{
+  "code": 200,
+  "currentTime": 1541141817860,
+  "data": {
+    "entry": {
+      "arrivalsAndDepartures": [
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 9,
+          "departureEnabled": true,
+          "distanceFromStop": 1232.648659247323,
+          "frequency": null,
+          "lastUpdateTime": 1541141749000,
+          "numberOfStopsAway": 4,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1541142156000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1541142156000,
+          "routeId": "1_100447",
+          "routeLongName": "",
+          "routeShortName": "49",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1541142000000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1541142000000,
+          "serviceDate": 1541055600000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "1_10914",
+          "stopSequence": 3,
+          "totalStopsInTrip": 22,
+          "tripHeadsign": "Downtown Seattle Broadway",
+          "tripId": "1_40984902",
+          "tripStatus": {
+            "activeTripId": "1_40984840",
+            "blockTripSequence": 8,
+            "closestStop": "1_9650",
+            "closestStopTimeOffset": -1,
+            "distanceAlongTrip": 10052.41120684016,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 47.66180419921875,
+              "lon": -122.31656646728516
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1541141749000,
+            "lastUpdateTime": 1541141749000,
+            "nextStop": "1_10910",
+            "nextStopTimeOffset": 167,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 47.66179839856307,
+              "lon": -122.316566
+            },
+            "predicted": true,
+            "scheduleDeviation": 1176,
+            "scheduledDistanceAlongTrip": 10052.41120684016,
+            "serviceDate": 1541055600000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "totalDistanceAlongTrip": 10375.845555925045,
+            "vehicleId": "1_4559"
+          },
+          "vehicleId": "1_4559"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 9,
+          "departureEnabled": true,
+          "distanceFromStop": 1232.648659247323,
+          "frequency": null,
+          "lastUpdateTime": 1541141749000,
+          "numberOfStopsAway": 4,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1541143056000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1541143056000,
+          "routeId": "1_100447",
+          "routeLongName": "",
+          "routeShortName": "49",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1541142900000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1541142900000,
+          "serviceDate": 1541055600000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "1_10914",
+          "stopSequence": 3,
+          "totalStopsInTrip": 22,
+          "tripHeadsign": "Downtown Seattle Broadway",
+          "tripId": "1_40984903",
+          "tripStatus": {
+            "activeTripId": "1_40984840",
+            "blockTripSequence": 8,
+            "closestStop": "1_9650",
+            "closestStopTimeOffset": -1,
+            "distanceAlongTrip": 10052.41120684016,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 47.66180419921875,
+              "lon": -122.31656646728516
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1541141749000,
+            "lastUpdateTime": 1541141749000,
+            "nextStop": "1_10910",
+            "nextStopTimeOffset": 167,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 47.66179839856307,
+              "lon": -122.316566
+            },
+            "predicted": true,
+            "scheduleDeviation": 1176,
+            "scheduledDistanceAlongTrip": 10052.41120684016,
+            "serviceDate": 1541055600000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "totalDistanceAlongTrip": 10375.845555925045,
+            "vehicleId": "1_4559"
+          },
+          "vehicleId": "1_4570"
+        },
+        {
+          "arrivalEnabled": true,
+          "blockTripSequence": 9,
+          "departureEnabled": true,
+          "distanceFromStop": 1232.648659247323,
+          "frequency": null,
+          "lastUpdateTime": 1541141809000,
+          "numberOfStopsAway": 4,
+          "predicted": true,
+          "predictedArrivalInterval": null,
+          "predictedArrivalTime": 1541142156000,
+          "predictedDepartureInterval": null,
+          "predictedDepartureTime": 1541142156000,
+          "routeId": "1_100447",
+          "routeLongName": "",
+          "routeShortName": "49",
+          "scheduledArrivalInterval": null,
+          "scheduledArrivalTime": 1541142000000,
+          "scheduledDepartureInterval": null,
+          "scheduledDepartureTime": 1541142000000,
+          "serviceDate": 1541055600000,
+          "situationIds": [],
+          "status": "default",
+          "stopId": "1_10914",
+          "stopSequence": 3,
+          "totalStopsInTrip": 22,
+          "tripHeadsign": "Downtown Seattle Broadway",
+          "tripId": "1_40984902",
+          "tripStatus": {
+            "activeTripId": "1_40984840",
+            "blockTripSequence": 8,
+            "closestStop": "1_9650",
+            "closestStopTimeOffset": -1,
+            "distanceAlongTrip": 10052.41120684016,
+            "frequency": null,
+            "lastKnownDistanceAlongTrip": 0,
+            "lastKnownLocation": {
+              "lat": 47.66180419921875,
+              "lon": -122.31656646728516
+            },
+            "lastKnownOrientation": 0,
+            "lastLocationUpdateTime": 1541141749000,
+            "lastUpdateTime": 1541141749000,
+            "nextStop": "1_10910",
+            "nextStopTimeOffset": 167,
+            "orientation": 90,
+            "phase": "in_progress",
+            "position": {
+              "lat": 47.66179839856307,
+              "lon": -122.316566
+            },
+            "predicted": true,
+            "scheduleDeviation": 1176,
+            "scheduledDistanceAlongTrip": 10052.41120684016,
+            "serviceDate": 1541055600000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "totalDistanceAlongTrip": 10375.845555925045,
+            "vehicleId": "1_4559"
+          },
+          "vehicleId": "1_8109999",
+          "occupancyStatus": "EMPTY"
+        }
+      ],
+      "nearbyStopIds": [
+        "1_29440",
+        "1_9575",
+        "1_9144",
+        "1_9142"
+      ],
+      "situationIds": [],
+      "stopId": "1_10914"
+    },
+    "references": {
+      "agencies": [
+        {
+          "disclaimer": "",
+          "email": "",
+          "fareUrl": "",
+          "id": "1",
+          "lang": "EN",
+          "name": "Metro Transit",
+          "phone": "206-553-3000",
+          "privateService": false,
+          "timezone": "America/Los_Angeles",
+          "url": "http://metro.kingcounty.gov"
+        },
+        {
+          "disclaimer": "",
+          "email": "",
+          "fareUrl": "",
+          "id": "40",
+          "lang": "EN",
+          "name": "Sound Transit",
+          "phone": "1-888-889-6368",
+          "privateService": false,
+          "timezone": "America/Los_Angeles",
+          "url": "http://www.soundtransit.org"
+        }
+      ],
+      "routes": [
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Univ Dist-Montlake-Capitol Hill-Downtown Seattle",
+          "id": "1_100223",
+          "longName": "",
+          "shortName": "43",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/043/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Ballard - Montlake",
+          "id": "1_100224",
+          "longName": "",
+          "shortName": "44",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/044/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Mt Baker - University District",
+          "id": "1_100228",
+          "longName": "",
+          "shortName": "48",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/048/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Univ District - Broadway - Downtown Seattle",
+          "id": "1_100447",
+          "longName": "",
+          "shortName": "49",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/049/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "University District - Eastlake - Downtown Seattle",
+          "id": "1_100264",
+          "longName": "",
+          "shortName": "70",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/070/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "South Renton P&R - University District",
+          "id": "1_100059",
+          "longName": "",
+          "shortName": "167",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/167/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Twin Lakes P&R - University District",
+          "id": "1_100088",
+          "longName": "",
+          "shortName": "197",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/197/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Issaquah - University District",
+          "id": "1_100162",
+          "longName": "",
+          "shortName": "271",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/271/n0.html"
+        },
+        {
+          "agencyId": "40",
+          "color": "",
+          "description": "Overlake P&R - University District",
+          "id": "40_102640",
+          "longName": "",
+          "shortName": "541",
+          "textColor": "",
+          "type": 3,
+          "url": "http://www.soundtransit.org/Schedules/ST-Express-Bus/541"
+        },
+        {
+          "agencyId": "40",
+          "color": "",
+          "description": "Redmond - University District",
+          "id": "40_100511",
+          "longName": "Redmond - University District",
+          "shortName": "542",
+          "textColor": "",
+          "type": 3,
+          "url": "http://www.soundtransit.org/Schedules/ST-Express-Bus/542"
+        },
+        {
+          "agencyId": "40",
+          "color": "",
+          "description": "Issaquah - University District - Northgate",
+          "id": "40_100451",
+          "longName": "Issaquah - Northgate",
+          "shortName": "556",
+          "textColor": "",
+          "type": 3,
+          "url": "http://www.soundtransit.org/Schedules/ST-Express-Bus/556"
+        },
+        {
+          "agencyId": "40",
+          "color": "",
+          "description": "",
+          "id": "40_586",
+          "longName": "Tacoma - U. District",
+          "shortName": "586",
+          "textColor": "",
+          "type": 3,
+          "url": ""
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Northgate - Roosevelt - University District",
+          "id": "1_100259",
+          "longName": "",
+          "shortName": "67",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/067/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Sand Point - Downtown Seattle",
+          "id": "1_100268",
+          "longName": "",
+          "shortName": "74",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/074/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Juanita - University District",
+          "id": "1_100168",
+          "longName": "",
+          "shortName": "277",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/277/n0.html"
+        },
+        {
+          "agencyId": "40",
+          "color": "",
+          "description": "Kirkland - University District",
+          "id": "40_100235",
+          "longName": "Kirkland - University District",
+          "shortName": "540",
+          "textColor": "",
+          "type": 3,
+          "url": "http://www.soundtransit.org/Schedules/ST-Express-Bus/540"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Univ District - Fremont - Central Magnolia",
+          "id": "1_100184",
+          "longName": "",
+          "shortName": "31",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/031/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Lake City  - University District",
+          "id": "1_100254",
+          "longName": "",
+          "shortName": "65",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/065/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Northgate - Lake City - Sand Point - Univ District",
+          "id": "1_100269",
+          "longName": "",
+          "shortName": "75",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/075/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "UW/Cascadia College - University District",
+          "id": "1_100214",
+          "longName": "",
+          "shortName": "372",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/372/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Loyal Heights - University District",
+          "id": "1_100225",
+          "longName": "",
+          "shortName": "45",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/045/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Wedgwood - University District - Downtown Seattle",
+          "id": "1_100265",
+          "longName": "",
+          "shortName": "71",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/071/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Jackson Park - Univ District - Downtown Seattle",
+          "id": "1_100267",
+          "longName": "",
+          "shortName": "73",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/073/n0.html"
+        },
+        {
+          "agencyId": "1",
+          "color": "",
+          "description": "Aurora Village TC - University District",
+          "id": "1_100215",
+          "longName": "",
+          "shortName": "373",
+          "textColor": "",
+          "type": 3,
+          "url": "http://metro.kingcounty.gov/schedules/373/n0.html"
+        }
+      ],
+      "situations": [],
+      "stops": [
+        {
+          "code": "10914",
+          "direction": "S",
+          "id": "1_10914",
+          "lat": 47.656422,
+          "locationType": 0,
+          "lon": -122.312164,
+          "name": "15th Ave NE & NE Campus Pkwy",
+          "routeIds": [
+            "1_100223",
+            "1_100224",
+            "1_100228",
+            "1_100447",
+            "1_100264",
+            "1_100059",
+            "1_100088",
+            "1_100162",
+            "40_102640",
+            "40_100511",
+            "40_100451",
+            "40_586"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "9650",
+          "direction": "N",
+          "id": "1_9650",
+          "lat": 47.661781,
+          "locationType": 0,
+          "lon": -122.316467,
+          "name": "11th Ave NE & NE 45th St",
+          "routeIds": [
+            "1_100447",
+            "1_100259",
+            "1_100264",
+            "1_100268"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "10910",
+          "direction": "S",
+          "id": "1_10910",
+          "lat": 47.662281,
+          "locationType": 0,
+          "lon": -122.315475,
+          "name": "12th Ave NE & NE 47th St",
+          "routeIds": [
+            "1_100447",
+            "1_100264"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "29440",
+          "direction": "N",
+          "id": "1_29440",
+          "lat": 47.655708,
+          "locationType": 0,
+          "lon": -122.311974,
+          "name": "15th Ave NE & NE Campus Pkwy",
+          "routeIds": [
+            "1_100223",
+            "1_100224",
+            "1_100228",
+            "1_100059",
+            "1_100162",
+            "1_100168",
+            "40_100235",
+            "40_102640",
+            "40_100511",
+            "40_100451"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "9575",
+          "direction": "E",
+          "id": "1_9575",
+          "lat": 47.655918,
+          "locationType": 0,
+          "lon": -122.313354,
+          "name": "NE Campus Pkwy & University Way NE - Bay 2",
+          "routeIds": [
+            "1_100184",
+            "1_100254",
+            "1_100269",
+            "1_100214"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "9144",
+          "direction": "W",
+          "id": "1_9144",
+          "lat": 47.656281,
+          "locationType": 0,
+          "lon": -122.313187,
+          "name": "NE Campus Pkwy & University Way NE",
+          "routeIds": [
+            "1_100214"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        },
+        {
+          "code": "9142",
+          "direction": "S",
+          "id": "1_9142",
+          "lat": 47.656948,
+          "locationType": 0,
+          "lon": -122.313339,
+          "name": "University Way NE & NE 41st St",
+          "routeIds": [
+            "1_100225",
+            "1_100265",
+            "1_100267",
+            "1_100215"
+          ],
+          "wheelchairBoarding": "UNKNOWN"
+        }
+      ],
+      "trips": [
+        {
+          "blockId": "1_5126019",
+          "directionId": "1",
+          "id": "1_40984902",
+          "routeId": "1_100447",
+          "routeShortName": "",
+          "serviceId": "1_137160",
+          "shapeId": "1_20049030",
+          "timeZone": "",
+          "tripHeadsign": "Downtown Seattle Broadway",
+          "tripShortName": "LOCAL"
+        },
+        {
+          "blockId": "1_5126019",
+          "directionId": "0",
+          "id": "1_40984840",
+          "routeId": "1_100447",
+          "routeShortName": "",
+          "serviceId": "1_137160",
+          "shapeId": "1_11049048",
+          "timeZone": "",
+          "tripHeadsign": "University District Broadway",
+          "tripShortName": "LOCAL"
+        },
+        {
+          "blockId": "1_5126019",
+          "directionId": "1",
+          "id": "1_40984903",
+          "routeId": "1_100447",
+          "routeShortName": "",
+          "serviceId": "1_137160",
+          "shapeId": "1_20049030",
+          "timeZone": "",
+          "tripHeadsign": "Downtown Seattle Broadway",
+          "tripShortName": "LOCAL"
+        }
+      ]
+    }
+  },
+  "text": "OK",
+  "version": 2
+}

--- a/docs/superpowers/plans/2026-07-10-stop-page-rethink.md
+++ b/docs/superpowers/plans/2026-07-10-stop-page-rethink.md
@@ -1,0 +1,2725 @@
+# Stop Page Rethink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the Stop screen as a SwiftUI page with two list modes (Chronological / By route), an inline trip-detail panel with a live approach timeline, and one-tap Obaco alarms — shipped behind a default-ON flag alongside the existing `StopViewController`.
+
+**Architecture:** A new `StopPageViewController` (thin `UIHostingController`) hosts `StopPageView`, which is the *only* view observing the existing `StopViewModel` (all subviews take plain values). Pure presentation logic (`DepartureStatus`, list transforms, alarm clamp, approach slice) lives in small value types unit-tested in `OBAKitTests`. The router picks new vs. old screen by feature flag.
+
+**Tech Stack:** Swift / SwiftUI (iOS 18.0), existing `StopViewModel` (Combine `ObservableObject`), `OBAListView`-free, Obaco server-push alarms, XcodeGen project generation, Nimble-free plain XCTest for new tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md` — read it before starting. Section references (§4.1 etc.) are to the brief nuances embedded in that spec.
+
+## Global Constraints
+
+- **Deployment target: iOS 18.0** (`Apps/Shared/app_shared.yml`). Do not use iOS 26-only API (e.g. `LazyVStack` swipe actions).
+- **Regenerate the project after adding/removing files**: `scripts/generate_project OneBusAway` (XcodeGen; new files are invisible to the build until you do).
+- **Build/test commands** (iPhone 17 simulator — iPhone 16 is NOT installed):
+  - Build for testing: `xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+  - Run one test class: `xcodebuild test-without-building -only-testing:OBAKitTests/<ClassName> -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+  - Known issue: under Xcode 27 the local test *runner* can crash with a UIScene-lifecycle error after tests build. If that happens, `TEST BUILD SUCCEEDED` plus the compile of the test target is the local bar — say so honestly, never claim tests passed if the runner crashed.
+- **Only `StopPageView` observes the view model.** Subviews receive plain values (`let` properties). Never pass the `StopViewModel` into a subview.
+- **`ForEach`/`List` identity**: key on `ArrivalDeparture.id` (a `String`). Never `id: \.self` on `ArrivalDeparture`.
+- **Rows are unary**: one root `HStack`/`VStack` per row; conditional content goes *inside* it. No `AnyView`, no top-level `if`/`switch` as the row root.
+- **Colors**: bridge `UIColor` with `Color(uiColor:)` (never soft-deprecated `Color(_:)`). Status palette from `ThemeColors.shared` — early = red, late = blue, on-time = green, no-real-time = gray (`.secondaryLabel`). Route color (`route.color`) is used ONLY for the route badge and grouped-card stripe.
+- **Real-time hard gate (§4.1)**: when `!predicted` — clock glyph, gray countdown, occupancy hidden, "schedule data" label, no approach timeline.
+- **User-facing strings** use `OBALoc("key", value:comment:)` like the rest of OBAKit.
+- **Reduce Motion**: read `@Environment(\.accessibilityReduceMotion)`; all pulse/wave animations must have a static fallback.
+- New UI files go in `OBAKit/Stops/StopPage/`. `OBAKitCore` must stay application-extension-safe (no view controllers there; `UIColor` is fine).
+- Run `scripts/swiftlint.sh` before each commit.
+- Commit after every task (small, descriptive commits).
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `OBAKitCore/Orchestration/FeatureFlags.swift` (modify) | add `useNewStopPageKey` + default-ON resolution helper |
+| `OBAKit/ViewRouting/Router.swift` (modify) | branch stop navigation on the flag |
+| `OBAKit/Settings/SettingsViewController.swift` (modify) | Experimental toggle row; default-alarm-lead-time row |
+| `OBAKitCore/Models/UserData/UserDataStore.swift` (modify) | `defaultAlarmLeadTimeMinutes` setting |
+| `OBAKit/ViewModels/StopViewModel.swift` (modify) | walk time, alarm index/set/cancel/change, approach fetch |
+| `OBAKit/Stops/StopPage/StopPageViewController.swift` | hosting shell, nav items, Previewable |
+| `OBAKit/Stops/StopPage/StopPageView.swift` | root List; sole VM observer |
+| `OBAKit/Stops/StopPage/StopPageHeaderView.swift` | map card + walk chip |
+| `OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift` | past block, walk partition, rows |
+| `OBAKit/Stops/StopPage/Departures/GroupedListView.swift` | route cards |
+| `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift` | shared row |
+| `OBAKit/Stops/StopPage/Shared/DepartureStatus.swift` | status color/label/gate |
+| `OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift` | partition + grouping transforms |
+| `OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift` | lead-time clamp |
+| `OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift` | walk time computation |
+| `OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift`, `CountdownView.swift`, `RouteBadgeView.swift`, `WalkLineDivider.swift` | shared leaf views |
+| `OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift`, `ApproachTimelineView.swift`, `AlarmControlView.swift`, `ApproachSlice.swift` | trip panel |
+| `OBAKitTests/Stops/StopPage/*` | unit tests for all pure logic |
+
+---
+
+### Task 1: Feature flag, router branch, hosting shell
+
+**Files:**
+- Modify: `OBAKitCore/Orchestration/FeatureFlags.swift`
+- Modify: `OBAKit/ViewRouting/Router.swift:87-99`
+- Modify: `OBAKit/Settings/SettingsViewController.swift` (~line 58 values dict, ~129 save, ~174 experimental section)
+- Create: `OBAKit/Stops/StopPage/StopPageViewController.swift`
+- Create: `OBAKit/Stops/StopPage/StopPageView.swift`
+- Test: `OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift`
+
+**Interfaces:**
+- Produces: `FeatureFlags.useNewStopPageKey: String`, `FeatureFlags.isNewStopPageEnabled(userDefaults:) -> Bool` (default true), `StopPageViewController(application:stopID:)` / `(application:stop:)` with `bookmarkContext`/`transferContext` vars, `StopPageView(viewModel:)` placeholder.
+- Consumes: existing `StopViewModel(application:stopID:stop:bookmarkContext:transferContext:)`, `Router.navigateTo(stop:from:bookmark:transferContext:)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+import XCTest
+@testable import OBAKitCore
+
+final class FeatureFlagsTests: XCTestCase {
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "FeatureFlagsTests")!
+        defaults.removePersistentDomain(forName: "FeatureFlagsTests")
+    }
+
+    func test_newStopPage_defaultsToEnabled() {
+        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+
+    func test_newStopPage_respectsExplicitFalse() {
+        defaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
+        XCTAssertFalse(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+
+    func test_newStopPage_respectsExplicitTrue() {
+        defaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
+        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: compile FAILURE — `isNewStopPageEnabled` / `useNewStopPageKey` not found.
+
+- [ ] **Step 3: Implement flag + helper**
+
+In `OBAKitCore/Orchestration/FeatureFlags.swift`, add to the enum:
+
+```swift
+    /// Gates the redesigned SwiftUI Stop page over the classic
+    /// `StopViewController`. Enabled by default; the Settings > Experimental
+    /// toggle writes an explicit value.
+    public static let useNewStopPageKey = "OBAUseNewStopPage"
+
+    /// Resolves the new-stop-page flag, defaulting to enabled when the user
+    /// has never touched the toggle.
+    public static func isNewStopPageEnabled(userDefaults: UserDefaults) -> Bool {
+        userDefaults.object(forKey: useNewStopPageKey) as? Bool ?? true
+    }
+```
+
+- [ ] **Step 4: Create the hosting shell and placeholder view**
+
+`OBAKit/Stops/StopPage/StopPageView.swift`:
+
+```swift
+//
+//  StopPageView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Root view of the redesigned Stop page. This is the ONLY view that observes
+/// `StopViewModel`; every subview receives plain values so the VM's frequent
+/// `@Published` churn (refresh + status timers) re-evaluates one shallow body.
+struct StopPageView: View {
+    @ObservedObject var viewModel: StopViewModel
+
+    var body: some View {
+        List {
+            Section {
+                Text(viewModel.stop?.name ?? "…")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .task { await viewModel.start() }
+        .onDisappear { viewModel.deactivate() }
+        .refreshable { await viewModel.refresh() }
+    }
+}
+```
+
+`OBAKit/Stops/StopPage/StopPageViewController.swift`:
+
+```swift
+//
+//  StopPageViewController.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import SwiftUI
+import OBAKitCore
+
+/// Hosting shell for the redesigned SwiftUI Stop page. Owns UIKit-side chrome
+/// (nav bar items, menus) and keeps parity entry points (`Previewable` etc.)
+/// working while `FeatureFlags.useNewStopPageKey` is enabled.
+class StopPageViewController: UIHostingController<StopPageView>, AppContext {
+    let application: Application
+    let viewModel: StopViewModel
+
+    var bookmarkContext: Bookmark? {
+        get { viewModel.bookmarkContext }
+        set { viewModel.bookmarkContext = newValue }
+    }
+
+    var transferContext: TransferContext? {
+        get { viewModel.transferContext }
+        set { viewModel.transferContext = newValue }
+    }
+
+    convenience init(application: Application, stop: Stop) {
+        self.init(application: application, stopID: stop.id, stop: stop)
+    }
+
+    convenience init(application: Application, stopID: StopID) {
+        self.init(application: application, stopID: stopID, stop: nil)
+    }
+
+    private init(application: Application, stopID: StopID, stop: Stop?) {
+        self.application = application
+        self.viewModel = StopViewModel(application: application, stopID: stopID, stop: stop)
+        super.init(rootView: StopPageView(viewModel: viewModel))
+        hidesBottomBarWhenPushed = false
+    }
+
+    @available(*, unavailable)
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.stop.map(Formatters.formattedTitle(stop:)) ?? Strings.loading
+        navigationItem.largeTitleDisplayMode = .never
+    }
+}
+```
+
+Note: if `AppContext` requires more than an `application` property, check `OBAKit/Orchestration/AppContext.swift` and conform minimally; if conformance drags in unwanted requirements, drop the protocol — nothing in this task needs it. If `Strings.loading` doesn't exist, use `OBALoc("stop_page_controller.loading", value: "Loading…", comment: "Stop page placeholder title while the stop loads")`.
+
+- [ ] **Step 5: Branch the router**
+
+In `OBAKit/ViewRouting/Router.swift`, replace the bodies of `navigateTo(stop:...)` and `navigateTo(stopID:)`:
+
+```swift
+    public func navigateTo(stop: Stop, from fromController: UIViewController, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil) {
+        guard shouldNavigate(from: fromController, to: .stop(stop)) else { return }
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+            let stopController = StopPageViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            navigate(to: stopController, from: fromController)
+        } else {
+            let stopController = StopViewController(application: application, stop: stop)
+            stopController.bookmarkContext = bookmark
+            stopController.transferContext = transferContext
+            navigate(to: stopController, from: fromController)
+        }
+    }
+
+    public func navigateTo(stopID: StopID, from fromController: UIViewController) {
+        guard shouldNavigate(from: fromController, to: .stopID(stopID)) else { return }
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+            navigate(to: StopPageViewController(application: application, stopID: stopID), from: fromController)
+        } else {
+            navigate(to: StopViewController(application: application, stopID: stopID), from: fromController)
+        }
+    }
+```
+
+Check `StopViewModel.bookmarkContext`/`transferContext` are settable (`var` — they are, `StopViewModel.swift:95-98`).
+
+- [ ] **Step 6: Settings toggle**
+
+In `OBAKit/Settings/SettingsViewController.swift`:
+- In the values dictionary near line 58 (alongside `FeatureFlags.useMapPanelExperienceKey`), add:
+  ```swift
+  FeatureFlags.useNewStopPageKey: FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults),
+  ```
+- In `saveExperimentalValues(_:)` (~line 129), add:
+  ```swift
+  if let useNewStopPage = values[FeatureFlags.useNewStopPageKey] as? Bool {
+      application.userDefaults.set(useNewStopPage, forKey: FeatureFlags.useNewStopPageKey)
+  }
+  ```
+- In `experimentalSection` (~line 176), add a row after the map-panel row:
+  ```swift
+  section <<< SwitchRow {
+      $0.tag = FeatureFlags.useNewStopPageKey
+      $0.title = OBALoc("settings_controller.experimental_section.new_stop_page", value: "Use new stop page", comment: "Settings > Experimental section > New stop page toggle")
+  }
+  ```
+
+- [ ] **Step 7: Regenerate, build, run tests**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests/FeatureFlagsTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+Expected: BUILD SUCCEEDED; 3 tests pass (or runner crashes with known UIScene issue — then TEST BUILD SUCCEEDED is the bar).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "Add new-stop-page feature flag, router branch, and SwiftUI hosting shell"
+```
+
+---
+
+### Task 2: DepartureStatus (the §4.1 gate)
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Shared/DepartureStatus.swift`
+- Test: `OBAKitTests/Stops/StopPage/DepartureStatusTests.swift`
+
+**Interfaces:**
+- Produces:
+  ```swift
+  struct DepartureStatus {
+      let isRealTime: Bool
+      let scheduleStatus: ScheduleStatus
+      let deviationMinutes: Int
+      init(arrivalDeparture: ArrivalDeparture)
+      init(isRealTime: Bool, scheduleStatus: ScheduleStatus, deviationMinutes: Int) // test seam
+      var color: UIColor          // status palette; .secondaryLabel when !isRealTime
+      var label: String           // "on time" / "3 min late" / "3 min early" / "schedule data"
+      var showsOccupancy: Bool    // == isRealTime
+      var accessibilityStatusDescription: String // "live, on time" / "scheduled time only, no live data"
+  }
+  ```
+- Consumes: `ScheduleStatus` (OBAKitCore), `ThemeColors.shared`, `ArrivalDeparture.predicted/.scheduleStatus/.deviationFromScheduleInMinutes`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+final class DepartureStatusTests: XCTestCase {
+
+    func test_scheduledOnly_isGrayWithScheduleDataLabel() {
+        let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
+        XCTAssertEqual(status.color, UIColor.secondaryLabel)
+        XCTAssertEqual(status.label, "schedule data")
+        XCTAssertFalse(status.showsOccupancy)
+    }
+
+    func test_scheduledOnly_neverClaimsOnTime_evenWithZeroDeviation() {
+        // §4.1: a scheduled bus is NOT "on time" — we have no idea if it's on time.
+        let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
+        XCTAssertNotEqual(status.label, "on time")
+    }
+
+    func test_onTime_isGreen() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureOnTime)
+        XCTAssertEqual(status.label, "on time")
+        XCTAssertTrue(status.showsOccupancy)
+    }
+
+    func test_late_isBlue_withMinuteCount() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .delayed, deviationMinutes: 4)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureLate)
+        XCTAssertEqual(status.label, "4 min late")
+    }
+
+    func test_early_isRed_withMinuteCount() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .early, deviationMinutes: -3)
+        XCTAssertEqual(status.color, ThemeColors.shared.departureEarly)
+        XCTAssertEqual(status.label, "3 min early")
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify tests fail**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: compile FAILURE — `DepartureStatus` not found.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+
+/// The single home of the Stop page's status visual language: countdowns,
+/// adherence labels, and the real-time hard gate. When `isRealTime == false`
+/// the UI must show a clock glyph, gray text, no occupancy, and never claim
+/// the trip is "on time" — a scheduled bus's punctuality is unknown.
+struct DepartureStatus {
+    let isRealTime: Bool
+    let scheduleStatus: ScheduleStatus
+    let deviationMinutes: Int
+
+    init(arrivalDeparture: ArrivalDeparture) {
+        self.init(
+            isRealTime: arrivalDeparture.predicted,
+            scheduleStatus: arrivalDeparture.scheduleStatus,
+            deviationMinutes: arrivalDeparture.deviationFromScheduleInMinutes
+        )
+    }
+
+    init(isRealTime: Bool, scheduleStatus: ScheduleStatus, deviationMinutes: Int) {
+        self.isRealTime = isRealTime
+        self.scheduleStatus = scheduleStatus
+        self.deviationMinutes = deviationMinutes
+    }
+
+    var showsOccupancy: Bool { isRealTime }
+
+    var color: UIColor {
+        guard isRealTime else { return .secondaryLabel }
+        switch scheduleStatus {
+        case .onTime: return ThemeColors.shared.departureOnTime
+        case .early: return ThemeColors.shared.departureEarly
+        case .delayed: return ThemeColors.shared.departureLate
+        default: return .secondaryLabel
+        }
+    }
+
+    var label: String {
+        guard isRealTime else {
+            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+        }
+        switch scheduleStatus {
+        case .onTime:
+            return OBALoc("stop_page.status.on_time", value: "on time", comment: "Adherence label for an on-time departure")
+        case .delayed:
+            let fmt = OBALoc("stop_page.status.late_fmt", value: "%d min late", comment: "Adherence label for a late departure. %d is minutes late.")
+            return String(format: fmt, abs(deviationMinutes))
+        case .early:
+            let fmt = OBALoc("stop_page.status.early_fmt", value: "%d min early", comment: "Adherence label for an early departure. %d is minutes early.")
+            return String(format: fmt, abs(deviationMinutes))
+        default:
+            return OBALoc("stop_page.status.schedule_data", value: "schedule data", comment: "Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time.")
+        }
+    }
+
+    var accessibilityStatusDescription: String {
+        if isRealTime {
+            let fmt = OBALoc("stop_page.status.a11y_live_fmt", value: "live tracking, %@", comment: "VoiceOver status suffix for a live departure. %@ is the adherence label.")
+            return String(format: fmt, label)
+        }
+        return OBALoc("stop_page.status.a11y_scheduled", value: "scheduled time only, no live data", comment: "VoiceOver status suffix for a schedule-only departure")
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests/DepartureStatusTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+Expected: 5 tests pass (or TEST BUILD SUCCEEDED + known runner crash).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "Add DepartureStatus: adherence colors, labels, and the real-time hard gate"
+```
+
+---
+
+### Task 3: List transforms (partition + grouping)
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift`
+- Test: `OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift`
+
+**Interfaces:**
+- Produces:
+  ```swift
+  protocol DepartureListEntry {
+      var id: String { get }
+      var routeID: RouteID { get }
+      var arrivalDepartureMinutes: Int { get }
+      var temporalState: TemporalState { get }
+  }
+  extension ArrivalDeparture: DepartureListEntry {} // members already exist
+
+  enum StopPageListBuilder {
+      struct ChronologicalPartition<D: DepartureListEntry> {
+          let past: [D]        // temporalState == .past; dim only (§4.2)
+          let missed: [D]      // upcoming but sooner than walk time; dim + strikethrough
+          let reachable: [D]
+      }
+      static func chronologicalPartition<D: DepartureListEntry>(_ departures: [D], walkMinutes: Int?) -> ChronologicalPartition<D>
+
+      struct RouteGroup<D: DepartureListEntry> {
+          let routeID: RouteID
+          let departures: [D]  // time-sorted; [0] is the "next" header departure
+          var next: D { departures[0] }
+          var upcoming: [D] { Array(departures.dropFirst()) }
+          var chips: [D] { Array(departures.dropFirst().prefix(3)) }
+      }
+      static func routeGroups<D: DepartureListEntry>(_ departures: [D]) -> [RouteGroup<D>]
+  }
+  ```
+- Consumes: `RouteID` (= `String`), `TemporalState` (OBAKitCore). Hidden-route filtering is NOT done here — callers pre-filter with the existing `Sequence.filter(preferences:)` (`ArrivalDeparture.swift:469`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+private struct StubDeparture: DepartureListEntry {
+    let id: String
+    let routeID: RouteID
+    let arrivalDepartureMinutes: Int
+    var temporalState: TemporalState {
+        arrivalDepartureMinutes < 0 ? .past : (arrivalDepartureMinutes == 0 ? .present : .future)
+    }
+}
+
+private func dep(_ id: String, route: String, mins: Int) -> StubDeparture {
+    StubDeparture(id: id, routeID: route, arrivalDepartureMinutes: mins)
+}
+
+final class StopPageListBuilderTests: XCTestCase {
+
+    // MARK: - Chronological partition
+
+    func test_partition_splitsAtWalkThreshold() {
+        let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5), dep("c", route: "62", mins: 7)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
+        XCTAssertEqual(p.missed.map(\.id), ["a"])       // 1 < 4: can't reach on foot
+        XCTAssertEqual(p.reachable.map(\.id), ["b", "c"]) // 5 and 7 >= 4 (§4.5: catchable iff mins >= walk)
+        XCTAssertTrue(p.past.isEmpty)
+    }
+
+    func test_partition_boundaryIsCatchable() {
+        // minutesAway == walkMinutes is catchable (§4.5: >=)
+        let p = StopPageListBuilder.chronologicalPartition([dep("x", route: "5", mins: 4)], walkMinutes: 4)
+        XCTAssertEqual(p.reachable.map(\.id), ["x"])
+        XCTAssertTrue(p.missed.isEmpty)
+    }
+
+    func test_partition_nilWalk_hasNoMissedBucket() {
+        let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
+        XCTAssertTrue(p.missed.isEmpty)
+        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+    }
+
+    func test_partition_pastIsSeparateFromMissed() {
+        // §4.2: past (already departed) and missed (can't walk there in time) are distinct.
+        let deps = [dep("gone", route: "24", mins: -3), dep("miss", route: "H", mins: 1), dep("ok", route: "5", mins: 9)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
+        XCTAssertEqual(p.past.map(\.id), ["gone"])
+        XCTAssertEqual(p.missed.map(\.id), ["miss"])
+        XCTAssertEqual(p.reachable.map(\.id), ["ok"])
+    }
+
+    func test_partition_sortsByMinutes() {
+        let deps = [dep("b", route: "1", mins: 9), dep("a", route: "2", mins: 5)]
+        let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
+        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+    }
+
+    // MARK: - Route groups
+
+    func test_groups_orderedBySoonestDeparture_notRouteName() {
+        // §4.9: route with a bus in 1m outranks a route whose next is 5m.
+        let deps = [
+            dep("z5", route: "5", mins: 5), dep("h1", route: "H Line", mins: 1),
+            dep("h2", route: "H Line", mins: 12), dep("z5b", route: "5", mins: 30)
+        ]
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups.map(\.routeID), ["H Line", "5"])
+        XCTAssertEqual(groups[0].departures.map(\.id), ["h1", "h2"])
+        XCTAssertEqual(groups[0].next.id, "h1")
+    }
+
+    func test_groups_excludePastDepartures() {
+        let deps = [dep("gone", route: "5", mins: -2), dep("soon", route: "5", mins: 6)]
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].departures.map(\.id), ["soon"])
+    }
+
+    func test_groups_chips_areAtMostThree_afterNext() {
+        let deps = (0..<6).map { dep("d\($0)", route: "40", mins: 5 + $0 * 5) }
+        let groups = StopPageListBuilder.routeGroups(deps)
+        XCTAssertEqual(groups[0].chips.map(\.id), ["d1", "d2", "d3"])
+        XCTAssertEqual(groups[0].upcoming.count, 5)
+    }
+
+    func test_groups_singleDeparture_hasEmptyChips() {
+        // Renders as "later trips not loaded" (§4.4) — builder just returns empty.
+        let groups = StopPageListBuilder.routeGroups([dep("only", route: "24", mins: 8)])
+        XCTAssertTrue(groups[0].chips.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify failure**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: compile FAILURE.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// OBAKit/Stops/StopPage/Shared/StopPageListBuilder.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The list-shape abstraction over `ArrivalDeparture` that the Stop page's
+/// pure transforms operate on; production code passes `ArrivalDeparture`,
+/// tests pass lightweight stubs (the real type only decodes from JSON).
+protocol DepartureListEntry {
+    var id: String { get }
+    var routeID: RouteID { get }
+    var arrivalDepartureMinutes: Int { get }
+    var temporalState: TemporalState { get }
+}
+
+extension ArrivalDeparture: DepartureListEntry {}
+
+/// Pure transforms shared by both Stop page list modes. Both modes are
+/// projections of the same filtered departure list (spec §3); callers apply
+/// `filter(preferences:)` for hidden routes before calling in.
+enum StopPageListBuilder {
+
+    // MARK: - Chronological
+
+    struct ChronologicalPartition<D: DepartureListEntry> {
+        /// Already departed. Rendered dimmed, no strikethrough (§4.2).
+        let past: [D]
+        /// Upcoming, but arriving sooner than the user can walk to the stop.
+        /// Rendered dimmed + struck-through (§4.2).
+        let missed: [D]
+        /// Catchable on foot: `arrivalDepartureMinutes >= walkMinutes` (§4.5).
+        let reachable: [D]
+    }
+
+    static func chronologicalPartition<D: DepartureListEntry>(_ departures: [D], walkMinutes: Int?) -> ChronologicalPartition<D> {
+        let sorted = departures.sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+        let past = sorted.filter { $0.temporalState == .past }
+        let upcoming = sorted.filter { $0.temporalState != .past }
+
+        guard let walkMinutes else {
+            return ChronologicalPartition(past: past, missed: [], reachable: upcoming)
+        }
+
+        let missed = upcoming.filter { $0.arrivalDepartureMinutes < walkMinutes }
+        let reachable = upcoming.filter { $0.arrivalDepartureMinutes >= walkMinutes }
+        return ChronologicalPartition(past: past, missed: missed, reachable: reachable)
+    }
+
+    // MARK: - Grouped ("By route")
+
+    struct RouteGroup<D: DepartureListEntry> {
+        let routeID: RouteID
+        /// Time-sorted; never empty. `[0]` is the card-header "next" departure.
+        let departures: [D]
+
+        var next: D { departures[0] }
+        var upcoming: [D] { Array(departures.dropFirst()) }
+        /// The small status-tinted pills; empty renders "later trips not loaded" (§4.4).
+        var chips: [D] { Array(departures.dropFirst().prefix(3)) }
+    }
+
+    /// Groups by route, preserving first-appearance order after the time sort,
+    /// so routes rank by their soonest departure (§4.9). Past departures are
+    /// excluded — grouped mode has no past block.
+    static func routeGroups<D: DepartureListEntry>(_ departures: [D]) -> [RouteGroup<D>] {
+        let sorted = departures
+            .filter { $0.temporalState != .past }
+            .sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+
+        var order: [RouteID] = []
+        var buckets: [RouteID: [D]] = [:]
+        for departure in sorted {
+            if buckets[departure.routeID] == nil { order.append(departure.routeID) }
+            buckets[departure.routeID, default: []].append(departure)
+        }
+        return order.map { RouteGroup(routeID: $0, departures: buckets[$0]!) }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests/StopPageListBuilderTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+Expected: 9 tests pass (or TEST BUILD SUCCEEDED bar).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "Add StopPageListBuilder: walk-line partition and soonest-first route grouping"
+```
+
+---
+
+### Task 4: AlarmLeadTime clamp + WalkTimeInfo + default lead-time setting
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift`
+- Create: `OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift`
+- Modify: `OBAKitCore/Models/UserData/UserDataStore.swift` (add `defaultAlarmLeadTimeMinutes`)
+- Test: `OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift`, `OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift`
+
+**Interfaces:**
+- Produces:
+  ```swift
+  enum AlarmLeadTime {
+      static let minimumMinutes = 1
+      static let maximumMinutes = 15
+      static let defaultMinutes = 5
+      /// nil when no valid lead time exists (departure too soon: minutes <= 1)
+      static func clamped(_ requested: Int, minutesUntilDeparture: Int) -> Int?
+  }
+  struct WalkTimeInfo: Equatable {
+      let walkMinutes: Int          // rounded UP — never promise a shorter walk
+      let distance: CLLocationDistance
+      static func compute(from userLocation: CLLocation?, to stopLocation: CLLocation?, speedMetersPerSecond: Double) -> WalkTimeInfo?
+      // nil when either location missing, speed <= 0, or distance <= 40m (matches WalkTimeView behavior)
+  }
+  ```
+- Produces on `UserDataStore` (and its protocol if one declares user-defaults settings — follow the pattern of `walkingSpeedMetersPerSecond` in that file): `var defaultAlarmLeadTimeMinutes: Int` (get/set, defaults to 5, UserDefaults-backed with key `"defaultAlarmLeadTimeMinutes"` added to the private keys enum near line 353).
+- Consumes: `WalkingSpeed.defaultMetersPerSecond` (exists — see `WalkingDirections.swift:24`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
+import XCTest
+@testable import OBAKit
+
+final class AlarmLeadTimeTests: XCTestCase {
+    func test_requestWithinRange_passesThrough() {
+        XCTAssertEqual(AlarmLeadTime.clamped(5, minutesUntilDeparture: 20), 5)
+    }
+
+    func test_clampsToMaximum15() {
+        XCTAssertEqual(AlarmLeadTime.clamped(30, minutesUntilDeparture: 60), 15)
+    }
+
+    func test_clampsToMinimum1() {
+        XCTAssertEqual(AlarmLeadTime.clamped(0, minutesUntilDeparture: 20), 1)
+    }
+
+    func test_cappedBelowMinutesUntilDeparture() {
+        // A buzz can't be scheduled for a moment that's already passed.
+        XCTAssertEqual(AlarmLeadTime.clamped(10, minutesUntilDeparture: 4), 3)
+    }
+
+    func test_departureTooSoon_returnsNil() {
+        // Matches StopViewModel.canCreateAlarm: requires arrivalDepartureMinutes > 1.
+        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 1))
+        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 0))
+    }
+}
+```
+
+```swift
+// OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift
+import XCTest
+import CoreLocation
+@testable import OBAKit
+
+final class WalkTimeInfoTests: XCTestCase {
+    // ~111m per 0.001 degree latitude at the equator; use real CLLocations.
+    private let stopLocation = CLLocation(latitude: 47.6097, longitude: -122.3331)
+
+    func test_computesMinutesRoundedUp() {
+        // ~500m at 1.25 m/s = 400s = 6.67 min -> 7 min
+        let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
+        let info = WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25)
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info!.walkMinutes, 7)
+    }
+
+    func test_nilWhenUserLocationMissing() {
+        XCTAssertNil(WalkTimeInfo.compute(from: nil, to: stopLocation, speedMetersPerSecond: 1.25))
+    }
+
+    func test_nilWhenVeryClose() {
+        // <= 40m: suppress, matching today's WalkTimeView behavior.
+        let user = CLLocation(latitude: 47.60972, longitude: -122.3331)
+        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25))
+    }
+
+    func test_nilWhenSpeedInvalid() {
+        let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
+        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 0))
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify failure**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: compile FAILURE.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// OBAKit/Stops/StopPage/Shared/AlarmLeadTime.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Lead-time rules for departure alarms: user-adjustable within 1–15 minutes,
+/// but never scheduled at or past the departure itself.
+enum AlarmLeadTime {
+    static let minimumMinutes = 1
+    static let maximumMinutes = 15
+    static let defaultMinutes = 5
+
+    /// Clamps a requested lead time into the valid range for a departure
+    /// `minutesUntilDeparture` away, or nil when no valid lead time exists
+    /// (mirrors `StopViewModel.canCreateAlarm`'s `> 1` gate).
+    static func clamped(_ requested: Int, minutesUntilDeparture: Int) -> Int? {
+        guard minutesUntilDeparture > 1 else { return nil }
+        let ceiling = min(maximumMinutes, minutesUntilDeparture - 1)
+        return min(max(requested, minimumMinutes), ceiling)
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+
+/// The single source of walk time on the Stop page (§4.5): the header chip
+/// and the chronological walk line must both read from the same instance.
+struct WalkTimeInfo: Equatable {
+    /// Rounded up — never promise a shorter walk than reality.
+    let walkMinutes: Int
+    let distance: CLLocationDistance
+
+    /// Straight-line walk estimate, matching `WalkingDirections.travelTime`.
+    /// Returns nil with no user location, an invalid speed, or when the user
+    /// is effectively at the stop (<= 40 m, matching `WalkTimeView`).
+    static func compute(from userLocation: CLLocation?, to stopLocation: CLLocation?, speedMetersPerSecond: Double) -> WalkTimeInfo? {
+        guard let userLocation, let stopLocation, speedMetersPerSecond > 0 else { return nil }
+        let distance = userLocation.distance(from: stopLocation)
+        guard distance > 40 else { return nil }
+        let seconds = distance / speedMetersPerSecond
+        return WalkTimeInfo(walkMinutes: Int(ceil(seconds / 60.0)), distance: distance)
+    }
+}
+```
+
+In `OBAKitCore/Models/UserData/UserDataStore.swift`, follow the exact pattern used by `walkingSpeedMetersPerSecond` (same file): add a key `defaultAlarmLeadTimeMinutes` to the keys enum (~line 353) and a property:
+
+```swift
+    /// The user's preferred alarm lead time in minutes for one-tap alarms on
+    /// the Stop page. Adjustable per-alarm afterward.
+    public var defaultAlarmLeadTimeMinutes: Int {
+        get {
+            let value = userDefaults.integer(forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes.rawValue)
+            return value == 0 ? 5 : value
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes.rawValue)
+        }
+    }
+```
+
+(Adapt the key-enum name/spelling to what that file actually uses — inspect it first; the explorer notes keys are defined around lines 353–373. If a `UserDataStore` protocol declares the store's public surface, add the property there too.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests/AlarmLeadTimeTests -only-testing:OBAKitTests/WalkTimeInfoTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+Expected: 9 tests pass (or TEST BUILD SUCCEEDED bar).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "Add alarm lead-time clamp, walk-time computation, and default lead-time setting"
+```
+
+---
+
+### Task 5: StopViewModel additions (walk time, alarms, approach fetch)
+
+**Files:**
+- Modify: `OBAKit/ViewModels/StopViewModel.swift`
+- Test: extend `OBAKitTests` coverage only where pure (the network paths are exercised by build + existing VM test infrastructure; do not fake coverage)
+
+**Interfaces:**
+- Produces on `StopViewModel`:
+  ```swift
+  var walkTime: WalkTimeInfo? { get }                       // computed
+  @Published private(set) var alarmsByDepartureID: [String: Alarm]
+  func alarm(for arrivalDeparture: ArrivalDeparture) -> Alarm?
+  func setAlarm(for: ArrivalDeparture, leadTimeMinutes: Int) async
+  func cancelAlarm(for: ArrivalDeparture) async
+  func changeAlarm(for: ArrivalDeparture, leadTimeMinutes: Int) async
+  func alarmLeadTimeMinutes(_ alarm: Alarm) -> Int          // derive from tripDate - alarmDate
+  var defaultAlarmLeadTime: Int { get }
+  func approachTripDetails(for: ArrivalDeparture) async -> TripDetails?
+  @Published private(set) var alarmError: Error?
+  ```
+- Consumes: `ObacoAPIService.postAlarm(minutesBefore:arrivalDeparture:userPushID:)` and `deleteAlarm(url:)` (`ObacoAPIService.swift:72,142`), `PushService.pushID()` (`PushService.swift:122`), `ArrivalDepartureDeepLink(arrivalDeparture:regionID:)` (see `AlarmBuilder.swift:112`), `UserDataStore.alarms/.add(alarm:)/.delete(alarm:)`, `apiService.getTrip(tripID:vehicleID:serviceDate:)` (see `TripViewModel.swift:136`), `AlarmLeadTime`, `WalkTimeInfo` (Task 4).
+
+- [ ] **Step 1: Add the code to `StopViewModel.swift`**
+
+Add stored/published state near the other `@Published` vars:
+
+```swift
+    /// Alarms owned by this stop's departures, keyed by `ArrivalDeparture.id`.
+    /// All four alarm entry points (swipe, pill, row icon, trip panel) read and
+    /// write through this single index (§4.7).
+    @Published private(set) var alarmsByDepartureID: [String: Alarm] = [:]
+
+    /// Non-nil after an alarm create/cancel fails; consumer shows a toast/alert.
+    @Published private(set) var alarmError: Error?
+
+    /// Cache for trip-panel approach timelines, invalidated on each refresh.
+    private var approachCache: [String: TripDetails] = [:]
+```
+
+Add the members (new `// MARK: - Stop Page` section at the end of the class):
+
+```swift
+    // MARK: - Stop Page: Walk Time
+
+    /// Walk time from the user's current location to this stop; the single
+    /// source for the header chip and the chronological walk line (§4.5).
+    var walkTime: WalkTimeInfo? {
+        WalkTimeInfo.compute(
+            from: application.locationService.currentLocation,
+            to: stop?.location,
+            speedMetersPerSecond: application.userDataStore.walkingSpeedMetersPerSecond
+        )
+    }
+
+    // MARK: - Stop Page: Alarms
+
+    var defaultAlarmLeadTime: Int {
+        application.userDataStore.defaultAlarmLeadTimeMinutes
+    }
+
+    func alarm(for arrivalDeparture: ArrivalDeparture) -> Alarm? {
+        alarmsByDepartureID[arrivalDeparture.id]
+    }
+
+    /// Minutes-before-departure for a persisted alarm, derived from its dates.
+    func alarmLeadTimeMinutes(_ alarm: Alarm) -> Int {
+        guard let tripDate = alarm.tripDate, let alarmDate = alarm.alarmDate else {
+            return AlarmLeadTime.defaultMinutes
+        }
+        return max(AlarmLeadTime.minimumMinutes, Int(round(tripDate.timeIntervalSince(alarmDate) / 60.0)))
+    }
+
+    func setAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
+        guard
+            canCreateAlarm(for: arrivalDeparture),
+            let obacoService = application.obacoService,
+            let pushService = application.pushService,
+            let region = application.currentRegion,
+            let minutes = AlarmLeadTime.clamped(leadTimeMinutes, minutesUntilDeparture: arrivalDeparture.arrivalDepartureMinutes)
+        else { return }
+
+        do {
+            let userPushID = await pushService.pushID()
+            let alarm = try await obacoService.postAlarm(minutesBefore: minutes, arrivalDeparture: arrivalDeparture, userPushID: userPushID)
+            alarm.deepLink = ArrivalDepartureDeepLink(arrivalDeparture: arrivalDeparture, regionID: region.regionIdentifier)
+            alarm.set(tripDate: arrivalDeparture.arrivalDepartureDate, alarmOffset: minutes)
+            application.userDataStore.add(alarm: alarm)
+            alarmsByDepartureID[arrivalDeparture.id] = alarm
+            alarmError = nil
+        } catch {
+            alarmError = error
+        }
+    }
+
+    func cancelAlarm(for arrivalDeparture: ArrivalDeparture) async {
+        guard let alarm = alarm(for: arrivalDeparture) else { return }
+        // Optimistic removal; restore on failure.
+        alarmsByDepartureID[arrivalDeparture.id] = nil
+        do {
+            if let obacoService = application.obacoService {
+                try await obacoService.deleteAlarm(url: alarm.url)
+            }
+            application.userDataStore.delete(alarm: alarm)
+            alarmError = nil
+        } catch {
+            alarmsByDepartureID[arrivalDeparture.id] = alarm
+            alarmError = error
+        }
+    }
+
+    /// Obaco has no update endpoint: change = delete + re-post.
+    func changeAlarm(for arrivalDeparture: ArrivalDeparture, leadTimeMinutes: Int) async {
+        await cancelAlarm(for: arrivalDeparture)
+        guard alarmError == nil else { return }
+        await setAlarm(for: arrivalDeparture, leadTimeMinutes: leadTimeMinutes)
+    }
+
+    /// Rebuilds the departure-id → alarm index by matching each persisted
+    /// alarm's deep link against the current departures. Called after each
+    /// successful fetch so expired/foreign alarms fall out naturally.
+    private func rebuildAlarmIndex() {
+        guard let region = application.currentRegion,
+              let departures = stopArrivals?.arrivalsAndDepartures
+        else {
+            alarmsByDepartureID = [:]
+            return
+        }
+        application.userDataStore.deleteExpiredAlarms()
+        var index: [String: Alarm] = [:]
+        for departure in departures {
+            let candidate = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
+            if let match = application.userDataStore.alarms.first(where: { $0.deepLink == candidate }) {
+                index[departure.id] = match
+            }
+        }
+        alarmsByDepartureID = index
+    }
+
+    // MARK: - Stop Page: Approach Timeline
+
+    /// Trip details backing the trip panel's approach timeline. Fetched on
+    /// panel open, cached until the next refresh, live trips only (§4.1).
+    func approachTripDetails(for arrivalDeparture: ArrivalDeparture) async -> TripDetails? {
+        guard arrivalDeparture.predicted, let apiService = application.apiService else { return nil }
+        if let cached = approachCache[arrivalDeparture.tripID] { return cached }
+        do {
+            let details = try await apiService.getTrip(
+                tripID: arrivalDeparture.tripID,
+                vehicleID: arrivalDeparture.vehicleID,
+                serviceDate: arrivalDeparture.serviceDate
+            ).entry
+            approachCache[arrivalDeparture.tripID] = details
+            return details
+        } catch {
+            return nil // panel silently omits the timeline on failure
+        }
+    }
+```
+
+Then wire invalidation into `applySuccessfulFetch(stop:arrivals:)` — after `stopArrivals = arrivals`, add:
+
+```swift
+        approachCache.removeAll()
+        rebuildAlarmIndex()
+```
+
+Adjustments to verify while implementing (do not guess):
+- `deleteExpiredAlarms()` exists on `UserDataStore` (~line 715) — check its exact name/visibility.
+- `ArrivalDepartureDeepLink(arrivalDeparture:regionID:)` — confirm the initializer signature at its definition; `AlarmBuilder.swift:112` shows this exact usage.
+- `stop?.location` — `Stop` exposes `location: CLLocation` (used at `StopViewModel.swift:425`).
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Run the existing StopViewModel tests to catch regressions**
+
+Run: `xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17' 2>&1 | tail -20`
+Expected: existing suite unaffected (or TEST BUILD SUCCEEDED bar per Global Constraints).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "StopViewModel: walk time, shared alarm index with Obaco set/cancel/change, approach fetch"
+```
+
+---
+
+### Task 6: Shared leaf views (glyph, countdown, badge, walk divider)
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift`
+- Create: `OBAKit/Stops/StopPage/Shared/CountdownView.swift`
+- Create: `OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift`
+- Create: `OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift`
+
+**Interfaces:**
+- Produces: `RealtimeGlyph(isRealTime: Bool, color: Color, size: CGFloat)`, `CountdownView(minutes: Int, isRealTime: Bool, color: Color, emphasized: Bool)`, `RouteBadgeView(routeShortName: String, routeColor: Color, size: CGFloat)`, `WalkLineDivider(walkMinutes: Int)`.
+- Consumes: `DepartureStatus` (Task 2) for colors at call sites.
+
+- [ ] **Step 1: Implement the four views**
+
+```swift
+// OBAKit/Stops/StopPage/Shared/RealtimeGlyph.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The at-a-glance "is this tracked?" signal (§4.1): animated radiating waves
+/// for live trips, a static outline clock for schedule-only. Uses an SF Symbol
+/// variable-color effect so the system batches animation across the ~15
+/// instances a full list shows — never per-instance repeatForever loops.
+struct RealtimeGlyph: View {
+    let isRealTime: Bool
+    let color: Color
+    var size: CGFloat = 14
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        // Unary root: one Image; the live/scheduled fork is symbol + modifier state.
+        Image(systemName: isRealTime ? "dot.radiowaves.up.forward" : "clock")
+            .font(.system(size: size, weight: .semibold))
+            .foregroundStyle(isRealTime ? color : Color(uiColor: .secondaryLabel))
+            .symbolEffect(.variableColor.iterative, options: .repeating, isActive: isRealTime && !reduceMotion)
+            .accessibilityHidden(true) // status is conveyed in the row's combined label
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/Shared/CountdownView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The "{n}m" countdown with its real-time glyph. Color encodes adherence
+/// status, never route (§4.3).
+struct CountdownView: View {
+    let minutes: Int
+    let isRealTime: Bool
+    let color: Color
+    /// true = card-header size (grouped card / chrono row), false = compact.
+    var emphasized: Bool = true
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text("\(minutes)m")
+                .font(.system(size: emphasized ? 27 : 17, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(color)
+            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 13 : 11)
+        }
+        .accessibilityElement(children: .ignore)
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Rounded-square route identity badge. The ONLY place (besides the grouped
+/// card stripe) that renders the route's brand color (§4.3).
+struct RouteBadgeView: View {
+    let routeShortName: String
+    let routeColor: Color
+    var size: CGFloat = 44
+
+    var body: some View {
+        Text(routeShortName)
+            .font(.system(size: routeShortName.count <= 2 ? 18 : 13, weight: .heavy))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size, height: size)
+            .background(routeColor, in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous))
+            .accessibilityHidden(true) // route name is in the row's combined label
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The dashed reachability divider in chronological mode: everything above is
+/// "just missed", everything below is catchable on foot (§4.5).
+struct WalkLineDivider: View {
+    let walkMinutes: Int
+
+    private var text: String {
+        let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
+        return String(format: fmt, walkMinutes)
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            dash
+            Label(text, systemImage: "figure.walk")
+                .font(.system(size: 12, weight: .heavy))
+                .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            dash
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(format: OBALoc("stop_page.walk_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute walk to the stop", comment: "VoiceOver description of the walk divider. %d is walk minutes."), walkMinutes))
+    }
+
+    private var dash: some View {
+        Line()
+            .stroke(style: StrokeStyle(lineWidth: 2, dash: [7, 6]))
+            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+            .frame(height: 2)
+            .frame(maxWidth: .infinity)
+    }
+
+    private struct Line: Shape {
+        func path(in rect: CGRect) -> Path {
+            var path = Path()
+            path.move(to: CGPoint(x: 0, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            return path
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate, build**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: BUILD SUCCEEDED. (If `symbolEffect(_:options:isActive:)` has an availability complaint, it's iOS 17+ — fine on our 18.0 floor; fix the exact spelling against the SDK.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "Add Stop page shared leaf views: realtime glyph, countdown, route badge, walk divider"
+```
+
+---
+
+### Task 7: DepartureRowView with swipe actions and context menu
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift`
+
+**Interfaces:**
+- Produces:
+  ```swift
+  struct DepartureRowView: View {
+      let departure: ArrivalDeparture
+      let status: DepartureStatus
+      let hasAlarm: Bool
+      var style: Style = .normal   // enum Style { case normal, missed, past } (§4.2)
+      // Callbacks so the row never touches the VM:
+      let onTap: () -> Void
+  }
+  struct DepartureRowActions {   // reusable swipe/context config, applied at the List call site
+      let canAlarm: Bool
+      let canSchedule: Bool
+      let hasAlarm: Bool
+      let onAlarmToggle: () -> Void
+      let onSchedule: () -> Void
+      let onBookmark: () -> Void
+      let onShowTrip: () -> Void
+  }
+  extension View {
+      func departureRowActions(_ actions: DepartureRowActions) -> some View
+  }
+  ```
+- Consumes: `RouteBadgeView`, `CountdownView`, `DepartureStatus` (Tasks 2, 6); `Formatters` for the scheduled-time string; `ArrivalDeparture.routeShortName/.tripHeadsign/.scheduledDate/.arrivalDepartureMinutes/.route.color`.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// One departure row, used by chronological mode and (compact) by grouped
+/// expansion. Unary root HStack; all conditional content is interior so the
+/// List fast path holds.
+struct DepartureRowView: View {
+    enum Style {
+        case normal
+        /// Upcoming but unreachable on foot: dim + strikethrough (§4.2).
+        case missed
+        /// Already departed: dim only (§4.2).
+        case past
+    }
+
+    let departure: ArrivalDeparture
+    let status: DepartureStatus
+    let hasAlarm: Bool
+    var style: Style = .normal
+    let onTap: () -> Void
+
+    private var dimmed: Bool { style != .normal }
+
+    private var scheduledTimeText: String {
+        DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 13) {
+            RouteBadgeView(
+                routeShortName: departure.routeShortName,
+                routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+            )
+            VStack(alignment: .leading, spacing: 3) {
+                Text(departure.tripHeadsign ?? departure.routeShortName)
+                    .font(.system(size: 15.5, weight: .bold))
+                    .lineLimit(2)
+                    .strikethrough(style == .missed)
+                HStack(spacing: 6) {
+                    Text(scheduledTimeText)
+                        .font(.footnote)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                    Text("·").foregroundStyle(.tertiary)
+                    Text(status.label)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color(uiColor: status.color))
+                    if hasAlarm {
+                        Image(systemName: "bell.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            CountdownView(
+                minutes: departure.arrivalDepartureMinutes,
+                isRealTime: status.isRealTime,
+                color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
+            )
+        }
+        .opacity(dimmed ? 0.55 : 1.0)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var accessibilityText: String {
+        let fmt = OBALoc("stop_page.row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for a departure row: route, headsign, minutes, status.")
+        return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+    }
+}
+
+/// Swipe + context-menu parity with today's `ArrivalDepartureItem`
+/// trailing actions (Alarm / Schedule / Save) and long-press menu.
+struct DepartureRowActions {
+    let canAlarm: Bool
+    let canSchedule: Bool
+    let hasAlarm: Bool
+    let onAlarmToggle: () -> Void
+    let onSchedule: () -> Void
+    let onBookmark: () -> Void
+    let onShowTrip: () -> Void
+}
+
+extension View {
+    func departureRowActions(_ actions: DepartureRowActions) -> some View {
+        self
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                if actions.canAlarm {
+                    Button(action: actions.onAlarmToggle) {
+                        Label(actions.hasAlarm ? Strings.removeAlarm : Strings.addAlarm, systemImage: actions.hasAlarm ? "bell.slash" : "bell")
+                    }
+                    .tint(Color(uiColor: ThemeColors.shared.departureOnTime))
+                }
+                if actions.canSchedule {
+                    Button(action: actions.onSchedule) {
+                        Label(Strings.schedules, systemImage: "calendar")
+                    }
+                    .tint(.teal)
+                }
+                Button(action: actions.onBookmark) {
+                    Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+                .tint(.orange)
+            }
+            .contextMenu {
+                Button(action: actions.onShowTrip) {
+                    Label(OBALoc("stop_page.row.show_trip", value: "Show Trip Details", comment: "Context menu action opening the full trip screen"), systemImage: "bus")
+                }
+                if actions.canAlarm {
+                    Button(action: actions.onAlarmToggle) {
+                        Label(actions.hasAlarm ? Strings.removeAlarm : Strings.addAlarm, systemImage: "bell")
+                    }
+                }
+                Button(action: actions.onBookmark) {
+                    Label(Strings.addBookmark, systemImage: "bookmark")
+                }
+            }
+    }
+}
+```
+
+Verify `Strings.addAlarm`, `Strings.removeAlarm`, `Strings.schedules`, `Strings.addBookmark` exist in `OBAKitCore/Strings` (`Strings.addAlarm` is used by `AlarmBuilder.swift:143`; `Strings.schedules` by `StopViewController.swift:315`; `Strings.addBookmark` by `StopViewController.swift:362`). If `removeAlarm` is missing, add an `OBALoc` string inline instead.
+
+- [ ] **Step 2: Build**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "Add DepartureRowView with swipe actions and context menu"
+```
+
+---
+
+### Task 8: Chronological mode
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift`
+- Modify: `OBAKit/Stops/StopPage/StopPageView.swift` (render it; still placeholder elsewhere)
+
+**Interfaces:**
+- Produces:
+  ```swift
+  struct ChronologicalListView: View {
+      let partition: StopPageListBuilder.ChronologicalPartition<ArrivalDeparture>
+      let walkMinutes: Int?
+      let showPast: Bool
+      let expandedDepartureID: String?
+      let statusProvider: (ArrivalDeparture) -> DepartureStatus
+      let alarmLookup: (ArrivalDeparture) -> Alarm?
+      let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
+      let onTogglePast: () -> Void
+      let onToggleExpand: (ArrivalDeparture) -> Void
+      let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder // replaced in Task 10
+  }
+  struct TripDetailPanelPlaceholder: View // temporary; Task 10 swaps in TripDetailPanelView
+  ```
+  These are `List` *content* (Sections), not a standalone `List` — `StopPageView` owns the single `List`.
+- Consumes: Tasks 2, 3, 6, 7. Past-collapsed persistence key: reuse `"StopViewController.pastDeparturesCollapsed"` (`StopViewController.swift:279` `UserDefaultsKeys`) so the preference round-trips with the old screen.
+
+**Accordion rule (validated):** the open trip panel is a *separate row inserted after* the tapped row inside the same `ForEach` — never height-growth inside a row.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Temporary stand-in for `TripDetailPanelView` (Task 10). Keeps the accordion
+/// mechanics testable in the simulator before the panel exists.
+struct TripDetailPanelPlaceholder: View {
+    let departure: ArrivalDeparture
+    var body: some View {
+        Text(departure.routeAndHeadsign)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+    }
+}
+
+/// Chronological mode: past block, missed block, walk divider, reachable
+/// block. Rendered as Sections inside StopPageView's single List (each
+/// Section is one rounded card in inset-grouped style).
+struct ChronologicalListView: View {
+    let partition: StopPageListBuilder.ChronologicalPartition<ArrivalDeparture>
+    let walkMinutes: Int?
+    let showPast: Bool
+    let expandedDepartureID: String?
+    let statusProvider: (ArrivalDeparture) -> DepartureStatus
+    let alarmLookup: (ArrivalDeparture) -> Alarm?
+    let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
+    let onTogglePast: () -> Void
+    let onToggleExpand: (ArrivalDeparture) -> Void
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+
+    var body: some View {
+        // Section header with the Past toggle
+        Section {
+            if showPast {
+                rows(partition.past, style: .past)
+            }
+        } header: {
+            HStack {
+                Text(OBALoc("stop_page.section.arrivals_departures", value: "Arrivals & Departures", comment: "Chronological list section header"))
+                Spacer()
+                if !partition.past.isEmpty {
+                    Button(action: onTogglePast) {
+                        let fmt = OBALoc("stop_page.past_toggle_fmt", value: "Past · %d", comment: "Button revealing recently departed trips. %d is the count.")
+                        Text(showPast ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips") : String(format: fmt, partition.past.count))
+                            .font(.caption.weight(.bold))
+                    }
+                }
+            }
+        }
+
+        if let walkMinutes, !partition.missed.isEmpty {
+            Section {
+                rows(partition.missed, style: .missed)
+            }
+            // Walk divider escapes the card chrome (out-of-card row rules).
+            Section {
+                WalkLineDivider(walkMinutes: walkMinutes)
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+        }
+
+        Section {
+            rows(partition.reachable, style: .normal)
+        }
+    }
+
+    @ViewBuilder
+    private func rows(_ departures: [ArrivalDeparture], style: DepartureRowView.Style) -> some View {
+        // Identity: ArrivalDeparture.id (stable across prediction refreshes).
+        ForEach(departures, id: \.id) { departure in
+            DepartureRowView(
+                departure: departure,
+                status: statusProvider(departure),
+                hasAlarm: alarmLookup(departure) != nil,
+                style: style,
+                onTap: { onToggleExpand(departure) }
+            )
+            .departureRowActions(actionsProvider(departure))
+
+            // Accordion: the panel is an INSERTED SIBLING ROW, keyed off the
+            // expanded id — List animates insert/remove smoothly.
+            if expandedDepartureID == departure.id {
+                panelBuilder(departure)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `StopPageView`**
+
+Replace `StopPageView.body`'s placeholder Section with real state + content (this version still lacks header/toggle — Task 11 finishes assembly):
+
+```swift
+struct StopPageView: View {
+    @ObservedObject var viewModel: StopViewModel
+
+    @State private var expandedDepartureID: String?
+    @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
+
+    private var filteredDepartures: [ArrivalDeparture] {
+        let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
+        return viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
+    }
+
+    var body: some View {
+        List {
+            ChronologicalListView(
+                partition: StopPageListBuilder.chronologicalPartition(filteredDepartures, walkMinutes: viewModel.walkTime?.walkMinutes),
+                walkMinutes: viewModel.walkTime?.walkMinutes,
+                showPast: !pastCollapsed,
+                expandedDepartureID: expandedDepartureID,
+                statusProvider: { DepartureStatus(arrivalDeparture: $0) },
+                alarmLookup: { viewModel.alarm(for: $0) },
+                actionsProvider: makeActions(for:),
+                onTogglePast: { withAnimation { pastCollapsed.toggle() } },
+                onToggleExpand: { departure in
+                    withAnimation(.snappy) {
+                        expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+                    }
+                },
+                panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+            )
+        }
+        .listStyle(.insetGrouped)
+        .task { await viewModel.start() }
+        .onDisappear { viewModel.deactivate() }
+        .refreshable { await viewModel.refresh() }
+    }
+
+    private func makeActions(for departure: ArrivalDeparture) -> DepartureRowActions {
+        DepartureRowActions(
+            canAlarm: viewModel.canCreateAlarm(for: departure),
+            canSchedule: false,        // wired in Task 12 (region-gated)
+            hasAlarm: viewModel.alarm(for: departure) != nil,
+            onAlarmToggle: {
+                Task {
+                    if viewModel.alarm(for: departure) != nil {
+                        await viewModel.cancelAlarm(for: departure)
+                    } else {
+                        await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
+                    }
+                }
+            },
+            onSchedule: {},            // Task 12
+            onBookmark: {},            // Task 12
+            onShowTrip: {}             // Task 12
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Build + simulator smoke test**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: BUILD SUCCEEDED. Then boot the app in the iPhone 17 simulator, open any stop from the map, and verify: rows render sorted; tapping a row inserts the placeholder panel row with a smooth animation and tapping again removes it; swiping a row reveals Alarm/Save. **This is the accordion spike from the spec — if the insert/remove animation stutters or clips, stop and fix the row structure before continuing.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "Add chronological mode with walk partition, past block, and inserted-row accordion"
+```
+
+---
+
+### Task 9: Grouped ("By route") mode + segmented toggle
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/Departures/GroupedListView.swift`
+- Modify: `OBAKit/Stops/StopPage/StopPageView.swift` (toggle + mode switch)
+
+**Interfaces:**
+- Produces:
+  ```swift
+  struct GroupedListView: View {
+      let groups: [StopPageListBuilder.RouteGroup<ArrivalDeparture>]
+      let expandedRouteID: RouteID?
+      let openTripDepartureID: String?
+      let statusProvider: (ArrivalDeparture) -> DepartureStatus
+      let alarmLookup: (ArrivalDeparture) -> Alarm?
+      let alarmLeadTime: (Alarm) -> Int
+      let onToggleRoute: (RouteID) -> Void
+      let onToggleTrip: (ArrivalDeparture) -> Void
+      let onAlarmToggle: (ArrivalDeparture) -> Void
+      let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+  }
+  struct StopPageModeToggle: View { let mode: StopSort; let onChange: (StopSort) -> Void }
+  ```
+- Consumes: Tasks 2, 3, 6, 7; `StopSort` (`.time`/`.route`); `viewModel.updateSortType(_:)`.
+
+- [ ] **Step 1: Implement `GroupedListView`**
+
+```swift
+// OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Grouped mode: one Section (= one inset-grouped card) per route, ordered by
+/// soonest departure (§4.9). Card header is the next departure; expansion
+/// lists every loaded departure; tapping one opens the shared trip panel.
+struct GroupedListView: View {
+    let groups: [StopPageListBuilder.RouteGroup<ArrivalDeparture>]
+    let expandedRouteID: RouteID?
+    let openTripDepartureID: String?
+    let statusProvider: (ArrivalDeparture) -> DepartureStatus
+    let alarmLookup: (ArrivalDeparture) -> Alarm?
+    let alarmLeadTime: (Alarm) -> Int
+    let onToggleRoute: (RouteID) -> Void
+    let onToggleTrip: (ArrivalDeparture) -> Void
+    let onAlarmToggle: (ArrivalDeparture) -> Void
+    let panelBuilder: (ArrivalDeparture) -> TripDetailPanelPlaceholder
+
+    var body: some View {
+        ForEach(groups, id: \.routeID) { group in
+            Section {
+                cardHeader(group)
+                if expandedRouteID == group.routeID {
+                    expandedRows(group)
+                }
+            }
+        }
+    }
+
+    // MARK: - Card header (the route's next departure)
+
+    @ViewBuilder
+    private func cardHeader(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        let next = group.next
+        let status = statusProvider(next)
+        let routeColor = Color(uiColor: next.route.color ?? ThemeColors.shared.brand)
+
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 13) {
+                RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(next.tripHeadsign ?? next.routeShortName)
+                        .font(.system(size: 16.5, weight: .heavy))
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        Text(DateFormatter.localizedString(from: next.scheduledDate, dateStyle: .none, timeStyle: .short))
+                            .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                        Text("·").foregroundStyle(.tertiary)
+                        Text(status.label)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(Color(uiColor: status.color))
+                    }
+                }
+                Spacer(minLength: 8)
+                CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+            }
+
+            HStack(spacing: 8) {
+                if group.chips.isEmpty {
+                    Text(OBALoc("stop_page.grouped.not_loaded", value: "later trips not loaded", comment: "Empty upcoming-chips state; must never imply no later trips exist (§4.4)"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                } else {
+                    ForEach(group.chips, id: \.id) { chip in
+                        let chipStatus = statusProvider(chip)
+                        Text("\(chip.arrivalDepartureMinutes)m")
+                            .font(.caption.weight(.heavy)).monospacedDigit()
+                            .foregroundStyle(Color(uiColor: chipStatus.color))
+                            .padding(.horizontal, 8).padding(.vertical, 3)
+                            .background(Color(uiColor: chipStatus.color).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+                Spacer()
+                alarmPill(for: next)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(expandedRouteID == group.routeID ? 180 : 0))
+            }
+        }
+        .padding(.vertical, 4)
+        .listRowBackground(cardStripe(routeColor))
+        .contentShape(Rectangle())
+        .onTapGesture { onToggleRoute(group.routeID) }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(groupAccessibilityLabel(group, status: status))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Route-color accent stripe on the card's left edge — the only other
+    /// place route color appears (§4.3).
+    private func cardStripe(_ routeColor: Color) -> some View {
+        HStack(spacing: 0) {
+            routeColor.frame(width: 5)
+            Color(uiColor: .secondarySystemGroupedBackground)
+        }
+    }
+
+    private func alarmPill(for departure: ArrivalDeparture) -> some View {
+        let alarm = alarmLookup(departure)
+        return Button {
+            onAlarmToggle(departure)
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: alarm != nil ? "bell.fill" : "bell")
+                Text(alarm.map { "\(alarmLeadTime($0))m" } ?? Strings.alarm)
+                    .monospacedDigit()
+            }
+            .font(.caption.weight(.heavy))
+            .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
+            .padding(.horizontal, 10).padding(.vertical, 6)
+            .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color(uiColor: .tertiarySystemFill), in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Expanded rows
+
+    @ViewBuilder
+    private func expandedRows(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>) -> some View {
+        ForEach(group.departures, id: \.id) { departure in
+            let status = statusProvider(departure)
+            HStack(spacing: 12) {
+                Button { onAlarmToggle(departure) } label: {
+                    Image(systemName: alarmLookup(departure) != nil ? "bell.fill" : "bell")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(alarmLookup(departure) != nil ? Color.white : Color.secondary)
+                        .frame(width: 34, height: 34)
+                        .background(alarmLookup(departure) != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                        .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: alarmLookup(departure) != nil ? 0 : 1.5))
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Text(DateFormatter.localizedString(from: departure.scheduledDate, dateStyle: .none, timeStyle: .short))
+                            .font(.subheadline.weight(.semibold)).monospacedDigit()
+                        Text("· \(status.label)")
+                            .font(.subheadline)
+                            .foregroundStyle(Color(uiColor: status.color))
+                    }
+                    if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
+                        Text(String(describing: occupancy)) // Task 10 replaces with OccupancyStatusView reuse
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 8)
+                CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .bold)).foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(openTripDepartureID == departure.id ? 180 : 0))
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { onToggleTrip(departure) }
+
+            if openTripDepartureID == departure.id {
+                panelBuilder(departure)
+            }
+        }
+    }
+
+    private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
+        let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
+        return String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+    }
+}
+```
+
+If `Strings.alarm` doesn't exist, use `OBALoc("stop_page.grouped.alarm_pill", value: "Alarm", comment: "Compact alarm pill label when no alarm is set")`.
+
+- [ ] **Step 2: Add the mode toggle and mode switch to `StopPageView`**
+
+Add to `StopPageView` (above the mode content, as an out-of-card Section):
+
+```swift
+    @State private var expandedRouteID: RouteID?
+
+    // In body's List, before the mode content:
+    Section {
+        Picker("", selection: Binding(
+            get: { viewModel.stopPreferences.sortType },
+            set: { newValue in
+                withAnimation {
+                    expandedDepartureID = nil
+                    expandedRouteID = nil
+                    viewModel.updateSortType(newValue)
+                }
+            }
+        )) {
+            Text(OBALoc("stop_page.mode.chronological", value: "Chronological", comment: "Stop page mode toggle: flat time-sorted list")).tag(StopSort.time)
+            Text(OBALoc("stop_page.mode.by_route", value: "By route", comment: "Stop page mode toggle: grouped by route")).tag(StopSort.route)
+        }
+        .pickerStyle(.segmented)
+        .listRowInsets(EdgeInsets())
+        .listRowBackground(Color.clear)
+    }
+
+    // Then switch the mode content:
+    if viewModel.stopPreferences.sortType == .time {
+        ChronologicalListView(/* as in Task 8 */)
+    } else {
+        GroupedListView(
+            groups: StopPageListBuilder.routeGroups(filteredDepartures),
+            expandedRouteID: expandedRouteID,
+            openTripDepartureID: expandedDepartureID,
+            statusProvider: { DepartureStatus(arrivalDeparture: $0) },
+            alarmLookup: { viewModel.alarm(for: $0) },
+            alarmLeadTime: { viewModel.alarmLeadTimeMinutes($0) },
+            onToggleRoute: { routeID in
+                withAnimation(.snappy) {
+                    expandedRouteID = expandedRouteID == routeID ? nil : routeID
+                    expandedDepartureID = nil
+                }
+            },
+            onToggleTrip: { departure in
+                withAnimation(.snappy) {
+                    expandedDepartureID = expandedDepartureID == departure.id ? nil : departure.id
+                }
+            },
+            onAlarmToggle: { departure in
+                Task {
+                    if viewModel.alarm(for: departure) != nil {
+                        await viewModel.cancelAlarm(for: departure)
+                    } else {
+                        await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime)
+                    }
+                }
+            },
+            panelBuilder: { TripDetailPanelPlaceholder(departure: $0) }
+        )
+    }
+```
+
+Also seed the last-used-mode default: when the VM's `stopPreferences` come back as the never-customized default, apply a global `"OBALastUsedStopSort"` UserDefaults value — implement as an `.onAppear` one-shot in `StopPageView` that reads `UserDefaults.standard.string(forKey: "OBALastUsedStopSort")`, and write the same key inside the Picker's `set`. Keep it to these two touch points.
+
+- [ ] **Step 3: Build + simulator smoke test**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet`
+Expected: BUILD SUCCEEDED. In the simulator: toggle modes (open accordions collapse — §4.6), verify route cards order by soonest departure, chips tint by each departure's own status, single-departure routes read "later trips not loaded".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "Add grouped by-route mode with route cards, status chips, and mode toggle"
+```
+
+---
+
+### Task 10: Trip-detail panel (approach timeline + alarm control)
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift`
+- Create: `OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift`
+- Create: `OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift`
+- Create: `OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift`
+- Modify: `OBAKit/Stops/StopPage/StopPageView.swift`, `ChronologicalListView.swift`, `GroupedListView.swift` — replace `TripDetailPanelPlaceholder` with `TripDetailPanelView` (change the `panelBuilder` closure type accordingly), delete the placeholder.
+- Test: `OBAKitTests/Stops/StopPage/ApproachSliceTests.swift`
+
+**Interfaces:**
+- Produces:
+  ```swift
+  protocol ApproachTimelineStop { var stopID: StopID { get }; var stopName: String { get } }
+  struct ApproachSlice<S: ApproachTimelineStop> {
+      let stops: [S]        // up to 4 upstream + the user's stop (last)
+      let vehicleIndex: Int? // index in `stops` of the vehicle's closest stop
+      static func make(stopTimes: [S], userStopID: StopID, closestStopID: StopID?) -> ApproachSlice?
+      // nil when userStopID absent, or vehicle already past the user's stop
+  }
+  struct TripDetailPanelView: View {
+      let departure: ArrivalDeparture
+      let status: DepartureStatus
+      let alarm: Alarm?
+      let alarmLeadTimeMinutes: Int         // current or default
+      let canAlarm: Bool
+      let approachLoader: () async -> TripDetails?
+      let onSetAlarm: () -> Void
+      let onCancelAlarm: () -> Void
+      let onChangeAlarm: (Int) -> Void
+      let onSchedule: () -> Void
+      let onViewFullTrip: () -> Void
+  }
+  ```
+- Consumes: `TripDetails.stopTimes: [TripStopTime]`, `TripStopTime.stopID` (+ resolve stop name via its `stop` reference — check `TripStopTime.swift` for the exact property, `TripStopListItem.swift` shows how the Trip screen reads names), `ArrivalDeparture.tripStatus?.closestStopID` (same field as `TripStopListItem.swift:73`), `AlarmLeadTime` (Task 4), VM methods from Task 5.
+
+- [ ] **Step 1: Write the failing ApproachSlice tests**
+
+```swift
+// OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
+import XCTest
+@testable import OBAKit
+import OBAKitCore
+
+private struct StubStop: ApproachTimelineStop {
+    let stopID: StopID
+    let stopName: String
+}
+
+private func stops(_ ids: [String]) -> [StubStop] {
+    ids.map { StubStop(stopID: $0, stopName: "Stop \($0)") }
+}
+
+final class ApproachSliceTests: XCTestCase {
+
+    func test_takesFourUpstreamStopsPlusUserStop() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "d")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 1) // "d" within the slice
+    }
+
+    func test_shortTrip_usesAllAvailableUpstream() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "user"]), userStopID: "user", closestStopID: "a")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "user"])
+        XCTAssertEqual(slice?.vehicleIndex, 0)
+    }
+
+    func test_vehiclePastUserStop_returnsNil() {
+        // Vehicle beyond the user's stop: timeline is meaningless, drop it.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "user", "b"]), userStopID: "user", closestStopID: "b")
+        XCTAssertNil(slice)
+    }
+
+    func test_vehicleOutsideWindow_hasNilVehicleIndex() {
+        // Vehicle is upstream but further back than the 4-stop window.
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "a")
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
+        XCTAssertNil(slice?.vehicleIndex)
+    }
+
+    func test_userStopMissing_returnsNil() {
+        XCTAssertNil(ApproachSlice.make(stopTimes: stops(["a", "b"]), userStopID: "user", closestStopID: "a"))
+    }
+
+    func test_nilClosestStop_stillShowsStops() {
+        let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "user"]), userStopID: "user", closestStopID: nil)
+        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
+        XCTAssertNil(slice?.vehicleIndex)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify failure, then implement `ApproachSlice`**
+
+```swift
+// OBAKit/Stops/StopPage/TripPanel/ApproachSlice.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Abstraction over `TripStopTime` so the windowing logic is testable with
+/// stubs (the real type only decodes from JSON).
+protocol ApproachTimelineStop {
+    var stopID: StopID { get }
+    var stopName: String { get }
+}
+
+/// The trip panel's approach window: the user's stop plus up to 4 upstream
+/// stops, with the vehicle's position resolved from `closestStopID` — the
+/// same field the Trip screen uses (`TripStopListItem`).
+struct ApproachSlice<S: ApproachTimelineStop> {
+    let stops: [S]
+    let vehicleIndex: Int?
+
+    static func make(stopTimes: [S], userStopID: StopID, closestStopID: StopID?) -> ApproachSlice? {
+        guard let userIndex = stopTimes.firstIndex(where: { $0.stopID == userStopID }) else { return nil }
+
+        if let closestStopID,
+           let vehicleAbsolute = stopTimes.firstIndex(where: { $0.stopID == closestStopID }),
+           vehicleAbsolute > userIndex {
+            return nil // vehicle already past the user's stop
+        }
+
+        let start = max(0, userIndex - 4)
+        let window = Array(stopTimes[start...userIndex])
+        let vehicleIndex = closestStopID.flatMap { closest in
+            window.firstIndex(where: { $0.stopID == closest })
+        }
+        return ApproachSlice(stops: window, vehicleIndex: vehicleIndex)
+    }
+}
+```
+
+Conform the real model where the panel builds the slice (in `TripDetailPanelView`, below): check `TripStopTime` for its stop-name access (the Trip screen resolves names via the stop reference; mirror what `TripStopListItem.swift` does) and add:
+
+```swift
+extension TripStopTime: ApproachTimelineStop {
+    // stopID exists on the model already; expose stopName from the resolved stop reference.
+    var stopName: String { stop.name } // adjust to the actual property found in TripStopTime.swift
+}
+```
+
+- [ ] **Step 3: Run the slice tests**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests/ApproachSliceTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17'`
+Expected: 6 tests pass (or TEST BUILD SUCCEEDED bar).
+
+- [ ] **Step 4: Implement the panel views**
+
+```swift
+// OBAKit/Stops/StopPage/TripPanel/AlarmControlView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The trip panel's alarm block: a single "Set an alarm" button by default;
+/// once set, an info row with Change (inline stepper) and Cancel.
+struct AlarmControlView: View {
+    let alarmIsSet: Bool
+    let leadTimeMinutes: Int
+    let maxLeadTime: Int   // min(15, minutesUntilDeparture - 1)
+    let onSet: () -> Void
+    let onCancel: () -> Void
+    let onChange: (Int) -> Void
+
+    @State private var editing = false
+    @State private var pendingMinutes: Int = AlarmLeadTime.defaultMinutes
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if !alarmIsSet {
+                Button(action: onSet) {
+                    Label(OBALoc("stop_page.alarm.set", value: "Set an alarm", comment: "Primary alarm button in the trip panel"), systemImage: "bell")
+                        .font(.system(size: 15, weight: .heavy))
+                        .frame(maxWidth: .infinity, minHeight: 46)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color(uiColor: ThemeColors.shared.departureOnTime))
+            } else {
+                HStack(spacing: 10) {
+                    Image(systemName: "bell.fill")
+                        .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+                        .frame(width: 32, height: 32)
+                        .background(Color(uiColor: ThemeColors.shared.departureOnTime).opacity(0.14), in: Circle())
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(OBALoc("stop_page.alarm.set_title", value: "Alarm set", comment: "Title of the set-alarm info row"))
+                            .font(.subheadline.weight(.bold))
+                        Text(String(format: OBALoc("stop_page.alarm.buzz_fmt", value: "Buzz %d min before it arrives", comment: "Subtitle of the set-alarm info row. %d is lead-time minutes."), leadTimeMinutes))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if !editing {
+                        Button(OBALoc("stop_page.alarm.change", value: "Change", comment: "Reveals the alarm lead-time stepper")) {
+                            pendingMinutes = leadTimeMinutes
+                            editing = true
+                        }
+                        .buttonStyle(.bordered)
+                        Button(Strings.cancel, role: .destructive, action: onCancel)
+                            .buttonStyle(.bordered)
+                    }
+                }
+                if editing {
+                    HStack {
+                        Text(OBALoc("stop_page.alarm.minutes_before", value: "Minutes before", comment: "Stepper label"))
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Stepper(value: $pendingMinutes, in: AlarmLeadTime.minimumMinutes...max(AlarmLeadTime.minimumMinutes, maxLeadTime)) {
+                            Text("\(pendingMinutes)m").font(.subheadline.weight(.heavy)).monospacedDigit()
+                        }
+                        .fixedSize()
+                        Button(OBALoc("stop_page.alarm.done", value: "Done", comment: "Commits the lead-time change")) {
+                            editing = false
+                            onChange(pendingMinutes)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color(uiColor: ThemeColors.shared.departureOnTime))
+                    }
+                    .padding(.top, 10)
+                }
+            }
+        }
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/TripPanel/ApproachTimelineView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Vertical line-and-dot approach timeline: upstream stops leading to the
+/// user's stop with a "bus here" marker at the vehicle's position. Live
+/// trips only (§4.1). Stops at/behind the bus are gray, stops between bus
+/// and user use the route color.
+struct ApproachTimelineView: View {
+    struct Row: Identifiable {
+        let id: String       // stopID
+        let name: String
+        let isUserStop: Bool
+        let isVehicleHere: Bool
+        let isPassed: Bool   // at or behind the vehicle
+    }
+
+    let rows: [Row]
+    let minutesAway: Int
+    let routeColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(rows) { row in
+                HStack(spacing: 12) {
+                    Circle()
+                        .strokeBorder(row.isPassed ? Color(uiColor: .quaternaryLabel) : routeColor, lineWidth: 2.5)
+                        .background(Circle().fill(row.isUserStop ? routeColor : Color.clear))
+                        .frame(width: row.isUserStop ? 12 : 9, height: row.isUserStop ? 12 : 9)
+                    Text(row.name)
+                        .font(.system(size: 13.5, weight: row.isUserStop ? .heavy : .medium))
+                        .foregroundStyle(row.isUserStop ? .primary : (row.isPassed ? Color(uiColor: .tertiaryLabel) : .secondary))
+                        .lineLimit(1)
+                    if row.isUserStop {
+                        Text(OBALoc("stop_page.timeline.your_stop", value: "· your stop", comment: "Marker on the user's stop in the approach timeline"))
+                            .font(.caption.weight(.bold)).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if row.isVehicleHere {
+                        Label(String(format: OBALoc("stop_page.timeline.bus_here_fmt", value: "bus here · %dm away", comment: "Vehicle-position pill. %d is minutes to the user's stop."), minutesAway), systemImage: "bus")
+                            .font(.caption2.weight(.heavy)).monospacedDigit()
+                            .foregroundStyle(routeColor)
+                            .padding(.horizontal, 8).padding(.vertical, 3)
+                            .background(routeColor.opacity(0.14), in: Capsule())
+                    }
+                }
+                .frame(minHeight: 30)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+```
+
+```swift
+// OBAKit/Stops/StopPage/TripPanel/TripDetailPanelView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The shared "second tap" panel (§4.6), rendered as an inserted row beneath
+/// its departure in either mode: live-vehicle strip (or the scheduled-only
+/// honesty notice), approach timeline, alarm control, and actions.
+struct TripDetailPanelView: View {
+    let departure: ArrivalDeparture
+    let status: DepartureStatus
+    let alarm: Alarm?
+    let alarmLeadTimeMinutes: Int
+    let canAlarm: Bool
+    let approachLoader: () async -> TripDetails?
+    let onSetAlarm: () -> Void
+    let onCancelAlarm: () -> Void
+    let onChangeAlarm: (Int) -> Void
+    let onSchedule: () -> Void
+    let onViewFullTrip: () -> Void
+
+    @State private var tripDetails: TripDetails?
+    @State private var timelineLoading = false
+
+    private var routeColor: Color {
+        Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Live vehicle strip / scheduled-only notice (§4.1)
+            HStack(spacing: 8) {
+                RealtimeGlyph(isRealTime: status.isRealTime, color: routeColor, size: 15)
+                if status.isRealTime {
+                    Text(String(format: OBALoc("stop_page.panel.live_vehicle_fmt", value: "Live · vehicle %@", comment: "Trip panel live strip. %@ is the vehicle id."), departure.vehicleID ?? "—"))
+                        .font(.footnote.weight(.bold))
+                } else {
+                    Text(OBALoc("stop_page.panel.scheduled_strip", value: "Scheduled · no live position yet", comment: "Trip panel strip for schedule-only trips"))
+                        .font(.footnote.weight(.bold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if status.isRealTime {
+                if let slice = approachSlice {
+                    ApproachTimelineView(
+                        rows: timelineRows(slice),
+                        minutesAway: departure.arrivalDepartureMinutes,
+                        routeColor: routeColor
+                    )
+                } else if timelineLoading {
+                    ProgressView().frame(maxWidth: .infinity)
+                }
+                // fetch failed / vehicle past window: omit silently
+            } else {
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(OBALoc("stop_page.panel.scheduled_title", value: "Scheduled time only", comment: "Title of the schedule-only notice"))
+                            .font(.footnote.weight(.bold))
+                        Text(OBALoc("stop_page.panel.scheduled_body", value: "No live signal from this bus yet — this is when it's supposed to arrive. It may run early, late, or not at all.", comment: "Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4)"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "calendar").foregroundStyle(.secondary)
+                }
+            }
+
+            if canAlarm {
+                AlarmControlView(
+                    alarmIsSet: alarm != nil,
+                    leadTimeMinutes: alarmLeadTimeMinutes,
+                    maxLeadTime: min(AlarmLeadTime.maximumMinutes, departure.arrivalDepartureMinutes - 1),
+                    onSet: onSetAlarm,
+                    onCancel: onCancelAlarm,
+                    onChange: onChangeAlarm
+                )
+            }
+
+            HStack(spacing: 10) {
+                Button(action: onSchedule) {
+                    Label(Strings.schedules, systemImage: "calendar")
+                        .frame(maxWidth: .infinity, minHeight: 40)
+                }
+                .buttonStyle(.bordered)
+                Button(action: onViewFullTrip) {
+                    Label(OBALoc("stop_page.panel.full_trip", value: "View full trip", comment: "Opens the full trip screen"), systemImage: "bus")
+                        .frame(maxWidth: .infinity, minHeight: 40)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(.vertical, 6)
+        .task(id: departure.id) {
+            guard status.isRealTime, tripDetails == nil else { return }
+            timelineLoading = true
+            tripDetails = await approachLoader()
+            timelineLoading = false
+        }
+    }
+
+    private var approachSlice: ApproachSlice<TripStopTime>? {
+        guard let stopTimes = tripDetails?.stopTimes else { return nil }
+        return ApproachSlice.make(
+            stopTimes: stopTimes,
+            userStopID: departure.stopID,
+            closestStopID: departure.tripStatus?.closestStopID
+        )
+    }
+
+    private func timelineRows(_ slice: ApproachSlice<TripStopTime>) -> [ApproachTimelineView.Row] {
+        slice.stops.enumerated().map { index, stopTime in
+            ApproachTimelineView.Row(
+                id: stopTime.stopID,
+                name: stopTime.stopName,
+                isUserStop: index == slice.stops.count - 1,
+                isVehicleHere: slice.vehicleIndex == index,
+                isPassed: slice.vehicleIndex.map { index <= $0 } ?? false
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Replace the placeholder**
+
+In `ChronologicalListView` and `GroupedListView`, change `panelBuilder`'s type from `(ArrivalDeparture) -> TripDetailPanelPlaceholder` to `(ArrivalDeparture) -> TripDetailPanelView`; delete `TripDetailPanelPlaceholder`. In `StopPageView`, build the real panel:
+
+```swift
+    private func makePanel(for departure: ArrivalDeparture) -> TripDetailPanelView {
+        let status = DepartureStatus(arrivalDeparture: departure)
+        let alarm = viewModel.alarm(for: departure)
+        return TripDetailPanelView(
+            departure: departure,
+            status: status,
+            alarm: alarm,
+            alarmLeadTimeMinutes: alarm.map { viewModel.alarmLeadTimeMinutes($0) } ?? viewModel.defaultAlarmLeadTime,
+            canAlarm: viewModel.canCreateAlarm(for: departure),
+            approachLoader: { await viewModel.approachTripDetails(for: departure) },
+            onSetAlarm: { Task { await viewModel.setAlarm(for: departure, leadTimeMinutes: viewModel.defaultAlarmLeadTime) } },
+            onCancelAlarm: { Task { await viewModel.cancelAlarm(for: departure) } },
+            onChangeAlarm: { minutes in Task { await viewModel.changeAlarm(for: departure, leadTimeMinutes: minutes) } },
+            onSchedule: {},      // Task 12
+            onViewFullTrip: {}   // Task 12
+        )
+    }
+```
+
+Pass `panelBuilder: makePanel(for:)` at both call sites.
+
+- [ ] **Step 6: Build + simulator smoke test, then commit**
+
+Run the standard build; in the simulator verify: expanding a live departure shows the strip and (after the fetch) the timeline with the bus pill; a schedule-only departure shows the honesty notice with a clock glyph and no occupancy; setting an alarm from the panel flips the swipe action, pill, and row icon simultaneously (§4.7).
+
+```bash
+git add -A && git commit -m "Add trip-detail panel with approach timeline and alarm control"
+```
+
+---
+
+### Task 11: Header card, live status row, footer, alerts/surveys/donations
+
+**Files:**
+- Create: `OBAKit/Stops/StopPage/StopPageHeaderView.swift`
+- Modify: `OBAKit/Stops/StopPage/StopPageView.swift` (final assembly)
+
+**Interfaces:**
+- Produces: `StopPageHeaderView(stop: Stop, walkTime: WalkTimeInfo?, snapshotLoader: (CGSize) async -> UIImage?)`.
+- Consumes: `MapSnapshotter` (`OBAKit/Mapping/MapSnapshotter.swift` — callback-based; bridge with a continuation; see how `StopHeaderView` in `StopHeaderController.swift` configures it, including `ThemeColors.shared.mapSnapshotOverlayColor`), `Formatters` for the `Stop #### · direction` subhead (`StopHeaderView` shows the existing format strings to reuse), `viewModel.statusText`, `viewModel.currentSurvey`, `viewModel.stopArrivals?.serviceAlerts`, `viewModel.loadMoreDepartures()`, `viewModel.isLoadMoreExhausted`.
+
+- [ ] **Step 1: Implement `StopPageHeaderView`**
+
+```swift
+// OBAKit/Stops/StopPage/StopPageHeaderView.swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The inset map-card header: snapshot background, stop identity, and the
+/// walk chip — the single visual source of walk time (§4.5). Tap toggles the
+/// routes-served line (parity with the old header).
+struct StopPageHeaderView: View {
+    let stop: Stop
+    let walkTime: WalkTimeInfo?
+    let snapshotLoader: (CGSize) async -> UIImage?
+
+    @State private var snapshot: UIImage?
+    @State private var showsRoutes = false
+
+    private var subtitle: String {
+        // Reuse the exact format the old header shows; see StopHeaderView for
+        // the localized "Stop #%@" + direction strings and mirror them.
+        Formatters.formattedCodeAndDirection(stop: stop)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Group {
+                if let snapshot {
+                    Image(uiImage: snapshot).resizable().scaledToFill()
+                } else {
+                    Color(uiColor: .secondarySystemGroupedBackground)
+                }
+            }
+            LinearGradient(
+                colors: [Color(uiColor: .systemBackground).opacity(0.92), Color(uiColor: .systemBackground).opacity(0.4), .clear],
+                startPoint: .top, endPoint: .bottom
+            )
+            VStack(alignment: .leading, spacing: 4) {
+                Text(stop.name)
+                    .font(.system(size: 22, weight: .heavy))
+                    .lineLimit(2)
+                Text(subtitle)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                if showsRoutes {
+                    Text(stop.routes.map(\.shortName).joined(separator: ", "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .padding(16)
+        }
+        .frame(height: 150)
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .bottomLeading) {
+            if let walkTime {
+                Label(walkChipText(walkTime), systemImage: "figure.walk")
+                    .font(.system(size: 13, weight: .heavy))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                    .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+                    .padding(12)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture { withAnimation { showsRoutes.toggle() } }
+        .task {
+            // MapSnapshotter needs concrete dimensions; commit to the card size.
+            snapshot = await snapshotLoader(CGSize(width: UIScreen.main.bounds.width - 40, height: 150))
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func walkChipText(_ info: WalkTimeInfo) -> String {
+        let distance = Formatters.formattedDistance(info.distance)
+        let fmt = OBALoc("stop_page.walk_chip_fmt", value: "%d min walk · %@", comment: "Walk chip on the header card. %d minutes, %@ formatted distance.")
+        return String(format: fmt, info.walkMinutes, distance)
+    }
+}
+```
+
+Verification notes for the implementer: `Formatters.formattedCodeAndDirection` and `Formatters.formattedDistance` — check `Formatters.swift` and `StopHeaderController.swift`/`WalkTimeView.swift` for the actual helper names; if they differ, use the existing ones rather than inventing new formatting. Bridge `MapSnapshotter` in `StopPageViewController` (it owns `application`):
+
+```swift
+    func loadSnapshot(size: CGSize) async -> UIImage? {
+        await withCheckedContinuation { continuation in
+            // Mirror StopHeaderView's MapSnapshotter configuration (stop annotation,
+            // overlay color, zoom) — see StopHeaderController.swift.
+            let snapshotter = MapSnapshotter(size: size, stopIconFactory: application.stopIconFactory)
+            snapshotter.snapshot(stop: viewModel.stop!, traitCollection: traitCollection) { image in
+                continuation.resume(returning: image)
+            }
+        }
+    }
+```
+
+(Adjust to `MapSnapshotter`'s real initializer/method — read the file first; do not guess.) Pass it into `StopPageView` as a closure so the view stays UIKit-free.
+
+- [ ] **Step 2: Final `StopPageView` assembly**
+
+Assemble the full list order (spec "Screen structure"): header card (out-of-card Section, `listRowInsets(EdgeInsets())` + clear background) → live status row (`viewModel.statusText` with a pulsing dot: `Circle` 7pt in `departureOnTime`, `.symbolEffect`-free — use `.opacity` phase animation gated on Reduce Motion, or static when reduced) → survey card if `viewModel.currentSurvey != nil` (reuse the same SwiftUI/hosted view the old screen's survey section uses — find it via `surveySection` in `StopViewController.swift` and render its content view here; if it is UIKit-only, wrap in a representable) → service alerts Section (rows: `Image(systemName: "exclamationmark.triangle.fill")` + alert title from `viewModel.stopArrivals?.serviceAlerts`, tap → callback to the hosting VC which pushes the existing alert detail via `application.viewRouter`) → mode toggle → mode content → footer Section:
+
+```swift
+    Section {
+        if !viewModel.isLoadMoreExhausted {
+            Button {
+                Task { await viewModel.loadMoreDepartures() }
+            } label: {
+                Label(OBALoc("stop_page.load_more", value: "Load more", comment: "Extends the departure time window"), systemImage: "plus")
+                    .font(.system(size: 14.5, weight: .bold))
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+        }
+        Text(String(format: OBALoc("stop_page.attribution_fmt", value: "Real-time data provided by %@", comment: "Data attribution footer. %@ is the region/agency name."), viewModel.stop?.routes.first?.agency.name ?? ""))
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+    }
+```
+
+Also add the empty states: when `filteredDepartures.isEmpty && !viewModel.isLoading` show "No departures in the next \(viewModel.minutesAfter) minutes" (never "no more buses" — §4.4); when everything is filtered out (`!all.isEmpty && filtered.isEmpty`) show "All routes at this stop are filtered" with a button invoking the filter callback; when `viewModel.operationError != nil` and there's no data, show the error text with a Retry button calling `viewModel.refresh()`.
+
+Check the attribution source: the old screen has a `dataAttributionSection` (`StopViewController.swift`, search `dataAttribution`) — reuse its string/source instead of the agency guess above if it differs.
+
+Donations: check `donationsSection` in `StopViewController.swift`; if it renders a SwiftUI view (donations UI is SwiftUI elsewhere), embed the same view behind `if` on the same condition; if it's UIKit-only and heavy, defer to the parity task (Task 12) with a note — do not silently drop it.
+
+- [ ] **Step 3: Build + simulator smoke test, then commit**
+
+```bash
+git add -A && git commit -m "Assemble Stop page: header card, status row, alerts, surveys, footer, empty states"
+```
+
+---
+
+### Task 12: Hosting-VC chrome parity (menus, filter, navigation, Previewable)
+
+**Files:**
+- Modify: `OBAKit/Stops/StopPage/StopPageViewController.swift`
+- Modify: `OBAKit/Stops/StopPage/StopPageView.swift` (navigation callbacks struct)
+
+**Interfaces:**
+- Produces: `StopPageNavigationHandler` — a struct of closures injected into `StopPageView` for everything that leaves the screen: `showTrip(ArrivalDeparture)`, `showSchedule()`, `showAlertDetail(ServiceAlert)`, `showBookmarkEditor(ArrivalDeparture?)`, `showFilter()`. The hosting VC implements them with the same code paths `StopViewController` uses.
+- Consumes: `StopViewController.swift` as the reference implementation — port these, adapting `self`/`viewModel` references (menu code is at the cited lines; it is UIKit and lives on the hosting VC):
+  - `filterMenu()` (`:327-359`) and Filter bar button (`configureTabBarButtons()` `:300-321`)
+  - `fileMenu()` (`:361-377`), `locationMenu()` (`:379-420`), `helpMenu()` (`:446-452`) — compose the More pulldown WITHOUT `sortMenu()` (the toggle supersedes it)
+  - Schedules bar button → `showScheduleForStop` (find its implementation in `StopViewController` and port)
+  - Route filter presentation `filter()` (`:1216` — presents SwiftUI `StopPreferencesWrappedView` in a `UIHostingController`)
+  - `Previewable` conformance (see `StopViewController`'s implementation, search `Previewable`)
+
+- [ ] **Step 1: Port nav-bar items and menus onto `StopPageViewController`**
+
+In `viewDidLoad`, mirror `configureTabBarButtons()`: right bar items = More menu (File/Location/Help submenus, no Sort), Filter menu, Schedules button. Rebuild the menus when `viewModel.stopPreferences` or `viewModel.stopArrivals` changes — subscribe with Combine exactly as `StopViewController.bindViewModel()` does (`StopViewController.swift:198` and the binding extension at `:1267` show the pattern):
+
+```swift
+    private var cancellables = Set<AnyCancellable>()
+
+    private func bindChrome() {
+        viewModel.$stop
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] stop in
+                guard let self, let stop else { return }
+                self.title = Formatters.formattedTitle(stop: stop)
+                self.configureBarButtons()
+            }
+            .store(in: &cancellables)
+
+        viewModel.$stopPreferences
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.configureBarButtons() }
+            .store(in: &cancellables)
+    }
+```
+
+`configureBarButtons()` is the ported `configureTabBarButtons()` minus the sort menu. Port the menu bodies verbatim from the cited lines, changing `self.stop` → `viewModel.stop`, `self.stopArrivals` → `viewModel.stopArrivals`.
+
+- [ ] **Step 2: Wire `StopPageNavigationHandler`**
+
+```swift
+/// Everything that navigates away from the Stop page, implemented by the
+/// hosting VC so SwiftUI stays router-free.
+struct StopPageNavigationHandler {
+    let showTrip: (ArrivalDeparture) -> Void
+    let showSchedule: () -> Void
+    let showAlertDetail: (ServiceAlert) -> Void
+    let showBookmarkEditor: (ArrivalDeparture?) -> Void
+    let showFilter: () -> Void
+}
+```
+
+In `StopPageViewController`, construct it with:
+- `showTrip`: `application.viewRouter.navigateTo(arrivalDeparture: $0, from: self)`
+- `showSchedule`: port `showScheduleForStop` from `StopViewController`
+- `showAlertDetail`: the same presentation the old screen uses for a tapped alert (search `StopViewController` for its service-alert selection handling and port)
+- `showBookmarkEditor`: port the `addBookmark(sender:)` / arrival-bookmark flow (`StopViewController` — search `BookmarkEditor`); pass `nil` for the stop-level bookmark, an `ArrivalDeparture` for trip bookmarks
+- `showFilter`: port `filter()` (`:1216`)
+
+Rebuild `rootView` with the handler included (add `let navigation: StopPageNavigationHandler` to `StopPageView` and thread it to `makeActions`/`makePanel`: `onShowTrip` → `navigation.showTrip(departure)`, `onSchedule` → `navigation.showSchedule()`, `onBookmark` → `navigation.showBookmarkEditor(departure)`; alert row taps → `navigation.showAlertDetail(alert)`). Set `canSchedule` from the same region gating the old screen uses (find the region-gated Schedule condition in `StopArrivalItem.swift:54`'s action construction and reuse it).
+
+Add the `Previewable` conformance ported from `StopViewController` (search `extension StopViewController: Previewable`), so map peeks work.
+
+Add the context-menu trip preview: in `departureRowActions`, extend `.contextMenu` to `.contextMenu(menuItems:preview:)` where the preview is:
+
+```swift
+    TripViewControllerPreview(departure: departure, application: application)
+        .frame(width: 320, height: 400)
+```
+
+with:
+
+```swift
+/// Lazily-built UIKit preview for row long-presses; constructed only when the
+/// preview is actually presented.
+struct TripViewControllerPreview: UIViewControllerRepresentable {
+    let departure: ArrivalDeparture
+    let application: Application
+    func makeUIViewController(context: Context) -> TripViewController {
+        TripViewController(application: application, arrivalDeparture: departure)
+    }
+    func updateUIViewController(_ uiViewController: TripViewController, context: Context) {}
+}
+```
+
+(This requires `application` to reach the row call site — pass it through `StopPageNavigationHandler` as `let makeTripPreview: (ArrivalDeparture) -> AnyView` built by the hosting VC instead, keeping `Application` out of the view layer. AnyView is acceptable here: it's inside a lazily-evaluated preview closure, not row structure.)
+
+- [ ] **Step 3: Build + full simulator parity pass, then commit**
+
+Verify in the simulator: More menu (bookmark/alerts/nearby/walking directions/report), Filter menu + sheet, Schedules button, long-press preview opens, swipe Save opens the bookmark editor, panel's "View full trip" pushes the trip screen.
+
+```bash
+git add -A && git commit -m "Stop page chrome parity: menus, filter, navigation handler, trip previews"
+```
+
+---
+
+### Task 13: Settings row for default alarm lead time
+
+**Files:**
+- Modify: `OBAKit/Settings/SettingsViewController.swift` (Alerts section — search `alertsSection` or the section registered around the "Alerts" title)
+
+- [ ] **Step 1: Add the row**
+
+Follow the walking-speed preset row pattern in the same file (segmented `SegmentedRow` or `ActionSheetRow` — match what the file uses; the walking-speed section shows the house style). Options: 2, 5, 10 minutes; read/write `application.userDataStore.defaultAlarmLeadTimeMinutes`:
+
+```swift
+    section <<< ActionSheetRow<Int> {
+        $0.tag = "defaultAlarmLeadTimeMinutes"
+        $0.title = OBALoc("settings_controller.alerts_section.default_alarm_lead_time", value: "Default alarm lead time", comment: "Settings > Alerts > default minutes-before for one-tap departure alarms")
+        $0.options = [2, 5, 10]
+        $0.value = application.userDataStore.defaultAlarmLeadTimeMinutes
+        $0.displayValueFor = { value in
+            guard let value else { return nil }
+            return String(format: OBALoc("settings_controller.alerts_section.lead_time_fmt", value: "%d minutes", comment: "Lead-time option label"), value)
+        }
+    }.onChange { [weak self] row in
+        guard let self, let value = row.value else { return }
+        self.application.userDataStore.defaultAlarmLeadTimeMinutes = value
+    }
+```
+
+(Adapt to the file's actual save pattern — it may batch values in `form.values()` on exit like the experimental toggles; if so, register/save the same way instead of `.onChange`.)
+
+- [ ] **Step 2: Build, verify in Settings UI, commit**
+
+```bash
+git add -A && git commit -m "Settings: default alarm lead time (2/5/10 min)"
+```
+
+---
+
+### Task 14: Full verification pass + doc touch-ups
+
+**Files:**
+- Modify: `CLAUDE.md` (stale "Target iOS Version: 17.0+" → "18.0+")
+
+- [ ] **Step 1: Run the full unit-test suite**
+
+Run: `scripts/generate_project OneBusAway && xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17' -quiet && xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17' 2>&1 | tail -15`
+Expected: suite green (or TEST BUILD SUCCEEDED bar with the known runner crash, reported honestly).
+
+- [ ] **Step 2: SwiftLint**
+
+Run: `scripts/swiftlint.sh`
+Expected: no new violations in `OBAKit/Stops/StopPage/` or modified files.
+
+- [ ] **Step 3: Manual simulator walkthrough (both modes, against the live Puget Sound region)**
+
+Checklist — each item maps to a spec requirement:
+- [ ] Chronological: sorted rows; walk chip and walk divider show the same minutes (§4.5); missed rows dim+strikethrough, past rows dim only (§4.2)
+- [ ] Past toggle reveals/hides the dimmed past card; state persists across screens (shared key with old UI)
+- [ ] Grouped: cards ordered by soonest (§4.9); chips tinted per-departure; "later trips not loaded" on single-trip routes (§4.4)
+- [ ] Mode toggle collapses open accordions (§4.6) and round-trips with the old screen's Sort menu (flip the flag off, check the old screen shows the same sort)
+- [ ] Schedule-only departure: clock glyph, gray countdown, "schedule data", no occupancy anywhere, honesty notice in panel (§4.1)
+- [ ] Alarm set/cancel/change from all four surfaces stays in sync (§4.7); alarm survives app relaunch (persisted in UserDataStore) and appears in Recents' alarm list
+- [ ] Load more extends the window; button hides when exhausted
+- [ ] Reduce Motion (Settings → Accessibility → Motion in the simulator): glyphs and status dot static
+- [ ] Dark mode: status colors legible, header scrim correct
+- [ ] VoiceOver: rows read as single elements with route/headsign/minutes/status; swipe actions reachable via the rotor
+- [ ] Flag OFF (Settings → Experimental): old StopViewController returns, all existing behavior intact
+
+- [ ] **Step 4: Fix CLAUDE.md target and commit**
+
+In `CLAUDE.md`, change `- **Target iOS Version**: 17.0+` to `- **Target iOS Version**: 18.0+`.
+
+```bash
+git add -A && git commit -m "Stop page rethink: verification pass; fix stale iOS target in CLAUDE.md"
+```
+
+---
+
+## Self-Review Notes (already applied)
+
+- **Spec coverage**: flag/router (T1), status gate §4.1 (T2), partition/grouping §4.2/§4.5/§4.9 (T3), clamp + walk source + lead-time setting (T4, T13), VM alarm/walk/approach (T5), glyph §4.8 + shared views (T6), rows + swipe/context (T7), chrono mode + accordion spike (T8), grouped mode + toggle + last-used-mode seed (T9), trip panel §4.6 + timeline + alarm UX (T10), header/status/alerts/surveys/footer/empty states §4.4 (T11), menus/filter/navigation/Previewable/previews (T12), settings row (T13), verification + a11y + dark mode + flag-off regression (T14).
+- **Known intentional deferrals**: `@Observable` migration (post-legacy-retirement), donations card may land in T12 if UIKit-only (flagged in T11, never silently dropped).
+- **Type consistency**: `DepartureStatus`, `StopPageListBuilder.ChronologicalPartition/RouteGroup`, `DepartureRowActions`, `TripDetailPanelView`, `StopPageNavigationHandler`, `WalkTimeInfo`, `AlarmLeadTime`, `ApproachSlice` are each defined once and consumed by name in later tasks.
+- **Codebase-verification hooks**: wherever the plan touches API surfaces it couldn't fully verify (`MapSnapshotter` init, `TripStopTime` stop-name property, `UserDataStore` key-enum spelling, `Strings.*` constants, Eureka save pattern), the step says "read the file first, adapt, don't guess" with the exact file to read.

--- a/docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md
+++ b/docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md
@@ -1,0 +1,178 @@
+# Stop Page Rethink — Design
+
+**Date:** 2026-07-10
+**Branch:** `new-stop`
+**Source of truth for visuals/behavior:** Claude Design project "OBA iOS" — `Stop Page Rethink - Implementation Brief.md` + `OBA Stop Page Rethink.html` (components `oba-dep-core.jsx`, `oba-dep-chrome.jsx`, `oba-dep-views.jsx`).
+
+## Summary
+
+A ground-up SwiftUI rebuild of the Stop screen shipping two co-equal list modes behind one segmented toggle — **Chronological** (flat, time-sorted, with a walk-reachability line) and **By route** (one expandable card per route) — plus an inline per-departure **trip-detail panel** with a live approach timeline, and **one-tap alarms** reachable from four surfaces. Three data points are elevated everywhere: real-time vs. scheduled, schedule adherence, and alarms.
+
+Ships behind a **default-ON flag** with fallback to the existing `StopViewController`. Reuses the existing `StopViewModel` (built for exactly this), Obaco server-push alarms, and OBA's existing status color conventions (early = red, late = blue).
+
+## Decisions made (with rationale)
+
+| Decision | Choice | Why |
+|---|---|---|
+| UI framework | SwiftUI, hosted in `UIHostingController` | `StopViewModel` was explicitly built for a future SwiftUI stop screen; accordions/animated glyphs/toggle are cheap in SwiftUI; matches app direction (sheets, schedules, vehicles are SwiftUI). |
+| Rollout | Feature flag, default ON | De-risks white-label variants; fallback while parity gaps get found; like the existing map-panel experimental toggle. |
+| Alarm engine | Obaco server-push (existing) | Server tracks prediction and pushes at the right moment even when the app is killed. The brief's local-notification approach cannot reschedule reliably from a suspended app. **Deliberate deviation from brief §4.7's mechanism; its UX requirements all still hold.** |
+| Chrome scope | Header card + live status; standard `UINavigationBar` and tab bar | Most of the visual payoff without custom-nav risk. Prototype's floating nav pills and floating tab bar are out of scope. |
+| Data layer | Reuse `StopViewModel`, extend | One source of truth for old + new screens while the flag exists; keeps fetch/refresh/pagination/survey/preference logic single-copy. |
+| Mode persistence | Existing per-stop `StopPreferences.sortType` (`.time` = Chronological, `.route` = By route) | Round-trips with the old screen; per-stop is richer than the brief's global suggestion. New stops default from a new global "last-used mode" UserDefaults key. |
+| V1 parity | Service alerts, surveys + donations, route filter, context menus + previews | Flag defaults ON, so these can't regress. |
+
+## Architecture
+
+### Entry point & flag
+
+- `ViewRouter.navigateTo(stop:)` — already the chokepoint for map taps, bookmarks, deep links, search — instantiates `StopPageViewController` when the flag is on, `StopViewController` when off.
+- Flag: UserDefaults bool, default `true`, toggle in Settings → Experimental (pattern: existing map-panel flag).
+- `StopPageViewController` is a thin `UIHostingController<StopPageView>` subclass owning nav-bar items and `Previewable` conformance (so stop peeks from map/bookmarks keep working).
+
+### View model
+
+`StopPageView` observes the **existing** `StopViewModel` (`OBAKit/ViewModels/StopViewModel.swift`), which already owns: arrivals fetch, 15 s refresh timer, load-more + auto-extension (35 → +30 min, cap 720), per-stop `StopPreferences` (sortType + hiddenRoutes), survey state, alarm gating (`canCreateAlarm`). It grows four things:
+
+1. **`walkTime: (minutes: Int, distance: Measurement)?`** — computed as `StopViewController` does today (`WalkingDirections.travelTime` straight-line ÷ `userDataStore.walkingSpeedMetersPerSecond`; nil when no location or distance ≤ 40 m). Published; the header chip and walk line read this one value (brief §4.5).
+2. **Alarm lookup + mutation** — `alarm(for: ArrivalDeparture) -> Alarm?` matched via `Alarm.deepLink` (tripID + serviceDate + stopID + stopSequence); `setAlarm(departure:leadTime:)` (`ObacoAPIService.postAlarm`), `cancelAlarm(_:)` (`deleteAlarm(url:)` + `userDataStore.delete`), `changeAlarm(_:leadTime:)` (= delete + re-post; Obaco has no update). All alarm UI everywhere calls these three.
+3. **`approach(for: ArrivalDeparture) async -> TripDetails?`** — `apiService.getTrip(tripID:vehicleID:serviceDate:)` on trip-panel open, live trips only, cached per trip and invalidated each refresh tick.
+4. **`lastUpdated` relative string** for the live status row (largely exists).
+
+### Presentation layer
+
+`DepartureStatus` — a value type wrapping `ArrivalDeparture`, the single home of the brief's visual rules:
+
+- `statusColor`: via existing `Formatters.colorForScheduleStatus` → `ThemeColors` (`departureOnTime` green, `departureLate` blue, `departureEarly` red), **gray when `!predicted`**.
+- `statusLabel`: "on time" / "{n} min late" / "{n} min early" / **"schedule data"** when `!predicted`.
+- The §4.1 hard gate: when `!predicted` → clock glyph (not waves), gray countdown, **occupancy suppressed entirely**, no approach timeline, "scheduled only" notice in the panel.
+- Route color (`route.color`, GTFS/agency) is used **only** for the badge and grouped-card stripe — never the countdown (§4.3).
+
+### File layout
+
+```
+OBAKit/Stops/StopPage/
+  StopPageViewController.swift      hosting shell, nav menus, Previewable, flag glue
+  StopPageView.swift                root List: header, status, surveys/donations,
+                                    alerts, toggle, mode switch, footer
+  StopPageHeaderView.swift          map-snapshot card + walk chip
+  Departures/
+    ChronologicalListView.swift     past block, walk partition, rows
+    GroupedListView.swift           route grouping + card ordering
+    RouteCardView.swift             card header, chips, expansion
+    DepartureRowView.swift          shared chrono/expanded row
+    UpcomingChipsView.swift
+  Shared/
+    DepartureStatus.swift           status color/label/gate (unit-tested)
+    RealtimeGlyph.swift             3-wave pulse / static clock
+    CountdownView.swift             "{n}m" + glyph, monospaced digits
+    RouteBadgeView.swift
+    WalkLineDivider.swift           dashed "N MIN WALK — CATCH BELOW"
+  TripPanel/
+    TripDetailPanelView.swift       vehicle strip, timeline, alarm, actions
+    ApproachTimelineView.swift
+    AlarmControlView.swift          set button / info row / stepper
+```
+
+`OBAKitCore` changes: `UserDataStore.defaultAlarmLeadTime` (default 5 min) and, if needed, the "schedule data" label in `Formatters`. Nothing else.
+
+## Screen structure
+
+Root is a SwiftUI `List`, inset-grouped styling (rounded cards on `systemGroupedBackground`; native `.swipeActions`). Top to bottom:
+
+1. **Header card** (`StopPageHeaderView`): `MapSnapshotter` image as card background (rounded, inset), top-down white scrim, stop name (bold ~22 pt), `Stop #### · {direction} bound` subhead, **walk chip** pinned bottom-left (`{n} min walk · {distance}`, brand green) — rendered only when `walkTime != nil`. Tapping the card toggles the routes-served line, matching today's header behavior.
+2. **Live status row**: centered `● Updated {relative}` with pulsing dot (static under Reduce Motion), fed by the VM refresh clock.
+3. **Surveys / donations** cards — same relative positions as today.
+4. **Service alerts** card — icon + title rows, tap → existing alert detail via `ViewRouter`; collapses to a summary row beyond two alerts; honors `stopViewShowsServiceAlerts`.
+5. **Segmented toggle** `Chronological ⇄ By route` — custom capsule matching the prototype, `Picker`-equivalent semantics and VoiceOver traits; writes `viewModel.updateSortType(_:)`; mode switch collapses any open accordion.
+6. **Mode content** (below).
+7. **Footer**: `Load more` (existing pagination/auto-extend; hidden when exhausted) + data-attribution line.
+
+### Chronological mode
+
+- Filtered (`hiddenRoutes`) departures sorted by `arrivalDepartureMinutes`.
+- **Past block**: section header `ARRIVALS & DEPARTURES` with trailing `Past · N / Hide past` toggle (persists existing `pastDeparturesCollapsed` key). Past rows are **dimmed only** — no strikethrough (§4.2) — in their own card above an `— UPCOMING —` divider.
+- **Walk partition** (only when `walkTime != nil`): rows with `minutesAway < walkMinutes` form the "missed" card — **dimmed + strikethrough destination + gray countdown** — followed by the dashed green **`{n} MIN WALK — CATCH BELOW`** divider, then the reachable card. No walk data → no partition, no divider, no chip (same nil source).
+- **Row** (`DepartureRowView`): route badge · destination (2-line wrap) · `{sched time} · {adherence}` line (time secondary, adherence in status color) · trailing `CountdownView` (big `{n}m` in status color + `RealtimeGlyph`). Bell-on glyph appears in the second line when the departure has an alarm.
+- **Swipe actions**: Alarm (green, only if `canCreateAlarm`) · Schedule (teal, region-gated) · Save (orange → bookmark editor). Same gating as today's `trailingContextualActions`.
+- Row tap toggles the inline trip panel.
+
+### Grouped ("By route") mode
+
+- Group filtered list by route, preserving first-appearance order after the time sort → routes ranked by soonest departure (§4.9).
+- **Card header** = the route's next departure: 5 pt route-color accent stripe (left edge), badge, destination, `sched · adherence`, big countdown + glyph.
+- **Upcoming chips**: up to 3 pills (`12m`, `27m`, …), each tinted by *its own* status color; empty state reads **"later trips not loaded"** — never "no later trips" (§4.4).
+- Header right side: compact **Alarm pill** (bell; shows `{n}m` when the next departure has an alarm; toggles it) + rotating disclosure chevron.
+- **Expansion** (one route at a time): every loaded departure for the route — far-left icon-only alarm toggle (filled when set), `{time} · {adherence}` with occupancy beneath (or "schedule data"), right-aligned compact countdown, chevron. Tapping a row opens the trip panel beneath it.
+- No walk line or past block in grouped mode (matches prototype and today). Header walk chip still shows.
+
+### Shared visual rules
+
+- Countdown, glyph, and chips colored by **adherence status only**; route color confined to badge + stripe (§4.3).
+- OBA convention: **early = red, late = blue** (existing `ThemeColors`).
+- Monospaced digits on all countdowns and chips.
+- Occupancy rendered **only** when `predicted` (§4.1).
+- Two kinds of dimmed rows (§4.2): *missed* = dim + strikethrough; *past* = dim only.
+
+## Trip-detail panel
+
+`TripDetailPanelView` renders inline beneath the opening row (chrono row or grouped expanded row) on the grouped-background tint with an expand animation. One panel open per screen; mode switch or the departure dropping from the feed closes it. Input is `(ArrivalDeparture, DepartureStatus, alarm state)` + callbacks — entry-point-agnostic (§4.6).
+
+- **Live vehicle strip** (predicted): route-colored wave glyph + `Live · vehicle {id}` + occupancy.
+- **Scheduled-only notice** (unpredicted): static clock + *"Scheduled time only — no live signal from this bus yet; this is when it's supposed to arrive. It may run early, late, or not at all."* No vehicle, occupancy, or timeline.
+- **Approach timeline** (live only): from the on-open `TripDetails` fetch, take the user's stop (`stopID` + departure `stopSequence`) and the **4 preceding stops**; vehicle marker at `tripStatus.closestStopID` (same flag `TripStopListItem` uses). Vertical line-and-dot: stops at/behind the bus gray, stops between bus and user in route color, user's stop a larger route-color dot labeled `· your stop`, tinted `bus here · {n}m away` pill at the vehicle row. Loading → compact shimmer placeholder; fetch failure or vehicle past the 5-stop window → drop the timeline silently, keep the strip. Cache invalidated per refresh tick so the marker advances.
+- **Alarm control**: default full-width green **"Set an alarm"**; once set, info row *"Alarm set · Buzz {n} min before it arrives"* with **Change** (inline −/+ stepper) and **Cancel**.
+- **Actions**: half-width **Schedule** (existing `ScheduleForStopView`, region-gated) and **View full trip** (existing `TripViewController` via `ViewRouter`).
+
+## Alarms
+
+Four entry points, one state (§4.7): chrono swipe, grouped header pill, grouped expanded-row icon, trip-panel control — all render from `alarm(for:)` and call the same three VM methods, so any surface's change is instantly visible everywhere.
+
+- **Set**: `postAlarm` with `UserDataStore.defaultAlarmLeadTime` (default 5 min; new Settings row offering the prototype's 2/5/10). No picker interruption (replaces the `AlarmBuilder` bulletin flow on this screen).
+- **Clamp**: stepper 1–15 min, additionally capped at `arrivalDepartureMinutes − 1`. Departures ≤ 1 min away: alarm affordances disabled (existing `canCreateAlarm` gating requires `arrivalDepartureMinutes > 1`; the same gate covers regions without Obaco/push — there, alarm UI is absent from all four surfaces).
+- **Change**: delete + re-post, optimistic UI, rollback + toast on failure.
+- **Cancel**: `deleteAlarm(url:)` + local removal — Stop screen finally gains cancel (today: Recents only).
+- **Push permission**: first set runs the existing `PushService` registration; denial shows the existing guidance alert.
+- Expired alarms purge on refresh via existing `deleteExpiredAlarms()`.
+- **No client-side rescheduling** — the Obaco server owns prediction tracking (deliberate deviation from brief §4.7's local-notification mechanism).
+
+## Chrome parity
+
+- **Nav bar**: standard `UINavigationBar`, stop name as small title. Menus carry over as bar items on the hosting VC: **Filter** (route filter → existing `StopPreferencesView` sheet) and **More** pulldown (Add Bookmark, Share, Report a Problem, Nearby Stops, All Service Alerts, Walking Directions) calling the same VM/router methods as today. The **Sort menu is removed** — the toggle supersedes it.
+- **Context menus**: rows get `.contextMenu` mirroring swipe actions + "Show Trip Details"; preview embeds `TripViewController` via `UIViewControllerRepresentable`.
+- Prototype's floating nav pills and floating tab bar: **out of scope** (v1 uses standard chrome).
+
+## Error & empty states
+
+- Fetch failure with data: keep last-good data visible (VM already does); failure with none: existing error card + retry.
+- Zero upcoming departures: "No departures in the next {n} minutes" above Load more — never wording implying no more service exists (§4.4).
+- Everything filtered out: "All routes at this stop are filtered" + button opening the filter sheet.
+- No location permission: chip and walk line simply absent.
+
+## Accessibility
+
+- Each row is one VoiceOver element: "Route 132 to Downtown Seattle, departs in 5 minutes, 4 minutes late, live tracking" / "…scheduled time only, no live data." Glyph decorative/hidden. Swipe actions surface as custom actions via `List`.
+- Replaces the old screen's dedicated accessibility layout with combined elements + Dynamic Type (rows scale; destination line-limit relaxes at accessibility sizes; chips wrap).
+- Reduce Motion: wave glyph and status pulse render static; accordion uses opacity fade.
+- Color never the sole signal — every status color pairs with a text label; palette is `ThemeColors`' dynamic (dark-mode-aware) colors.
+
+## Testing
+
+Unit tests in `OBAKitTests` against pure logic (no UI tests, per repo convention):
+
+- **`DepartureStatus`**: `!predicted` ⇒ gray + "schedule data" + occupancy suppressed; deviation → color/label mapping incl. early=red/late=blue.
+- **Chronological partition**: missed/reachable split at walk threshold; nil walk ⇒ no partition; past vs missed distinction.
+- **Grouping**: soonest-departure route order; hiddenRoutes respected; chips = departures 2–4; "later trips not loaded" when a route has one loaded trip.
+- **Alarms**: `alarm(for:)` deep-link identity matching; clamp math (1–15 ∧ minutes−1); change = delete-then-post ordering.
+- **Approach slice**: 5-stop window by stopSequence; vehicle index from `closestStopID`; past-the-window ⇒ nil.
+- Existing `StopViewModel` tests keep passing (extensions only add surface).
+
+Verification: `scripts/generate_project OneBusAway`, build-for-testing + `OBAKitTests` on the iPhone 17 simulator (TEST BUILD SUCCEEDED is the local bar; the runner crashes under Xcode 27's UIScene issue), plus a manual simulator walkthrough of both modes against a live region.
+
+## Out of scope
+
+- Prototype Tweaks panel (design-tool control only).
+- Floating nav pills / floating tab bar chrome.
+- Changes to the Trip screen, Schedule screen, map rendering, or past-departures data source (existing surfaces we link into).
+- Local-notification alarms.
+- Removing `StopViewController` (happens after the flag proves out, separate effort).

--- a/docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md
+++ b/docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-07-10
 **Branch:** `new-stop`
+**Deployment target:** iOS 18.0 (`Apps/Shared/app_shared.yml`; CLAUDE.md's "17.0+" is stale). All API choices below assume 18.0 — `@Observable`, `@Entry`, `symbolEffect`, `contextMenu(preview:)`, `.swipeActions` are all available; `LazyVStack` swipe actions (iOS 26) are not.
 **Source of truth for visuals/behavior:** Claude Design project "OBA iOS" — `Stop Page Rethink - Implementation Brief.md` + `OBA Stop Page Rethink.html` (components `oba-dep-core.jsx`, `oba-dep-chrome.jsx`, `oba-dep-views.jsx`).
 
 ## Summary
@@ -39,6 +40,8 @@ Ships behind a **default-ON flag** with fallback to the existing `StopViewContro
 3. **`approach(for: ArrivalDeparture) async -> TripDetails?`** — `apiService.getTrip(tripID:vehicleID:serviceDate:)` on trip-panel open, live trips only, cached per trip and invalidated each refresh tick.
 4. **`lastUpdated` relative string** for the live status row (largely exists).
 
+**Observation discipline (validated risk).** `StopViewModel` is a Combine `ObservableObject`, whose invalidation is coarse: any `@Published` mutation invalidates every observing view, and this VM churns (`stopArrivals` every ~15 s, `isLoading` twice per refresh, `statusText` on its own 15 s timer). Mitigation for v1: **`StopPageView` is the only view that observes the VM**; every subview (header, status row, both mode lists, rows, panel) takes plain value inputs, so a timer tick re-evaluates one shallow root body and SwiftUI's value diffing stops the propagation. The live status row is its own child taking only the status string, so its churn is isolated. Migrating the VM to `@Observable` (per-property tracking) is the right end state but breaks `StopViewController`'s Combine sinks — deferred until the legacy screen retires.
+
 ### Presentation layer
 
 `DepartureStatus` — a value type wrapping `ArrivalDeparture`, the single home of the brief's visual rules:
@@ -65,6 +68,10 @@ OBAKit/Stops/StopPage/
   Shared/
     DepartureStatus.swift           status color/label/gate (unit-tested)
     RealtimeGlyph.swift             3-wave pulse / static clock
+                                    (one shared animation clock for all instances —
+                                    a single list-level TimelineView/phase driver, or
+                                    symbolEffect(.variableColor.iterative); never
+                                    ~15 independent repeatForever loops)
     CountdownView.swift             "{n}m" + glyph, monospaced digits
     RouteBadgeView.swift
     WalkLineDivider.swift           dashed "N MIN WALK — CATCH BELOW"
@@ -78,9 +85,16 @@ OBAKit/Stops/StopPage/
 
 ## Screen structure
 
-Root is a SwiftUI `List`, inset-grouped styling (rounded cards on `systemGroupedBackground`; native `.swipeActions`). Top to bottom:
+Root is a SwiftUI `List`, inset-grouped styling (rounded cards on `systemGroupedBackground`; native `.swipeActions` — the deciding constraint: on iOS 18 only `List` provides them). Structural rules from validation:
 
-1. **Header card** (`StopPageHeaderView`): `MapSnapshotter` image as card background (rounded, inset), top-down white scrim, stop name (bold ~22 pt), `Stop #### · {direction} bound` subhead, **walk chip** pinned bottom-left (`{n} min walk · {distance}`, brand green) — rendered only when `walkTime != nil`. Tapping the card toggles the routes-served line, matching today's header behavior.
+- **Section model differs per mode**: in inset-grouped `List` the rounded card *is* the `Section`. Chronological mode = a few `Section`s (past card, missed card, reachable card); grouped mode = **one `Section` per route card**. Don't hand-draw card backgrounds on composite rows.
+- **Row identity**: `ForEach` keyed on `ArrivalDeparture.id` (the composite string — verified stable across prediction refreshes, so diffs animate in place). Never `id: \.self` — `ArrivalDeparture` is an `NSObject` whose equality walks ~30 fields.
+- **Rows stay unary**: the predicted/scheduled branching lives *inside* each row's single root `HStack` — no `AnyView`, no top-level `if`/`switch` at the row root, preserving `List`'s templating fast path.
+- **Out-of-card rows** (walk-line divider, `— UPCOMING —` divider, live status row) escape the card chrome via `.listRowInsets(EdgeInsets())` + `.listRowBackground(Color.clear)` + `.listRowSeparator(.hidden)`.
+
+Top to bottom:
+
+1. **Header card** (`StopPageHeaderView`): `MapSnapshotter` image as card background (rounded, inset), top-down white scrim, stop name (bold ~22 pt), `Stop #### · {direction} bound` subhead, **walk chip** pinned bottom-left (`{n} min walk · {distance}`, brand green) — rendered only when `walkTime != nil`. Tapping the card toggles the routes-served line, matching today's header behavior. `MapSnapshotter` is callback-based and needs concrete dimensions: bridge via `.task` + continuation into `@State` image, and commit to a fixed card aspect ratio rather than a layout-derived size.
 2. **Live status row**: centered `● Updated {relative}` with pulsing dot (static under Reduce Motion), fed by the VM refresh clock.
 3. **Surveys / donations** cards — same relative positions as today.
 4. **Service alerts** card — icon + title rows, tap → existing alert detail via `ViewRouter`; collapses to a summary row beyond two alerts; honors `stopViewShowsServiceAlerts`.
@@ -116,7 +130,9 @@ Root is a SwiftUI `List`, inset-grouped styling (rounded cards on `systemGrouped
 
 ## Trip-detail panel
 
-`TripDetailPanelView` renders inline beneath the opening row (chrono row or grouped expanded row) on the grouped-background tint with an expand animation. One panel open per screen; mode switch or the departure dropping from the feed closes it. Input is `(ArrivalDeparture, DepartureStatus, alarm state)` + callbacks — entry-point-agnostic (§4.6).
+`TripDetailPanelView` renders inline beneath the opening row (chrono row or grouped expanded row) on the grouped-background tint. One panel open per screen; mode switch or the departure dropping from the feed closes it. Input is `(ArrivalDeparture, DepartureStatus, alarm state)` + callbacks — entry-point-agnostic (§4.6).
+
+**Accordion mechanics (validated risk):** the panel is a **separate row inserted into the `ForEach` after the opening row** (keyed off the selected departure id), not content growing inside the tapped row — `List` animates row insert/remove smoothly but handles self-sizing row-height growth poorly (clipping/cross-fade). Same mechanism for the grouped card's expanded departure rows. **This interaction gets prototyped first** (spike task in the plan) since it shapes the row structure.
 
 - **Live vehicle strip** (predicted): route-colored wave glyph + `Live · vehicle {id}` + occupancy.
 - **Scheduled-only notice** (unpredicted): static clock + *"Scheduled time only — no live signal from this bus yet; this is when it's supposed to arrive. It may run early, late, or not at all."* No vehicle, occupancy, or timeline.
@@ -138,8 +154,8 @@ Four entry points, one state (§4.7): chrono swipe, grouped header pill, grouped
 
 ## Chrome parity
 
-- **Nav bar**: standard `UINavigationBar`, stop name as small title. Menus carry over as bar items on the hosting VC: **Filter** (route filter → existing `StopPreferencesView` sheet) and **More** pulldown (Add Bookmark, Share, Report a Problem, Nearby Stops, All Service Alerts, Walking Directions) calling the same VM/router methods as today. The **Sort menu is removed** — the toggle supersedes it.
-- **Context menus**: rows get `.contextMenu` mirroring swipe actions + "Show Trip Details"; preview embeds `TripViewController` via `UIViewControllerRepresentable`.
+- **Nav bar**: standard `UINavigationBar`, stop name as small title (small title deliberately avoids large-title-collapse coordination with a hosted `List`; configure the scroll-edge appearance so the bar background behaves on scroll). Bar items live on the hosting VC (UIKit), sidestepping the deprecated SwiftUI `navigationBarItems` path. Menus carry over as bar items on the hosting VC: **Filter** (route filter → existing `StopPreferencesView` sheet) and **More** pulldown (Add Bookmark, Share, Report a Problem, Nearby Stops, All Service Alerts, Walking Directions) calling the same VM/router methods as today. The **Sort menu is removed** — the toggle supersedes it.
+- **Context menus**: rows get `.contextMenu(menuItems:preview:)` mirroring swipe actions + "Show Trip Details". The preview embeds `TripViewController` via `UIViewControllerRepresentable` **constructed lazily inside the preview closure** (SwiftUI builds it on long-press, not per row) with an explicit frame — a representable has no intrinsic size. If the live-map preview proves heavy, fall back to a static snapshot + trip-summary preview.
 - Prototype's floating nav pills and floating tab bar: **out of scope** (v1 uses standard chrome).
 
 ## Error & empty states
@@ -154,7 +170,7 @@ Four entry points, one state (§4.7): chrono swipe, grouped header pill, grouped
 - Each row is one VoiceOver element: "Route 132 to Downtown Seattle, departs in 5 minutes, 4 minutes late, live tracking" / "…scheduled time only, no live data." Glyph decorative/hidden. Swipe actions surface as custom actions via `List`.
 - Replaces the old screen's dedicated accessibility layout with combined elements + Dynamic Type (rows scale; destination line-limit relaxes at accessibility sizes; chips wrap).
 - Reduce Motion: wave glyph and status pulse render static; accordion uses opacity fade.
-- Color never the sole signal — every status color pairs with a text label; palette is `ThemeColors`' dynamic (dark-mode-aware) colors.
+- Color never the sole signal — every status color pairs with a text label; palette is `ThemeColors`' dynamic (dark-mode-aware) colors. `ThemeColors`/`Formatters` return `UIColor` — bridge with `Color(uiColor:)`, not the soft-deprecated `Color(_:)`. Reduce Motion is read from `@Environment(\.accessibilityReduceMotion)`.
 
 ## Testing
 
@@ -168,6 +184,10 @@ Unit tests in `OBAKitTests` against pure logic (no UI tests, per repo convention
 - Existing `StopViewModel` tests keep passing (extensions only add surface).
 
 Verification: `scripts/generate_project OneBusAway`, build-for-testing + `OBAKitTests` on the iPhone 17 simulator (TEST BUILD SUCCEEDED is the local bar; the runner crashes under Xcode 27's UIScene issue), plus a manual simulator walkthrough of both modes against a live region.
+
+## Validation
+
+An independent review (Opus agent, swiftui-specialist skill + Apple docs) confirmed the architecture with no blockers, and verified against the codebase: `ArrivalDeparture.id` is stable across prediction refreshes (animated diffs work), `canCreateAlarm` gating and `ArrivalDepartureDeepLink` matching exist exactly as this spec assumes, and `tripStatus.closestStopID` is the same vehicle-position field the Trip screen uses. Its should-fix findings are incorporated above (observation discipline, accordion-as-inserted-row + spike, per-mode section models, out-of-card row modifiers, lazy context-menu preview, shared glyph animation clock, `MapSnapshotter` bridging, `Color(uiColor:)` bridging, iOS 18.0 target). The two items to prototype before broad build-out: the inserted-row accordion animation, and root-only VM observation under the 15 s refresh churn.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

A ground-up SwiftUI rebuild of the Stop screen, shipped behind a **default-ON** feature flag (Settings → Experimental → "Use new stop page") with the legacy `StopViewController` as fallback:

- **Two co-equal list modes** behind a segmented toggle: **Chronological** (time-sorted, with a walk-reachability line separating "just missed" from catchable departures, and a collapsible past block) and **By route** (one expandable card per route ordered by soonest departure, with status-tinted upcoming chips). The toggle surfaces the existing per-stop `sortType` preference, so it round-trips with the legacy screen.
- **Inline trip-detail panel** (same panel from both modes): live vehicle strip, approach timeline with a "bus here · Nm away" marker that advances on each refresh, and a one-tap **alarm control** (set/change/cancel) — alarms are reachable from four surfaces (swipe, card pill, row icon, panel) sharing one state, powered by the existing Obaco server-push backend, now cancellable from the stop screen.
- **Elevated honesty about real-time data** (the design's core rule): scheduled-only trips get a static clock glyph, gray countdown, "schedule data" label (never "on time"), no occupancy, and an explicit notice in the panel. Adherence colors keep OBA's early=red/late=blue convention; route color is confined to badges/stripes.
- Full chrome parity: menus (minus the now-redundant Sort menu), route filter, schedules, context-menu trip previews, service alerts (collapse + preference), surveys, donations, `Previewable` peeks — and all stop-screen construction routed through flag-honoring `Router` factories so map/bookmark long-presses honor the flag too. Transfer-context stops deliberately route to the legacy screen until transfer parity is built.
- Architecture: reuses the existing `StopViewModel` (built for this); pure, unit-tested value types for the visual rules (`DepartureStatus`), list transforms, alarm lead-time clamp, walk time, and timeline windowing. Suite: **1214 tests, 0 failures**.

Design docs in-repo: `docs/superpowers/specs/2026-07-10-stop-page-rethink-design.md` (spec) and `docs/superpowers/plans/2026-07-10-stop-page-rethink.md` (plan). Built task-by-task with per-task review, a whole-branch review + fix wave, a simplify pass, and a multi-agent PR review.

## Test plan

- [x] Full unit suite on iPhone 17 Pro simulator: 1214/0 (includes new suites: FeatureFlags, DepartureStatus + fixture bridge, StopPageListBuilder, AlarmLeadTime, WalkTimeInfo, ApproachSlice, lead-time derivation, store round-trip)
- [x] Live-data simulator walkthrough (Puget Sound): both modes render with correct adherence colors/glyphs; walk divider + dimming rules; grouped cards ordered by soonest with chips + "later trips not loaded"; trip panel shows live strip + timeline ("bus here" marker) for tracked trips and the honesty notice for scheduled-only; sort preference persists
- [x] Flag OFF → legacy screen returns everywhere (including long-press peeks); flag ON → new page
- [x] Swipe actions (gated), header map snapshot (fixed a blank-render bug found during wrap-up: deallocated `MapSnapshotter` never resumed its continuation), dark mode, Dynamic Type render at accessibility size
- [ ] **Needs a human/device pass** (not exercisable in sim): alarm end-to-end (requires Obaco+push), Settings lead-time row interactive tap-through, VoiceOver double-tap activation on combined rows

## Review notes (non-blocking judgment calls surfaced by review)

- `changeAlarm` = cancel + re-post (Obaco has no update). If the re-post fails the user's alarm is gone and the alert reads as a generic create failure — consider a change-specific message or restore attempt.
- A departure crossing the 1-minute boundary while on screen makes the alarm affordance a silent no-op tap (guard-gated); could reactively disable instead.
- Alarm create/cancel network paths have no unit seam (would need `Application` feature/service injection) — top deferred test gap.

## Follow-ups (tracked during development)

Transfer parity on the new page (currently legacy-fallback) · PushService continuation hang on permission-denial-at-prompt (pre-existing) · localizer pass for the 12 non-English locales (English strings extracted) · dark-mode map-snapshot refresh on appearance switch · timeline connector line between dots · Reduce-Motion fade for accordion animation · iPad popover anchor for donation action sheet (pre-existing, both screens) · ScheduleTip coach-mark port decision · footer date-range subtitle · "Restart to apply" Experimental footer copy vs live-read flag · ≤1-min cancel asymmetry across alarm surfaces · ApproachSlice stopSequence anchoring for loop routes · "— UPCOMING —" divider · only-past-departures empty state · past-row "-3m" countdown rendering · header routes-toggle VoiceOver action · @Observable migration once the legacy screen retires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out the redesigned stop page with **Chronological** and **By route** modes, including inline **trip detail** panels, live **approach timelines**, and walk-time guidance.
  * Added one-tap **alarm** controls and a persisted default alarm lead time in **Settings**, plus an **Experimental** toggle for enabling the new stop page.
* **Bug Fixes**
  * Improved stop context-menu previews to consistently open the correct stop-page experience.
  * Reduced duplicate real-time trip entries in arrivals/departures.
* **Documentation**
  * Updated testing/build instructions (iOS Simulator **iPhone 17 Pro**) and minimum iOS target (**18.0+**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->