### PR TITLE
fix: harden BulletinOverlayWindow before it ships to production (#1170)

### DIFF
--- a/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
+++ b/OBAKit/BLTNBoard/BulletinOverlayWindow.swift
@@ -33,23 +33,35 @@ final class BulletinOverlayWindow {
 
     private var window: UIWindow?
 
+    /// The item currently being presented, held weakly so we can restore
+    /// its original `dismissalHandler` on teardown without extending its
+    /// lifetime. Items outlive this window in practice (they're stored
+    /// properties on bulletin classes like `ReachabilityBulletin`), but the
+    /// weak reference is correct regardless.
+    private weak var savedRootItem: BLTNItem?
+
+    /// The `dismissalHandler` the caller had on `rootItem` before `install`
+    /// swapped in the overlay's wrapper. Restored verbatim on teardown so
+    /// the item goes back to exactly the state we found it in — no matter
+    /// how many prior presentations occurred.
+    private var savedDismissalHandler: ((BLTNItem) -> Void)?
+
     private init() {}
 
     /// Installs the overlay window and returns its host controller for
-    /// `showBulletin(above:)`. Hooks `rootItem.dismissalHandler` to tear the
-    /// window down once the bulletin dismisses, chaining any handler the
-    /// caller already set.
+    /// `showBulletin(above:)`. Snapshots `rootItem.dismissalHandler` and
+    /// replaces it with a wrapper that dispatches to the original then
+    /// tears the window down. On teardown the original handler is restored,
+    /// so a reused item (e.g. `ReachabilityBulletin.connectivityPage` re-shown
+    /// across connectivity flaps) never accumulates nested wrappers.
     ///
     /// One bulletin at a time. Each `BLTNItemManager` already guards on
     /// `isShowingBulletin`, but those guards are per-manager; this singleton is
     /// shared across every OBA bulletin manager, so two managers can call
-    /// `install` while a third is mid-presentation. If that ever happens, the
-    /// second caller's `dismissalHandler` chain would never be installed (the
-    /// early-return path used to silently skip it) and teardown would fire on
-    /// the first dismissal, yanking the window out from under the second
-    /// bulletin. The DEBUG assert flags the violation at the point it occurs;
-    /// release builds still return the existing host so the second bulletin at
-    /// worst piggybacks on the first's window rather than crashing.
+    /// `install` while a third is mid-presentation. The DEBUG assert flags the
+    /// violation at the point it occurs; release builds still return the
+    /// existing host so the second bulletin at worst piggybacks on the first's
+    /// window rather than crashing.
     func install(in scene: UIWindowScene, rootItem: BLTNItem) -> UIViewController {
         // Single-page only: teardown rides `rootItem.dismissalHandler`, but
         // BLTN fires the dismissal handler on `currentItem` — which only
@@ -79,16 +91,35 @@ final class BulletinOverlayWindow {
 
         self.window = window
 
-        let originalDismissal = rootItem.dismissalHandler
-        rootItem.dismissalHandler = { [weak self] item in
-            originalDismissal?(item)
-            self?.teardown()
-        }
+        swapDismissalHandler(on: rootItem)
 
         return host
     }
 
+    /// Snapshots the item's current `dismissalHandler` and swaps in a wrapper
+    /// that fires the original handler then tears down. Extracted from
+    /// `install` so tests can exercise the handler-management contract without
+    /// synthesizing a `UIWindowScene`.
+    internal func swapDismissalHandler(on rootItem: BLTNItem) {
+        savedRootItem = rootItem
+        savedDismissalHandler = rootItem.dismissalHandler
+        rootItem.dismissalHandler = { [weak self] item in
+            self?.savedDismissalHandler?(item)
+            self?.teardown()
+        }
+    }
+
+    /// Restores the previously-saved `dismissalHandler` onto the tracked item
+    /// and clears the saved state. Extracted from `teardown` for testability.
+    internal func restoreDismissalHandler() {
+        savedRootItem?.dismissalHandler = savedDismissalHandler
+        savedRootItem = nil
+        savedDismissalHandler = nil
+    }
+
     private func teardown() {
+        restoreDismissalHandler()
+
         let scene = window?.windowScene
         window?.rootViewController = nil
         window?.isHidden = true

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -60,7 +60,17 @@ extension BLTNItemManager {
         // intended behavior — callers (e.g. reachability flapping) lean on this.
         guard !isShowingBulletin else { return }
 
-        if UserDefaults.standard.bool(forKey: FeatureFlags.useMapPanelExperienceKey) {
+        // Settings writes this flag to `application.userDefaults`, which the
+        // OBA app initializes as an app-group suite (see `AppDelegate.m` and
+        // `CoreApplicationKey.defaultValue`). `UserDefaults.standard` reads a
+        // different suite and would always see the flag as OFF. Resolve the
+        // same suite here; if it can't be resolved (unlikely outside tests),
+        // treat the flag as OFF — the classic path is the safe production
+        // default anyway.
+        let appGroupDefaults = Bundle.main.appGroup.flatMap { UserDefaults(suiteName: $0) }
+        let useMapPanelExperience = appGroupDefaults?.bool(forKey: FeatureFlags.useMapPanelExperienceKey) ?? false
+
+        if useMapPanelExperience {
             // No usable scene means the bulletin disappears with no UI trace,
             // including for the error path (`Application.displayError`). Log so
             // there's at least a diagnostic breadcrumb instead of silent loss.

--- a/OBAKit/BLTNBoard/OBABulletinPage.swift
+++ b/OBAKit/BLTNBoard/OBABulletinPage.swift
@@ -32,36 +32,55 @@ class ThemedBulletinPage: BLTNPageItem {
 }
 
 extension BLTNItemManager {
-    /// Presents the bulletin in a dedicated overlay `UIWindow` attached to the
-    /// active scene.
+    /// Presents the bulletin in the appropriate host for the current experience.
     ///
-    /// Avoid `showBulletin(in:)` (BLTNBoard's built-in): it creates a `UIWindow`
+    /// Map-panel experience (`OBAUseMapPanelExperience` on): the SwiftUI home
+    /// sheet's hosting controller is inside a `UISheetPresentationController`
+    /// that clamps modal presentations to the current detent — presenting from
+    /// there squeezes the bulletin into the collapsed sheet's ~80pt strip. To
+    /// dodge the sheet hierarchy, we present into a dedicated `.alert`-level
+    /// `UIWindow` via `BulletinOverlayWindow`.
+    ///
+    /// Classic experience (flag off, production default): fall back to the
+    /// pre-#1163 presentation — `keyWindowFromScene?.topViewController`. The
+    /// clamping bug doesn't exist there, so the extra window path (and its
+    /// singleton lifecycle) is unnecessary.
+    ///
+    /// Avoid BLTNBoard's built-in `showBulletin(in:)`: it creates a `UIWindow`
     /// without a `windowScene`, which iOS won't display in a scene-based app.
-    /// Avoid presenting from `keyWindowFromScene?.topViewController` directly:
-    /// in the SwiftUI map-panel experience that walk lands inside the home
-    /// sheet's hosting controller, and `UISheetPresentationController` clamps
-    /// modal presentations to the sheet's current detent — the bulletin then
-    /// renders inside the collapsed sheet's ~80pt strip.
     ///
     /// `rootItem` is the item passed to `BLTNItemManager.init(rootItem:)`; it
     /// has to be supplied here because the manager keeps its reference private,
-    /// and we hook its `dismissalHandler` to retire the overlay window.
+    /// and the overlay-window path hooks its `dismissalHandler` to retire the
+    /// window. It is unused in the classic branch but stays in the signature so
+    /// all call sites are identical across experiences.
     @MainActor
     func show(in application: UIApplication, rootItem: BLTNItem) {
         // Re-entrant call while a bulletin is already up: silent no-op is the
         // intended behavior — callers (e.g. reachability flapping) lean on this.
         guard !isShowingBulletin else { return }
 
-        // No usable scene means the bulletin disappears with no UI trace,
-        // including for the error path (`Application.displayError`). Log so
-        // there's at least a diagnostic breadcrumb instead of silent loss.
-        guard let scene = application.bulletinTargetScene else {
-            Logger.error("Bulletin dropped: no foreground-active window scene available to host it.")
-            return
-        }
+        if UserDefaults.standard.bool(forKey: FeatureFlags.useMapPanelExperienceKey) {
+            // No usable scene means the bulletin disappears with no UI trace,
+            // including for the error path (`Application.displayError`). Log so
+            // there's at least a diagnostic breadcrumb instead of silent loss.
+            guard let scene = application.bulletinTargetScene else {
+                Logger.error("Bulletin dropped: no foreground-active window scene available to host it.")
+                return
+            }
 
-        let host = BulletinOverlayWindow.shared.install(in: scene, rootItem: rootItem)
-        showBulletin(above: host)
+            let host = BulletinOverlayWindow.shared.install(in: scene, rootItem: rootItem)
+            showBulletin(above: host)
+        } else {
+            // Classic: present above whatever's at the top of the key window.
+            // `topViewController` is defined on `UIWindow` in
+            // `OBAKitCore/Extensions/UIKitExtensions.swift`.
+            guard let topViewController = application.keyWindowFromScene?.topViewController else {
+                Logger.error("Bulletin dropped: no key window / top view controller available to host it.")
+                return
+            }
+            showBulletin(above: topViewController)
+        }
     }
 }
 

--- a/OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift
+++ b/OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift
@@ -1,0 +1,73 @@
+//
+//  BulletinOverlayWindowTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+import BLTNBoard
+@testable import OBAKit
+
+/// Regression tests for the `BulletinOverlayWindow` handler-management fix
+/// from issue #1170. The public `install(in:rootItem:)` path requires a live
+/// `UIWindowScene`, which is fragile to synthesize in a test host, so these
+/// tests drive the internal `swapDismissalHandler(on:)` / `restoreDismissalHandler()`
+/// helpers directly — the same helpers `install`/`teardown` use.
+@MainActor
+class BulletinOverlayWindowTests: XCTestCase {
+
+    /// Item 2 from issue #1170: on a reused page item (like
+    /// `ReachabilityBulletin.connectivityPage`), repeated presentations must
+    /// not stack the caller's dismissal handler. Each cycle should see the
+    /// original handler fire exactly once.
+    func test_reused_item_does_not_accumulate_dismissal_handlers() {
+        let overlay = BulletinOverlayWindow.shared
+        let page = BLTNPageItem(title: "Test")
+
+        var originalCallCount = 0
+        let originalHandler: (BLTNItem) -> Void = { _ in originalCallCount += 1 }
+        page.dismissalHandler = originalHandler
+
+        // Simulate five install/teardown cycles.
+        for _ in 0..<5 {
+            overlay.swapDismissalHandler(on: page)
+            // Fire the swapped-in handler; it should invoke the original once,
+            // then internally call teardown (which restores).
+            page.dismissalHandler?(page)
+        }
+
+        // Now that we're restored to the original, invoke it directly to
+        // confirm it hasn't been wrapped. One more call → one more increment.
+        page.dismissalHandler?(page)
+
+        // Five swap cycles each fired the original once, plus one direct call.
+        expect(originalCallCount) == 6
+    }
+
+    /// Teardown must put the original handler back onto the item, so the next
+    /// presentation cycle starts from a pristine state.
+    func test_teardown_restores_original_handler() {
+        let overlay = BulletinOverlayWindow.shared
+        let page = BLTNPageItem(title: "Test")
+
+        var originalFired = false
+        page.dismissalHandler = { _ in originalFired = true }
+
+        overlay.swapDismissalHandler(on: page)
+
+        // Handler is now the overlay's wrapper — not the original.
+        page.dismissalHandler?(page)
+        expect(originalFired) == true
+
+        // After the wrapper ran (which calls restore), a subsequent dismissal
+        // handler invocation must go straight to the original — no wrapper
+        // left in place, no self-reference back into the overlay.
+        originalFired = false
+        page.dismissalHandler?(page)
+        expect(originalFired) == true
+    }
+}

--- a/OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift
+++ b/OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift
@@ -7,67 +7,125 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
-import Nimble
+import Foundation
+import Testing
 import BLTNBoard
 @testable import OBAKit
 
-/// Regression tests for the `BulletinOverlayWindow` handler-management fix
-/// from issue #1170. The public `install(in:rootItem:)` path requires a live
+/// Regression tests for the `BulletinOverlayWindow` handler-management fix from
+/// issue #1170. The public `install(in:rootItem:)` path requires a live
 /// `UIWindowScene`, which is fragile to synthesize in a test host, so these
 /// tests drive the internal `swapDismissalHandler(on:)` / `restoreDismissalHandler()`
 /// helpers directly — the same helpers `install`/`teardown` use.
+///
+/// **What these assert, and why it isn't a call count.** The pre-fix code
+/// wrapped whatever handler was on the item and never put the original back, so
+/// a reused item accumulated a chain of wrappers. A chain of N wrappers still
+/// calls the caller's handler exactly once per dismissal — each wrapper invokes
+/// its inner handler once — so "the original fired once per presentation" is
+/// true of the buggy implementation too, and counting can't tell the two apart.
+/// What differs is what the item holds *after* the bulletin is gone: chaining
+/// leaves the overlay's wrapper installed (one deeper per presentation), the fix
+/// leaves exactly what the caller set. That's what's asserted below, using an
+/// item whose handler starts out `nil` so "restored to the caller's value" is
+/// directly observable — no closure-identity comparison required.
 @MainActor
-class BulletinOverlayWindowTests: XCTestCase {
+@Suite(.serialized)
+final class BulletinOverlayWindowTests {
+
+    private let overlay = BulletinOverlayWindow.shared
+
+    /// The overlay is a singleton shared with the rest of the test bundle. Any
+    /// test that swaps without firing the wrapper would otherwise strand the
+    /// swapped state on it.
+    isolated deinit {
+        overlay.restoreDismissalHandler()
+    }
 
     /// Item 2 from issue #1170: on a reused page item (like
-    /// `ReachabilityBulletin.connectivityPage`), repeated presentations must
-    /// not stack the caller's dismissal handler. Each cycle should see the
-    /// original handler fire exactly once.
-    func test_reused_item_does_not_accumulate_dismissal_handlers() {
-        let overlay = BulletinOverlayWindow.shared
+    /// `ReachabilityBulletin.connectivityPage`, re-shown on every connectivity
+    /// flap), each presentation must leave the item exactly as it found it.
+    ///
+    /// Pre-fix, the post-dismissal assertion fails on the very first pass — the
+    /// item is left holding wrapper 1 — and every later pass buries it one level
+    /// deeper.
+    @Test func `Repeated presentations leave no wrapper on a reused item`() {
+        let page = BLTNPageItem(title: "Test")
+        #expect(page.dismissalHandler == nil)
+
+        for cycle in 1...5 {
+            overlay.swapDismissalHandler(on: page)
+            #expect(page.dismissalHandler != nil, "cycle \(cycle): the overlay's wrapper should be installed while the bulletin is up")
+
+            // BLTN dispatching dismissal: the wrapper runs the caller's handler,
+            // then tears the window down, which restores.
+            page.dismissalHandler?(page)
+            #expect(page.dismissalHandler == nil, "cycle \(cycle): dismissal should restore the item to the caller's handler, not leave a wrapper behind")
+        }
+    }
+
+    /// Teardown must put the caller's handler back on the item, so the next
+    /// presentation cycle starts from a pristine state.
+    @Test func `Teardown restores the caller's handler`() {
         let page = BLTNPageItem(title: "Test")
 
-        var originalCallCount = 0
-        let originalHandler: (BLTNItem) -> Void = { _ in originalCallCount += 1 }
-        page.dismissalHandler = originalHandler
+        overlay.swapDismissalHandler(on: page)
+        #expect(page.dismissalHandler != nil)
 
-        // Simulate five install/teardown cycles.
+        page.dismissalHandler?(page)
+
+        // Pre-fix, this is still the overlay's wrapper.
+        #expect(page.dismissalHandler == nil)
+    }
+
+    /// A stale wrapper left on a dismissed item would reach back into the
+    /// overlay and tear down whatever bulletin is up *now* — under the current
+    /// implementation that also restores the live item's handler out from under
+    /// it. This pins that a dismissed item is inert with respect to a later
+    /// presentation of a different item.
+    @Test func `A dismissed item cannot tear down a later presentation`() {
+        let dismissed = BLTNPageItem(title: "Dismissed")
+        overlay.swapDismissalHandler(on: dismissed)
+        dismissed.dismissalHandler?(dismissed)
+
+        let presented = BLTNPageItem(title: "Presented")
+        overlay.swapDismissalHandler(on: presented)
+
+        // The already-dismissed item is dismissed again (BLTN fires the handler
+        // on `currentItem`; a caller can also invoke it directly).
+        dismissed.dismissalHandler?(dismissed)
+
+        // The live presentation is untouched: its wrapper is still installed.
+        #expect(presented.dismissalHandler != nil)
+
+        // Clean up: dismiss the live one for real.
+        presented.dismissalHandler?(presented)
+        #expect(presented.dismissalHandler == nil)
+    }
+
+    /// Forwarding: the wrapper has to run the caller's handler, once, with the
+    /// item, on every presentation. This holds for the pre-fix implementation
+    /// too — it's here to pin forwarding, not to distinguish the fix.
+    @Test func `The caller's handler runs once per presentation, with the item`() {
+        let page = BLTNPageItem(title: "Test")
+
+        var callCount = 0
+        var receivedItems: [ObjectIdentifier] = []
+        page.dismissalHandler = { item in
+            callCount += 1
+            receivedItems.append(ObjectIdentifier(item))
+        }
+
         for _ in 0..<5 {
             overlay.swapDismissalHandler(on: page)
-            // Fire the swapped-in handler; it should invoke the original once,
-            // then internally call teardown (which restores).
             page.dismissalHandler?(page)
         }
 
-        // Now that we're restored to the original, invoke it directly to
-        // confirm it hasn't been wrapped. One more call → one more increment.
+        #expect(callCount == 5)
+        #expect(receivedItems.allSatisfy { $0 == ObjectIdentifier(page) })
+
+        // Restored to the caller's handler, so a direct call reaches it.
         page.dismissalHandler?(page)
-
-        // Five swap cycles each fired the original once, plus one direct call.
-        expect(originalCallCount) == 6
-    }
-
-    /// Teardown must put the original handler back onto the item, so the next
-    /// presentation cycle starts from a pristine state.
-    func test_teardown_restores_original_handler() {
-        let overlay = BulletinOverlayWindow.shared
-        let page = BLTNPageItem(title: "Test")
-
-        var originalFired = false
-        page.dismissalHandler = { _ in originalFired = true }
-
-        overlay.swapDismissalHandler(on: page)
-
-        // Handler is now the overlay's wrapper — not the original.
-        page.dismissalHandler?(page)
-        expect(originalFired) == true
-
-        // After the wrapper ran (which calls restore), a subsequent dismissal
-        // handler invocation must go straight to the original — no wrapper
-        // left in place, no self-reference back into the overlay.
-        originalFired = false
-        page.dismissalHandler?(page)
-        expect(originalFired) == true
+        #expect(callCount == 6)
     }
 }

--- a/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
@@ -1,0 +1,122 @@
+# Harden `BulletinOverlayWindow` — Design
+
+Fast-follow to PR #1163. Fixes GitHub issue [#1170](https://github.com/OneBusAway/onebusaway-ios/issues/1170).
+
+## Background
+
+PR #1163 introduced `BulletinOverlayWindow`, a dedicated `.alert`-level `UIWindow` for hosting `BLTNItemManager` presentations, and routed every OBA bulletin (`AgencyAlertBulletin`, `ErrorBulletin`, `ReachabilityBulletin`, `RegionMismatchBulletin`) through it.
+
+The bug that motivated the window path — `UISheetPresentationController` clamping a bulletin to the map-panel home sheet's detent — only exists when `FeatureFlags.useMapPanelExperienceKey` is enabled. The fix, however, was applied globally, so it ships to classic (production) users too. On top of that, the current implementation has two latent issues that only bite the flag-enabled path but grow in severity under real-world use:
+
+1. `dismissalHandler` chaining accumulates closures across presentations for long-lived reusable page items (notably `ReachabilityBulletin.connectivityPage`, re-shown on every connectivity flap).
+2. Cross-manager coordination is absent: two `BLTNItemManager` instances can race and orphan a live bulletin's window.
+
+## Goals
+
+- Restrict the new overlay-window presentation path to the map-panel experience.
+- Eliminate the `dismissalHandler` chaining growth on reused page items.
+- Add a regression test proving the flap loop no longer accumulates handlers.
+
+## Non-goals
+
+- Cross-manager coordination / queueing (issue work-item 3). After gating, this only affects flag-enabled testers, and the DEBUG `assertionFailure` in `install` catches the condition in development. A follow-up issue may be filed.
+- Routing bulletin-drop paths (`no foreground scene`) through `analytics?.reportError`. Optional per acceptance criteria; not addressed here.
+
+## Design
+
+### Change 1 — Gate the overlay window on the map-panel flag
+
+**File:** `OBAKit/BLTNBoard/OBABulletinPage.swift`
+
+`BLTNItemManager.show(in:rootItem:)` branches on `UserDefaults.standard.bool(forKey: FeatureFlags.useMapPanelExperienceKey)`:
+
+- **Flag ON** — current behavior: `BulletinOverlayWindow.shared.install(in:rootItem:)` then `showBulletin(above: host)`.
+- **Flag OFF** — restore the pre-#1163 presentation: walk `keyWindowFromScene?.topViewController` and `showBulletin(above: rootVC)`. The `rootItem` parameter is unused in this branch but stays in the signature so all four call sites are untouched.
+
+The `isShowingBulletin` re-entrancy guard and the "no foreground scene" `Logger.error` drop diagnostic run before the branch — they are shared prerequisites.
+
+**Why `UserDefaults.standard` here:** matches how `ApplicationRootControllerFactory` and `SettingsViewController` read the same flag today — no plumbing through `Application` needed. The flag is also read once at app construction time in production, so a mid-session change requires a relaunch to take effect (documented in `FeatureFlags`).
+
+### Change 2 — Stop chaining `dismissalHandler` on reused items
+
+**File:** `OBAKit/BLTNBoard/BulletinOverlayWindow.swift`
+
+**Current shape (the bug):**
+
+```swift
+let originalDismissal = rootItem.dismissalHandler
+rootItem.dismissalHandler = { [weak self] item in
+    originalDismissal?(item)
+    self?.teardown()
+}
+```
+
+On a persisted item like `ReachabilityBulletin.connectivityPage`, `dismissalHandler` is never reset between presentations, so each `install` wraps the previous cycle's closure. After N flaps the chain is N deep and `teardown()` runs N times per dismissal. Idempotent and bounded by flap count, but unbounded in principle on a shared singleton.
+
+**Fix:** snapshot and *restore* rather than wrap.
+
+`BulletinOverlayWindow` grows two private stored properties:
+```swift
+private weak var savedRootItem: BLTNItem?
+private var savedDismissalHandler: ((BLTNItem) -> Void)?
+```
+
+On `install`:
+1. Snapshot `rootItem.dismissalHandler` into `savedDismissalHandler` **before** replacing it.
+2. Store `savedRootItem = rootItem` (weak).
+3. Replace (not wrap) `rootItem.dismissalHandler` with:
+   ```swift
+   { [weak self] item in
+       self?.savedDismissalHandler?(item)
+       self?.teardown()
+   }
+   ```
+
+On `teardown`:
+1. Restore `savedRootItem?.dismissalHandler = savedDismissalHandler`.
+2. Clear both saved references (`savedRootItem = nil`, `savedDismissalHandler = nil`).
+3. Perform existing window teardown (root VC nil, hidden, scene nil, main-window key reclaim).
+
+This restores the item to exactly the state it had before `install` ran, so the next `install` sees the pristine original handler — no matter how many prior presentations occurred.
+
+DEBUG assertions are preserved: `assert(rootItem.next == nil, ...)` and the "already in use" `assertionFailure` on re-entry.
+
+### Call sites
+
+The four bulletin call sites (`AgencyAlertBulletin`, `ErrorBulletin`, `ReachabilityBulletin`, `RegionMismatchBulletin`) are **not touched**. All flag-gating and handler-management logic lives inside the two files above.
+
+## Testing
+
+New file: `OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift`.
+
+Both tests are `@MainActor`. They exercise `BulletinOverlayWindow` directly against a synthesized `BLTNPageItem`; the presentation path itself is not driven — only handler management and teardown restoration.
+
+1. **`test_reachability_flapping_does_not_accumulate_handlers`** — the direct regression test for the item-2 bug.
+   - Create a `BLTNPageItem`. Assign a `dismissalHandler` whose closure captures a counter.
+   - Loop 5×: acquire an installable scene, call `install(in:rootItem:)`, then invoke the item's new `dismissalHandler` (simulating BLTN dispatching dismissal), which triggers `teardown()`.
+   - After the loop, invoke `dismissalHandler` one final time on a fresh install cycle.
+   - Assert the counter incremented exactly the expected number of times (1 per cycle, no compounding).
+
+2. **`test_teardown_restores_original_handler`** — asserts item-state restoration.
+   - Create a `BLTNPageItem` with a known original handler.
+   - Install, then teardown.
+   - Assert `rootItem.dismissalHandler` is either the original object (via `ObjectIdentifier` if reference identity survives the round-trip) or, more robustly, invoke it and assert a spy-flag captured in the original closure fires — proving the restored handler is the pre-`install` one, not the overlay's wrapper.
+
+**Fallback:** if synthesizing a `UIWindowScene` in the test host proves fragile (`OBAKitTests` runs headless), extract the handler-management steps into a small helper on `BulletinOverlayWindow` — e.g. `internal func swapDismissalHandler(on: BLTNItem)` and `internal func restoreDismissalHandler()` — and drive those directly, sidestepping scene synthesis. The `install`/`teardown` public API keeps its current signature.
+
+**Flag-gating is not unit-tested.** It's a two-line branch on `UserDefaults.standard.bool(forKey:)` with no logic beyond it. Manual verification: toggle `OBAUseMapPanelExperience` in Settings, force a reachability drop, confirm classic mode gets the pre-#1163 presentation and map-panel gets the overlay window.
+
+## Acceptance criteria mapping
+
+| Criterion | Where met |
+| --- | --- |
+| Blast radius decision made and reflected in code | Change 1 (flag gate in `show(in:rootItem:)`) |
+| Reachability flapping no longer accumulates nested `dismissalHandler` closures | Change 2 + regression test 1 |
+| Concurrent bulletins from different managers can't orphan/corrupt each other | **Deferred.** Scoped to flag-on testers post-Change 1; DEBUG asserts still fire in development. Follow-up. |
+| Bulletin drops route through analytics | Not addressed (optional in the issue) |
+
+## Risks
+
+- **Flag read timing.** `UserDefaults.standard.bool` reflects the current value; if a user flips the flag mid-session, the next bulletin's presentation path could switch. This matches how the flag behaves everywhere else in the app (a relaunch is expected), and both paths present a valid bulletin — the visible result is a slightly different visual/hosting behavior, not a broken state.
+- **Test-host scene availability.** If `OBAKitTests` can't synthesize a scene, the fallback helper-method approach is documented above. This is a minor implementation detail, not a design change.
+- **Item identity assumption in test 2.** `BLTN` may or may not preserve exact handler identity across reassignment — the spy-flag alternative avoids depending on identity semantics.

--- a/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
@@ -35,7 +35,7 @@ The bug that motivated the window path — `UISheetPresentationController` clamp
 
 The `isShowingBulletin` re-entrancy guard and the "no foreground scene" `Logger.error` drop diagnostic run before the branch — they are shared prerequisites.
 
-**Why `UserDefaults.standard` here:** matches how `ApplicationRootControllerFactory` and `SettingsViewController` read the same flag today — no plumbing through `Application` needed. The flag is also read once at app construction time in production, so a mid-session change requires a relaunch to take effect (documented in `FeatureFlags`).
+**Which `UserDefaults` here:** the OBA app persists this flag to an app-group suite (`AppDelegate.m` initializes `NSUserDefaults` via `initWithSuiteName:` using `Bundle.main.appGroup`), and `SettingsViewController` + `ApplicationRootControllerFactory` both read/write it through `application.userDefaults`. Because this extension only receives `UIApplication` (not the OBA-specific `Application`) and we can't change the four call sites, we resolve the same suite ourselves via `Bundle.main.appGroup` — matching the pattern `CoreApplicationKey.defaultValue` uses. If the suite can't be resolved (unlikely outside test hosts without an app group entitlement), the code treats the flag as OFF and falls through to the classic path, which is the safe production default.
 
 ### Change 2 — Stop chaining `dismissalHandler` on reused items
 

--- a/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-05-bulletin-overlay-window-hardening-design.md
@@ -28,7 +28,7 @@ The bug that motivated the window path — `UISheetPresentationController` clamp
 
 **File:** `OBAKit/BLTNBoard/OBABulletinPage.swift`
 
-`BLTNItemManager.show(in:rootItem:)` branches on `UserDefaults.standard.bool(forKey: FeatureFlags.useMapPanelExperienceKey)`:
+`BLTNItemManager.show(in:rootItem:)` branches on the flag read from the app-group suite — `Bundle.main.appGroup.flatMap { UserDefaults(suiteName: $0) }?.bool(forKey: FeatureFlags.useMapPanelExperienceKey)`, see "Which `UserDefaults` here" below:
 
 - **Flag ON** — current behavior: `BulletinOverlayWindow.shared.install(in:rootItem:)` then `showBulletin(above: host)`.
 - **Flag OFF** — restore the pre-#1163 presentation: walk `keyWindowFromScene?.topViewController` and `showBulletin(above: rootVC)`. The `rootItem` parameter is unused in this branch but stays in the signature so all four call sites are untouched.
@@ -89,22 +89,18 @@ The four bulletin call sites (`AgencyAlertBulletin`, `ErrorBulletin`, `Reachabil
 
 New file: `OBAKitTests/BLTNBoard/BulletinOverlayWindowTests.swift`.
 
-Both tests are `@MainActor`. They exercise `BulletinOverlayWindow` directly against a synthesized `BLTNPageItem`; the presentation path itself is not driven — only handler management and teardown restoration.
+A `@MainActor`, `.serialized` Swift Testing suite. It exercises `BulletinOverlayWindow` directly against a synthesized `BLTNPageItem`; the presentation path itself is not driven — only handler management and teardown restoration. Synthesizing a `UIWindowScene` in the test host is fragile (`OBAKitTests` runs headless), so the tests take the fallback documented below and drive `swapDismissalHandler(on:)` / `restoreDismissalHandler()` — the same helpers `install`/`teardown` use.
 
-1. **`test_reachability_flapping_does_not_accumulate_handlers`** — the direct regression test for the item-2 bug.
-   - Create a `BLTNPageItem`. Assign a `dismissalHandler` whose closure captures a counter.
-   - Loop 5×: acquire an installable scene, call `install(in:rootItem:)`, then invoke the item's new `dismissalHandler` (simulating BLTN dispatching dismissal), which triggers `teardown()`.
-   - After the loop, invoke `dismissalHandler` one final time on a fresh install cycle.
-   - Assert the counter incremented exactly the expected number of times (1 per cycle, no compounding).
+**What the tests can and can't assert.** Counting how often the caller's `dismissalHandler` fires does *not* separate the fix from the bug it fixes. Under the pre-fix chaining, wrapper *N* wraps wrapper *N-1*, and each wrapper calls its inner handler exactly once — so the caller's handler still fires exactly once per dismissal no matter how deep the chain. The signal that differs is what the item is left holding after dismissal: chaining leaves the overlay's wrapper installed (one level deeper each presentation), snapshot-and-restore leaves exactly what the caller set. The tests therefore assert *item state after dismissal*, using an item whose handler starts `nil` so "restored to the caller's value" is observable without comparing closure identity (which Swift can't do).
 
-2. **`test_teardown_restores_original_handler`** — asserts item-state restoration.
-   - Create a `BLTNPageItem` with a known original handler.
-   - Install, then teardown.
-   - Assert `rootItem.dismissalHandler` is either the original object (via `ObjectIdentifier` if reference identity survives the round-trip) or, more robustly, invoke it and assert a spy-flag captured in the original closure fires — proving the restored handler is the pre-`install` one, not the overlay's wrapper.
+1. **`Repeated presentations leave no wrapper on a reused item`** — the direct regression test for the item-2 bug. Loop 5×: swap, assert the wrapper is installed (`dismissalHandler != nil`), fire it, assert the item is back to `nil`. Pre-fix this fails on the first pass and the item gets one level deeper on each subsequent one.
+2. **`Teardown restores the caller's handler`** — the single-cycle form of the same assertion.
+3. **`A dismissed item cannot tear down a later presentation`** — dismiss item A, present item B, fire A's handler again, assert B's presentation is untouched. A stale wrapper on A would reach back into the shared overlay and tear down B (and, under the current implementation, restore B's handler out from under it).
+4. **`The caller's handler runs once per presentation, with the item`** — pins the wrapper's forwarding behavior (count and the item passed through). Noted in the suite as holding for the pre-fix implementation too: it guards forwarding, not the fix.
 
-**Fallback:** if synthesizing a `UIWindowScene` in the test host proves fragile (`OBAKitTests` runs headless), extract the handler-management steps into a small helper on `BulletinOverlayWindow` — e.g. `internal func swapDismissalHandler(on: BLTNItem)` and `internal func restoreDismissalHandler()` — and drive those directly, sidestepping scene synthesis. The `install`/`teardown` public API keeps its current signature.
+**Fallback (taken):** extract the handler-management steps into small helpers on `BulletinOverlayWindow` — `internal func swapDismissalHandler(on: BLTNItem)` and `internal func restoreDismissalHandler()` — and drive those directly, sidestepping scene synthesis. The `install`/`teardown` public API keeps its current signature.
 
-**Flag-gating is not unit-tested.** It's a two-line branch on `UserDefaults.standard.bool(forKey:)` with no logic beyond it. Manual verification: toggle `OBAUseMapPanelExperience` in Settings, force a reachability drop, confirm classic mode gets the pre-#1163 presentation and map-panel gets the overlay window.
+**Flag-gating is not unit-tested.** It's a two-line branch on the app-group suite's `bool(forKey:)` with no logic beyond it. Manual verification: toggle `OBAUseMapPanelExperience` in Settings, force a reachability drop, confirm classic mode gets the pre-#1163 presentation and map-panel gets the overlay window.
 
 ## Acceptance criteria mapping
 
@@ -117,6 +113,6 @@ Both tests are `@MainActor`. They exercise `BulletinOverlayWindow` directly agai
 
 ## Risks
 
-- **Flag read timing.** `UserDefaults.standard.bool` reflects the current value; if a user flips the flag mid-session, the next bulletin's presentation path could switch. This matches how the flag behaves everywhere else in the app (a relaunch is expected), and both paths present a valid bulletin — the visible result is a slightly different visual/hosting behavior, not a broken state.
-- **Test-host scene availability.** If `OBAKitTests` can't synthesize a scene, the fallback helper-method approach is documented above. This is a minor implementation detail, not a design change.
-- **Item identity assumption in test 2.** `BLTN` may or may not preserve exact handler identity across reassignment — the spy-flag alternative avoids depending on identity semantics.
+- **Flag read timing.** The app-group suite's `bool(forKey:)` reflects the current value; if a user flips the flag mid-session, the next bulletin's presentation path could switch. This matches how the flag behaves everywhere else in the app (a relaunch is expected), and both paths present a valid bulletin — the visible result is a slightly different visual/hosting behavior, not a broken state.
+- **Test-host scene availability.** `OBAKitTests` can't be relied on to have a `UIWindowScene`, so the tests take the fallback helper-method approach documented above. This is a minor implementation detail, not a design change.
+- **Closure identity is not comparable in Swift.** "The restored handler is the caller's" can't be asserted by comparing closures, and a spy flag inside the caller's handler can't do it either — a chained wrapper fires that spy just the same. The tests get around this by starting from a `nil` handler, where restoration is directly observable.


### PR DESCRIPTION
Fast-follow to #1163. Closes #1170.

## Summary

- **Gates the dedicated `BulletinOverlayWindow` presentation path behind `OBAUseMapPanelExperience`.** Classic (production) mode reverts to the pre-#1163 `keyWindowFromScene?.topViewController` presentation. The `UISheetPresentationController` sheet-clamping bug the overlay window was created to fix only exists when the map-panel flag is on, so classic users no longer take on the new window path (and its singleton lifecycle) for a bug they don't have.
- **Reads the flag from the same app-group suite Settings writes to** (`Bundle.main.appGroup` → `UserDefaults(suiteName:)`), matching `SettingsViewController`, `ApplicationRootControllerFactory`, and `CoreApplicationKey.defaultValue`. Reading `UserDefaults.standard` would have silently kept the overlay-window path off for map-panel testers.
- **Replaces `dismissalHandler` closure wrapping in `BulletinOverlayWindow.install` with snapshot-and-restore semantics.** Reused BLTN page items (`ReachabilityBulletin.connectivityPage` re-shown across connectivity flaps) no longer accumulate nested handlers across presentations.

## Notes

The four bulletin call sites (`AgencyAlertBulletin`, `ErrorBulletin`, `ReachabilityBulletin`, `RegionMismatchBulletin`) are unchanged — all logic changes live in `OBABulletinPage.swift` and `BulletinOverlayWindow.swift`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flag-controlled bulletin presentation for the map-panel experience, with an automatic fallback to the classic presentation when disabled.

* **Bug Fixes**
  * Hardened overlay bulletin lifecycles by snapshotting and restoring dismissal behavior, preventing duplicated/accumulated dismissal handling across repeated presentations.
  * Improved resilience when the required presentation scene or top view controller isn’t available.

* **Documentation**
  * Updated the bulletin overlay hardening design spec and clarified testing expectations for the overlay path.

* **Tests**
  * Added regression coverage for repeated presentations and correct one-time dismissal invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->