### PR TITLE
Upgrade GRDB 6.29 → 7.11.1 (Sendable-annotated major)

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -45,11 +45,24 @@ jobs:
     # change. The previous `**/*.yml` glob also matched vendored yml under
     # .build/checkouts and caused needless cache misses (→ full rebuilds).
     - uses: actions/cache@v4
+      id: deriveddata-cache
       with:
         path: DerivedData
         key: ${{ runner.os }}-deriveddata-${{ hashFiles('**/Package.resolved', 'project.yml', 'Apps/**/project.yml', '.github/workflows/obakittests.yml') }}
         restore-keys: |
           ${{ runner.os }}-deriveddata-
+
+    # A restore-keys fallback restores DerivedData built against a different
+    # dependency graph. Freshly resolved package checkouts then carry newer
+    # mtimes than the cached explicit precompiled modules, and swift-frontend
+    # hard-errors ("file ... has been modified since the module file was
+    # built", exit 65) instead of rebuilding the stale .pcm. Purge the
+    # precompiled modules on inexact restores — they rebuild in a fraction of
+    # the build step, unlike the rest of DerivedData. (Observed 2026-07-19 on
+    # the GRDB 6→7 pin bump, matching the same local failure mode.)
+    - name: Purge stale precompiled modules on inexact cache restore
+      if: steps.deriveddata-cache.outputs.cache-hit != 'true'
+      run: rm -rf DerivedData/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules
 
     # Pin Xcode deterministically so the set of bundled simulator runtimes is
     # known, instead of relying on `xcode-select` against whatever the image ships.

--- a/Apps/KiedyBus/Package.resolved
+++ b/Apps/KiedyBus/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
-        "version" : "6.29.3"
+        "revision" : "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "version" : "7.11.1"
       }
     },
     {

--- a/Apps/OneBusAway/Package.resolved
+++ b/Apps/OneBusAway/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
-        "version" : "6.29.3"
+        "revision" : "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "version" : "7.11.1"
       }
     },
     {

--- a/Apps/OneBusAway/Package.resolved
+++ b/Apps/OneBusAway/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3543cb8092dbcf0d77c4a955a2142d1e35ec5a10206d60b9a11338218bbc5554",
+  "originHash" : "dcbf237be397b725408870be6a00caa210933cb68672ae765af39a1c7e0f2f39",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "674d9a7ee9858207181a3dd0b42c77298c6fb71b",
-        "version" : "12.8.0"
+        "revision" : "9ab4a7e6e5d6d3df2a2aa002a11d25e078c8d6e5",
+        "version" : "12.16.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SCENEE/FloatingPanel.git",
       "state" : {
-        "revision" : "a2646dd2704656fa5a679af68953249a70c77f40",
-        "version" : "3.0.1"
+        "revision" : "7efcc769e0ffe62f530e9276ab26309f758b7cc3",
+        "version" : "3.2.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
-        "version" : "3.2.0"
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "2ffd220823f3716904733162e9ae685545c276d1",
-        "version" : "12.8.0"
+        "revision" : "ce606e3768abddff0510783e1a6d2f270b943b35",
+        "version" : "12.16.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
-        "version" : "5.0.0"
+        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
+        "version" : "5.3.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "c6fe6442e6a64250495669325044052e113e990c",
-        "version" : "1.32.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tevelee/SwiftUI-Flow.git",
       "state" : {
-        "revision" : "d227f999b2894ab737ef5786d9b14d02d3e5362e",
-        "version" : "3.1.1"
+        "revision" : "798364823cdfc6afb4aff43eff5a3ddbca89b54f",
+        "version" : "3.4.0"
       }
     }
   ],

--- a/Apps/Shared/analytics_fx_config.yml
+++ b/Apps/Shared/analytics_fx_config.yml
@@ -4,7 +4,7 @@ packages:
     majorVersion: 1.0.1
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk.git
-    majorVersion: 12.4.0
+    majorVersion: 12.16.0
 
 targets:
   App:

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -118,7 +118,7 @@ packages:
         exactVersion: 3.2.2
     GRDB:
         url: https://github.com/groue/GRDB.swift.git
