### PR TITLE
Expand add-region deep link and custom region form with sidecar and Umami analytics support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ scripts/extract_strings               # Extract strings for localization
 ## Configuration & Deployment
 
 - **Target iOS Version**: 18.0+
-- **Swift Version**: 5.3+
+- **Swift Version**: Swift 5/6 language modes, current Xcode toolchain (modern syntax like shorthand optional binding and `URL.host()` is fine — the iOS 18 deployment target exceeds their requirements)
 - **Package Manager**: Swift Package Manager
 - **Project Generation**: XcodeGen from YAML configurations
 - **Localization**: in-repo .strings files (OBAKit/Strings, OBAKitCore/Strings)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,26 @@ The codebase supports easy customization through:
 
 Custom region addition:
 ```
-onebusaway://add-region?name=REGION_NAME&oba-url=ENCODED_SERVER_URL
+onebusaway://add-region?name=REGION_NAME
+    &oba-url=ENCODED_OBA_URL
+    &otp-url=ENCODED_OTP_URL
+    &sidecar-url=ENCODED_SIDECAR_URL
+    &umami-url=ENCODED_UMAMI_URL
+    &umami-id=UMAMI_WEBSITE_ID
 ```
+
+**Parameter details:**
+- `name` (required): Region display name
+- `oba-url` (required): OneBusAway server base URL
+- `otp-url` (optional): OpenTripPlanner server URL
+- `sidecar-url` (optional): Obaco sidecar server URL for OneBusAway.co features
+- `umami-url` and `umami-id` (optional, both required together): Umami analytics URL and website ID—leave both blank to disable analytics
+
+**Rules:**
+1. All optional parameters can be omitted; their absence preserves existing behavior
+2. **Umami is "both-or-nothing"**: analytics are enabled only if both `umami-url` and `umami-id` are present and valid; a partial pair is silently ignored
+3. URL parameters must be percent-encoded (e.g., query strings in nested URLs: `https://example.com/api?a=1&b=2` must be encoded as `https%3A%2F%2Fexample.com%2Fapi%3Fa%3D1%26b%3D2`)
+4. New URL fields are validated for well-formedness only; invalid optional URLs degrade to `nil`; only `oba-url` triggers a live server validation (existing behavior)
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,13 +130,13 @@ onebusaway://add-region?name=REGION_NAME
 - `oba-url` (required): OneBusAway server base URL
 - `otp-url` (optional): OpenTripPlanner server URL
 - `sidecar-url` (optional): Obaco sidecar server URL for OneBusAway.co features
-- `umami-url` and `umami-id` (optional, both required together): Umami analytics URL and website ID—leave both blank to disable analytics
+- `umami-url` and `umami-id` (optional, both required together): Umami analytics URL and website ID—omit both to disable analytics
 
 **Rules:**
 1. All optional parameters can be omitted; their absence preserves existing behavior
 2. **Umami is "both-or-nothing"**: analytics are enabled only if both `umami-url` and `umami-id` are present and valid; a partial pair is silently ignored
 3. URL parameters must be percent-encoded (e.g., query strings in nested URLs: `https://example.com/api?a=1&b=2` must be encoded as `https%3A%2F%2Fexample.com%2Fapi%3Fa%3D1%26b%3D2`)
-4. New URL fields are validated for well-formedness only; invalid optional URLs degrade to `nil`; only `oba-url` triggers a live server validation (existing behavior)
+4. New URL fields are validated for well-formedness only; invalid optional URLs degrade to nil. The Add Custom Region form live-validates the base URL on save; the deep link path checks well-formedness only
 
 ## Development Notes
 

--- a/OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift
@@ -24,6 +24,9 @@ struct RegionCustomForm: View {
     // MARK: Form Fields
     @State private var regionName: String = ""
     @State private var baseURLString: String = ""
+    @State private var sidecarURLString: String = ""
+    @State private var umamiURLString: String = ""
+    @State private var umamiIDString: String = ""
     @State private var serviceArea: MKMapRect = MKMapRect(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 27.9654987, longitude: -82.5101761), latitudinalMeters: 2000, longitudinalMeters: 2000))
     @State private var cameraPosition: MapCameraPosition = .automatic
 
@@ -32,12 +35,41 @@ struct RegionCustomForm: View {
         Self.normalizeBaseURL(baseURLString)
     }
 
