### PR TITLE
Work around Xcode 26.4 SIL optimizer crash when archiving

### DIFF
--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -54,6 +54,15 @@ final class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
         currentDetent = root.detentConfiguration.initialDetent
     }
 
+    // Workaround for a Swift 6.3 (Xcode 26.4) SIL optimizer crash: the
+    // EarlyPerfInliner segfaults inlining into this generic MainActor class's
+    // synthesized deinit under `-O`, so `xcodebuild archive` (Release) fails
+    // while Debug builds and Xcode 27 (Swift 6.4, bug fixed) are fine. Pinning
+    // this empty deinit to `@_optimize(none)` keeps the inliner off it. Remove
+    // once the minimum toolchain is past the fix.
+    @_optimize(none)
+    deinit {}
+
     // MARK: - Unified navigation
 
     /// Pushes a route on whichever layer it prefers.


### PR DESCRIPTION
## Problem

`xcodebuild archive` (Release) fails on **Xcode 26.4** with a Swift compiler crash — not a source error:

\`\`\`
Apple Swift version 6.3 (swiftlang-6.3.0.123.5)
While running pass "EarlyPerfInliner" on SILFunction "@\$s6OBAKit16SheetCoordinatorCfD"
  for 'deinit' (at OBAKit/Sheet/Coordinator/SheetCoordinator.swift:17:13)
crash → isCallerAndCalleeLayoutConstraintsCompatible → SILPerformanceInliner
\`\`\`

The optimizer's performance-inliner segfaults inlining into the synthesized `deinit` of the generic `@MainActor final class SheetCoordinator<Route>`.

## Why it only shows up when archiving

| Environment | Config | Optimizer | Result |
|---|---|---|---|
| CI (Xcode 26.6) | Debug `build-for-testing` | off (`-Onone`) | ✅ inliner never runs |
| Xcode 27 | Release archive | on | ✅ Swift 6.4 has the bug fixed |
| Xcode 26.4 | Release archive | on (`-O`) | ❌ inliner crashes on the deinit |

CI passes because it only runs a Debug test build, where this pass is disabled.

## Fix

Pin an empty `deinit` on `SheetCoordinator` to `@_optimize(none)` so `EarlyPerfInliner` never touches it. No behavioral change — member destruction is still synthesized normally. Verified with a full Release build succeeding.

`@_optimize(none)` is an underscored/unofficial attribute; the comment ties it to the compiler bug and notes it should be removed once the minimum toolchain is past the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a Release-build crash affecting sheet coordination in Swift 6.3.
  * Improved stability when dismissing or cleaning up sheets under optimized builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->