-        minorVersion: 6.29.0
+        minorVersion: 7.11.0
     Hyperconnectivity:
         url: https://github.com/rwbutler/Hyperconnectivity.git
         exactVersion: 1.2.0

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -6,7 +6,7 @@ name: OBAKit
 
 settings:
   base:
-    MARKETING_VERSION: 26.2.2
+    MARKETING_VERSION: 26.3.0
     # Swift 6 migration Phases 3–4 (docs/swift6-migration-plan.md): every
     # framework and app target builds in the Swift 6 language mode with
     # main-actor default isolation. Two targets override this base:

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -115,7 +115,7 @@ packages:
         exactVersion: 5.5.0
     FloatingPanel:
         url: https://github.com/SCENEE/FloatingPanel.git
-        exactVersion: 3.0.1
+        exactVersion: 3.2.2
     GRDB:
         url: https://github.com/groue/GRDB.swift.git
         minorVersion: 6.29.0
@@ -131,4 +131,4 @@ packages:
         maxVersion: 1.0.0
     SwiftProtobuf:
         url: https://github.com/apple/swift-protobuf.git
-        minorVersion: 1.32.0
+        minorVersion: 1.38.1

--- a/OBAKitCore/Persistence/StopCacheDatabase.swift
+++ b/OBAKitCore/Persistence/StopCacheDatabase.swift
@@ -12,15 +12,15 @@ import GRDB
 
 /// Manages the SQLite database used to cache transit stops for offline access and faster map rendering.
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/62
-public final class StopCacheDatabase: @unchecked Sendable {
+public final class StopCacheDatabase: Sendable {
 
     /// The underlying GRDB database queue for serialized access.
     let dbQueue: DatabaseQueue
 
-    /// Creates a persistent database at the specified directory.
+    /// Creates a persistent database at the specified path.
     /// If the database file is corrupted, it is deleted and recreated since this is a cache.
-    /// - Parameter databasePath: The directory in which to create the database file.
-    ///   Defaults to the app's Application Support directory.
+    /// - Parameter databasePath: The full path to the database file.
+    ///   Defaults to `stop_cache.sqlite` in the app's Application Support directory.
     public init(databasePath: String? = nil) throws {
         let path: String
         if let databasePath {

--- a/OBAKitCore/Persistence/StopCacheRepository.swift
+++ b/OBAKitCore/Persistence/StopCacheRepository.swift
@@ -13,7 +13,7 @@ import GRDB
 
 /// Provides read/write access to the cached stops database.
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/62
-public final class StopCacheRepository: @unchecked Sendable {
+public final class StopCacheRepository: Sendable {
 
     private let database: StopCacheDatabase
 

--- a/docs/swift6-migration-plan.md
+++ b/docs/swift6-migration-plan.md
@@ -118,12 +118,12 @@ Two rules that come straight from the review of those sources:
    concurrency groups on that target so it can't regress (all five tags are
    real diagnostic groups in `swiftlang/swift`'s `DiagnosticGroups.def`, and
    the setting passes them via `-Werror <group>`).
-3. Fix the committed `Package.resolved` staleness: `Apps/OneBusAway/Package.resolved`
-   and `Apps/KiedyBus/Package.resolved` are missing entries (GRDB among them)
-   relative to the dependencies declared in `app_shared.yml`
-   (`minorVersion: 6.29.0`, resolving to 6.29.3 locally). Run
-   `scripts/update_package_resolved` so the Phase 1 GRDB upgrade is
-   reproducible in CI.
+3. Fix the committed `Package.resolved` staleness: the GRDB entries are now
+   pinned in both `Apps/OneBusAway/Package.resolved` and
+   `Apps/KiedyBus/Package.resolved` (`minorVersion: 7.11.0` in
+   `app_shared.yml`, resolving to 7.11.1; done alongside the Phase 1 GRDB
+   upgrade, issue #1195). KiedyBus still lacks an OTPKit pin (and its
+   transitives) — run `scripts/update_package_resolved` to finish this step.
 
 Do **not** set these via `xcodebuild` command-line overrides or a global
 xcconfig — they leak into SPM package compilation (measured: `swift-http-types`
@@ -383,7 +383,7 @@ is lifted. The ratchet still counts their warnings.
 
 | Package | Pinned | Swift 6 posture |
 |---|---|---|
-| GRDB.swift | `minorVersion: 6.29.0` range (resolves to 6.29.3) | GRDB 7 is the Sendable-annotated major (requires Xcode 16+); upgrade early in Phase 1 (its `6.x` works with `@preconcurrency` but 7 removes a whole class of warnings in `StopCacheDatabase`/`StopCacheRepository`, which are already `@unchecked Sendable` workarounds). Fix the stale committed `Package.resolved` files first (Phase 0 step 3) |
+| GRDB.swift | `minorVersion: 7.11.0` range (resolves to 7.11.1) | Done (issue #1195): GRDB 7 is the Sendable-annotated major; `StopCacheDatabase`/`StopCacheRepository` now declare compiler-checked `Sendable` instead of `@unchecked Sendable` |
 | Eureka, BLTNBoard, FloatingPanel, MarqueeLabel, Hyperconnectivity | 5.x-era | Unmaintained or slow-moving; plan on `@preconcurrency import` indefinitely. BLTNBoard is archived upstream — the existing `OBAKit/BLTNBoard` wrapper layer is the eventual replacement seam |
 | SwiftProtobuf | 1.32 | Generated `gtfs-realtime.pb.swift` is already `@unchecked Sendable`-annotated; regenerate with a current plugin if warnings appear |
 | firebase-ios-sdk, OTPKit, swift-openapi-* | current | Already tools-6.x; no action |


### PR DESCRIPTION
Fixes #1195

## Summary
- Upgrades GRDB from 6.29.3 to 7.11.1 (`minorVersion: 7.11.0` in `Apps/Shared/app_shared.yml`; pins updated in **both** `Apps/OneBusAway/Package.resolved` and `Apps/KiedyBus/Package.resolved`, per the seeding gotcha in the issue).
- `StopCacheDatabase` and `StopCacheRepository` now declare compiler-checked `Sendable` instead of `@unchecked Sendable` — GRDB 7's `DatabaseQueue` is Sendable, so the conformances are verified rather than asserted.
- Checked the upstream GRDB 7 migration guide: none of the breaking changes (column coding strategies, association inflections, `ValueObservation` main-actor default, `Record` base class, C SQLite access, default transaction kind) apply to our usage. Doc updates in `docs/swift6-migration-plan.md` mark the Phase 1 GRDB step done.
- This branch also carries two earlier 26.3 release-prep commits (version bump to 26.3.0, other dependency version updates).

## Test plan
- [x] `scripts/generate_project OneBusAway` + clean build-for-testing succeeds on GRDB 7.11.1 with the compiler-checked conformances
- [x] All 19 `StopCacheRepositoryTests` pass (round-trip, upsert, bounding-box queries, purge, clear — real SQLite through GRDB 7)
- [x] Full `OBAKitTests` suite: 1336 passed, 0 failed
- [x] SwiftLint clean on touched files
- [x] Verified pinned revision `b83108d1` is the upstream `v7.11.1` tag on both app pin files

## Review notes
- Pre-existing, not addressed here: `Apps/KiedyBus/Package.resolved` is still missing an OTPKit pin (and its transitives), so CI resolution for KiedyBus remains unpinned for that package. Noted in `docs/swift6-migration-plan.md`; left for a follow-up to keep this PR scoped to GRDB.
- GRDB 7 makes *async* database accesses cancellable; our stop cache uses the synchronous `read`/`write` API, whose semantics are unchanged. Adopting the cancellable async accessors in `MapRegionManager`'s cache path is a possible future improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the app version to 26.3.0.
* **Bug Fixes**
  * Improved concurrency safety for stop cache storage and repository operations (now compiler-checked for safe cross-thread use).
* **Documentation**
  * Updated the Swift 6 migration plan with refreshed dependency pinning and concurrency guidance.
* **Maintenance**
  * Refreshed analytics and core library versions for continued compatibility.
  * Improved CI DerivedData caching to avoid stale precompiled module build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->