+    /// The Sidecar URL field, normalized. Empty or invalid input degrades to `nil`.
+    var normalizedSidecarURL: URL? {
+        Self.normalizeURL(sidecarURLString)
+    }
+
+    /// The Umami analytics URL field, normalized. Empty or invalid input degrades to `nil`.
+    var normalizedUmamiURL: URL? {
+        Self.normalizeURL(umamiURLString)
+    }
+
     /// Normalizes user input into a base URL: trims whitespace, assumes
     /// `https://` when no scheme was typed, and strips a trailing `/api/where`
     /// (the field's help text promises that part is added automatically, so
     /// pasting a full API URL must not double it). Static and pure for
     /// testability.
     static func normalizeBaseURL(_ string: String) -> URL? {
+        guard let url = normalizeURL(string) else {
+            return nil
+        }
+
+        var urlString = url.absoluteString
+        if urlString.lowercased().hasSuffix("/api/where") {
+            urlString = String(urlString.dropLast("/api/where".count))
+            while urlString.hasSuffix("/") {
+                urlString = String(urlString.dropLast())
+            }
+        }
+        return URL(string: urlString)
+    }
+
+    /// General URL normalization for human-typed input: trims whitespace,
+    /// assumes `https://` when no scheme was typed, strips trailing slashes,
+    /// and requires an http(s) scheme and a host. Static and pure for
+    /// testability.
+    static func normalizeURL(_ string: String) -> URL? {
         var urlString = string.strip()
         guard !urlString.isEmpty else {
             return nil
@@ -49,9 +81,6 @@ struct RegionCustomForm: View {
 
         while urlString.hasSuffix("/") {
             urlString = String(urlString.dropLast())
-        }
-        if urlString.lowercased().hasSuffix("/api/where") {
-            urlString = String(urlString.dropLast("/api/where".count))
         }
 
         guard
@@ -121,6 +150,35 @@ struct RegionCustomForm: View {
                 Text(OBALoc("custom_region_builder_controller.service_area_section.explanation", value: "Drag the map to the approximate service area of this region.", comment: "An explanation of dragging the map to highlight the service area of a custom region."))
             }
 
+            Section {
+                TextField("onebusaway.co", text: $sidecarURLString)
+                    .textContentType(.URL)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } header: {
+                Text(OBALoc("custom_region_builder_controller.sidecar_section.header_title", value: "Sidecar Server", comment: "Title of the Sidecar Server header."))
+            } footer: {
+                // "OneBusAway.co" here names the Obaco sidecar service's own domain, not this app's brand.
+                // swiftlint:disable:next hardcoded_app_name
+                Text(OBALoc("custom_region_builder_controller.sidecar_section.explanation", value: "Optional. The address of an Obaco (OneBusAway.co) sidecar server, which powers features like alarms and surveys. \"https://\" is assumed.", comment: "An explanation of the optional Obaco sidecar server URL field of a custom region."))
+            }
+
+            Section {
+                TextField("analytics.example.com", text: $umamiURLString)
+                    .textContentType(.URL)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                TextField(OBALoc("custom_region_builder_controller.analytics_section.website_id_placeholder", value: "Website ID", comment: "Placeholder for the Umami analytics website ID field."), text: $umamiIDString)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } header: {
+                Text(OBALoc("custom_region_builder_controller.analytics_section.header_title", value: "Analytics", comment: "Title of the Analytics header."))
+            } footer: {
+                Text(OBALoc("custom_region_builder_controller.analytics_section.explanation", value: "Optional. The address of an Umami analytics server and this region's website ID. Both fields are required to enable analytics; leave them blank to disable it.", comment: "An explanation of the optional Umami analytics fields of a custom region."))
+            }
+
             if editingRegion != nil {
                 Section {
                     Button(role: .destructive) {
@@ -164,6 +222,13 @@ struct RegionCustomForm: View {
             regionName = editingRegion.name
             baseURLString = displayString(for: editingRegion.OBABaseURL)
             serviceArea = editingRegion.serviceRect
+            if let sidecarBaseURL = editingRegion.sidecarBaseURL {
+                sidecarURLString = displayString(for: sidecarBaseURL)
+            }
+            if let umamiAnalytics = editingRegion.umamiAnalytics {
+                umamiURLString = displayString(for: umamiAnalytics.url)
+                umamiIDString = umamiAnalytics.id
+            }
         }
         else if let location = regionProvider.currentLocation {
             serviceArea = MKMapRect(MKCoordinateRegion(center: location.coordinate, latitudinalMeters: 2000, longitudinalMeters: 2000))
@@ -229,12 +294,17 @@ struct RegionCustomForm: View {
             name = agencies.first?.agency?.name ?? Self.defaultRegionName
         }
 
+        // openTripPlannerURL isn't editable in this form, so editing must carry
+        // the existing value forward rather than silently dropping it.
         let region = Region(
             name: name,
             OBABaseURL: baseURL,
             coordinateRegion: MKCoordinateRegion(serviceArea),
             contactEmail: editingRegion?.contactEmail ?? Self.placeholderContactEmail,
-            regionIdentifier: editingRegion?.regionIdentifier
+            regionIdentifier: editingRegion?.regionIdentifier,
+            openTripPlannerURL: editingRegion?.openTripPlannerURL,
+            sidecarBaseURL: normalizedSidecarURL,
+            umamiAnalytics: UmamiAnalyticsConfig(url: normalizedUmamiURL, id: umamiIDString)
         )
 
         do {

--- a/OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift
+++ b/OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift
@@ -62,7 +62,11 @@ struct RegionCustomForm: View {
                 urlString = String(urlString.dropLast())
             }
         }
-        return URL(string: urlString)
+
+        guard let finalURL = URL(string: urlString), finalURL.host() != nil else {
+            return nil
+        }
+        return finalURL
     }
 
     /// General URL normalization for human-typed input: trims whitespace,

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -599,8 +599,16 @@ public class Application: CoreApplication, PushServiceDelegate {
                     // Create region provider
                     let regionProvider = RegionPickerCoordinator(regionsService: self.regionsService, userDataStore: self.userDataStore)
 
-                    // Construct Region from URL data
-                    let currentRegion = Region(name: regionData.name, OBABaseURL: regionData.obaURL, coordinateRegion: adjustedRegionCoordinate, contactEmail: "example@example.com", openTripPlannerURL: regionData.otpURL)
+                    // Construct Region from URL data. umamiAnalytics applies the
+                    // both-or-nothing rule; no rule logic lives here.
+                    let currentRegion = Region(
+                        name: regionData.name,
+                        OBABaseURL: regionData.obaURL,
+                        coordinateRegion: adjustedRegionCoordinate,
+                        contactEmail: "example@example.com",
+                        openTripPlannerURL: regionData.otpURL,
+                        sidecarBaseURL: regionData.sidecarURL,
+                        umamiAnalytics: regionData.umamiAnalytics)
 
                     // Add and set current region
                     try await regionProvider.add(customRegion: currentRegion)

--- a/OBAKitCore/DeepLinks/URLSchemeRouter.swift
+++ b/OBAKitCore/DeepLinks/URLSchemeRouter.swift
@@ -16,18 +16,31 @@ public struct StopURLData {
 }
 
 /// `AddRegionURLData` is a data structure that encapsulates the information needed to add a new region
-/// through a deep link. It contains the name of the region, the URL to the OneBusAway (OBA) server, and an optional
-/// URL to the OpenTripPlanner (OTP) server.
+/// through a deep link. All URL values must be percent-encoded inside the deep link; an unencoded `&`
+/// inside a nested URL ends that value.
 ///
 /// - Parameters:
 ///   - name: The name of the region to be added. This is a human-readable string that identifies the region.
 ///   - obaURL: The URL to the OneBusAway (OBA) server for the region. This URL is used to access transit data.
-///   - otpURL: An optional URL to the OpenTripPlanner (OTP) server. If provided, it can be used for trip planning.
-///             If nil, it indicates that the region does not support OTP or that the URL was not provided.
+///   - otpURL: An optional URL to the OpenTripPlanner (OTP) server, used for trip planning.
+///   - sidecarURL: An optional base URL for the Obaco sidecar server.
+///   - umamiURL: An optional Umami analytics server URL. Never read this directly to decide whether
+///               analytics is enabled — use `umamiAnalytics`.
+///   - umamiID: An optional Umami website ID. Like `umamiURL`, this can dangle (e.g. an ID with an
+///              invalid URL); use `umamiAnalytics`.
 public struct AddRegionURLData {
     public let name: String
     public let obaURL: URL
     public let otpURL: URL?
+    public let sidecarURL: URL?
+    public let umamiURL: URL?
+    public let umamiID: String?
+
+    /// The both-or-nothing Umami config: non-nil only when both `umamiURL` and a
+    /// non-blank `umamiID` are present. Consumers must use this, not the raw fields.
+    public var umamiAnalytics: UmamiAnalyticsConfig? {
+        UmamiAnalyticsConfig(url: umamiURL, id: umamiID)
+    }
 }
 
 /// `URLType` represents the types of URLs that the `URLSchemeRouter` can handle.
@@ -104,7 +117,9 @@ public class URLSchemeRouter: NSObject {
     }
 
     // MARK: - Add Region URLs
-    /// Encodes the OBA URL for adding custom region  along with its Name into an URL with the scheme `extensionURLScheme`. It also has optional OTP URL
+    /// Decodes an `AddRegionURLData` from `add-region` URL components. `name` and a valid
+    /// `oba-url` are required; `otp-url`, `sidecar-url`, `umami-url`, and `umami-id` are
+    /// optional, and invalid optional values degrade to `nil`.
     private func decodeAddRegion(from components: URLComponents) -> URLType? {
         guard
             let name = components.queryItem(named: "name")?.value,
@@ -113,12 +128,27 @@ public class URLSchemeRouter: NSObject {
             return .addRegion(nil)
         }
 
-        var otpURL: URL?
-        if let otpUrlString = components.queryItem(named: "otp-url")?.value {
-            otpURL = validateAndCreateURL(from: otpUrlString)
+        var umamiID: String?
+        if let rawUmamiID = components.queryItem(named: "umami-id")?.value {
+            let trimmed = rawUmamiID.strip()
+            umamiID = trimmed.isEmpty ? nil : trimmed
         }
 
-        return .addRegion(AddRegionURLData(name: name, obaURL: obaURL, otpURL: otpURL))
+        return .addRegion(AddRegionURLData(
+            name: name,
+            obaURL: obaURL,
+            otpURL: optionalURL(named: "otp-url", in: components),
+            sidecarURL: optionalURL(named: "sidecar-url", in: components),
+            umamiURL: optionalURL(named: "umami-url", in: components),
+            umamiID: umamiID))
+    }
+
+    /// Extracts and validates an optional URL query item; missing or invalid values become `nil`.
+    private func optionalURL(named name: String, in components: URLComponents) -> URL? {
+        guard let string = components.queryItem(named: name)?.value else {
+            return nil
+        }
+        return validateAndCreateURL(from: string)
     }
 
     /// Validates that a URL string represents a proper URL with a scheme or is a valid path

--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -541,6 +541,21 @@ public struct UmamiAnalyticsConfig: Codable, Equatable, Hashable {
 
     /// The Umami website UUID that events are keyed/routed by.
     public let id: String
+
+    public init(url: URL, id: String) {
+        self.url = url
+        self.id = id
+    }
+
+    /// The single source of truth for the both-or-nothing rule: a config exists
+    /// only when both a URL and a non-blank website ID are present. Partial
+    /// pairs collapse to `nil`, which means "analytics disabled."
+    public init?(url: URL?, id: String?) {
+        guard let url, let id = id?.strip(), !id.isEmpty else {
+            return nil
+        }
+        self.init(url: url, id: id)
+    }
 }
 
 // MARK: - Open311Server

--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -207,7 +207,9 @@ public class Region: NSObject, Identifiable, Codable {
     /// - Parameter contactEmail: The contact email address for this region.
     /// - Parameter regionIdentifier: The identifier for this region. If unassigned, it will be given a random value.
     /// - Parameter regionIdentifier: The identifier for this region. If unassigned, it will be given a random value.
-    public required init(name: String, OBABaseURL: URL, coordinateRegion: MKCoordinateRegion, contactEmail: String, regionIdentifier: Int? = nil, openTripPlannerURL: URL? = nil) {
+    /// - Parameter sidecarBaseURL: Optional base URL for the Obaco sidecar server.
+    /// - Parameter umamiAnalytics: Optional Umami analytics configuration.
+    public required init(name: String, OBABaseURL: URL, coordinateRegion: MKCoordinateRegion, contactEmail: String, regionIdentifier: Int? = nil, openTripPlannerURL: URL? = nil, sidecarBaseURL: URL? = nil, umamiAnalytics: UmamiAnalyticsConfig? = nil) {
         self.name = name
         self.regionIdentifier = regionIdentifier ?? 1000 + Int.random(in: 0...999)
         isActive = true
@@ -215,7 +217,7 @@ public class Region: NSObject, Identifiable, Codable {
         isCustom = true
 
         self.OBABaseURL = OBABaseURL
-        self.sidecarBaseURL = nil
+        self.sidecarBaseURL = sidecarBaseURL
 
         let bound = RegionBound(lat: coordinateRegion.center.latitude, lon: coordinateRegion.center.longitude, latSpan: coordinateRegion.span.latitudeDelta, lonSpan: coordinateRegion.span.longitudeDelta)
         regionBounds = [bound]
@@ -235,7 +237,7 @@ public class Region: NSObject, Identifiable, Codable {
         paymentiOSAppStoreIdentifier = nil
         paymentiOSAppURLScheme = nil
         plausibleAnalyticsServerURL = nil
-        umamiAnalytics = nil
+        self.umamiAnalytics = umamiAnalytics
         siriBaseURL = nil
         stopInfoURL = nil
         supportsEmbeddedSocial = false

--- a/OBAKitCore/Models/Region.swift
+++ b/OBAKitCore/Models/Region.swift
@@ -206,7 +206,7 @@ public class Region: NSObject, Identifiable, Codable {
     /// - Parameter coordinateRegion: The coordinate region that circumscribes this region.
     /// - Parameter contactEmail: The contact email address for this region.
     /// - Parameter regionIdentifier: The identifier for this region. If unassigned, it will be given a random value.
-    /// - Parameter regionIdentifier: The identifier for this region. If unassigned, it will be given a random value.
+    /// - Parameter openTripPlannerURL: Optional URL for the region's OpenTripPlanner server.
     /// - Parameter sidecarBaseURL: Optional base URL for the Obaco sidecar server.
     /// - Parameter umamiAnalytics: Optional Umami analytics configuration.
     public required init(name: String, OBABaseURL: URL, coordinateRegion: MKCoordinateRegion, contactEmail: String, regionIdentifier: Int? = nil, openTripPlannerURL: URL? = nil, sidecarBaseURL: URL? = nil, umamiAnalytics: UmamiAnalyticsConfig? = nil) {

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -74,6 +74,18 @@ class Fixtures {
         return Region(name: "Custom Region", OBABaseURL: URL(string: "http://www.example.com")!, coordinateRegion: coordinateRegion, contactEmail: "contact@example.com")
     }
 
+    class var customRegionWithSidecarAndUmami: Region {
+        let coordinateRegion = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 44.9778, longitude: -93.2650), latitudinalMeters: 1000.0, longitudinalMeters: 1000.0)
+
+        return Region(
+            name: "Custom Region",
+            OBABaseURL: URL(string: "http://www.example.com")!,
+            coordinateRegion: coordinateRegion,
+            contactEmail: "contact@example.com",
+            sidecarBaseURL: URL(string: "https://obaco.example.com")!,
+            umamiAnalytics: UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com")!, id: "site-uuid-123"))
+    }
+
     class var pugetSoundRegion: Region {
         let regions = try! loadSomeRegions()
         return regions[1]

--- a/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
@@ -537,6 +537,132 @@ class URLSchemeRouterTests: XCTestCase {
             fail("Expected addRegion URLType")
         }
     }
+
+    // MARK: - Sidecar & Umami Parameters
+
+    private func decodeAddRegion(_ queryItems: [URLQueryItem]) -> AddRegionURLData? {
+        var components = URLComponents()
+        components.scheme = "onebusaway"
+        components.host = "add-region"
+        components.queryItems = queryItems
+        guard let url = components.url, case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return nil
+        }
+        return data
+    }
+
+    func test_decodeURLType_addRegion_decodesAllNewParameters() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "sidecar-url", value: "https://obaco.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com"
+        expect(data?.umamiURL?.absoluteString) == "https://analytics.example.com"
+        expect(data?.umamiID) == "site-uuid-123"
+        expect(data?.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(data?.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func test_decodeURLType_addRegion_newParametersDefaultToNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com")
+        ])
+
+        expect(data?.sidecarURL).to(beNil())
+        expect(data?.umamiURL).to(beNil())
+        expect(data?.umamiID).to(beNil())
+        expect(data?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_partialUmamiPairCollapsesToNilConfig() {
+        // URL without ID.
+        let urlOnly = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com")
+        ])
+        expect(urlOnly?.umamiURL).toNot(beNil())
+        expect(urlOnly?.umamiAnalytics).to(beNil())
+
+        // ID without URL — the region still decodes; the dangling ID never becomes a config.
+        let idOnly = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+        expect(idOnly?.umamiID) == "site-uuid-123"
+        expect(idOnly?.umamiAnalytics).to(beNil())
+
+        // Invalid umami URL + valid ID — dangling ID, nil config.
+        let invalidURL = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "not a valid url"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+        expect(invalidURL?.umamiURL).to(beNil())
+        expect(invalidURL?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_blankUmamiIDBecomesNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com"),
+            URLQueryItem(name: "umami-id", value: "   ")
+        ])
+        expect(data?.umamiID).to(beNil())
+        expect(data?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_invalidSidecarURLDegradesToNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "sidecar-url", value: "not a valid url")
+        ])
+        expect(data).toNot(beNil())
+        expect(data?.sidecarURL).to(beNil())
+    }
+
+    // MARK: - Raw-String Decoding (percent-encoding behavior)
+
+    // The queryItems-based tests above auto-encode values on the way out, so they
+    // can never exercise encoding bugs. These two lock in the documented contract:
+    // nested URLs MUST be percent-encoded; an unencoded `&` truncates.
+
+    func test_decodeURLType_addRegion_rawString_percentEncodedNestedURL() {
+        let url = URL(string: "onebusaway://add-region?name=Raw%20Region&oba-url=https%3A%2F%2Foba.example.com&sidecar-url=https%3A%2F%2Fobaco.example.com%2Fapi%3Fa%3D1%26b%3D2&umami-url=https%3A%2F%2Fanalytics.example.com&umami-id=site-uuid-123")!
+
+        guard case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return
+        }
+
+        expect(data?.name) == "Raw Region"
+        expect(data?.obaURL.absoluteString) == "https://oba.example.com"
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com/api?a=1&b=2"
+        expect(data?.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func test_decodeURLType_addRegion_rawString_unencodedAmpersandTruncates() {
+        let url = URL(string: "onebusaway://add-region?name=Raw&oba-url=https://oba.example.com&sidecar-url=https://obaco.example.com/api?a=1&b=2")!
+
+        guard case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return
+        }
+
+        // The unencoded `&` ends the sidecar-url value; `b=2` parses as a separate
+        // (ignored) query item. This is documented behavior, not a bug.
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com/api?a=1"
+    }
 }
 
 // MARK: - Helper Extensions

--- a/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
@@ -157,4 +157,21 @@ class RegionsEncodingTests: OBATestCase {
         expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "   ")).to(beNil())
         expect(UmamiAnalyticsConfig(url: nil, id: nil)).to(beNil())
     }
+
+    func testCustomRegions_creation_withSidecarAndUmami() {
+        let region = Fixtures.customRegionWithSidecarAndUmami
+        expect(region.sidecarBaseURL?.absoluteString) == "https://obaco.example.com"
+        expect(region.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(region.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func testCustomRegions_roundtripping_withSidecarAndUmami() {
+        let plistData = try! PropertyListEncoder().encode([Fixtures.customRegionWithSidecarAndUmami])
+        let rt = try! PropertyListDecoder().decode([Region].self, from: plistData)[0]
+
+        expect(rt.sidecarBaseURL?.absoluteString) == "https://obaco.example.com"
+        expect(rt.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(rt.umamiAnalytics?.id) == "site-uuid-123"
+        expect(rt.isCustom) == true
+    }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
@@ -131,4 +131,30 @@ class RegionsEncodingTests: OBATestCase {
         expect(customRegionRT.serviceRect.height).to(beCloseTo(9485.2270, within: 0.1))
         expect(customRegionRT.serviceRect.width).to(beCloseTo(9453.3477, within: 0.1))
     }
+
+    // MARK: - UmamiAnalyticsConfig inits
+
+    func testUmamiConfig_memberwiseInit() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com")!, id: "site-123")
+        expect(config.url.absoluteString) == "https://analytics.example.com"
+        expect(config.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_bothPresent() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "site-123")
+        expect(config?.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_trimsID() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "  site-123 \n")
+        expect(config?.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_partialPairsCollapseToNil() {
+        expect(UmamiAnalyticsConfig(url: nil, id: "site-123")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: nil)).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "   ")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: nil, id: nil)).to(beNil())
+    }
 }

--- a/OBAKitTests/Onboarding/RegionCustomFormTests.swift
+++ b/OBAKitTests/Onboarding/RegionCustomFormTests.swift
@@ -51,6 +51,12 @@ class RegionCustomFormTests: XCTestCase {
         expect(self.normalize("   ")).to(beNil())
         expect(self.normalize("ftp://example.com")).to(beNil())
         expect(self.normalize("https://")).to(beNil())
+
+        // Regression: stripping "/api/where" from input where "api" parses as
+        // the host (e.g. "api/where" -> "https://api/where") must not leave a
+        // scheme-only, host-less URL like "https:" behind unvalidated.
+        expect(self.normalize("api/where")).to(beNil())
+        expect(self.normalize("https://api/where")).to(beNil())
     }
 
     // MARK: - normalizeURL (general, no /api/where handling)

--- a/OBAKitTests/Onboarding/RegionCustomFormTests.swift
+++ b/OBAKitTests/Onboarding/RegionCustomFormTests.swift
@@ -52,4 +52,34 @@ class RegionCustomFormTests: XCTestCase {
         expect(self.normalize("ftp://example.com")).to(beNil())
         expect(self.normalize("https://")).to(beNil())
     }
+
+    // MARK: - normalizeURL (general, no /api/where handling)
+
+    private func normalizeGeneral(_ string: String) -> String? {
+        RegionCustomForm.normalizeURL(string)?.absoluteString
+    }
+
+    func test_normalizeURL_prependsHTTPS() {
+        expect(self.normalizeGeneral("obaco.example.com")) == "https://obaco.example.com"
+    }
+
+    func test_normalizeURL_preservesExplicitScheme() {
+        expect(self.normalizeGeneral("http://example.com")) == "http://example.com"
+    }
+
+    func test_normalizeURL_stripsWhitespaceAndTrailingSlashes() {
+        expect(self.normalizeGeneral("  analytics.example.com/ \n")) == "https://analytics.example.com"
+    }
+
+    /// Unlike the Base URL field, general URLs keep an `/api/where` path verbatim.
+    func test_normalizeURL_doesNotStripAPIWhere() {
+        expect(self.normalizeGeneral("example.com/api/where")) == "https://example.com/api/where"
+    }
+
+    func test_normalizeURL_rejectsInvalidInput() {
+        expect(self.normalizeGeneral("")).to(beNil())
+        expect(self.normalizeGeneral("   ")).to(beNil())
+        expect(self.normalizeGeneral("ftp://example.com")).to(beNil())
+        expect(self.normalizeGeneral("https://")).to(beNil())
+    }
 }

--- a/docs/superpowers/plans/2026-07-18-add-region-url-expansion.md
+++ b/docs/superpowers/plans/2026-07-18-add-region-url-expansion.md
@@ -1,0 +1,784 @@
+# Add-Region Deep Link & Custom Region Form Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the `onebusaway://add-region` deep link and the Add/Edit Custom Region form set a region's Obaco sidecar URL and Umami analytics config (URL + website ID).
+
+**Architecture:** Three new optional query params (`sidecar-url`, `umami-url`, `umami-id`) flow through `URLSchemeRouter` → `AddRegionURLData` → the `Region` custom initializer; the SwiftUI `RegionCustomForm` gains two sections feeding the same initializer. The both-or-nothing Umami rule lives in one place: a failable `UmamiAnalyticsConfig.init?(url:id:)`.
+
+**Tech Stack:** Swift, SwiftUI, XCTest + Nimble. Frameworks: OBAKitCore (models, deep links), OBAKit (UI, app orchestration).
+
+**Spec:** `docs/superpowers/specs/2026-07-18-add-region-url-expansion-design.md`
+
+## Global Constraints
+
+- All three new values are optional; their absence changes nothing about existing behavior.
+- Umami is both-or-nothing: config exists only when both a valid URL and a non-blank (whitespace-trimmed) ID are present; partial pairs are silently ignored (`umamiAnalytics = nil`), the region still saves.
+- Well-formed-only validation for the new URLs — no network reachability checks. Invalid optional URLs degrade to `nil` (matches `otp-url` posture). Only a bad `oba-url` hard-fails.
+- Deep link URLs require an explicit scheme (router's `validateAndCreateURL` semantics); the form assumes `https://` for human-typed input. This split is deliberate.
+- Nested URLs in deep links must be percent-encoded; unencoded `&` truncates. Document, don't recover.
+- OBAKitCore must remain application-extension safe (no UIKit app APIs).
+- New user-facing strings use `OBALoc` with `custom_region_builder_controller.*` keys.
+- Do not create new source files — all changes land in existing files, so `scripts/generate_project` regeneration is not required. (If you DO add a file, run `scripts/generate_project OneBusAway` afterward or the test target won't see it.)
+
+## Build & Test Commands
+
+One-time setup (required before any build):
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios
+scripts/generate_project OneBusAway
+```
+
+Per-task test cycle (always `set -o pipefail` if you pipe xcodebuild — a masked build failure leaves stale products that produce confusing test results):
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/<TestClass> -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -30
+```
+
+The simulator is **iPhone 17 Pro** (iPhone 16 is not installed on this machine).
+
+---
+
+### Task 1: `UmamiAnalyticsConfig` public inits (memberwise + both-or-nothing failable)
+
+**Files:**
+- Modify: `OBAKitCore/Models/Region.swift:538-544` (the `UmamiAnalyticsConfig` struct)
+- Test: `OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift` (append to class)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `public init(url: URL, id: String)` and `public init?(url: URL?, id: String?)` on `UmamiAnalyticsConfig`. The failable init is the single source of truth for the both-or-nothing rule; Tasks 3, 4, and 5 all call it. Trimming uses the existing `String.strip()` from `OBAKitCore/Extensions/FoundationExtensions.swift:288`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `RegionsEncodingTests` class in `OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift`:
+
+```swift
+    // MARK: - UmamiAnalyticsConfig inits
+
+    func testUmamiConfig_memberwiseInit() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com")!, id: "site-123")
+        expect(config.url.absoluteString) == "https://analytics.example.com"
+        expect(config.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_bothPresent() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "site-123")
+        expect(config?.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_trimsID() {
+        let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "  site-123 \n")
+        expect(config?.id) == "site-123"
+    }
+
+    func testUmamiConfig_failableInit_partialPairsCollapseToNil() {
+        expect(UmamiAnalyticsConfig(url: nil, id: "site-123")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: nil)).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "   ")).to(beNil())
+        expect(UmamiAnalyticsConfig(url: nil, id: nil)).to(beNil())
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (after build-for-testing; see Build & Test Commands):
+`xcodebuild build-for-testing …` — Expected: **build FAILS** with "extra argument" / "no exact matches in call to initializer" because `init?(url: URL?, id: String?)` does not exist. (A compile failure is the red state here.)
+
+- [ ] **Step 3: Implement the inits**
+
+In `OBAKitCore/Models/Region.swift`, replace the `UmamiAnalyticsConfig` struct body (lines 538-544) with:
+
+```swift
+public struct UmamiAnalyticsConfig: Codable, Equatable, Hashable {
+    /// The Umami host to POST events to, e.g. `https://analytics.onebusawaycloud.com`.
+    public let url: URL
+
+    /// The Umami website UUID that events are keyed/routed by.
+    public let id: String
+
+    public init(url: URL, id: String) {
+        self.url = url
+        self.id = id
+    }
+
+    /// The single source of truth for the both-or-nothing rule: a config exists
+    /// only when both a URL and a non-blank website ID are present. Partial
+    /// pairs collapse to `nil`, which means "analytics disabled."
+    public init?(url: URL?, id: String?) {
+        guard let url, let id = id?.strip(), !id.isEmpty else {
+            return nil
+        }
+        self.init(url: url, id: id)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RegionsEncodingTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -30
+```
+
+Expected: all `RegionsEncodingTests` PASS (new + pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Models/Region.swift "OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift"
+git commit -m "Add public memberwise and both-or-nothing failable inits to UmamiAnalyticsConfig"
+```
+
+---
+
+### Task 2: `Region` custom initializer accepts sidecar + umami; Codable round-trip proof
+
+**Files:**
+- Modify: `OBAKitCore/Models/Region.swift:210-248` (the custom-region `init`)
+- Modify: `OBAKitTests/Helpers/Fixtures.swift:71-75` (add fixture next to `customMinneapolisRegion`)
+- Test: `OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift`
+
+**Interfaces:**
+- Consumes: `UmamiAnalyticsConfig.init(url:id:)` from Task 1.
+- Produces: `Region.init(name:OBABaseURL:coordinateRegion:contactEmail:regionIdentifier:openTripPlannerURL:sidecarBaseURL:umamiAnalytics:)` — the last two parameters are new, both defaulted to `nil` (source-compatible with the two existing call sites: `Application.swift:603` and `Fixtures.swift:74`). Also `Fixtures.customRegionWithSidecarAndUmami` for later tests.
+
+- [ ] **Step 1: Write the failing test and fixture**
+
+In `OBAKitTests/Helpers/Fixtures.swift`, directly below the `customMinneapolisRegion` class var (after line 75), add:
+
+```swift
+    class var customRegionWithSidecarAndUmami: Region {
+        let coordinateRegion = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 44.9778, longitude: -93.2650), latitudinalMeters: 1000.0, longitudinalMeters: 1000.0)
+
+        return Region(
+            name: "Custom Region",
+            OBABaseURL: URL(string: "http://www.example.com")!,
+            coordinateRegion: coordinateRegion,
+            contactEmail: "contact@example.com",
+            sidecarBaseURL: URL(string: "https://obaco.example.com")!,
+            umamiAnalytics: UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com")!, id: "site-uuid-123"))
+    }
+```
+
+Append inside `RegionsEncodingTests`:
+
+```swift
+    func testCustomRegions_creation_withSidecarAndUmami() {
+        let region = Fixtures.customRegionWithSidecarAndUmami
+        expect(region.sidecarBaseURL?.absoluteString) == "https://obaco.example.com"
+        expect(region.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(region.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func testCustomRegions_roundtripping_withSidecarAndUmami() {
+        let plistData = try! PropertyListEncoder().encode([Fixtures.customRegionWithSidecarAndUmami])
+        let rt = try! PropertyListDecoder().decode([Region].self, from: plistData)[0]
+
+        expect(rt.sidecarBaseURL?.absoluteString) == "https://obaco.example.com"
+        expect(rt.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(rt.umamiAnalytics?.id) == "site-uuid-123"
+        expect(rt.isCustom) == true
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Build-for-testing. Expected: **build FAILS** — "extra arguments at positions … in call" (the initializer has no `sidecarBaseURL`/`umamiAnalytics` parameters yet).
+
+- [ ] **Step 3: Add the initializer parameters**
+
+In `OBAKitCore/Models/Region.swift`, change the custom-region initializer. The signature (line 210) becomes:
+
+```swift
+    public required init(name: String, OBABaseURL: URL, coordinateRegion: MKCoordinateRegion, contactEmail: String, regionIdentifier: Int? = nil, openTripPlannerURL: URL? = nil, sidecarBaseURL: URL? = nil, umamiAnalytics: UmamiAnalyticsConfig? = nil) {
+```
+
+In the body, replace the hardcoded nils:
+- Line 218: `self.sidecarBaseURL = nil` → `self.sidecarBaseURL = sidecarBaseURL`
+- Line 238 (inside the "Uninitialized properties" block): `umamiAnalytics = nil` → `self.umamiAnalytics = umamiAnalytics`
+
+Also extend the doc comment above the init with:
+
+```swift
+    /// - Parameter sidecarBaseURL: Optional base URL for the Obaco sidecar server.
+    /// - Parameter umamiAnalytics: Optional Umami analytics configuration.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Build-for-testing, then run `-only-testing:OBAKitTests/RegionsEncodingTests`. Expected: PASS, including the pre-existing `testCustomRegions_roundtripping` (nil fields still round-trip).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Models/Region.swift OBAKitTests/Helpers/Fixtures.swift "OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift"
+git commit -m "Allow custom regions to carry sidecarBaseURL and umamiAnalytics"
+```
+
+---
+
+### Task 3: `URLSchemeRouter` parses `sidecar-url`, `umami-url`, `umami-id`
+
+**Files:**
+- Modify: `OBAKitCore/DeepLinks/URLSchemeRouter.swift` (`AddRegionURLData` struct at lines 27-31; `decodeAddRegion` at lines 108-122; doc comment at lines 18-26)
+- Test: `OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift`
+
+**Interfaces:**
+- Consumes: `UmamiAnalyticsConfig.init?(url:id:)` from Task 1; existing `validateAndCreateURL(from:)` (`URLSchemeRouter.swift:125`); `String.strip()`.
+- Produces: `AddRegionURLData` gains `public let sidecarURL: URL?`, `public let umamiURL: URL?`, `public let umamiID: String?`, and `public var umamiAnalytics: UmamiAnalyticsConfig? { get }`. Task 4 consumes `sidecarURL` and `umamiAnalytics` (never raw `umamiID` — a dangling ID with an invalid URL must not read as "enabled").
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `URLSchemeRouterTests` class in `OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift`:
+
+```swift
+    // MARK: - Sidecar & Umami Parameters
+
+    private func decodeAddRegion(_ queryItems: [URLQueryItem]) -> AddRegionURLData? {
+        var components = URLComponents()
+        components.scheme = "onebusaway"
+        components.host = "add-region"
+        components.queryItems = queryItems
+        guard let url = components.url, case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return nil
+        }
+        return data
+    }
+
+    func test_decodeURLType_addRegion_decodesAllNewParameters() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "sidecar-url", value: "https://obaco.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com"
+        expect(data?.umamiURL?.absoluteString) == "https://analytics.example.com"
+        expect(data?.umamiID) == "site-uuid-123"
+        expect(data?.umamiAnalytics?.url.absoluteString) == "https://analytics.example.com"
+        expect(data?.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func test_decodeURLType_addRegion_newParametersDefaultToNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com")
+        ])
+
+        expect(data?.sidecarURL).to(beNil())
+        expect(data?.umamiURL).to(beNil())
+        expect(data?.umamiID).to(beNil())
+        expect(data?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_partialUmamiPairCollapsesToNilConfig() {
+        // URL without ID.
+        let urlOnly = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com")
+        ])
+        expect(urlOnly?.umamiURL).toNot(beNil())
+        expect(urlOnly?.umamiAnalytics).to(beNil())
+
+        // ID without URL — the region still decodes; the dangling ID never becomes a config.
+        let idOnly = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+        expect(idOnly?.umamiID) == "site-uuid-123"
+        expect(idOnly?.umamiAnalytics).to(beNil())
+
+        // Invalid umami URL + valid ID — dangling ID, nil config.
+        let invalidURL = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "not a valid url"),
+            URLQueryItem(name: "umami-id", value: "site-uuid-123")
+        ])
+        expect(invalidURL?.umamiURL).to(beNil())
+        expect(invalidURL?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_blankUmamiIDBecomesNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "umami-url", value: "https://analytics.example.com"),
+            URLQueryItem(name: "umami-id", value: "   ")
+        ])
+        expect(data?.umamiID).to(beNil())
+        expect(data?.umamiAnalytics).to(beNil())
+    }
+
+    func test_decodeURLType_addRegion_invalidSidecarURLDegradesToNil() {
+        let data = decodeAddRegion([
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
+            URLQueryItem(name: "sidecar-url", value: "not a valid url")
+        ])
+        expect(data).toNot(beNil())
+        expect(data?.sidecarURL).to(beNil())
+    }
+
+    // MARK: - Raw-String Decoding (percent-encoding behavior)
+
+    // The queryItems-based tests above auto-encode values on the way out, so they
+    // can never exercise encoding bugs. These two lock in the documented contract:
+    // nested URLs MUST be percent-encoded; an unencoded `&` truncates.
+
+    func test_decodeURLType_addRegion_rawString_percentEncodedNestedURL() {
+        let url = URL(string: "onebusaway://add-region?name=Raw%20Region&oba-url=https%3A%2F%2Foba.example.com&sidecar-url=https%3A%2F%2Fobaco.example.com%2Fapi%3Fa%3D1%26b%3D2&umami-url=https%3A%2F%2Fanalytics.example.com&umami-id=site-uuid-123")!
+
+        guard case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return
+        }
+
+        expect(data?.name) == "Raw Region"
+        expect(data?.obaURL.absoluteString) == "https://oba.example.com"
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com/api?a=1&b=2"
+        expect(data?.umamiAnalytics?.id) == "site-uuid-123"
+    }
+
+    func test_decodeURLType_addRegion_rawString_unencodedAmpersandTruncates() {
+        let url = URL(string: "onebusaway://add-region?name=Raw&oba-url=https://oba.example.com&sidecar-url=https://obaco.example.com/api?a=1&b=2")!
+
+        guard case .addRegion(let data)? = router.decodeURLType(from: url) else {
+            fail("Expected addRegion URLType")
+            return
+        }
+
+        // The unencoded `&` ends the sidecar-url value; `b=2` parses as a separate
+        // (ignored) query item. This is documented behavior, not a bug.
+        expect(data?.sidecarURL?.absoluteString) == "https://obaco.example.com/api?a=1"
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Build-for-testing. Expected: **build FAILS** — `AddRegionURLData` has no member `sidecarURL` / `umamiURL` / `umamiID` / `umamiAnalytics`.
+
+- [ ] **Step 3: Implement parsing**
+
+In `OBAKitCore/DeepLinks/URLSchemeRouter.swift`, replace the `AddRegionURLData` struct (lines 18-31 including doc comment) with:
+
+```swift
+/// `AddRegionURLData` is a data structure that encapsulates the information needed to add a new region
+/// through a deep link. All URL values must be percent-encoded inside the deep link; an unencoded `&`
+/// inside a nested URL ends that value.
+///
+/// - Parameters:
+///   - name: The name of the region to be added. This is a human-readable string that identifies the region.
+///   - obaURL: The URL to the OneBusAway (OBA) server for the region. This URL is used to access transit data.
+///   - otpURL: An optional URL to the OpenTripPlanner (OTP) server, used for trip planning.
+///   - sidecarURL: An optional base URL for the Obaco sidecar server.
+///   - umamiURL: An optional Umami analytics server URL. Never read this directly to decide whether
+///               analytics is enabled — use `umamiAnalytics`.
+///   - umamiID: An optional Umami website ID. Like `umamiURL`, this can dangle (e.g. an ID with an
+///              invalid URL); use `umamiAnalytics`.
+public struct AddRegionURLData {
+    public let name: String
+    public let obaURL: URL
+    public let otpURL: URL?
+    public let sidecarURL: URL?
+    public let umamiURL: URL?
+    public let umamiID: String?
+
+    /// The both-or-nothing Umami config: non-nil only when both `umamiURL` and a
+    /// non-blank `umamiID` are present. Consumers must use this, not the raw fields.
+    public var umamiAnalytics: UmamiAnalyticsConfig? {
+        UmamiAnalyticsConfig(url: umamiURL, id: umamiID)
+    }
+}
+```
+
+Replace `decodeAddRegion` (lines 108-122) with:
+
+```swift
+    /// Decodes an `AddRegionURLData` from `add-region` URL components. `name` and a valid
+    /// `oba-url` are required; `otp-url`, `sidecar-url`, `umami-url`, and `umami-id` are
+    /// optional, and invalid optional values degrade to `nil`.
+    private func decodeAddRegion(from components: URLComponents) -> URLType? {
+        guard
+            let name = components.queryItem(named: "name")?.value,
+            let obaUrlString = components.queryItem(named: "oba-url")?.value,
+            let obaURL = validateAndCreateURL(from: obaUrlString) else {
+            return .addRegion(nil)
+        }
+
+        var umamiID: String?
+        if let rawUmamiID = components.queryItem(named: "umami-id")?.value {
+            let trimmed = rawUmamiID.strip()
+            umamiID = trimmed.isEmpty ? nil : trimmed
+        }
+
+        return .addRegion(AddRegionURLData(
+            name: name,
+            obaURL: obaURL,
+            otpURL: optionalURL(named: "otp-url", in: components),
+            sidecarURL: optionalURL(named: "sidecar-url", in: components),
+            umamiURL: optionalURL(named: "umami-url", in: components),
+            umamiID: umamiID))
+    }
+
+    /// Extracts and validates an optional URL query item; missing or invalid values become `nil`.
+    private func optionalURL(named name: String, in components: URLComponents) -> URL? {
+        guard let string = components.queryItem(named: name)?.value else {
+            return nil
+        }
+        return validateAndCreateURL(from: string)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Build-for-testing, then run `-only-testing:OBAKitTests/URLSchemeRouterTests`. Expected: all PASS, including every pre-existing test (backward compat: `test_decodeURLType_addRegion_decodesValidURLWithOTPURL` etc.).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/DeepLinks/URLSchemeRouter.swift OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
+git commit -m "Parse sidecar-url, umami-url, and umami-id in add-region deep links"
+```
+
+---
+
+### Task 4: Deep link handler passes the new values into `Region`
+
+**Files:**
+- Modify: `OBAKit/Orchestration/Application.swift:603` (the `Region` construction in the `.addRegion` case)
+- Test: existing `OBAKitTests/Application/ApplicationTests.swift` (no new tests — the rule logic was tested at the `AddRegionURLData` layer in Task 3; this task is pure plumbing)
+
+**Interfaces:**
+- Consumes: `AddRegionURLData.sidecarURL` and `.umamiAnalytics` (Task 3); `Region` init params (Task 2).
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Update the Region construction**
+
+In `OBAKit/Orchestration/Application.swift`, replace line 603:
+
+```swift
+                    // Construct Region from URL data
+                    let currentRegion = Region(name: regionData.name, OBABaseURL: regionData.obaURL, coordinateRegion: adjustedRegionCoordinate, contactEmail: "example@example.com", openTripPlannerURL: regionData.otpURL)
+```
+
+with:
+
+```swift
+                    // Construct Region from URL data. umamiAnalytics applies the
+                    // both-or-nothing rule; no rule logic lives here.
+                    let currentRegion = Region(
+                        name: regionData.name,
+                        OBABaseURL: regionData.obaURL,
+                        coordinateRegion: adjustedRegionCoordinate,
+                        contactEmail: "example@example.com",
+                        openTripPlannerURL: regionData.otpURL,
+                        sidecarBaseURL: regionData.sidecarURL,
+                        umamiAnalytics: regionData.umamiAnalytics)
+```
+
+- [ ] **Step 2: Build and run the Application tests**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -project 'OBAKit.xcodeproj' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/ApplicationTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -30
+```
+
+Expected: build succeeds, `ApplicationTests` PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add OBAKit/Orchestration/Application.swift
+git commit -m "Wire sidecar and umami deep link values into region creation"
+```
+
+---
+
+### Task 5: `RegionCustomForm` — Sidecar Server and Analytics sections
+
+**Files:**
+- Modify: `OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift`
+- Test: `OBAKitTests/Onboarding/RegionCustomFormTests.swift`
+
+**Interfaces:**
+- Consumes: `Region` init params (Task 2); `UmamiAnalyticsConfig.init?(url:id:)` (Task 1).
+- Produces: `static func normalizeURL(_ string: String) -> URL?` on `RegionCustomForm` (general URL normalization: trim, assume `https://`, strip trailing slashes, require http(s) + host). `normalizeBaseURL` becomes a wrapper that additionally strips `/api/where`.
+
+- [ ] **Step 1: Write the failing `normalizeURL` tests**
+
+Append inside `RegionCustomFormTests` in `OBAKitTests/Onboarding/RegionCustomFormTests.swift`:
+
+```swift
+    // MARK: - normalizeURL (general, no /api/where handling)
+
+    private func normalizeGeneral(_ string: String) -> String? {
+        RegionCustomForm.normalizeURL(string)?.absoluteString
+    }
+
+    func test_normalizeURL_prependsHTTPS() {
+        expect(self.normalizeGeneral("obaco.example.com")) == "https://obaco.example.com"
+    }
+
+    func test_normalizeURL_preservesExplicitScheme() {
+        expect(self.normalizeGeneral("http://example.com")) == "http://example.com"
+    }
+
+    func test_normalizeURL_stripsWhitespaceAndTrailingSlashes() {
+        expect(self.normalizeGeneral("  analytics.example.com/ \n")) == "https://analytics.example.com"
+    }
+
+    /// Unlike the Base URL field, general URLs keep an `/api/where` path verbatim.
+    func test_normalizeURL_doesNotStripAPIWhere() {
+        expect(self.normalizeGeneral("example.com/api/where")) == "https://example.com/api/where"
+    }
+
+    func test_normalizeURL_rejectsInvalidInput() {
+        expect(self.normalizeGeneral("")).to(beNil())
+        expect(self.normalizeGeneral("   ")).to(beNil())
+        expect(self.normalizeGeneral("ftp://example.com")).to(beNil())
+        expect(self.normalizeGeneral("https://")).to(beNil())
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Build-for-testing. Expected: **build FAILS** — `RegionCustomForm` has no member `normalizeURL`.
+
+- [ ] **Step 3: Implement `normalizeURL` and the form changes**
+
+In `OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift`:
+
+**(a)** Replace `normalizeBaseURL` (lines 35-67, keeping its doc comment) with the pair:
+
+```swift
+    /// Normalizes user input into a base URL: trims whitespace, assumes
+    /// `https://` when no scheme was typed, and strips a trailing `/api/where`
+    /// (the field's help text promises that part is added automatically, so
+    /// pasting a full API URL must not double it). Static and pure for
+    /// testability.
+    static func normalizeBaseURL(_ string: String) -> URL? {
+        guard let url = normalizeURL(string) else {
+            return nil
+        }
+
+        var urlString = url.absoluteString
+        if urlString.lowercased().hasSuffix("/api/where") {
+            urlString = String(urlString.dropLast("/api/where".count))
+            while urlString.hasSuffix("/") {
+                urlString = String(urlString.dropLast())
+            }
+        }
+        return URL(string: urlString)
+    }
+
+    /// General URL normalization for human-typed input: trims whitespace,
+    /// assumes `https://` when no scheme was typed, strips trailing slashes,
+    /// and requires an http(s) scheme and a host. Static and pure for
+    /// testability.
+    static func normalizeURL(_ string: String) -> URL? {
+        var urlString = string.strip()
+        guard !urlString.isEmpty else {
+            return nil
+        }
+
+        if !urlString.contains("://") {
+            urlString = "https://" + urlString
+        }
+
+        while urlString.hasSuffix("/") {
+            urlString = String(urlString.dropLast())
+        }
+
+        guard
+            let url = URL(string: urlString),
+            let scheme = url.scheme,
+            scheme == "http" || scheme == "https",
+            url.host() != nil
+        else {
+            return nil
+        }
+
+        return url
+    }
+```
+
+**(b)** Add three `@State` fields below `baseURLString` (line 26):
+
+```swift
+    @State private var sidecarURLString: String = ""
+    @State private var umamiURLString: String = ""
+    @State private var umamiIDString: String = ""
+```
+
+**(c)** Add computed normalizers below `normalizedBaseURL` (lines 30-33):
+
+```swift
+    /// The Sidecar URL field, normalized. Empty or invalid input degrades to `nil`.
+    var normalizedSidecarURL: URL? {
+        Self.normalizeURL(sidecarURLString)
+    }
+
+    /// The Umami analytics URL field, normalized. Empty or invalid input degrades to `nil`.
+    var normalizedUmamiURL: URL? {
+        Self.normalizeURL(umamiURLString)
+    }
+```
+
+**(d)** In `body`, insert two new sections between the Service Area section's closing brace (line 122) and the `if editingRegion != nil` block (line 124):
+
+```swift
+            Section {
+                TextField("onebusaway.co", text: $sidecarURLString)
+                    .textContentType(.URL)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } header: {
+                Text(OBALoc("custom_region_builder_controller.sidecar_section.header_title", value: "Sidecar Server", comment: "Title of the Sidecar Server header."))
+            } footer: {
+                Text(OBALoc("custom_region_builder_controller.sidecar_section.explanation", value: "Optional. The address of an Obaco (OneBusAway.co) sidecar server, which powers features like alarms and surveys. \"https://\" is assumed.", comment: "An explanation of the optional Obaco sidecar server URL field of a custom region."))
+            }
+
+            Section {
+                TextField("analytics.example.com", text: $umamiURLString)
+                    .textContentType(.URL)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                TextField(OBALoc("custom_region_builder_controller.analytics_section.website_id_placeholder", value: "Website ID", comment: "Placeholder for the Umami analytics website ID field."), text: $umamiIDString)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } header: {
+                Text(OBALoc("custom_region_builder_controller.analytics_section.header_title", value: "Analytics", comment: "Title of the Analytics header."))
+            } footer: {
+                Text(OBALoc("custom_region_builder_controller.analytics_section.explanation", value: "Optional. The address of an Umami analytics server and this region's website ID. Both fields are required to enable analytics; leave them blank to disable it.", comment: "An explanation of the optional Umami analytics fields of a custom region."))
+            }
+```
+
+Note the website ID field: autocapitalization and autocorrection off (it's a UUID), but **no** URL content type or keyboard.
+
+**(e)** In `setInitialValues()` (line 162), populate the new fields inside the `if let editingRegion` branch, after `serviceArea = editingRegion.serviceRect`:
+
+```swift
+            if let sidecarBaseURL = editingRegion.sidecarBaseURL {
+                sidecarURLString = displayString(for: sidecarBaseURL)
+            }
+            if let umamiAnalytics = editingRegion.umamiAnalytics {
+                umamiURLString = displayString(for: umamiAnalytics.url)
+                umamiIDString = umamiAnalytics.id
+            }
+```
+
+**(f)** In `doSave()` (line 232), replace the `Region` construction:
+
+```swift
+        let region = Region(
+            name: name,
+            OBABaseURL: baseURL,
+            coordinateRegion: MKCoordinateRegion(serviceArea),
+            contactEmail: editingRegion?.contactEmail ?? Self.placeholderContactEmail,
+            regionIdentifier: editingRegion?.regionIdentifier
+        )
+```
+
+with:
+
+```swift
+        // openTripPlannerURL isn't editable in this form, so editing must carry
+        // the existing value forward rather than silently dropping it.
+        let region = Region(
+            name: name,
+            OBABaseURL: baseURL,
+            coordinateRegion: MKCoordinateRegion(serviceArea),
+            contactEmail: editingRegion?.contactEmail ?? Self.placeholderContactEmail,
+            regionIdentifier: editingRegion?.regionIdentifier,
+            openTripPlannerURL: editingRegion?.openTripPlannerURL,
+            sidecarBaseURL: normalizedSidecarURL,
+            umamiAnalytics: UmamiAnalyticsConfig(url: normalizedUmamiURL, id: umamiIDString)
+        )
+```
+
+(`UmamiAnalyticsConfig(url:id:)` here resolves to the failable init from Task 1 — `normalizedUmamiURL` is `URL?` — so the both-or-nothing rule is applied without any form-local logic. The `openTripPlannerURL` line also fixes a pre-existing drop-on-edit bug for OTP URLs set via deep link.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Build-for-testing, then run `-only-testing:OBAKitTests/RegionCustomFormTests`. Expected: all PASS — new `normalizeURL` tests and all pre-existing `normalizeBaseURL` tests (the wrapper must preserve exact behavior, including `/API/WHERE` case-insensitivity and trailing-slash handling).
+
+- [ ] **Step 5: Run the full OBAKitTests suite**
+
+```bash
+set -o pipefail
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' | tail -30
+```
+
+Expected: PASS (this is the integration checkpoint before docs).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift OBAKitTests/Onboarding/RegionCustomFormTests.swift
+git commit -m "Add Sidecar Server and Analytics sections to the custom region form"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (Deep Linking section)
+
+**Interfaces:** none.
+
+(The spec also mentions the README, but `README.md` contains no deep-linking
+section — verified via grep — so CLAUDE.md is the only doc to update.)
+
+- [ ] **Step 1: Update the deep-linking docs**
+
+In `CLAUDE.md`, replace:
+
+````markdown
+## Deep Linking
+
+Custom region addition:
+```
+onebusaway://add-region?name=REGION_NAME&oba-url=ENCODED_SERVER_URL
+```
+````
+
+with:
+
+````markdown
+## Deep Linking
+
+Custom region addition:
+```
+onebusaway://add-region?name=REGION_NAME&oba-url=ENCODED_SERVER_URL
+    [&otp-url=ENCODED_OTP_URL]
+    [&sidecar-url=ENCODED_OBACO_URL]
+    [&umami-url=ENCODED_UMAMI_URL&umami-id=UMAMI_WEBSITE_ID]
+```
+
+All URL parameter values must be percent-encoded (an unencoded `&` inside a
+nested URL truncates it). `umami-url` and `umami-id` are both-or-nothing:
+analytics is configured only when both are present and valid.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "Document expanded add-region deep link parameters"
+```

--- a/docs/superpowers/specs/2026-07-18-add-region-url-expansion-design.md
+++ b/docs/superpowers/specs/2026-07-18-add-region-url-expansion-design.md
@@ -6,8 +6,9 @@
 ## Goal
 
 Allow the `onebusaway://add-region` deep link and the Add/Edit Custom Region UI to
-specify three additional, optional region values that the `Region` model already
-supports but that custom regions cannot currently set:
+specify additional optional region values (three query parameters mapping onto two
+`Region` model fields) that the model already supports but that custom regions
+cannot currently set:
 
 - **Obaco sidecar server URL** (`Region.sidecarBaseURL`)
 - **Umami analytics URL + website ID** (`Region.umamiAnalytics: UmamiAnalyticsConfig`)
@@ -41,12 +42,26 @@ Naming follows the Region model's internal naming (`sidecarBaseURL`,
    its existing live server validation. Invalid optional URLs degrade to `nil`,
    matching the current `otp-url` posture. The only hard failure remains a bad
    `oba-url`.
+4. **Nested URLs must be percent-encoded.** `URLComponents` percent-decodes query
+   item values and splits on unencoded `&`, so an unencoded
+   `sidecar-url=https://x.co/api?a=1&b=2` truncates at `&b`. Deep links are
+   machine-authored; document the encoding requirement rather than trying to
+   recover from unencoded input.
+5. **Deep link URLs require an explicit scheme; the form assumes `https://`.**
+   The router's `validateAndCreateURL` rejects scheme-less strings; the form's
+   normalization assumes `https://` for human-typed input. This split matches the
+   existing `oba-url`/`otp-url` behavior and is deliberate: machine-authored links
+   carry full percent-encoded URLs, humans type hostnames.
 
 ## Components
 
 ### 1. `URLSchemeRouter` (`OBAKitCore/DeepLinks/URLSchemeRouter.swift`)
 
-- `AddRegionURLData` gains `sidecarURL: URL?`, `umamiURL: URL?`, `umamiID: String?`.
+- `AddRegionURLData` gains `sidecarURL: URL?`, `umamiURL: URL?`, `umamiID: String?`,
+  plus a computed `umamiAnalytics: UmamiAnalyticsConfig?` that applies the
+  both-or-nothing rule via the shared failable init (see §2). Consumers must use
+  the computed property — `umamiID != nil` alone does not mean analytics is
+  enabled (an invalid `umami-url` can leave a dangling ID).
 - `decodeAddRegion` parses `sidecar-url`, `umami-url`, `umami-id`. URLs go through
   the existing `validateAndCreateURL`; failures yield `nil` for that field.
   `umami-id` is whitespace-trimmed; blank becomes `nil`.
@@ -57,12 +72,17 @@ Naming follows the Region model's internal naming (`sidecarBaseURL`,
   `umamiAnalytics: UmamiAnalyticsConfig? = nil` parameters, assigned instead of
   hardcoded `nil`.
 - `UmamiAnalyticsConfig` gains a public memberwise `init` (currently only the
-  synthesized internal one exists, invisible outside OBAKitCore).
+  synthesized internal one exists, invisible outside OBAKitCore) **and** a public
+  failable `init?(url: URL?, id: String?)` that returns `nil` unless `url` is
+  present and `id` (whitespace-trimmed) is non-blank. This failable init is the
+  single source of truth for the both-or-nothing rule; `AddRegionURLData` and the
+  form both call it rather than re-implementing the check.
 
 ### 3. Deep link handling (`OBAKit/Orchestration/Application.swift`)
 
-- The `.addRegion` case builds `UmamiAnalyticsConfig` only when both umami values
-  are present, and passes it plus `sidecarURL` to the `Region` initializer.
+- The `.addRegion` case passes `regionData.sidecarURL` and
+  `regionData.umamiAnalytics` (the computed property from §1) to the `Region`
+  initializer. No rule logic lives here.
 
 ### 4. `RegionCustomForm` (`OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift`)
 
@@ -72,22 +92,35 @@ Naming follows the Region model's internal naming (`sidecarBaseURL`,
   - **Analytics** — Umami URL field + website ID field. Footer: optional; both
     fields are required to enable analytics, leave blank to disable.
 - URL fields styled like Base URL (URL keyboard/content type, no
-  autocapitalization/autocorrection).
+  autocapitalization/autocorrection). The website ID field is a UUID: disable
+  autocapitalization and autocorrection, but do **not** set the URL content type
+  or keyboard.
 - URL normalization: extract a general static `normalizeURL` helper (trim, assume
   `https://`, strip trailing slashes, require http(s) + host) shared with
   `normalizeBaseURL`; the `/api/where` stripping applies only to the base URL.
