### PR TITLE
Add floating More button to SwiftUI map panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ OBAKitTests.xcresult
 .DS_Store
 .claude/settings.local.json
 .env
+
+# Review artifacts (e.g. /aaron-pr-review)
+pr-*.md

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -37,16 +37,18 @@ final class AppSheetViewFactory {
         switch route {
         case .home:
             homeView()
-            // Wiring a push for one of these routes before its view exists will
-            // trip the debug assertion in `unimplementedView(for:)` — register the
-            // view here before reaching for `SheetCoordinator.push(...)`.
-            //
-            // TODO: `.search` is base-layer and has `isDismissDisabled: true`
-            // — its real view needs to wire up an explicit back affordance
-            // (the home sheet only knows how to push, not pop), otherwise the
-            // route is unreachable once entered.
+        case .more:
+            moreView()
+        // Wiring a push for one of these routes before its view exists will
+        // trip the debug assertion in `unimplementedView(for:)` — register the
+        // view here before reaching for `SheetCoordinator.push(...)`.
+        //
+        // TODO: `.search` is base-layer and has `isDismissDisabled: true`
+        // — its real view needs to wire up an explicit back affordance
+        // (the home sheet only knows how to push, not pop), otherwise the
+        // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-                .stopDetails, .tripPlanner, .tripDetails, .transitAlert, .more, .settings:
+             .stopDetails, .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
 
         case .routePicker:
@@ -61,6 +63,13 @@ final class AppSheetViewFactory {
 
     func homeView() -> HomeSheetView {
         HomeSheetView(viewModel: HomeSheetViewModel())
+    }
+
+    /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`
+    /// via `MoreSheetHost`. Swap this branch's return type once the SwiftUI
+    /// `MoreView` lands.
+    func moreView() -> MoreSheetHost {
+        MoreSheetHost(application: application)
     }
 
     func routePickerView() -> RoutePickerView {

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -37,8 +37,10 @@ final class AppSheetViewFactory {
         switch route {
         case .home:
             homeView()
+
         case .more:
             moreView()
+
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -82,6 +82,9 @@ struct MapPanelRootView: View {
         .overlay(alignment: .topLeading) {
             weatherButton
         }
+        .overlay(alignment: .topTrailing) {
+            moreButton
+        }
         .overlay(alignment: .bottomLeading) {
             bottomFloatingTripButton
         }
@@ -145,4 +148,10 @@ struct MapPanelRootView: View {
         )
     }
 
+    private var moreButton: some View {
+        MoreButton {
+            coordinator.push(.more)
+        }
+        .padding(ThemeMetrics.controllerMargin)
+    }
 }

--- a/OBAKit/Sheet/Root/MoreButton.swift
+++ b/OBAKit/Sheet/Root/MoreButton.swift
@@ -19,11 +19,10 @@ struct MoreButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: "line.3.horizontal")
-                .font(.title3.weight(.semibold))
-                .foregroundStyle(.primary)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .contentShape(Capsule())
+                .font(.body)
+                .imageScale(.medium)
+                .frame(width: 32, height: 32)
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .regularGlassEffectIfAvailable(in: Capsule())

--- a/OBAKit/Sheet/Root/MoreButton.swift
+++ b/OBAKit/Sheet/Root/MoreButton.swift
@@ -1,0 +1,36 @@
+//
+//  MoreButton.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Floating capsule button rendered in the top-trailing overlay slot of
+/// `MapPanelRootView`. Tapping it pushes `AppSheetRoute.more` onto the
+/// sheet coordinator; the button itself is pure presentation.
+struct MoreButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "line.3.horizontal")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .regularGlassEffectIfAvailable(in: Capsule())
+        .accessibilityLabel(Text(OBALoc(
+            "more_controller.title",
+            value: "More",
+            comment: "Title of the More tab / accessibility label for the map-panel more button."
+        )))
+    }
+}

--- a/OBAKit/Sheet/Root/MoreSheetHost.swift
+++ b/OBAKit/Sheet/Root/MoreSheetHost.swift
@@ -1,0 +1,32 @@
+//
+//  MoreSheetHost.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import OBAKitCore
+
+/// UIKit wiring wrapper: presents the existing `MoreViewController` inside
+/// a `UINavigationController` so its `navigationItem` bar buttons render
+/// correctly when reached via `AppSheetRoute.more`.
+///
+/// Deliberately minimal — a future SwiftUI `MoreView` will replace this
+/// wrapper in `AppSheetViewFactory` without touching the coordinator or
+/// route enum.
+struct MoreSheetHost: UIViewControllerRepresentable {
+    let application: Application
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let more = MoreViewController(application: application)
+        return UINavigationController(rootViewController: more)
+    }
+
+    // `MoreViewController` reads `application` and its stores directly, so
+    // nothing SwiftUI-side changes over the sheet's lifetime.
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+}

--- a/OBAKit/Sheet/Root/MoreSheetHost.swift
+++ b/OBAKit/Sheet/Root/MoreSheetHost.swift
@@ -22,11 +22,21 @@ struct MoreSheetHost: UIViewControllerRepresentable {
     let application: Application
 
     func makeUIViewController(context: Context) -> UINavigationController {
-        let more = MoreViewController(application: application)
-        return UINavigationController(rootViewController: more)
+        Self.makeNavigationController(application: application)
     }
 
     // `MoreViewController` reads `application` and its stores directly, so
     // nothing SwiftUI-side changes over the sheet's lifetime.
     func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+
+    /// Internal factory seam: mirrors what `makeUIViewController` does but
+    /// takes no `Context`, so tests can drive the wiring without going
+    /// through `UIHostingController` (whose lifecycle doesn't fire the
+    /// representable's `makeUIViewController` synchronously in a unit-test
+    /// process). Kept `internal` deliberately — production code must go
+    /// through `makeUIViewController`.
+    static func makeNavigationController(application: Application) -> UINavigationController {
+        let more = MoreViewController(application: application)
+        return UINavigationController(rootViewController: more)
+    }
 }

--- a/OBAKitTests/Helpers/OBATestCase.swift
+++ b/OBAKitTests/Helpers/OBATestCase.swift
@@ -159,6 +159,42 @@ open class OBATestCase: XCTestCase {
         "/regions-v3.json"
     }
 
+    // MARK: - Application
+
+    /// Builds a fully-wired `Application` against stubbed regions +
+    /// agencies-with-coverage for tests that need the real object graph
+    /// (e.g. anything that constructs a view controller which reads
+    /// `application.regionsService` / stores at init time).
+    ///
+    /// Test classes still own their own `queue` because a per-test queue
+    /// keeps `cancelAllOperations()` scoped to each `tearDown`.
+    func buildApplication(queue: OperationQueue, dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return Application(config: config)
+    }
+
     // MARK: - Surveys
 
     @MainActor

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -1,0 +1,76 @@
+//
+//  AppSheetViewFactoryTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import SwiftUI
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Per-route factory branch coverage. Each branch that's been "wired up"
+/// (i.e. removed from the shared `unimplementedView` catch-all) gets a
+/// dedicated test so a future refactor that accidentally drops the branch
+/// back into the catch-all fails the suite.
+final class AppSheetViewFactoryTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+        return Application(config: config)
+    }
+
+    @MainActor
+    func test_moreView_returnsMoreSheetHostForwardingApplication() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = createApplication(dataLoader: dataLoader)
+
+        let factory = AppSheetViewFactory(application: application)
+        let host = factory.moreView()
+
+        // Reference identity: the factory must forward its own `Application`
+        // into the host, not construct a new one or drop it. `MoreSheetHost`'s
+        // wiring itself (produces a UINavigationController wrapping
+        // MoreViewController) is covered by MoreSheetHostTests — this test
+        // owns the factory-to-host handoff only.
+        expect(host.application === application) == true
+    }
+}

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -32,38 +32,12 @@ final class AppSheetViewFactoryTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
-    private func createApplication(dataLoader: MockDataLoader) -> Application {
-        stubRegions(dataLoader: dataLoader)
-        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
-
-        let locManager = MockAuthorizedLocationManager(
-            updateLocation: TestData.mockSeattleLocation,
-            updateHeading: TestData.mockHeading
-        )
-        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
-
-        let config = AppConfig(
-            regionsBaseURL: regionsURL,
-            apiKey: apiKey,
-            appVersion: appVersion,
-            userDefaults: userDefaults,
-            analytics: AnalyticsMock(),
-            queue: queue,
-            locationService: locationService,
-            bundledRegionsFilePath: bundledRegionsPath,
-            regionsAPIPath: regionsAPIPath,
-            dataLoader: dataLoader,
-            fixedRegionName: Fixtures.pugetSoundRegion.name
-        )
-        return Application(config: config)
-    }
-
     @MainActor
     func test_moreView_returnsMoreSheetHostForwardingApplication() {
         let dataLoader = MockDataLoader(testName: name)
-        let application = createApplication(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application)
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
         let host = factory.moreView()
 
         // Reference identity: the factory must forward its own `Application`

--- a/OBAKitTests/Sheet/MoreSheetHostTests.swift
+++ b/OBAKitTests/Sheet/MoreSheetHostTests.swift
@@ -14,8 +14,9 @@ import Nimble
 
 /// Smoke-tests for the UIKit wiring wrapper around `MoreViewController`.
 /// The wrapping is the entire product surface of `MoreSheetHost`, so these
-/// tests exercise the representable by embedding it in a `UIHostingController`
-/// and inspecting the resulting child controller.
+/// tests drive the representable through its `internal`
+/// `makeNavigationController(application:)` factory seam and inspect the
+/// resulting controller hierarchy — no `UIHostingController` needed.
 final class MoreSheetHostTests: OBATestCase {
 
     private var queue: OperationQueue!
@@ -31,41 +32,10 @@ final class MoreSheetHostTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
-    /// `OBATestCase` doesn't own an `Application`; tests build one per-case,
-    /// mirroring the pattern in `MapPanelViewModelTests`. Only the pieces
-    /// `MoreViewController.init` actually reaches for (regions service,
-    /// analytics, user defaults) need to be real — everything else can rely
-    /// on the standard stubs.
-    private func createApplication(dataLoader: MockDataLoader) -> Application {
-        stubRegions(dataLoader: dataLoader)
-        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
-
-        let locManager = MockAuthorizedLocationManager(
-            updateLocation: TestData.mockSeattleLocation,
-            updateHeading: TestData.mockHeading
-        )
-        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
-
-        let config = AppConfig(
-            regionsBaseURL: regionsURL,
-            apiKey: apiKey,
-            appVersion: appVersion,
-            userDefaults: userDefaults,
-            analytics: AnalyticsMock(),
-            queue: queue,
-            locationService: locationService,
-            bundledRegionsFilePath: bundledRegionsPath,
-            regionsAPIPath: regionsAPIPath,
-            dataLoader: dataLoader,
-            fixedRegionName: Fixtures.pugetSoundRegion.name
-        )
-        return Application(config: config)
-    }
-
     @MainActor
     func test_makeNavigationController_wrapsMoreViewControllerInNav() {
         let dataLoader = MockDataLoader(testName: name)
-        let application = createApplication(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
         let nav = MoreSheetHost.makeNavigationController(application: application)
 

--- a/OBAKitTests/Sheet/MoreSheetHostTests.swift
+++ b/OBAKitTests/Sheet/MoreSheetHostTests.swift
@@ -8,7 +8,6 @@
 //
 
 import XCTest
-import SwiftUI
 import Nimble
 @testable import OBAKit
 @testable import OBAKitCore
@@ -64,24 +63,13 @@ final class MoreSheetHostTests: OBATestCase {
     }
 
     @MainActor
-    func test_makeUIViewController_returnsNavigationControllerWrappingMoreViewController() {
+    func test_makeNavigationController_wrapsMoreViewControllerInNav() {
         let dataLoader = MockDataLoader(testName: name)
         let application = createApplication(dataLoader: dataLoader)
 
-        let host = MoreSheetHost(application: application)
-        expect(host).toNot(beNil())
+        let nav = MoreSheetHost.makeNavigationController(application: application)
 
-        // Verify that MoreViewController can be instantiated with the application
-        let moreVC = MoreViewController(application: application)
-        expect(moreVC).toNot(beNil())
-        expect(moreVC).to(beAKindOf(MoreViewController.self))
-
-        // Create the navigation controller as the host would
-        let nav = UINavigationController(rootViewController: moreVC)
-        expect(nav).toNot(beNil())
+        expect(nav.viewControllers.count) == 1
         expect(nav.topViewController).to(beAKindOf(MoreViewController.self))
-
-        // Verify the host conforms to the representable protocol
-        expect(host).to(beAKindOf(UIViewControllerRepresentable.self))
     }
 }

--- a/OBAKitTests/Sheet/MoreSheetHostTests.swift
+++ b/OBAKitTests/Sheet/MoreSheetHostTests.swift
@@ -1,0 +1,87 @@
+//
+//  MoreSheetHostTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import SwiftUI
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Smoke-tests for the UIKit wiring wrapper around `MoreViewController`.
+/// The wrapping is the entire product surface of `MoreSheetHost`, so these
+/// tests exercise the representable by embedding it in a `UIHostingController`
+/// and inspecting the resulting child controller.
+final class MoreSheetHostTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        queue.cancelAllOperations()
+    }
+
+    /// `OBATestCase` doesn't own an `Application`; tests build one per-case,
+    /// mirroring the pattern in `MapPanelViewModelTests`. Only the pieces
+    /// `MoreViewController.init` actually reaches for (regions service,
+    /// analytics, user defaults) need to be real — everything else can rely
+    /// on the standard stubs.
+    private func createApplication(dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+        return Application(config: config)
+    }
+
+    @MainActor
+    func test_makeUIViewController_returnsNavigationControllerWrappingMoreViewController() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = createApplication(dataLoader: dataLoader)
+
+        let host = MoreSheetHost(application: application)
+        expect(host).toNot(beNil())
+
+        // Verify that MoreViewController can be instantiated with the application
+        let moreVC = MoreViewController(application: application)
+        expect(moreVC).toNot(beNil())
+        expect(moreVC).to(beAKindOf(MoreViewController.self))
+
+        // Create the navigation controller as the host would
+        let nav = UINavigationController(rootViewController: moreVC)
+        expect(nav).toNot(beNil())
+        expect(nav.topViewController).to(beAKindOf(MoreViewController.self))
+
+        // Verify the host conforms to the representable protocol
+        expect(host).to(beAKindOf(UIViewControllerRepresentable.self))
+    }
+}


### PR DESCRIPTION
Replaces #1184

## Summary

Adds a top-trailing floating "More" button to `MapPanelRootView` that pushes `AppSheetRoute.more` onto the SwiftUI sheet coordinator. The route is bridged to the existing UIKit `MoreViewController` via a new `MoreSheetHost` representable, so the More screen becomes reachable from the SwiftUI composition root without duplicating any of its functionality.

This is a wiring change only — no product behavior in `MoreViewController` moves. The `MoreSheetHost` wrapper is deliberately thin so a future SwiftUI `MoreView` can drop in at `AppSheetViewFactory.moreView()` without touching the coordinator, the route enum, or the overlay button.

## What's in the branch

- `MoreButton` — a stateless SwiftUI circular button rendered in the map's top-trailing overlay slot. Uses the new `liquidGlassButtonStyle(borderShape:fallbackShape:)` modifier so it picks up the interactive Liquid Glass surface (`.buttonStyle(.glass)`) on iOS 26+ and falls back to `.plain` + `.regularMaterial` on older systems.
- `MoreSheetHost` — a `UIViewControllerRepresentable` that wraps `MoreViewController` in a `UINavigationController` so its `navigationItem` bar buttons render correctly when reached via a sheet route. Exposes an `internal` `makeNavigationController(application:)` factory seam so tests can exercise the wiring without going through `UIHostingController`'s lifecycle.
- `AppSheetViewFactory.moreView()` — new per-route branch returning `MoreSheetHost(application:)`, replacing the previous `unimplementedView` fallback for `.more`.
- `MapPanelRootView` — adds a `.overlay(alignment: .topTrailing) { moreButton }` slot; the button calls `coordinator.push(.more)`.
- `liquidGlassButtonStyle(borderShape:fallbackShape:)` — new `View` extension in `SwiftUIExtensions.swift` centralizing the iOS 26 Liquid Glass button style + pre-26 material fallback for reuse by future floating controls.

## Tests

- `MoreSheetHostTests.test_makeNavigationController_wrapsMoreViewControllerInNav` — asserts the representable produces a `UINavigationController` rooted on a `MoreViewController`.
- `AppSheetViewFactoryTests.test_moreView_returnsMoreSheetHostForwardingApplication` — asserts the factory forwards its own `Application` into the host (identity check), guarding against future refactors that accidentally reconstruct or drop the reference.
- The shared `Application` builder was extracted from these two new files into `OBATestCase.buildApplication(queue:dataLoader:)` to remove the duplicated `createApplication` helpers.


## Notes for reviewers

- `MoreSheetHost.makeNavigationController(application:)` is `internal` on purpose — production code must go through `makeUIViewController`; the factory exists solely so the wiring can be unit-tested without a hosting-controller lifecycle. Marked in the doc comment.
- The `AppSheetViewFactory.moreView()` return type is `MoreSheetHost` today; the comment there flags that it should change when a SwiftUI `MoreView` lands.
- `pr-*.md` is now in `.gitignore` so review-artifact files don't get committed again.

## Video


https://github.com/user-attachments/assets/926fb2bf-cba6-4418-b5e1-d3b8df64857c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “More” button to the map overlay for quick access to additional options.
  * Added navigation from the map to the existing More screen.

* **Bug Fixes**
  * Improved routing so the More screen opens correctly within the sheet navigation flow.

* **Tests**
  * Added coverage validating More screen navigation and view presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->