-- Save applies the both-or-nothing umami rule via a small pure static helper.
-- `setInitialValues` populates the new fields when editing. This also fixes a
-  latent bug: editing a custom region today silently drops any existing
-  sidecar/umami values because the initializer nils them.
+- Save applies the both-or-nothing umami rule via
+  `UmamiAnalyticsConfig.init?(url:id:)` (§2) — no duplicate rule logic in the form.
+- `setInitialValues` populates the new fields when editing. This **must land in
+  the same change** as the new initializer parameters: once the fields become
+  settable (e.g. via deep link), an edit pass that didn't repopulate them would
+  silently drop them on save. (No such bug exists today, because nothing can set
+  these fields on a custom region yet.)
 
 ### 5. Tests (`OBAKitTests`)
 
 - `URLSchemeRouter` decode: all params present; none present (backward compat);
   partial umami pair; invalid URLs.
-- Form helpers: `normalizeURL` cases; umami both-or-nothing helper cases.
+- At least one decode test built from a **raw URL string** (not
+  `URLComponents.queryItems`, which auto-encodes and therefore can't exercise
+  encoding bugs) with a percent-encoded nested URL, plus one demonstrating that an
+  unencoded `&` truncates the nested URL — locking in the documented behavior.
+- `AddRegionURLData.umamiAnalytics` / `UmamiAnalyticsConfig.init?(url:id:)`:
+  both present → config; either missing/blank → nil (covers the partial-umami
+  collapse independent of Application).
+- Form helpers: `normalizeURL` cases.
 - `Region` Codable round-trip: custom region with sidecar + umami encodes and
-  decodes correctly.
+  decodes correctly. Add a `Fixtures` variant (alongside
+  `customMinneapolisRegion`) that sets both fields.
 
 ### 6. Docs
 

--- a/docs/superpowers/specs/2026-07-18-add-region-url-expansion-design.md
+++ b/docs/superpowers/specs/2026-07-18-add-region-url-expansion-design.md
@@ -1,0 +1,99 @@
+# Add-Region Deep Link & Custom Region Form Expansion — Design
+
+**Date:** 2026-07-18
+**Status:** Approved
+
+## Goal
+
+Allow the `onebusaway://add-region` deep link and the Add/Edit Custom Region UI to
+specify three additional, optional region values that the `Region` model already
+supports but that custom regions cannot currently set:
+
+- **Obaco sidecar server URL** (`Region.sidecarBaseURL`)
+- **Umami analytics URL + website ID** (`Region.umamiAnalytics: UmamiAnalyticsConfig`)
+
+## Deep Link Format
+
+New optional query parameters, alongside the existing `name`, `oba-url`, and `otp-url`:
+
+```
+onebusaway://add-region?name=REGION_NAME
+    &oba-url=ENCODED_OBA_URL
+    &otp-url=ENCODED_OTP_URL
+    &sidecar-url=ENCODED_OBACO_URL
+    &umami-url=ENCODED_UMAMI_URL
+    &umami-id=UMAMI_WEBSITE_ID
+```
+
+Naming follows the Region model's internal naming (`sidecarBaseURL`,
+`UmamiAnalyticsConfig`) rather than the regions.json feed keys.
+
+## Rules
+
+1. **All three new values are optional.** Their absence changes nothing about
+   existing behavior.
+2. **Umami is both-or-nothing.** A `UmamiAnalyticsConfig` is constructed only when
+   both a valid `umami-url` and a non-blank `umami-id` are present. A partial pair
+   is silently ignored (`umamiAnalytics = nil`); the region is still added/saved.
+   This applies identically to the deep link and the form.
+3. **Well-formed-only validation.** New URL fields get syntactic validation and
+   normalization only. No network reachability checks — only the OBA base URL keeps
+   its existing live server validation. Invalid optional URLs degrade to `nil`,
+   matching the current `otp-url` posture. The only hard failure remains a bad
+   `oba-url`.
+
+## Components
+
+### 1. `URLSchemeRouter` (`OBAKitCore/DeepLinks/URLSchemeRouter.swift`)
+
+- `AddRegionURLData` gains `sidecarURL: URL?`, `umamiURL: URL?`, `umamiID: String?`.
+- `decodeAddRegion` parses `sidecar-url`, `umami-url`, `umami-id`. URLs go through
+  the existing `validateAndCreateURL`; failures yield `nil` for that field.
+  `umami-id` is whitespace-trimmed; blank becomes `nil`.
+
+### 2. `Region` (`OBAKitCore/Models/Region.swift`)
+
+- The custom-region initializer gains `sidecarBaseURL: URL? = nil` and
+  `umamiAnalytics: UmamiAnalyticsConfig? = nil` parameters, assigned instead of
+  hardcoded `nil`.
+- `UmamiAnalyticsConfig` gains a public memberwise `init` (currently only the
+  synthesized internal one exists, invisible outside OBAKitCore).
+
+### 3. Deep link handling (`OBAKit/Orchestration/Application.swift`)
+
+- The `.addRegion` case builds `UmamiAnalyticsConfig` only when both umami values
+  are present, and passes it plus `sidecarURL` to the `Region` initializer.
+
+### 4. `RegionCustomForm` (`OBAKit/Onboarding/RegionPicker/RegionCustomForm.swift`)
+
+- Three new `@State` string fields in **two new sections** (Approach B):
+  - **Sidecar Server** — one URL field. Footer: optional, used for OneBusAway.co
+    features like alarms and surveys.
+  - **Analytics** — Umami URL field + website ID field. Footer: optional; both
+    fields are required to enable analytics, leave blank to disable.
+- URL fields styled like Base URL (URL keyboard/content type, no
+  autocapitalization/autocorrection).
+- URL normalization: extract a general static `normalizeURL` helper (trim, assume
+  `https://`, strip trailing slashes, require http(s) + host) shared with
+  `normalizeBaseURL`; the `/api/where` stripping applies only to the base URL.
+- Save applies the both-or-nothing umami rule via a small pure static helper.
+- `setInitialValues` populates the new fields when editing. This also fixes a
+  latent bug: editing a custom region today silently drops any existing
+  sidecar/umami values because the initializer nils them.
+
+### 5. Tests (`OBAKitTests`)
+
+- `URLSchemeRouter` decode: all params present; none present (backward compat);
+  partial umami pair; invalid URLs.
+- Form helpers: `normalizeURL` cases; umami both-or-nothing helper cases.
+- `Region` Codable round-trip: custom region with sidecar + umami encodes and
+  decodes correctly.
+
+### 6. Docs
+
+- Update the deep-linking example URL in `CLAUDE.md` and README.
+
+## Localization
+
+New form section headers/footers use `OBALoc` with new string keys, following the
+existing `custom_region_builder_controller.*` key convention.


### PR DESCRIPTION
## Summary

Expands the `onebusaway://add-region` custom URL scheme and the Add/Edit Custom Region form to optionally configure two region capabilities that previously could not be set on custom regions:

- **Obaco sidecar server URL** (`Region.sidecarBaseURL`) — powers features like alarms and surveys
- **Umami analytics** (`Region.umamiAnalytics`) — analytics server URL + website ID

### Deep link format

```
onebusaway://add-region?name=REGION_NAME&oba-url=ENCODED_OBA_URL
    [&otp-url=ENCODED_OTP_URL]
    [&sidecar-url=ENCODED_SIDECAR_URL]
    [&umami-url=ENCODED_UMAMI_URL&umami-id=UMAMI_WEBSITE_ID]
```

All URL values must be percent-encoded (an unencoded `&` inside a nested URL truncates it — locked in by raw-string decode tests). Umami is both-or-nothing: the config is built only when both `umami-url` and `umami-id` are present and valid; a partial pair is silently ignored and the region still saves. The rule lives in exactly one place — a new failable `UmamiAnalyticsConfig.init?(url:id:)` — called by the deep link path and the form alike.

### Form changes

Two new sections (Sidecar Server, Analytics) in the custom region form, with well-formedness-only validation (Save still gates only on the base URL; the base URL keeps its live server validation). URL normalization was extracted into a general `normalizeURL` helper with `normalizeBaseURL` wrapping it for the `/api/where`-stripping behavior.

### Bug fixes along the way

- Editing a custom region no longer drops values the form doesn't edit: `openTripPlannerURL` (pre-existing bug — a region added via deep link with an OTP URL lost it on any edit) and the new sidecar/umami fields are carried forward via `setInitialValues` repopulation and explicit init arguments.
- `normalizeBaseURL` now re-validates after stripping `/api/where`, so pathological input like `api/where` is rejected instead of yielding a host-less `https:` URL that enabled Save.

## Test plan

- Full OBAKitTests suite: **1336/1336 passing** on the final HEAD; SwiftLint 0 violations.
- New coverage: `UmamiAnalyticsConfig` init edge cases; `Region` Codable round-trip with sidecar+umami (plus backward-compat: old persisted regions decode with nils); URLSchemeRouter decode for all params, partial pairs, invalid URLs, and raw-string percent-encoding contracts; `normalizeURL`/`normalizeBaseURL` regression cases.

## Follow-ups (not in this PR)

- Form-level tests for `setInitialValues` repopulation and `doSave` carry-forward would require extracting the form's state into an inspectable view model; the behavior is code-reviewed but untested at the form level.
- Run `scripts/extract_strings` to get the 5 new `custom_region_builder_controller.*` keys in front of the 13 locales' translators (runtime falls back to the `OBALoc` default values meanwhile).
- Pre-existing deep-link oddity worth a tracking issue: the added region's map coordinate is derived from the *current* region's agency list (`Application.swift`), not the new server's.
- Deep links accept path-only values (e.g. `sidecar-url=/foo`) per long-standing `oba-url`/`otp-url` semantics; worth revisiting if Obaco request construction chokes on host-less URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sidecar Server configuration to the custom region form.
  * Added Umami analytics URL and website ID configuration.
  * Extended `add-region` deep links to support Sidecar and Umami parameters.
  * Updated custom region editing and saving to persist these settings.
* **Bug Fixes**
  * Improved URL normalization/validation (including stricter handling of invalid inputs and `/api/where` base URLs).
  * Umami analytics now follows an “all-or-nothing” rule; partial/invalid inputs are ignored.
* **Documentation**
  * Updated deep-link documentation with optional parameter behavior and percent-encoding guidance.
  * Refreshed Swift/toolchain guidance in the main documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->