### PR TITLE
Register for OBACloud service-alert push notifications

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -292,14 +292,17 @@ public class Application: CoreApplication, PushServiceDelegate {
         testDeviceProvider: { [weak self] in
             // "Test users only" audience: agencies preview an alert push against flagged
             // devices before sending it to everyone. Debug builds always qualify; release
-            // builds qualify via the hidden Debug Mode setting.
+            // builds qualify via the Debug Mode switch in Settings.
             #if DEBUG
             return true
             #else
             return self?.userDataStore.debugMode ?? false
             #endif
         },
-        currentRegionIdentifierProvider: { [weak self] in self?.currentRegionIdentifier }
+        currentRegionIdentifierProvider: { [weak self] in self?.currentRegionIdentifier },
+        errorReporter: { [weak self] error in
+            self?.analytics?.reportError?(error)
+        }
     )
 
     private func configurePushNotifications(launchOptions: [AnyHashable: Any]) {
@@ -472,10 +475,11 @@ public class Application: CoreApplication, PushServiceDelegate {
 
         alertsStore.checkForUpdates()
 
-        // Re-register the push token with OBACloud so the server's 180-day prune never drops
-        // this device, and so locale changes propagate. The manager dedupes, so this only
-        // hits the network when something changed or the last POST is a day old. Skipped on
-        // the Simulator, where pushService is never configured.
+        // Re-register the push token with OBACloud so the server's inactivity prune never
+        // drops this device, and so locale changes propagate. The manager dedupes, so this
+        // only hits the network when something changed or the last POST is older than
+        // PushRegistrationManager.refreshInterval. Skipped on the Simulator and in apps
+        // without a configured push provider, where pushService is never set.
         if pushService != nil {
             Task { await pushRegistrationManager.refreshRegistration() }
         }

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -292,12 +292,17 @@ public class Application: CoreApplication, PushServiceDelegate {
         testDeviceProvider: { [weak self] in
             // "Test users only" audience: agencies preview an alert push against flagged
             // devices before sending it to everyone. Debug builds always qualify; release
-            // builds qualify via the Debug Mode switch in Settings.
+            // builds qualify via the Debug Mode switch in Settings. Either way, the device
+            // only registers as a test device once a Test Device Name is set in the Debug
+            // settings.
             #if DEBUG
             return true
             #else
             return self?.userDataStore.debugMode ?? false
             #endif
+        },
+        testDeviceDescriptionProvider: { [weak self] in
+            self?.userDefaults.string(forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
         },
         currentRegionIdentifierProvider: { [weak self] in self?.currentRegionIdentifier },
         errorReporter: { [weak self] error in

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -284,6 +284,24 @@ public class Application: CoreApplication, PushServiceDelegate {
     /// An optional property that contains this app's configured push notifications service.
     public private(set) var pushService: PushService?
 
+    /// Keeps this device's APNs token registered with the current region's OBACloud server so
+    /// agencies can send service-alert push notifications to it. See #1204.
+    public private(set) lazy var pushRegistrationManager = PushRegistrationManager(
+        obacoServiceProvider: { [weak self] in self?.obacoService },
+        userDefaults: userDefaults,
+        testDeviceProvider: { [weak self] in
+            // "Test users only" audience: agencies preview an alert push against flagged
+            // devices before sending it to everyone. Debug builds always qualify; release
+            // builds qualify via the hidden Debug Mode setting.
+            #if DEBUG
+            return true
+            #else
+            return self?.userDataStore.debugMode ?? false
+            #endif
+        },
+        currentRegionIdentifierProvider: { [weak self] in self?.currentRegionIdentifier }
+    )
+
     private func configurePushNotifications(launchOptions: [AnyHashable: Any]) {
         guard let pushServiceProvider = config.pushServiceProvider else { return }
 
@@ -315,6 +333,11 @@ public class Application: CoreApplication, PushServiceDelegate {
             }
             self.viewRouter.navigateTo(stopID: pushBody.stopID, from: topViewController)
         }
+    }
+
+    public func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
+        pushRegistrationManager.updateDeviceToken(token)
+        Task { await pushRegistrationManager.registerIfNeeded() }
     }
 
     /// Deletes the stored alarm whose deep-link identity matches `pushBody`, so the stop

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -472,6 +472,14 @@ public class Application: CoreApplication, PushServiceDelegate {
 
         alertsStore.checkForUpdates()
 
+        // Re-register the push token with OBACloud so the server's 180-day prune never drops
+        // this device, and so locale changes propagate. The manager dedupes, so this only
+        // hits the network when something changed or the last POST is a day old. Skipped on
+        // the Simulator, where pushService is never configured.
+        if pushService != nil {
+            Task { await pushRegistrationManager.refreshRegistration() }
+        }
+
         drainPendingUIPresentations()
 
         if let region = regionsService.currentRegion, let analytics {
@@ -690,6 +698,10 @@ public class Application: CoreApplication, PushServiceDelegate {
                 analytics.reportEvent(pageURL: "app://localhost/regions", label: AnalyticsLabels.manuallySelectedRegionChanged, value: region.name)
             }
         }
+
+        // By the time updatedRegion fires, willUpdateToRegion has already rebuilt
+        // obacoService for the new region, so this registers the token there.
+        Task { await pushRegistrationManager.registerIfNeeded() }
     }
 
     public func regionsService(_ service: RegionsService, displayError error: Error) {

--- a/OBAKit/PushNotifications/OBACloudPushService.swift
+++ b/OBAKit/PushNotifications/OBACloudPushService.swift
@@ -30,6 +30,9 @@ public class OBACloudPushService: NSObject, PushServiceProvider {
     /// Called when an error occurs during push registration or authorization. Set by ``PushService`` during initialization.
     public var errorHandler: PushServiceErrorHandler!
 
+    /// Called with the hex token on every successful APNs registration. Set by ``PushService`` during initialization.
+    public var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+
     /// The hex-encoded APNs device token, or `nil` if the device has not yet registered.
     private var deviceToken: String?
 
@@ -107,6 +110,8 @@ public class OBACloudPushService: NSObject, PushServiceProvider {
         self.deviceToken = token
 
         Logger.info("APNs device token: \(token)")
+
+        deviceTokenUpdatedHandler?(token)
 
         let callbacks = pendingCallbacks
         pendingCallbacks.removeAll()

--- a/OBAKit/PushNotifications/OBACloudPushService.swift
+++ b/OBAKit/PushNotifications/OBACloudPushService.swift
@@ -31,7 +31,7 @@ public class OBACloudPushService: NSObject, PushServiceProvider {
     public var errorHandler: PushServiceErrorHandler!
 
     /// Called with the hex token on every successful APNs registration. Set by ``PushService`` during initialization.
-    public var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+    public var deviceTokenUpdatedHandler: PushServiceDeviceTokenCallback?
 
     /// The hex-encoded APNs device token, or `nil` if the device has not yet registered.
     private var deviceToken: String?

--- a/OBAKit/PushNotifications/PushRegistrationManager.swift
+++ b/OBAKit/PushNotifications/PushRegistrationManager.swift
@@ -17,17 +17,18 @@ import OBAKitCore
 ///
 /// Historically the server only learned tokens as a side effect of alarm creation, which
 /// misses riders who never set an alarm, carries no locale for translated alert copy, and
-/// lets tokens age past the server's 180-day prune. This manager registers proactively:
+/// lets tokens age out of the server's inactivity prune. This manager registers proactively:
 /// `Application` calls ``refreshRegistration()`` on every foreground, feeds rotated tokens in
 /// via ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, and calls ``registerIfNeeded()``
 /// again after a region change.
 ///
 /// The last successful registration (token, region, locale, test-device flag, timestamp) is
 /// persisted to user defaults; an unchanged registration is re-POSTed only after
-/// ``refreshInterval`` elapses, which keeps traffic well under the server's rate limit while
-/// still refreshing `last_seen_at` ahead of the prune.
+/// ``refreshInterval``, keeping routine traffic to roughly one POST per day while still
+/// refreshing the server's last-seen record ahead of its inactivity prune (failed POSTs retry
+/// on the next trigger).
 @MainActor
-public final class PushRegistrationManager: NSObject {
+public final class PushRegistrationManager {
 
     public typealias AuthorizationStatusProvider = @Sendable () async -> UNAuthorizationStatus
 
@@ -62,6 +63,8 @@ public final class PushRegistrationManager: NSObject {
     private let localeProvider: () -> String
     private let dateProvider: () -> Date
     private let requestRemoteNotificationsRegistration: () -> Void
+    /// Receives non-transient registration failures for remote error reporting. Injectable; defaults to a no-op.
+    private let errorReporter: (Error) -> Void
 
     private var deviceToken: String?
 
@@ -85,6 +88,8 @@ public final class PushRegistrationManager: NSObject {
     ///   - dateProvider: Injectable for tests; defaults to `Date()`.
     ///   - requestRemoteNotificationsRegistration: Injectable for tests; defaults to
     ///     `UIApplication.shared.registerForRemoteNotifications()`.
+    ///   - errorReporter: Receives non-transient registration failures for remote error
+    ///     reporting. Injectable; defaults to a no-op.
     public init(
         obacoServiceProvider: @escaping () -> ObacoAPIService?,
         userDefaults: UserDefaults,
@@ -97,7 +102,8 @@ public final class PushRegistrationManager: NSObject {
         dateProvider: @escaping () -> Date = { Date() },
         requestRemoteNotificationsRegistration: @escaping () -> Void = {
             UIApplication.shared.registerForRemoteNotifications()
-        }
+        },
+        errorReporter: @escaping (Error) -> Void = { _ in }
     ) {
         self.obacoServiceProvider = obacoServiceProvider
         self.userDefaults = userDefaults
@@ -107,19 +113,22 @@ public final class PushRegistrationManager: NSObject {
         self.localeProvider = localeProvider
         self.dateProvider = dateProvider
         self.requestRemoteNotificationsRegistration = requestRemoteNotificationsRegistration
+        self.errorReporter = errorReporter
     }
 
     /// Stores the latest hex-encoded APNs token. Side-effect free — follow with
     /// ``registerIfNeeded()``. Called from the push provider's token callback, which fires on
     /// every `registerForRemoteNotifications()` including token rotations.
     public func updateDeviceToken(_ token: String) {
+        guard !token.isEmpty else { return }
         deviceToken = token
     }
 
     /// Asks the OS for a (possibly rotated) device token and registers whatever token is
-    /// already known. Call on every app foreground: the token callback re-enters via
-    /// ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, so a rotated token is registered
-    /// as soon as APNs delivers it. No-ops unless notification permission is granted.
+    /// already known. Call on every app foreground: callers are expected to route the
+    /// resulting token callback back through ``updateDeviceToken(_:)`` + ``registerIfNeeded()``,
+    /// so a rotated token is registered as soon as APNs delivers it. No-ops unless notification
+    /// permission is granted.
     public func refreshRegistration() async {
         guard await isAuthorized() else { return }
         requestRemoteNotificationsRegistration()
@@ -128,10 +137,10 @@ public final class PushRegistrationManager: NSObject {
 
     /// POSTs the current token to the current region's Obaco server — but only if the token,
     /// region, locale, or test-device flag changed since the last successful POST, or that
-    /// POST is older than ``refreshInterval``. No-ops without a token, an Obaco service, or
-    /// notification permission. Concurrent calls coalesce: on the first foreground after a
-    /// permission grant, the becomeActive trigger and the APNs token callback can overlap,
-    /// and only one POST should result.
+    /// POST is older than ``refreshInterval``. No-ops without a token, an Obaco service
+    /// matching the current region, or notification permission. Concurrent calls coalesce: on
+    /// the first foreground after a permission grant, the becomeActive trigger and the APNs
+    /// token callback can overlap, and only one POST should result.
     public func registerIfNeeded() async {
         guard !registrationInProgress else {
             // An in-flight pass will loop and re-read all inputs (including a token that
@@ -150,15 +159,17 @@ public final class PushRegistrationManager: NSObject {
     }
 
     private func performRegistrationIfNeeded() async {
-        guard
-            let deviceToken,
-            let obacoService = obacoServiceProvider(),
-            // Switching to a region without a sidecar leaves the previous region's service in
-            // place (CoreApplication.refreshObacoService early-returns) — never register
-            // against a region the user left.
-            obacoService.regionID == currentRegionIdentifierProvider(),
-            await isAuthorized()
-        else { return }
+        guard let deviceToken, let obacoService = obacoServiceProvider() else { return }
+
+        // Switching to a region without a sidecar leaves the previous region's service in
+        // place (CoreApplication.refreshObacoService early-returns) — never register
+        // against a region the user left.
+        guard obacoService.regionID == currentRegionIdentifierProvider() else {
+            Logger.info("Skipping push registration: service region \(obacoService.regionID) is not the current region.")
+            return
+        }
+
+        guard await isAuthorized() else { return }
 
         let candidate = Registration(
             token: deviceToken,
@@ -179,9 +190,17 @@ public final class PushRegistrationManager: NSObject {
                 locale: candidate.locale,
                 testDevice: candidate.testDevice)
             lastRegistration = candidate
+            Logger.info("Registered push token with region \(candidate.regionID) (locale \(candidate.locale), testDevice \(candidate.testDevice)).")
+        } catch is CancellationError {
+            // Backgrounding mid-POST; the next trigger retries. Not a failure worth logging.
         } catch {
-            // Leave `lastRegistration` untouched so the next trigger retries.
+            // Leave `lastRegistration` untouched so the next trigger retries. Server-side
+            // rejections are reported remotely: registrations are the server's only audience
+            // source, so a systematic failure (fleet-wide 422s) must not be invisible.
             Logger.error("Push registration failed: \(error)")
+            if case APIError.requestFailure = error {
+                errorReporter(error)
+            }
         }
     }
 
@@ -196,7 +215,14 @@ public final class PushRegistrationManager: NSObject {
 
     private var lastRegistration: Registration? {
         get {
-            try? userDefaults.decodeUserDefaultsObjects(type: Registration.self, key: Self.lastRegistrationUserDefaultsKey)
+            do {
+                return try userDefaults.decodeUserDefaultsObjects(type: Registration.self, key: Self.lastRegistrationUserDefaultsKey)
+            } catch {
+                // Schema drift degrades safely to "never registered" — the next POST is an
+                // idempotent upsert — but leave a breadcrumb for the mystery re-POST.
+                Logger.warn("Discarding undecodable push registration state: \(error)")
+                return nil
+            }
         }
         set {
             guard let newValue else {

--- a/OBAKit/PushNotifications/PushRegistrationManager.swift
+++ b/OBAKit/PushNotifications/PushRegistrationManager.swift
@@ -63,7 +63,7 @@ public final class PushRegistrationManager: NSObject {
     private let dateProvider: () -> Date
     private let requestRemoteNotificationsRegistration: () -> Void
 
-    private(set) var deviceToken: String?
+    private var deviceToken: String?
 
     /// Coalescing state: `registrationInProgress` is held for the duration of a registration
     /// pass; a caller arriving mid-flight sets `needsAnotherPass` and returns, and the holder
@@ -196,15 +196,14 @@ public final class PushRegistrationManager: NSObject {
 
     private var lastRegistration: Registration? {
         get {
-            guard let data = userDefaults.data(forKey: Self.lastRegistrationUserDefaultsKey) else { return nil }
-            return try? JSONDecoder().decode(Registration.self, from: data)
+            try? userDefaults.decodeUserDefaultsObjects(type: Registration.self, key: Self.lastRegistrationUserDefaultsKey)
         }
         set {
-            guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
+            guard let newValue else {
                 userDefaults.removeObject(forKey: Self.lastRegistrationUserDefaultsKey)
                 return
             }
-            userDefaults.set(data, forKey: Self.lastRegistrationUserDefaultsKey)
+            try? userDefaults.encodeUserDefaultsObjects(newValue, key: Self.lastRegistrationUserDefaultsKey)
         }
     }
 }

--- a/OBAKit/PushNotifications/PushRegistrationManager.swift
+++ b/OBAKit/PushNotifications/PushRegistrationManager.swift
@@ -38,6 +38,7 @@ public final class PushRegistrationManager {
         let regionID: RegionIdentifier
         let locale: String
         let testDevice: Bool
+        let description: String?
         let registeredAt: Date
 
         /// Equivalence over everything except `registeredAt` — age is checked separately.
@@ -45,7 +46,8 @@ public final class PushRegistrationManager {
             token == other.token &&
             regionID == other.regionID &&
             locale == other.locale &&
-            testDevice == other.testDevice
+            testDevice == other.testDevice &&
+            description == other.description
         }
     }
 
@@ -55,9 +57,15 @@ public final class PushRegistrationManager {
 
     nonisolated static let lastRegistrationUserDefaultsKey = "PushRegistrationManager.lastRegistration"
 
+    nonisolated static let testDeviceDescriptionDefaultsKey = "PushRegistrationManager.testDeviceDescription"
+
     private let obacoServiceProvider: () -> ObacoAPIService?
     private let userDefaults: UserDefaults
     private let testDeviceProvider: () -> Bool
+    /// Human-readable name identifying this test device to OBACloud admins. The server
+    /// requires it for `test_device=true` registrations; without one the device registers
+    /// as a regular device.
+    private let testDeviceDescriptionProvider: () -> String?
     private let currentRegionIdentifierProvider: () -> RegionIdentifier?
     private let authorizationStatusProvider: AuthorizationStatusProvider
     private let localeProvider: () -> String
@@ -79,6 +87,9 @@ public final class PushRegistrationManager {
     ///     the service is recreated whenever the region changes, so it must not be captured.
     ///   - userDefaults: Backing store for the last-registration dedupe state.
     ///   - testDeviceProvider: Whether this install should receive "Test users only" sends.
+    ///   - testDeviceDescriptionProvider: Human-readable name identifying this test device to
+    ///     OBACloud admins. The server requires it for `test_device=true` registrations;
+    ///     without one the device registers as a regular device.
     ///   - currentRegionIdentifierProvider: The user's current region. Guards against the
     ///     stale-`obacoService` case: switching to a region without a sidecar leaves the old
     ///     region's service in place, and we must never register against a region the user left.
@@ -94,6 +105,7 @@ public final class PushRegistrationManager {
         obacoServiceProvider: @escaping () -> ObacoAPIService?,
         userDefaults: UserDefaults,
         testDeviceProvider: @escaping () -> Bool,
+        testDeviceDescriptionProvider: @escaping () -> String? = { nil },
         currentRegionIdentifierProvider: @escaping () -> RegionIdentifier?,
         authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
             await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
@@ -108,6 +120,7 @@ public final class PushRegistrationManager {
         self.obacoServiceProvider = obacoServiceProvider
         self.userDefaults = userDefaults
         self.testDeviceProvider = testDeviceProvider
+        self.testDeviceDescriptionProvider = testDeviceDescriptionProvider
         self.currentRegionIdentifierProvider = currentRegionIdentifierProvider
         self.authorizationStatusProvider = authorizationStatusProvider
         self.localeProvider = localeProvider
@@ -171,11 +184,19 @@ public final class PushRegistrationManager {
 
         guard await isAuthorized() else { return }
 
+        let trimmedDescription = testDeviceDescriptionProvider()?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let description = (trimmedDescription?.isEmpty ?? true) ? nil : trimmedDescription
+        // The server rejects test_device registrations without a description, so a test
+        // device that hasn't been named yet registers as a regular device instead of
+        // POSTing a guaranteed 422.
+        let testDevice = testDeviceProvider() && description != nil
+
         let candidate = Registration(
             token: deviceToken,
             regionID: obacoService.regionID,
             locale: localeProvider(),
-            testDevice: testDeviceProvider(),
+            testDevice: testDevice,
+            description: testDevice ? description : nil,
             registeredAt: dateProvider())
 
         if let last = lastRegistration,
@@ -188,7 +209,8 @@ public final class PushRegistrationManager {
             try await obacoService.postPushRegistration(
                 token: candidate.token,
                 locale: candidate.locale,
-                testDevice: candidate.testDevice)
+                testDevice: candidate.testDevice,
+                description: candidate.description)
             lastRegistration = candidate
             Logger.info("Registered push token with region \(candidate.regionID) (locale \(candidate.locale), testDevice \(candidate.testDevice)).")
         } catch is CancellationError {

--- a/OBAKit/PushNotifications/PushRegistrationManager.swift
+++ b/OBAKit/PushNotifications/PushRegistrationManager.swift
@@ -1,0 +1,210 @@
+//
+//  PushRegistrationManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+import OBAKitCore
+
+/// Keeps this device's APNs push token registered with the current region's OBACloud server
+/// so transit agencies can send service-alert push notifications to it.
+///
+/// Historically the server only learned tokens as a side effect of alarm creation, which
+/// misses riders who never set an alarm, carries no locale for translated alert copy, and
+/// lets tokens age past the server's 180-day prune. This manager registers proactively:
+/// `Application` calls ``refreshRegistration()`` on every foreground, feeds rotated tokens in
+/// via ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, and calls ``registerIfNeeded()``
+/// again after a region change.
+///
+/// The last successful registration (token, region, locale, test-device flag, timestamp) is
+/// persisted to user defaults; an unchanged registration is re-POSTed only after
+/// ``refreshInterval`` elapses, which keeps traffic well under the server's rate limit while
+/// still refreshing `last_seen_at` ahead of the prune.
+@MainActor
+public final class PushRegistrationManager: NSObject {
+
+    public typealias AuthorizationStatusProvider = @Sendable () async -> UNAuthorizationStatus
+
+    /// The inputs that determine whether a new POST is needed, plus when the last one happened.
+    private struct Registration: Codable {
+        let token: String
+        let regionID: RegionIdentifier
+        let locale: String
+        let testDevice: Bool
+        let registeredAt: Date
+
+        /// Equivalence over everything except `registeredAt` — age is checked separately.
+        func isEquivalent(to other: Registration) -> Bool {
+            token == other.token &&
+            regionID == other.regionID &&
+            locale == other.locale &&
+            testDevice == other.testDevice
+        }
+    }
+
+    /// Re-POST an otherwise-unchanged registration this often so the server's 180-day
+    /// `last_seen_at` prune never drops this device.
+    nonisolated public static let refreshInterval: TimeInterval = 60 * 60 * 24
+
+    nonisolated static let lastRegistrationUserDefaultsKey = "PushRegistrationManager.lastRegistration"
+
+    private let obacoServiceProvider: () -> ObacoAPIService?
+    private let userDefaults: UserDefaults
+    private let testDeviceProvider: () -> Bool
+    private let currentRegionIdentifierProvider: () -> RegionIdentifier?
+    private let authorizationStatusProvider: AuthorizationStatusProvider
+    private let localeProvider: () -> String
+    private let dateProvider: () -> Date
+    private let requestRemoteNotificationsRegistration: () -> Void
+
+    private(set) var deviceToken: String?
+
+    /// Coalescing state: `registrationInProgress` is held for the duration of a registration
+    /// pass; a caller arriving mid-flight sets `needsAnotherPass` and returns, and the holder
+    /// loops once more (the dedupe check makes a redundant pass a no-op).
+    private var registrationInProgress = false
+    private var needsAnotherPass = false
+
+    /// - Parameters:
+    ///   - obacoServiceProvider: Resolves the current region's Obaco service on each call —
+    ///     the service is recreated whenever the region changes, so it must not be captured.
+    ///   - userDefaults: Backing store for the last-registration dedupe state.
+    ///   - testDeviceProvider: Whether this install should receive "Test users only" sends.
+    ///   - currentRegionIdentifierProvider: The user's current region. Guards against the
+    ///     stale-`obacoService` case: switching to a region without a sidecar leaves the old
+    ///     region's service in place, and we must never register against a region the user left.
+    ///   - authorizationStatusProvider: Injectable for tests; defaults to the real
+    ///     notification-center authorization status.
+    ///   - localeProvider: Injectable for tests; defaults to the device's BCP-47 identifier.
+    ///   - dateProvider: Injectable for tests; defaults to `Date()`.
+    ///   - requestRemoteNotificationsRegistration: Injectable for tests; defaults to
+    ///     `UIApplication.shared.registerForRemoteNotifications()`.
+    public init(
+        obacoServiceProvider: @escaping () -> ObacoAPIService?,
+        userDefaults: UserDefaults,
+        testDeviceProvider: @escaping () -> Bool,
+        currentRegionIdentifierProvider: @escaping () -> RegionIdentifier?,
+        authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        },
+        localeProvider: @escaping () -> String = { Locale.current.identifier(.bcp47) },
+        dateProvider: @escaping () -> Date = { Date() },
+        requestRemoteNotificationsRegistration: @escaping () -> Void = {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    ) {
+        self.obacoServiceProvider = obacoServiceProvider
+        self.userDefaults = userDefaults
+        self.testDeviceProvider = testDeviceProvider
+        self.currentRegionIdentifierProvider = currentRegionIdentifierProvider
+        self.authorizationStatusProvider = authorizationStatusProvider
+        self.localeProvider = localeProvider
+        self.dateProvider = dateProvider
+        self.requestRemoteNotificationsRegistration = requestRemoteNotificationsRegistration
+    }
+
+    /// Stores the latest hex-encoded APNs token. Side-effect free — follow with
+    /// ``registerIfNeeded()``. Called from the push provider's token callback, which fires on
+    /// every `registerForRemoteNotifications()` including token rotations.
+    public func updateDeviceToken(_ token: String) {
+        deviceToken = token
+    }
+
+    /// Asks the OS for a (possibly rotated) device token and registers whatever token is
+    /// already known. Call on every app foreground: the token callback re-enters via
+    /// ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, so a rotated token is registered
+    /// as soon as APNs delivers it. No-ops unless notification permission is granted.
+    public func refreshRegistration() async {
+        guard await isAuthorized() else { return }
+        requestRemoteNotificationsRegistration()
+        await registerIfNeeded()
+    }
+
+    /// POSTs the current token to the current region's Obaco server — but only if the token,
+    /// region, locale, or test-device flag changed since the last successful POST, or that
+    /// POST is older than ``refreshInterval``. No-ops without a token, an Obaco service, or
+    /// notification permission. Concurrent calls coalesce: on the first foreground after a
+    /// permission grant, the becomeActive trigger and the APNs token callback can overlap,
+    /// and only one POST should result.
+    public func registerIfNeeded() async {
+        guard !registrationInProgress else {
+            // An in-flight pass will loop and re-read all inputs (including a token that
+            // rotated underneath it) — nothing is lost by returning here.
+            needsAnotherPass = true
+            return
+        }
+
+        registrationInProgress = true
+        defer { registrationInProgress = false }
+
+        repeat {
+            needsAnotherPass = false
+            await performRegistrationIfNeeded()
+        } while needsAnotherPass
+    }
+
+    private func performRegistrationIfNeeded() async {
+        guard
+            let deviceToken,
+            let obacoService = obacoServiceProvider(),
+            // Switching to a region without a sidecar leaves the previous region's service in
+            // place (CoreApplication.refreshObacoService early-returns) — never register
+            // against a region the user left.
+            obacoService.regionID == currentRegionIdentifierProvider(),
+            await isAuthorized()
+        else { return }
+
+        let candidate = Registration(
+            token: deviceToken,
+            regionID: obacoService.regionID,
+            locale: localeProvider(),
+            testDevice: testDeviceProvider(),
+            registeredAt: dateProvider())
+
+        if let last = lastRegistration,
+           last.isEquivalent(to: candidate),
+           candidate.registeredAt.timeIntervalSince(last.registeredAt) < Self.refreshInterval {
+            return
+        }
+
+        do {
+            try await obacoService.postPushRegistration(
+                token: candidate.token,
+                locale: candidate.locale,
+                testDevice: candidate.testDevice)
+            lastRegistration = candidate
+        } catch {
+            // Leave `lastRegistration` untouched so the next trigger retries.
+            Logger.error("Push registration failed: \(error)")
+        }
+    }
+
+    /// Provisional and ephemeral authorization still deliver notifications — those riders
+    /// count as opted in. Only `.denied`/`.notDetermined` block registration.
+    private func isAuthorized() async -> Bool {
+        switch await authorizationStatusProvider() {
+        case .authorized, .provisional, .ephemeral: return true
+        default: return false
+        }
+    }
+
+    private var lastRegistration: Registration? {
+        get {
+            guard let data = userDefaults.data(forKey: Self.lastRegistrationUserDefaultsKey) else { return nil }
+            return try? JSONDecoder().decode(Registration.self, from: data)
+        }
+        set {
+            guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
+                userDefaults.removeObject(forKey: Self.lastRegistrationUserDefaultsKey)
+                return
+            }
+            userDefaults.set(data, forKey: Self.lastRegistrationUserDefaultsKey)
+        }
+    }
+}

--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -17,6 +17,8 @@ public typealias PushManagerUserID = String
 public typealias PushManagerUserIDCallback = ((PushManagerUserID) -> Void)
 public typealias PushServiceNotificationReceivedHandler = ((String, [AnyHashable: Any]?) -> Void)
 public typealias PushServiceErrorHandler = ((Error) -> Void)
+/// Carries the hex-encoded APNs device token (distinct from a provider's push user ID).
+public typealias PushServiceDeviceTokenCallback = (String) -> Void
 
 // MARK: - Errors
 
@@ -38,7 +40,7 @@ public protocol PushServiceProvider: NSObjectProtocol {
 
     /// Called with the hex-encoded APNs token every time the device (re-)registers with APNs,
     /// including token rotations. Set by ``PushService`` during initialization.
-    var deviceTokenUpdatedHandler: PushManagerUserIDCallback? { get set }
+    var deviceTokenUpdatedHandler: PushServiceDeviceTokenCallback? { get set }
 
     var pushUserID: PushManagerUserID? { get }
 }

--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -36,6 +36,10 @@ public protocol PushServiceProvider: NSObjectProtocol {
     var notificationReceivedHandler: PushServiceNotificationReceivedHandler! { get set }
     var errorHandler: PushServiceErrorHandler! { get set }
 
+    /// Called with the hex-encoded APNs token every time the device (re-)registers with APNs,
+    /// including token rotations. Set by ``PushService`` during initialization.
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback? { get set }
+
     var pushUserID: PushManagerUserID? { get }
 }
 
@@ -45,6 +49,9 @@ public protocol PushServiceDelegate: NSObjectProtocol {
     func pushServicePresentingController(_ pushService: PushService) -> UIViewController?
     func pushService(_ pushService: PushService, received arrivalDeparture: AlarmPushBody)
     func pushService(_ pushService: PushService, receivedDonationPrompt id: String?)
+
+    /// Called whenever APNs issues the device a (possibly rotated) push token.
+    func pushService(_ pushService: PushService, receivedDeviceToken token: String)
 }
 
 // MARK: - PushService
@@ -63,6 +70,10 @@ public class PushService: NSObject {
 
         self.serviceProvider.notificationReceivedHandler = notificationReceivedHandler(message:additionalData:)
         self.serviceProvider.errorHandler = errorHandler(error:)
+        self.serviceProvider.deviceTokenUpdatedHandler = { [weak self] token in
+            guard let self else { return }
+            self.delegate?.pushService(self, receivedDeviceToken: token)
+        }
     }
 
     // MARK: - PushServiceProvider Callbacks

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -353,6 +353,7 @@ class SettingsViewController: FormViewController {
     private let debugModeEnabled = "debugModeEnabled"
     private let crashAppKey = "crashAppKey"
     private let pushIDKey = "pushIDKey"
+    private let testDeviceDescriptionKey = "testDeviceDescriptionKey"
 
     private lazy var debugSection: Section = makeDebugSection()
 
@@ -418,6 +419,19 @@ class SettingsViewController: FormViewController {
             }
             $0.cellUpdate { cell, _ in
                 cell.titleLabel?.textColor = .label
+            }
+        }
+
+        section <<< TextRow {
+            $0.tag = testDeviceDescriptionKey
+            $0.title = OBALoc("settings_controller.debug_section.test_device_description", value: "Test Device Name", comment: "Settings > Debug section > Name identifying this device for test push notifications")
+            $0.placeholder = OBALoc("settings_controller.debug_section.test_device_description.placeholder", value: "e.g. Aaron's iPhone", comment: "Placeholder example for the test device name field")
+            $0.value = application.userDefaults.string(forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
+            $0.hidden = Condition.function([debugModeEnabled], { form in
+                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
+            })
+            $0.onChange { [weak self] row in
+                self?.application.userDefaults.set(row.value, forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
             }
         }
 

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -174,17 +174,25 @@ public actor ObacoAPIService: @preconcurrency APIService {
     ///     pick the alert translation. Sent as-reported; the server does its own mapping.
     ///   - testDevice: Whether this device should receive "Test users only" sends. The server
     ///     resets an omitted value to `false` on every upsert, so it is always sent explicitly.
-    public nonisolated func postPushRegistration(token: String, locale: String, testDevice: Bool) async throws {
+    ///   - description: Free text identifying a test device to OBACloud admins (e.g. `"Aaron's
+    ///     iPhone 17"`). The server requires a non-blank value (≤255 chars) whenever
+    ///     `testDevice` is `true`, and rejects the registration with a `422` if it's missing.
+    ///     Sent only when non-nil and non-empty.
+    public nonisolated func postPushRegistration(token: String, locale: String, testDevice: Bool, description: String?) async throws {
         let url = await buildURL(path: String(format: "/api/v2/regions/%d/push_registrations", regionID))
         let urlRequest = NSMutableURLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
         urlRequest.httpMethod = "POST"
 
-        let params: [String: Any] = [
+        var params: [String: Any] = [
             "token": token,
             "operating_system": "ios",
             "locale": locale,
             "test_device": testDevice ? "true" : "false"
         ]
+
+        if let description, !description.isEmpty {
+            params["description"] = description
+        }
 
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -36,6 +36,8 @@ public actor ObacoAPIService: @preconcurrency APIService {
     }
 
     public init(regionID: RegionIdentifier, delegate: ObacoServiceDelegate?, configuration: APIServiceConfiguration, dataLoader: URLDataLoader) {
+        assert(configuration.regionIdentifier == nil || configuration.regionIdentifier == regionID,
+               "ObacoAPIService regionID must match its configuration's regionIdentifier")
         self.regionID = regionID
         self.delegate = delegate
         self.configuration = configuration
@@ -191,11 +193,11 @@ public actor ObacoAPIService: @preconcurrency APIService {
 
     /// Removes this device's push registration from the OBACloud server.
     ///
-    /// The token travels as a query item; the server is a Rails app whose `params` merge query
-    /// and body, and its own request spec exercises DELETE this way.
+    /// The token travels as a query item, matching the server's contract.
     ///
-    /// Answers `204` on success and `404` if the token was never registered — the latter throws
-    /// `APIError.requestNotFound`, which callers may safely ignore.
+    /// Answers `204` on success and `404` if the token was never registered — the latter
+    /// throws `APIError.requestNotFound`. Callers treating "never registered" as success
+    /// should catch that case specifically rather than discarding all errors.
     @discardableResult
     public nonisolated func deletePushRegistration(token: String) async throws -> (Data, URLResponse) {
         let url = await buildURL(

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -24,7 +24,7 @@ public actor ObacoAPIService: @preconcurrency APIService {
 
     public let logger = os.Logger(subsystem: "org.onebusaway.iphone", category: "ObacoAPIService")
 
-    private let regionID: RegionIdentifier
+    public nonisolated let regionID: RegionIdentifier
     private weak var delegate: ObacoServiceDelegate?
 
     private func shouldDisplayRegionTestAlerts() async -> Bool {
@@ -155,6 +155,54 @@ public actor ObacoAPIService: @preconcurrency APIService {
         let request = NSMutableURLRequest(url: url)
         request.httpMethod = "DELETE"
 
+        return try await data(for: request as URLRequest)
+    }
+
+    // MARK: - Push Registrations
+
+    /// Registers — or refreshes — this device's APNs push token with the OBACloud server so the
+    /// region's transit agencies can send service-alert push notifications to it.
+    ///
+    /// The server upserts on `(region, token)`, so create and update are the same call. A
+    /// successful response is a bare `204 No Content`.
+    ///
+    /// - Parameters:
+    ///   - token: The hex-encoded APNs device token.
+    ///   - locale: The device's BCP-47 locale identifier (e.g. `"es-MX"`), used by the server to
+    ///     pick the alert translation. Sent as-reported; the server does its own mapping.
+    ///   - testDevice: Whether this device should receive "Test users only" sends. The server
+    ///     resets an omitted value to `false` on every upsert, so it is always sent explicitly.
+    public nonisolated func postPushRegistration(token: String, locale: String, testDevice: Bool) async throws {
+        let url = await buildURL(path: String(format: "/api/v2/regions/%d/push_registrations", regionID))
+        let urlRequest = NSMutableURLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
+        urlRequest.httpMethod = "POST"
+
+        let params: [String: Any] = [
+            "token": token,
+            "operating_system": "ios",
+            "locale": locale,
+            "test_device": testDevice ? "true" : "false"
+        ]
+
+        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
+
+        _ = try await data(for: urlRequest as URLRequest)
+    }
+
+    /// Removes this device's push registration from the OBACloud server.
+    ///
+    /// The token travels as a query item; the server is a Rails app whose `params` merge query
+    /// and body, and its own request spec exercises DELETE this way.
+    ///
+    /// Answers `204` on success and `404` if the token was never registered — the latter throws
+    /// `APIError.requestNotFound`, which callers may safely ignore.
+    @discardableResult
+    public nonisolated func deletePushRegistration(token: String) async throws -> (Data, URLResponse) {
+        let url = await buildURL(
+            path: String(format: "/api/v2/regions/%d/push_registrations", regionID),
+            queryItems: [URLQueryItem(name: "token", value: token)])
+        let request = NSMutableURLRequest(url: url)
+        request.httpMethod = "DELETE"
         return try await data(for: request as URLRequest)
     }
 

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -725,7 +725,7 @@ class MockPushServiceProvider: NSObject, PushServiceProvider {
     var notificationReceivedHandler: PushServiceNotificationReceivedHandler!
     var errorHandler: PushServiceErrorHandler!
     var pushUserID: PushManagerUserID?
-    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+    var deviceTokenUpdatedHandler: PushServiceDeviceTokenCallback?
 
     func start(launchOptions: [AnyHashable: Any]) {
         // Mock implementation

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -725,6 +725,7 @@ class MockPushServiceProvider: NSObject, PushServiceProvider {
     var notificationReceivedHandler: PushServiceNotificationReceivedHandler!
     var errorHandler: PushServiceErrorHandler!
     var pushUserID: PushManagerUserID?
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
 
     func start(launchOptions: [AnyHashable: Any]) {
         // Mock implementation

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -1,0 +1,124 @@
+//
+//  PushRegistrationModelOperationTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_cast
+
+/// Tests for the OBACloud `push_registrations` API (issue #1204): registering the
+/// device's APNs token so agencies can push service alerts to opted-in riders.
+class PushRegistrationModelOperationTests: OBATestCase {
+
+    /// Captures the body of the request the service actually put on the wire. Single
+    /// request per test, written before the mock returns and read after the `await`
+    /// resumes, so there's no concurrent access in practice.
+    private final class RequestCapture: @unchecked Sendable {
+        nonisolated(unsafe) var body: String?
+        nonisolated(unsafe) var url: URL?
+    }
+
+    private func mockRegistrationPOST(statusCode: Int = 204) -> RequestCapture {
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            guard request.httpMethod == "POST", request.url?.path.hasSuffix("/push_registrations") ?? false else {
+                return false
+            }
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            capture.url = request.url
+            return true
+        }
+        return capture
+    }
+
+    func testSuccessfulRegistration_sendsAllContractParams() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "es-MX", testDevice: false)
+
+        let body = try XCTUnwrap(capture.body, "Expected postPushRegistration to send a form-encoded body")
+        XCTAssertTrue(body.contains("token=01abff007f"), "Body: \(body)")
+        XCTAssertTrue(body.contains("operating_system=ios"), "Body: \(body)")
+        XCTAssertTrue(body.contains("locale=es-MX"), "Body: \(body)")
+        // The server upserts on every call and an omitted test_device resets the stored
+        // value to false — the param's *presence* on every request is contract, not just
+        // its value.
+        XCTAssertTrue(body.contains("test_device=false"), "Body: \(body)")
+    }
+
+    func testRegistration_flagsTestDevices() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true)
+
+        let body = try XCTUnwrap(capture.body)
+        XCTAssertTrue(body.contains("test_device=true"), "Body: \(body)")
+    }
+
+    func testRegistration_targetsRegionScopedURL() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false)
+
+        let url = try XCTUnwrap(capture.url)
+        XCTAssertTrue(
+            url.absoluteString.starts(with: "https://alerts.example.com/api/v2/regions/1/push_registrations"),
+            "URL: \(url.absoluteString)")
+    }
+
+    /// The server answers validation failures with a 422 — that must surface as an error.
+    func testRegistrationValidationFailureThrows() async throws {
+        _ = mockRegistrationPOST(statusCode: 422)
+
+        do {
+            try await obacoService.postPushRegistration(token: "", locale: "en-US", testDevice: false)
+            XCTFail("Expected postPushRegistration to throw APIError.requestFailure")
+        } catch let error as APIError {
+            guard case .requestFailure = error else {
+                XCTFail("Expected APIError.requestFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testSuccessfulUnregistration() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 204) { request in
+            request.httpMethod == "DELETE" &&
+            (request.url?.path.hasSuffix("/push_registrations") ?? false) &&
+            (request.url?.query?.contains("token=01abff007f") ?? false)
+        }
+
+        let (_, response) = try await obacoService.deletePushRegistration(token: "01abff007f")
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 204)
+    }
+
+    /// A 404 means the token was never registered — safe for callers to ignore, but the
+    /// service layer still surfaces it faithfully.
+    func testUnregistrationWith404Throws() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 404) { request in
+            request.httpMethod == "DELETE" &&
+            (request.url?.path.hasSuffix("/push_registrations") ?? false)
+        }
+
+        do {
+            _ = try await obacoService.deletePushRegistration(token: "01abff007f")
+            XCTFail("Expected deletePushRegistration to throw APIError.requestNotFound")
+        } catch let error as APIError {
+            guard case .requestNotFound = error else {
+                XCTFail("Expected APIError.requestNotFound, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -42,7 +42,7 @@ class PushRegistrationModelOperationTests: OBATestCase {
     func testSuccessfulRegistration_sendsAllContractParams() async throws {
         let capture = mockRegistrationPOST()
 
-        try await obacoService.postPushRegistration(token: "01abff007f", locale: "es-MX", testDevice: false)
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "es-MX", testDevice: false, description: nil)
 
         let body = try XCTUnwrap(capture.body, "Expected postPushRegistration to send a form-encoded body")
         XCTAssertTrue(body.contains("token=01abff007f"), "Body: \(body)")
@@ -57,16 +57,31 @@ class PushRegistrationModelOperationTests: OBATestCase {
     func testRegistration_flagsTestDevices() async throws {
         let capture = mockRegistrationPOST()
 
-        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true)
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true, description: "Aarons iPhone")
 
         let body = try XCTUnwrap(capture.body)
         XCTAssertTrue(body.contains("test_device=true"), "Body: \(body)")
+        // NetworkHelpers.dictionary(toHTTPBodyData:) percent-encodes the space as %20 —
+        // CharacterSet.urlQueryAllowed doesn't include space.
+        XCTAssertTrue(body.contains("description=Aarons%20iPhone"), "Body: \(body)")
+    }
+
+    /// A blank/omitted description must never reach the wire — the server treats an empty
+    /// `description` param the same as a missing one, and `test_device=false` doesn't
+    /// require one at all.
+    func testRegistration_omitsBlankDescription() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false, description: nil)
+
+        let body = try XCTUnwrap(capture.body)
+        XCTAssertFalse(body.contains("description="), "Body: \(body)")
     }
 
     func testRegistration_targetsRegionScopedURL() async throws {
         let capture = mockRegistrationPOST()
 
-        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false)
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false, description: nil)
 
         let url = try XCTUnwrap(capture.url)
         XCTAssertTrue(
@@ -79,7 +94,7 @@ class PushRegistrationModelOperationTests: OBATestCase {
         _ = mockRegistrationPOST(statusCode: 422)
 
         do {
-            try await obacoService.postPushRegistration(token: "", locale: "en-US", testDevice: false)
+            try await obacoService.postPushRegistration(token: "", locale: "en-US", testDevice: false, description: nil)
             XCTFail("Expected postPushRegistration to throw APIError.requestFailure")
         } catch let error as APIError {
             guard case .requestFailure = error else {

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -89,13 +89,19 @@ class PushRegistrationModelOperationTests: OBATestCase {
         }
     }
 
-    func testSuccessfulUnregistration() async throws {
+    /// Mocks the `DELETE /push_registrations` response for the token used by the
+    /// unregistration tests.
+    private func mockUnregistrationDELETE(statusCode: Int) {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
-        dataLoader.mock(data: Data(), statusCode: 204) { request in
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
             request.httpMethod == "DELETE" &&
             (request.url?.path.hasSuffix("/push_registrations") ?? false) &&
             (request.url?.query?.contains("token=01abff007f") ?? false)
         }
+    }
+
+    func testSuccessfulUnregistration() async throws {
+        mockUnregistrationDELETE(statusCode: 204)
 
         let (_, response) = try await obacoService.deletePushRegistration(token: "01abff007f")
         let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
@@ -105,11 +111,7 @@ class PushRegistrationModelOperationTests: OBATestCase {
     /// A 404 means the token was never registered — safe for callers to ignore, but the
     /// service layer still surfaces it faithfully.
     func testUnregistrationWith404Throws() async throws {
-        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
-        dataLoader.mock(data: Data(), statusCode: 404) { request in
-            request.httpMethod == "DELETE" &&
-            (request.url?.path.hasSuffix("/push_registrations") ?? false)
-        }
+        mockUnregistrationDELETE(statusCode: 404)
 
         do {
             _ = try await obacoService.deletePushRegistration(token: "01abff007f")

--- a/OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift
@@ -96,4 +96,17 @@ class OBACloudPushServiceTests: OBATestCase {
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0x11]))
         XCTAssertTrue(receivedTokens.isEmpty)
     }
+
+    // MARK: - Token Update Handler
+
+    func test_didRegister_invokesDeviceTokenUpdatedHandlerOnEveryRegistration() {
+        var receivedTokens: [String] = []
+        service.deviceTokenUpdatedHandler = { receivedTokens.append($0) }
+
+        service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xBE, 0xEF]))
+        // Token rotation (restore/reinstall) re-fires the handler with the new token.
+        service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xCA, 0xFE]))
+
+        XCTAssertEqual(receivedTokens, ["beef", "cafe"])
+    }
 }

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -31,6 +31,7 @@ class PushRegistrationManagerTests: OBATestCase {
         /// lets the coalescing test hold a registration mid-flight deterministically.
         var holdNextAuthCheck = false
         var authGate: CheckedContinuation<Void, Never>?
+        var reportedErrors: [Error] = []
     }
 
     private var controls: Controls!
@@ -72,7 +73,8 @@ class PushRegistrationManagerTests: OBATestCase {
             },
             localeProvider: { controls.locale },
             dateProvider: { controls.now },
-            requestRemoteNotificationsRegistration: { controls.remoteRegistrationRequests += 1 }
+            requestRemoteNotificationsRegistration: { controls.remoteRegistrationRequests += 1 },
+            errorReporter: { controls.reportedErrors.append($0) }
         )
     }
 
@@ -198,7 +200,7 @@ class PushRegistrationManagerTests: OBATestCase {
         XCTAssertTrue(dataLoader.recordedRequestURLs.contains { $0.path.hasSuffix("/regions/2/push_registrations") })
     }
 
-    /// The server prunes tokens not seen for 180 days; an unchanged registration is
+    /// The server prunes tokens it hasn't seen recently; an unchanged registration is
     /// therefore re-POSTed once its age exceeds the refresh interval.
     func test_registerIfNeeded_repostsWhenStale() async {
         mockRegistrationResponse()
@@ -280,5 +282,76 @@ class PushRegistrationManagerTests: OBATestCase {
         await manager.refreshRegistration()
         XCTAssertEqual(controls.remoteRegistrationRequests, 0)
         XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    /// The foreground refresh must POST the already-known token itself — APNs is not
+    /// guaranteed to re-deliver a token callback, so this is what keeps `last_seen_at` fresh.
+    func test_refreshRegistration_postsAlreadyKnownToken() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.refreshRegistration()
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    /// A token that rotates while a registration is in flight must be registered by the
+    /// coalescing loop's follow-up pass — and recorded, so it isn't re-POSTed again.
+    func test_registerIfNeeded_registersRotatedTokenArrivingMidFlight() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        controls.holdNextAuthCheck = true
+        let first = Task { await manager.registerIfNeeded() }
+        while controls.authGate == nil { await Task.yield() }
+
+        manager.updateDeviceToken("cafed00d")
+        await manager.registerIfNeeded()
+
+        controls.authGate?.resume()
+        controls.authGate = nil
+        _ = await first.value
+
+        XCTAssertEqual(registrationRequestCount, 2, "Expected the follow-up pass to register the rotated token")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 2, "Expected the rotated token to be recorded as registered")
+    }
+
+    /// Corrupted persisted state must degrade to "never registered", not crash or skip.
+    func test_registerIfNeeded_recoversFromCorruptedPersistedState() async {
+        defaults.set("not a plist blob", forKey: PushRegistrationManager.lastRegistrationUserDefaultsKey)
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    func test_updateDeviceToken_ignoresEmptyToken() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("")
+
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    /// Server rejections reach the injected error reporter (Crashlytics in production);
+    /// registrations are the server's only audience source, so fleet-wide failures must
+    /// be observable somewhere.
+    func test_registerIfNeeded_reportsServerRejectionsToErrorReporter() async {
+        mockRegistrationResponse(statusCode: 422)
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(controls.reportedErrors.count, 1)
     }
 }

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -1,0 +1,284 @@
+//
+//  PushRegistrationManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import UserNotifications
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Tests for `PushRegistrationManager` (issue #1204): keeping the device's APNs token
+/// registered with the current region's OBACloud server — deduplicated, daily-refreshed,
+/// and gated on notification authorization.
+@MainActor
+class PushRegistrationManagerTests: OBATestCase {
+
+    /// Mutable state shared with the manager's injected closures. `@unchecked Sendable`
+    /// because tests mutate it only between awaited calls.
+    private final class Controls: @unchecked Sendable {
+        var authorizationStatus: UNAuthorizationStatus = .authorized
+        var locale = "en-US"
+        var testDevice = false
+        var currentRegionID: Int? = 1
+        var now = Date(timeIntervalSince1970: 1_752_800_000)
+        var remoteRegistrationRequests = 0
+        /// When true, the next auth-status check parks on `authGate` until the test resumes it —
+        /// lets the coalescing test hold a registration mid-flight deterministically.
+        var holdNextAuthCheck = false
+        var authGate: CheckedContinuation<Void, Never>?
+    }
+
+    private var controls: Controls!
+    private var dataLoader: MockDataLoader!
+    private var currentService: ObacoAPIService?
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        controls = Controls()
+        dataLoader = MockDataLoader(testName: name)
+        currentService = buildObacoService(dataLoader: dataLoader)
+        defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    /// Mocks the `POST /push_registrations` response. Installed per-test rather than in
+    /// `setUp` because `MockDataLoader` matching is first-added-wins and the
+    /// failure-handling test needs a non-204 answer.
+    private func mockRegistrationResponse(statusCode: Int = 204) {
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            request.httpMethod == "POST" && (request.url?.path.hasSuffix("/push_registrations") ?? false)
+        }
+    }
+
+    private func makeManager() -> PushRegistrationManager {
+        let controls = self.controls!
+        return PushRegistrationManager(
+            obacoServiceProvider: { [weak self] in self?.currentService },
+            userDefaults: defaults,
+            testDeviceProvider: { controls.testDevice },
+            currentRegionIdentifierProvider: { controls.currentRegionID },
+            authorizationStatusProvider: {
+                if controls.holdNextAuthCheck {
+                    controls.holdNextAuthCheck = false
+                    await withCheckedContinuation { controls.authGate = $0 }
+                }
+                return controls.authorizationStatus
+            },
+            localeProvider: { controls.locale },
+            dateProvider: { controls.now },
+            requestRemoteNotificationsRegistration: { controls.remoteRegistrationRequests += 1 }
+        )
+    }
+
+    private var registrationRequestCount: Int {
+        dataLoader.recordedRequestURLs.filter { $0.path.hasSuffix("/push_registrations") }.count
+    }
+
+    // MARK: - Registration
+
+    func test_registerIfNeeded_postsTokenOnce() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+
+        // Nothing changed: an immediate second call must not hit the network again.
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    func test_registerIfNeeded_withoutToken_doesNothing() async {
+        let manager = makeManager()
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    func test_registerIfNeeded_withoutAuthorization_doesNothing() async {
+        controls.authorizationStatus = .denied
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    /// Provisionally-authorized users receive quiet notifications — they count as opted in.
+    func test_registerIfNeeded_registersWithProvisionalAuthorization() async {
+        controls.authorizationStatus = .provisional
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    /// `CoreApplication.refreshObacoService()` leaves the previous region's service in place
+    /// when the user switches to a region without a sidecar — never register against a region
+    /// the user has left.
+    func test_registerIfNeeded_skipsWhenObacoServiceRegionIsStale() async {
+        controls.currentRegionID = 99
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    func test_registerIfNeeded_withoutObacoService_doesNothing() async {
+        currentService = nil
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    // MARK: - Re-registration triggers
+
+    func test_registerIfNeeded_repostsWhenTokenRotates() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        manager.updateDeviceToken("cafed00d")
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenLocaleChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.locale = "es-MX"
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenTestDeviceFlagChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.testDevice = true
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenRegionChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+
+        // Same host, different region — mirrors CoreApplication rebuilding obacoService
+        // after a region switch.
+        let config = APIServiceConfiguration(baseURL: obacoURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: 2)
+        currentService = ObacoAPIService(regionID: 2, delegate: nil, configuration: config, dataLoader: dataLoader)
+        controls.currentRegionID = 2
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 2)
+        XCTAssertTrue(dataLoader.recordedRequestURLs.contains { $0.path.hasSuffix("/regions/2/push_registrations") })
+    }
+
+    /// The server prunes tokens not seen for 180 days; an unchanged registration is
+    /// therefore re-POSTed once its age exceeds the refresh interval.
+    func test_registerIfNeeded_repostsWhenStale() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.now = controls.now.addingTimeInterval(PushRegistrationManager.refreshInterval + 60)
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    /// Dedupe state persists across manager instances (i.e., app launches).
+    func test_registerIfNeeded_dedupeSurvivesRelaunch() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        let relaunched = makeManager()
+        relaunched.updateDeviceToken("01abff007f")
+        await relaunched.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    // MARK: - Failure handling
+
+    /// A failed POST must not be recorded as a successful registration — the next call retries.
+    func test_registerIfNeeded_doesNotPersistOnServerError() async {
+        mockRegistrationResponse(statusCode: 422)
+
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2, "Expected a retry because the first POST failed")
+    }
+
+    // MARK: - Coalescing
+
+    /// On the first foreground after a permission grant, the becomeActive trigger and the
+    /// APNs token callback can both call `registerIfNeeded()` before either finishes — the
+    /// second caller must coalesce into the first instead of double-POSTing.
+    func test_registerIfNeeded_coalescesConcurrentCalls() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        // Hold the first registration at its auth check, mid-flight.
+        controls.holdNextAuthCheck = true
+        let first = Task { await manager.registerIfNeeded() }
+        while controls.authGate == nil { await Task.yield() }
+
+        // A second trigger arrives while the first is parked: it must return immediately
+        // after handing its work to the in-flight pass.
+        await manager.registerIfNeeded()
+
+        controls.authGate?.resume()
+        controls.authGate = nil
+        _ = await first.value
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    // MARK: - refreshRegistration
+
+    func test_refreshRegistration_requestsAPNsRegistrationWhenAuthorized() async {
+        let manager = makeManager()
+        await manager.refreshRegistration()
+        XCTAssertEqual(controls.remoteRegistrationRequests, 1)
+    }
+
+    func test_refreshRegistration_skipsAPNsRegistrationWhenDenied() async {
+        controls.authorizationStatus = .denied
+        let manager = makeManager()
+        await manager.refreshRegistration()
+        XCTAssertEqual(controls.remoteRegistrationRequests, 0)
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+}

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -24,6 +24,7 @@ class PushRegistrationManagerTests: OBATestCase {
         var authorizationStatus: UNAuthorizationStatus = .authorized
         var locale = "en-US"
         var testDevice = false
+        var testDeviceDescription: String?
         var currentRegionID: Int? = 1
         var now = Date(timeIntervalSince1970: 1_752_800_000)
         var remoteRegistrationRequests = 0
@@ -57,12 +58,34 @@ class PushRegistrationManagerTests: OBATestCase {
         }
     }
 
+    /// Captures the body of the request the service actually put on the wire, so the
+    /// downgrade/description tests can inspect what was (or wasn't) sent, not just how many
+    /// times it was sent.
+    private final class RequestCapture: @unchecked Sendable {
+        nonisolated(unsafe) var bodies: [String] = []
+    }
+
+    private func mockRegistrationResponseCapturingBody(statusCode: Int = 204) -> RequestCapture {
+        let capture = RequestCapture()
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            guard request.httpMethod == "POST", request.url?.path.hasSuffix("/push_registrations") ?? false else {
+                return false
+            }
+            if let body = request.httpBody.flatMap({ String(data: $0, encoding: .utf8) }) {
+                capture.bodies.append(body)
+            }
+            return true
+        }
+        return capture
+    }
+
     private func makeManager() -> PushRegistrationManager {
         let controls = self.controls!
         return PushRegistrationManager(
             obacoServiceProvider: { [weak self] in self?.currentService },
             userDefaults: defaults,
             testDeviceProvider: { controls.testDevice },
+            testDeviceDescriptionProvider: { controls.testDeviceDescription },
             currentRegionIdentifierProvider: { controls.currentRegionID },
             authorizationStatusProvider: {
                 if controls.holdNextAuthCheck {
@@ -176,7 +199,47 @@ class PushRegistrationManagerTests: OBATestCase {
         manager.updateDeviceToken("01abff007f")
         await manager.registerIfNeeded()
 
+        // Setting `testDevice` alone doesn't change the wire value — without a description
+        // the candidate downgrades to a regular device, same as before. Naming the device is
+        // what actually flips `test_device` on the wire.
         controls.testDevice = true
+        controls.testDeviceDescription = "Aarons iPhone"
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    /// The server rejects `test_device=true` without a `description` — a test device that
+    /// hasn't been named yet must register as a regular device rather than POST a
+    /// guaranteed 422.
+    func test_registerIfNeeded_downgradesTestDeviceWithoutDescription() async {
+        let capture = mockRegistrationResponseCapturingBody()
+        controls.testDevice = true
+        controls.testDeviceDescription = nil
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 1)
+        let body = try? XCTUnwrap(capture.bodies.first)
+        XCTAssertEqual(capture.bodies.count, 1)
+        XCTAssertTrue(body?.contains("test_device=false") ?? false, "Body: \(String(describing: body))")
+        XCTAssertFalse(body?.contains("description=") ?? true, "Body: \(String(describing: body))")
+    }
+
+    /// A changed description is a real change to the wire payload (it identifies the device
+    /// to admins), so it must trigger a re-POST even though token/region/locale/testDevice
+    /// are unchanged.
+    func test_registerIfNeeded_repostsWhenDescriptionChanges() async {
+        mockRegistrationResponse()
+        controls.testDevice = true
+        controls.testDeviceDescription = "A"
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.testDeviceDescription = "B"
         await manager.registerIfNeeded()
 
         XCTAssertEqual(registrationRequestCount, 2)

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -21,6 +21,7 @@ private class RecordingPushServiceProvider: NSObject, PushServiceProvider {
     var startedLaunchOptions: [AnyHashable: Any]?
     var stubbedPushUserID: PushManagerUserID? = "mock-token"
     var isRegisteredForRemoteNotifications: Bool = true
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
 
     func start(launchOptions: [AnyHashable: Any]) {
         startedLaunchOptions = launchOptions
@@ -38,6 +39,7 @@ private class RecordingPushServiceProvider: NSObject, PushServiceProvider {
 private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
     var receivedAlarms: [AlarmPushBody] = []
     var receivedDonationPromptIDs: [String?] = []
+    var receivedDeviceTokens: [String] = []
 
     func pushServicePresentingController(_ pushService: PushService) -> UIViewController? {
         nil
@@ -49,6 +51,10 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
 
     func pushService(_ pushService: PushService, receivedDonationPrompt id: String?) {
         receivedDonationPromptIDs.append(id)
+    }
+
+    func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
+        receivedDeviceTokens.append(token)
     }
 }
 
@@ -107,6 +113,14 @@ class PushServiceTests: OBATestCase {
     func test_pushID_asyncReturnsProviderToken() async {
         let token = await pushService.pushID()
         XCTAssertEqual(token, "mock-token")
+    }
+
+    func test_deviceTokenUpdates_areForwardedToDelegate() {
+        XCTAssertNotNil(provider.deviceTokenUpdatedHandler, "PushService must install the token handler during init")
+
+        provider.deviceTokenUpdatedHandler?("01abff007f")
+
+        XCTAssertEqual(delegate.receivedDeviceTokens, ["01abff007f"])
     }
 
     // MARK: - Alarm Payloads

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -21,7 +21,7 @@ private class RecordingPushServiceProvider: NSObject, PushServiceProvider {
     var startedLaunchOptions: [AnyHashable: Any]?
     var stubbedPushUserID: PushManagerUserID? = "mock-token"
     var isRegisteredForRemoteNotifications: Bool = true
-    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+    var deviceTokenUpdatedHandler: PushServiceDeviceTokenCallback?
 
     func start(launchOptions: [AnyHashable: Any]) {
         startedLaunchOptions = launchOptions

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,308 @@
+# Push Notifications in OneBusAway
+
+This document explains how push notifications work across the OneBusAway stack — what the server offers, what the iOS app implements, and what you need to do to integrate a mobile app (an OBAKit white-label app or an entirely separate client) with OBACloud push notifications.
+
+**Audience:** mobile developers integrating with OBACloud push, and contributors working on OBAKit's push code.
+
+---
+
+## 1. The big picture
+
+There are four push-driven features, all served by the same OBACloud (a.k.a. "Obaco" sidecar) server and the same APNs device token:
+
+| Feature | Who triggers the push | How the server learns the token | Notification shape |
+|---|---|---|---|
+| **Trip alarms** | The rider ("notify me 10 minutes before my bus arrives") | Attached to the alarm at creation (`user_push_id`) | Alert + custom `arrival_and_departure` payload |
+| **Live Activities** | Server-pushed updates to a Lock Screen activity | Attached to the activity at creation (`push_token`) | ActivityKit content updates (not a user-visible alert) |
+| **Service alerts** | A transit agency publishing an alert with a notification | Proactive device registration (`push_registrations`) | Plain alert: `title` + `body` only |
+| **Donation prompts** | Server campaign | Same token as alarms | Alert + `donation` payload |
+
+```mermaid
+flowchart LR
+    subgraph device [iOS Device]
+        APNsSDK[APNs registration] -->|hex token| App[OneBusAway app]
+    end
+    subgraph server [OBACloud sidecar]
+        Reg[POST /push_registrations] --> Tokens[(push_tokens)]
+        Alarms[POST /alarms] --> AlarmRows[(alarms)]
+        Agency[Agency publishes alert] --> Fanout[AlertPushSendJob]
+        Tokens --> Fanout
+    end
+    App -->|register on launch / rotation / region change| Reg
+    App -->|create alarm with user_push_id| Alarms
+    Fanout --> Gorush[gorush] --> APNs[Apple APNs] --> device
+    AlarmRows -->|alarm fires| Gorush
+```
+
+*(Diagram shows the trip-alarm and service-alert flows; Live Activities and donation prompts ride the same gorush → APNs path.)*
+
+Key facts that shape everything below:
+
+- **The token is the identity.** There are no accounts. Ownership of a registration or alarm is possession of the APNs token (or the alarm's URL). All endpoints are unauthenticated; `push_registrations` is additionally rate-limited to **30 requests/minute/IP** (alarms and Live Activities have no throttle today).
+- **Everything is region-scoped.** Each OBA region may run its own sidecar (`Region.sidecarBaseURL`). All paths embed the numeric region identifier. If the current region has no sidecar URL, push features are unavailable there.
+- **Tokens go stale.** The server prunes tokens whose `last_seen_at` is over 180 days old (a daily job), and APNs bounce feedback removes dead tokens. Clients keep themselves alive by re-registering periodically (see §3).
+
+---
+
+## 2. Server API contracts
+
+Base URL is the region's sidecar URL (e.g. `https://onebusaway.co`). All requests are `application/x-www-form-urlencoded`. Standard query params (`key`, `app_uid`, `app_ver`, `version=2`) are appended by OBAKit automatically; other clients should send an API key the same way.
+
+### 2.1 Device registration — service alerts audience
+
+**Register / refresh (upsert on `(region, token)` — create and update are the same call):**
+
+```
+POST /api/v2/regions/{region_id}/push_registrations
+```
+
+| param | presence | value |
+|---|---|---|
+| `token` | server-enforced (`422` if missing) | APNs device token, lowercase hex (see §4.1) |
+| `operating_system` | server-enforced (`422` if invalid) | `"ios"` (literal; `"android"` also accepted server-side) |
+| `locale` | always send (no server validation — omitting silently buckets the device into English) | Device BCP-47 identifier, e.g. `es-MX`, `zh-Hant-TW` — send exactly what the OS reports, do **not** normalize |
+| `test_device` | always send (omitting silently resets the stored value to `false` on upsert) | `true`/`false` — **send on every call.** The upsert overwrites the stored value |
+| `description` | server-enforced **when `test_device=true`** (`422` if blank) | Free text ≤255 chars identifying the device to admins, e.g. `"Aaron's iPhone 17"`. The server clears it automatically when a device is demoted to `test_device=false` |
+
+Responses: `204 No Content` on success; `422` `{error, messages}` on validation failure; `404` unknown region; `429` throttled.
+
+> ⚠️ The `description` requirement landed server-side on 2026-07-19. As of this writing the iOS client does **not** yet send it, so `test_device=true` registrations from the app will `422` until the client catches up — see the caveat in §6.
+
+```bash
+curl -X POST "https://onebusaway.co/api/v2/regions/1/push_registrations?key=org.example.app" \
+  -d token=01abff007fdeadbeef... \
+  -d operating_system=ios \
+  -d locale=es-MX \
+  -d test_device=false
+```
+
+**Locale mapping** happens server-side: exact match → known aliases (`zh-CN` → `zh-Hans`) → primary subtag (`es-MX` → `es`) → English for anything unrecognized. Your job is only to report the locale faithfully; the server picks the alert translation.
+
+**Unregister:**
+
+```
+DELETE /api/v2/regions/{region_id}/push_registrations?token={token}
+```
+
+`204` on success, `404` if the token was never registered (safe to treat as success — catch that case specifically rather than swallowing all errors). Call this if your app offers an in-app opt-out. OS-level permission revocation does *not* require a DELETE — APNs bounces clean the token up server-side.
+
+### 2.2 Trip alarms
+
+```
+POST /api/v2/regions/{region_id}/alarms
+```
+
+| param | value |
+|---|---|
+| `seconds_before` | seconds before arrival/departure to fire |
+| `stop_id`, `trip_id`, `stop_sequence` | identify the arrival-departure |
+| `service_date` | epoch **milliseconds** (Int64) |
+| `vehicle_id` | optional |
+| `user_push_id` | the APNs hex token |
+| `operating_system` | `"ios"` |
+| `apns_sandbox` | send `1` from debug-provisioned builds (see §6) |
+
+Response is JSON containing the alarm's own URL, which is also how you cancel it:
+
+```json
+{"url": "https://alerts.example.com/regions/1/alarms/1234567890"}
+```
+
+Creation answers `201 Created` with that JSON body.
+
+```
+DELETE {alarm.url}   →  204 (or legacy empty 200) on success, 404 if already gone
+```
+
+### 2.3 Live Activities
+
+```
+POST /api/v2/regions/{region_id}/live_activities
+```
+
+Registers an ActivityKit push token (`push_token`, plus `apns_sandbox` under debug) and returns a subscription URL; `DELETE` that URL to stop updates. See `ObacoAPIService.postLiveActivity`/`deleteLiveActivity` and `LiveActivityRegistry` for the full contract — the lifecycle mirrors alarms (server returns a URL; you delete it).
+
+---
+
+## 3. When to register (the contract every client must honor)
+
+Service-alert reach depends entirely on clients registering proactively. A conforming client registers:
+
+1. **On every app launch/foreground where notification permission is granted** — this refreshes the server's `last_seen_at` and is what keeps the token alive past the 180-day prune. Provisional and ephemeral authorization count as granted: those users receive (quiet) notifications and are exactly the audience the API exists to count.
+2. **Whenever APNs delivers a token** — tokens rotate on restore/reinstall. Register the new token; the old row simply ages out.
+3. **On region change** — register against the new region. (Optionally DELETE from the old one; otherwise the old row lingers until the prune, meaning a rider who moves can receive the old region's alerts for a while.)
+
+**Be polite about it.** Naively POSTing on every trigger works but wastes battery and flirts with the rate limit. The iOS implementation dedupes: it persists the last successful registration `(token, region, locale, test_device, timestamp)` and only re-POSTs when one of those inputs changes or the last POST is older than 24 hours. Failed POSTs must *not* be recorded as successes — retry on the next trigger.
+
+---
+
+## 4. iOS implementation (OBAKit)
+
+### 4.1 Component map
+
+```
+AppDelegate (per-app, Objective-C)
+  │  forwards didRegisterForRemoteNotificationsWithDeviceToken / didFail…
+  ▼
+OBACloudPushService (OBAKit/PushNotifications/OBACloudPushService.swift)
+  │  PushServiceProvider impl: requests authorization, hex-encodes the token,
+  │  UNUserNotificationCenterDelegate (foreground banners, tap routing)
+  ▼
+PushService (OBAKit/PushNotifications/PushService.swift)
+  │  wraps any PushServiceProvider; parses payloads; forwards to delegate
+  ▼
+Application (OBAKit/Orchestration/Application.swift)
+  │  PushServiceDelegate: navigates on alarm taps, feeds tokens to ↓
+  ▼
+PushRegistrationManager (OBAKit/PushNotifications/PushRegistrationManager.swift)
+  │  policy: auth gating, dedupe + 24h refresh, coalescing, stale-region guard
+  ▼
+ObacoAPIService (OBAKitCore/Network/ObacoAPIService.swift)
+     the actual HTTP calls (postPushRegistration / postAlarm / …)
+```
+
+The token is hex-encoded exactly once, in `OBACloudPushService`:
+
+```swift
+let token = tokenData.map { String(format: "%02.2hhx", $0) }.joined()
+// e.g. "01abff007f…" — lowercase hex, no separators
+```
+
+### 4.2 Registration lifecycle in practice
+
+Three triggers feed `PushRegistrationManager`; all of them are safe to fire redundantly because the manager dedupes and coalesces:
+
+```swift
+// 1. Every foreground (Application.applicationDidBecomeActive):
+if pushService != nil {                     // nil on Simulator / providerless apps
+    Task { await pushRegistrationManager.refreshRegistration() }
+}
+// refreshRegistration(): if authorized → registerForRemoteNotifications()
+// (APNs re-delivers the token, rotated or not) → registerIfNeeded()
+
+// 2. Every token delivery (PushServiceDelegate):
+public func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
+    pushRegistrationManager.updateDeviceToken(token)
+    Task { await pushRegistrationManager.registerIfNeeded() }
+}
+
+// 3. Region change (regionsService(_:updatedRegion:)) — obacoService has
+// already been rebuilt for the new region by the time this fires:
+Task { await pushRegistrationManager.registerIfNeeded() }
+```
+
+`registerIfNeeded()` is the single choke point. It no-ops unless there is a token, an Obaco service *matching the current region*, and notification permission; it skips the POST when nothing changed and the last POST is under 24h old; and concurrent calls (foreground trigger racing the token callback on first permission grant) coalesce into a single POST. Server rejections are reported through the app's configured `Analytics.reportError` implementation (Crashlytics in the OneBusAway app) via an injected `errorReporter` — registrations are the server's only audience source, so fleet-wide failures must be observable. Note that `reportError` is an optional protocol method: white-label apps using only Plausible/Umami analytics don't implement it, and currently have no remote visibility into registration failures.
+
+Two subtleties worth knowing before you touch this code:
+
+- **Stale-region guard:** switching to a region *without* a sidecar leaves the previous region's `obacoService` in place (`CoreApplication.refreshObacoService()` early-returns). The manager compares `obacoService.regionID` against the current region and refuses to register against a region the user left.
+- **`test_device` gating:** debug builds always send `true`; release builds send `true` only when the Debug Mode switch in Settings is on. Agencies use the "Test users only" audience to preview an alert push before sending to everyone.
+
+### 4.3 Receiving notifications
+
+`OBACloudPushService` presents foreground notifications as `[.banner, .sound]`. On tap, the payload's `userInfo` routes through `PushService`:
+
+**Trip alarm** — `userInfo` contains a single `arrival_and_departure` key:
+
+```json
+{
+  "aps": { "alert": { "body": "Your bus arrives in 10 minutes" } },
+  "arrival_and_departure": {
+    "trip_id": "1_604670535",
+    "stop_id": "1_75403",
+    "region_id": 1,
+    "vehicle_id": "1_4361",
+    "service_date": 1752624000000,
+    "stop_sequence": 3
+  }
+}
+```
+
+This decodes into `AlarmPushBody` (note `service_date` is epoch **milliseconds**) and the app navigates to the stop, deleting the fired alarm locally.
+
+> ⚠️ **Known issue in the routing guard:** `PushService.notificationReceivedHandler` only routes to the alarm/donation cases when `userInfo` contains **exactly one** key — but for a real remote notification, `UNNotificationContent.userInfo` contains the entire payload, i.e. `aps` *plus* the custom key. With the direct-APNs provider forwarding `userInfo` unfiltered, real alarm/donation taps fail that single-key check and fall through to the generic in-app dialog instead of navigating. (The existing unit tests exercise payloads without `aps`, which is why they pass.) The guard predates the OneSignal removal — OneSignal delivered custom data pre-stripped — and needs to become "exactly one key *besides* `aps`".
+
+**Donation prompt** — `{"donation": "<experiment-id>"}` → the app shows the donation UI.
+
+**Service alert** — plain `title` + `body`, no custom keys. No special handling is required to display it; on tap, `PushService`'s fallback re-presents the message body in an in-app dialog. Deep-linking to the alert detail would require a server-side payload addition first (possible follow-up, not yet specced).
+
+**Rule for new payload types:** the server sends exactly one *custom* key alongside `aps`; `PushService.notificationReceivedHandler` switches on it. Add a new key → add a new case + `PushServiceDelegate` method (and mind the guard caveat above).
+
+---
+
+## 5. Integrating a new app
+
+### 5.1 White-label OBAKit app
+
+Everything in §4 is already wired. You need to:
+
+1. **Provide APNs capability** — add the Push Notifications entitlement and an APNs key/cert for your bundle ID in your Apple Developer account; the OBACloud operator configures the matching credentials in gorush.
+2. **Create the provider and forward the delegate callbacks** in your `AppDelegate`:
+
+```objc
+// AppDelegate.m (see Apps/OneBusAway/AppDelegate.m for the full version)
+- (instancetype)init {
+    // …
+    _pushService = [[OBACloudPushService alloc] init];
+    appConfig.pushServiceProvider = _pushService;
+}
+
+- (void)application:(UIApplication *)application
+        didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [self.pushService didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application
+        didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    [self.pushService didFailToRegisterForRemoteNotificationsWithError:error];
+}
+```
+
+If `AppConfig.pushServiceProvider` is nil (as in KiedyBus today), the entire push stack is dormant and every code path no-ops safely — you don't have to do anything to *not* support push.
+
+3. **Ensure your region has a sidecar** — push features require `Region.sidecarBaseURL`.
+
+A custom `PushServiceProvider` (e.g. wrapping a third-party push SDK) must satisfy the protocol in `PushService.swift`; the non-obvious requirement is invoking `deviceTokenUpdatedHandler` on **every** token delivery, including rotations — that callback is what keeps rotated tokens registered.
+
+### 5.2 Non-OBAKit client (Android, forks, etc.)
+
+Implement the server contract directly:
+
+1. Obtain the platform push token; hex-encode APNs tokens (FCM tokens are sent as-is with `operating_system=android`).
+2. Implement the three registration triggers from §3, with dedupe (persist your last successful `(token, region, locale, test_device)` + timestamp; re-POST on change or after ~24h).
+3. Always send `test_device` explicitly. Always send the unnormalized BCP-47 locale.
+4. Treat `204` as success, `422` as a bug to surface to your crash reporter, `429` as "back off, your dedupe is broken," and DELETE `404` as success.
+5. For trip alarms, store the returned alarm `url` — it is the only handle for cancellation.
+
+---
+
+## 6. Testing and the APNs sandbox
+
+- **Simulators get no real APNs tokens.** OBAKit skips push configuration entirely under `#if targetEnvironment(simulator)`. Test registration logic with unit tests (see `PushRegistrationManagerTests` — the dedupe, coalescing, and auth-gating behaviors are all covered with injected closures and a mock data loader; no network or notification center needed).
+- **Debug builds hold *sandbox* tokens.** A debug-provisioned install registers with the APNs sandbox host; pushes sent through production APNs bounce off it. Alarms and Live Activities handle this by sending `apns_sandbox=1` from debug builds, which the server forwards to gorush as `development: true`.
+- **⚠️ Known gap #1 — test devices need a `description` the client doesn't send yet:** since 2026-07-19 the server rejects `test_device=true` registrations without a `description` param (`422`), and the iOS client doesn't send one — so debug-build registrations currently fail outright until the client adds it.
+- **⚠️ Known gap #2 — sandbox routing for service alerts:** the `push_registrations` API has no `apns_sandbox` param and the alert fan-out always uses production APNs — so even once registered, a *debug* build **cannot receive** the preview push. Until [OneBusAway/obacloud#983](https://github.com/OneBusAway/obacloud/issues/983) lands, verify alert delivery with a **TestFlight** build (production token) flagged via the Debug Mode switch.
+- **End-to-end check:** register a device with `test_device=true`, have an OBACloud admin publish an alert with the "Test users only" audience, and confirm only flagged devices receive it.
+
+---
+
+## 7. Operational notes
+
+- **Rate limit:** 30 requests/minute/IP on `push_registrations` (the other push endpoints are unthrottled today). The iOS dedupe keeps a healthy device to roughly one registration POST per day.
+- **Prune:** tokens unseen for exactly 180 days are dropped by a daily job; APNs "unregistered" bounces are cleaned continuously. Reach decays silently if clients stop refreshing — watch registration volume server-side after releases.
+- **Failure visibility:** client-side registration failures are logged (`Logger`) and server rejections (`APIError.requestFailure`) are reported to the analytics error channel. A fleet-wide flat-line in registrations is the signal that something systematic broke.
+- **Privacy:** the server stores `(token, region, operating_system, locale, test_device, timestamps)` plus — for test devices only — a free-text `description` identifying the device to admins (e.g. `"Aaron's iPhone 17"`; cleared automatically when the device stops being a test device). There is no account linkage for regular riders. The token is useless to third parties without the app's APNs credentials.
+
+## 8. Source map
+
+| What | Where |
+|---|---|
+| Provider protocol, payload routing | `OBAKit/PushNotifications/PushService.swift` |
+| Direct-APNs provider, token hex-encoding, UN delegate | `OBAKit/PushNotifications/OBACloudPushService.swift` |
+| Registration policy (dedupe/coalescing/gating) | `OBAKit/PushNotifications/PushRegistrationManager.swift` |
+| HTTP calls to the sidecar | `OBAKitCore/Network/ObacoAPIService.swift` |
+| Alarm creation UX | `OBAKit/PushNotifications/AlarmBuilder.swift` |
+| Alarm push payload model | `OBAKit/PushNotifications/AlarmPushBody.swift` |
+| App wiring, lifecycle triggers, delegate impls | `OBAKit/Orchestration/Application.swift` |
+| Reference AppDelegate forwarding | `Apps/OneBusAway/AppDelegate.m` |
+| Tests worth reading first | `OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift`, `OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift` |

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -66,7 +66,7 @@ POST /api/v2/regions/{region_id}/push_registrations
 
 Responses: `204 No Content` on success; `422` `{error, messages}` on validation failure; `404` unknown region; `429` throttled.
 
-> ⚠️ The `description` requirement landed server-side on 2026-07-19. As of this writing the iOS client does **not** yet send it, so `test_device=true` registrations from the app will `422` until the client catches up — see the caveat in §6.
+> The `description` requirement landed server-side on 2026-07-19; the iOS client sends it from the **Test Device Name** field in Settings → Debug, and registers as a regular device (`test_device=false`) until that field is filled in.
 
 ```bash
 curl -X POST "https://onebusaway.co/api/v2/regions/1/push_registrations?key=org.example.app" \
@@ -196,7 +196,7 @@ Task { await pushRegistrationManager.registerIfNeeded() }
 Two subtleties worth knowing before you touch this code:
 
 - **Stale-region guard:** switching to a region *without* a sidecar leaves the previous region's `obacoService` in place (`CoreApplication.refreshObacoService()` early-returns). The manager compares `obacoService.regionID` against the current region and refuses to register against a region the user left.
-- **`test_device` gating:** debug builds always send `true`; release builds send `true` only when the Debug Mode switch in Settings is on. Agencies use the "Test users only" audience to preview an alert push before sending to everyone.
+- **`test_device` gating:** debug builds and Debug-Mode-enabled release builds only register as test devices once a **Test Device Name** is set in Settings → Debug; without one, they downgrade to a regular registration (`test_device=false`, no `description` sent) rather than POST a guaranteed 422. Agencies use the "Test users only" audience to preview an alert push before sending it to everyone.
 
 ### 4.3 Receiving notifications
 
@@ -271,8 +271,9 @@ Implement the server contract directly:
 1. Obtain the platform push token; hex-encode APNs tokens (FCM tokens are sent as-is with `operating_system=android`).
 2. Implement the three registration triggers from §3, with dedupe (persist your last successful `(token, region, locale, test_device)` + timestamp; re-POST on change or after ~24h).
 3. Always send `test_device` explicitly. Always send the unnormalized BCP-47 locale.
-4. Treat `204` as success, `422` as a bug to surface to your crash reporter, `429` as "back off, your dedupe is broken," and DELETE `404` as success.
-5. For trip alarms, store the returned alarm `url` — it is the only handle for cancellation.
+4. Send `description` whenever registering with `test_device=true` — the server rejects (`422`) a test-device registration with a blank or missing `description`. If you have no name to send, register with `test_device=false` instead of guaranteeing a failure.
+5. Treat `204` as success, `422` as a bug to surface to your crash reporter, `429` as "back off, your dedupe is broken," and DELETE `404` as success.
+6. For trip alarms, store the returned alarm `url` — it is the only handle for cancellation.
 
 ---
 
@@ -280,8 +281,8 @@ Implement the server contract directly:
 
 - **Simulators get no real APNs tokens.** OBAKit skips push configuration entirely under `#if targetEnvironment(simulator)`. Test registration logic with unit tests (see `PushRegistrationManagerTests` — the dedupe, coalescing, and auth-gating behaviors are all covered with injected closures and a mock data loader; no network or notification center needed).
 - **Debug builds hold *sandbox* tokens.** A debug-provisioned install registers with the APNs sandbox host; pushes sent through production APNs bounce off it. Alarms and Live Activities handle this by sending `apns_sandbox=1` from debug builds, which the server forwards to gorush as `development: true`.
-- **⚠️ Known gap #1 — test devices need a `description` the client doesn't send yet:** since 2026-07-19 the server rejects `test_device=true` registrations without a `description` param (`422`), and the iOS client doesn't send one — so debug-build registrations currently fail outright until the client adds it.
-- **⚠️ Known gap #2 — sandbox routing for service alerts:** the `push_registrations` API has no `apns_sandbox` param and the alert fan-out always uses production APNs — so even once registered, a *debug* build **cannot receive** the preview push. Until [OneBusAway/obacloud#983](https://github.com/OneBusAway/obacloud/issues/983) lands, verify alert delivery with a **TestFlight** build (production token) flagged via the Debug Mode switch.
+- **Setting up a test device:** since 2026-07-19 the server rejects `test_device=true` registrations without a non-blank `description` (`422`). To register this install as a test device: enable **Debug Mode** in Settings → Debug, fill in **Test Device Name** (e.g. "Aaron's iPhone 17"), then re-foreground the app so `PushRegistrationManager` picks up the change and re-POSTs. Until the name is set, the device silently registers as a regular device (`test_device=false`) instead of failing.
+- **⚠️ Known gap — sandbox routing for service alerts:** the `push_registrations` API has no `apns_sandbox` param and the alert fan-out always uses production APNs — so even once registered, a *debug* build **cannot receive** the preview push. Until [OneBusAway/obacloud#983](https://github.com/OneBusAway/obacloud/issues/983) lands, verify alert delivery with a **TestFlight** build (production token) flagged via the Debug Mode switch.
 - **End-to-end check:** register a device with `test_device=true`, have an OBACloud admin publish an alert with the "Test users only" audience, and confirm only flagged devices receive it.
 
 ---

--- a/docs/superpowers/plans/2026-07-18-push-registrations.md
+++ b/docs/superpowers/plans/2026-07-18-push-registrations.md
@@ -1,0 +1,1068 @@
+# OBACloud Push Registrations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** https://github.com/OneBusAway/onebusaway-ios/issues/1204
+
+**Goal:** Proactively register the device's APNs push token (with locale and `test_device` flag) against the OBACloud `push_registrations` API — on launch/foreground, on token rotation, and on region change — so agencies can send service-alert push notifications to opted-in riders.
+
+**Architecture:** Two new form-encoded endpoints on the existing `ObacoAPIService` actor (mirroring `postAlarm`/`deleteAlarm`); a new `@MainActor` `PushRegistrationManager` in OBAKit that owns dedupe/staleness logic and persists the last registration to UserDefaults; a token-update callback threaded through the existing `PushServiceProvider` → `PushService` → `PushServiceDelegate` chain; trigger wiring in `Application` (`applicationDidBecomeActive`, `regionsService(_:updatedRegion:)`, and the new delegate method).
+
+**Tech Stack:** Swift 6, XCTest (+ existing `MockDataLoader`/`OBATestCase` harness), XcodeGen, no new dependencies.
+
+## Global Constraints
+
+- **`test_device` must be sent on every POST** — the server upsert resets an omitted `test_device` to `false`. Send it explicitly, always.
+- `test_device` value: `true` for DEBUG builds; for release builds, `true` only when the user has enabled the hidden "Debug Mode" setting (`userDataStore.debugMode`) — the issue's "internal developer setting" option. (No receipt/TestFlight detection: `Bundle.appStoreReceiptURL` is deprecated on iOS 18.)
+- `operating_system` is the literal string `"ios"` (matches the existing alarm POST).
+- `locale` is `Locale.current.identifier(.bcp47)` — the server wants BCP-47 (`es-MX`, `zh-Hant-TW`); `Locale.current.identifier` alone yields POSIX-style `es_MX`. Do not otherwise normalize; the server maps it.
+- Bodies are form-urlencoded via `NetworkHelpers.dictionary(toHTTPBodyData:)` and sent through `APIService.data(for:)` — do **not** use the JSON `sendData`/`postData` path. Success is `204 No Content`; the existing `data(for:)` already treats empty non-GET 2xx as success.
+- OBAKitCore must remain application-extension safe: `ObacoAPIService` changes touch no UIKit. All UIKit usage (`UIApplication.shared.registerForRemoteNotifications()`) stays in OBAKit.
+- After **creating any new file**, run `scripts/generate_project OneBusAway` before building (XcodeGen project; new files are invisible until regeneration).
+- Build/test destination: `platform=iOS Simulator,name=iPhone 17 Pro`. When piping `xcodebuild`, use `set -o pipefail` so failures aren't masked.
+- Work happens on the current `service-alerts` branch (currently identical to `main`).
+- Rate limit is 30 req/min/IP — the manager's dedupe (only re-POST on change or after 24h) keeps us far below it.
+
+**Out of scope (explicitly):** in-app opt-out UI (the DELETE endpoint is implemented and tested, but nothing calls it yet); DELETE from the *old* region on region change (server-side 180-day prune + APNs bounce feedback handle stale rows); deep-linking from the notification (needs a server payload addition first). The notification itself is plain `title`+`body` — the existing `UNUserNotificationCenterDelegate` in `OBACloudPushService` already displays it; no new receive-side code is added. One pre-existing nuance to mention in the PR body: tapping such a notification routes its single-key `userInfo` through `PushService.notificationReceivedHandler` into `displayMessage(_:)` (`PushService.swift:95-106`), so the app re-presents the alert body in an in-app dialog after opening. That is existing behavior, not a regression.
+
+**Authorization gate:** register when the notification authorization status is `.authorized`, `.provisional`, or `.ephemeral` — provisionally-authorized users receive quiet notifications and are exactly the riders the issue wants counted. Never register for `.denied` or `.notDetermined`.
+
+---
+
+### Task 1: `push_registrations` endpoints on `ObacoAPIService`
+
+**Files:**
+- Modify: `OBAKitCore/Network/ObacoAPIService.swift` (regionID visibility at ~line 26; new methods after `deleteAlarm`, ~line 160)
+- Create: `OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift`
+
+**Interfaces:**
+- Consumes: existing `buildURL(path:queryItems:)`, `NetworkHelpers.dictionary(toHTTPBodyData:)`, `data(for:)`.
+- Produces (Tasks 2–4 rely on these exact signatures):
+  - `public nonisolated let regionID: RegionIdentifier` (was `private let`)
+  - `public nonisolated func postPushRegistration(token: String, locale: String, testDevice: Bool) async throws`
+  - `@discardableResult public nonisolated func deletePushRegistration(token: String) async throws -> (Data, URLResponse)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift`:
+
+```swift
+//
+//  PushRegistrationModelOperationTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_cast
+
+/// Tests for the OBACloud `push_registrations` API (issue #1204): registering the
+/// device's APNs token so agencies can push service alerts to opted-in riders.
+class PushRegistrationModelOperationTests: OBATestCase {
+
+    /// Captures the body of the request the service actually put on the wire. Single
+    /// request per test, written before the mock returns and read after the `await`
+    /// resumes, so there's no concurrent access in practice.
+    private final class RequestCapture: @unchecked Sendable {
+        nonisolated(unsafe) var body: String?
+        nonisolated(unsafe) var url: URL?
+    }
+
+    private func mockRegistrationPOST(statusCode: Int = 204) -> RequestCapture {
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            guard request.httpMethod == "POST", request.url?.path.hasSuffix("/push_registrations") ?? false else {
+                return false
+            }
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            capture.url = request.url
+            return true
+        }
+        return capture
+    }
+
+    func testSuccessfulRegistration_sendsAllContractParams() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "es-MX", testDevice: false)
+
+        let body = try XCTUnwrap(capture.body, "Expected postPushRegistration to send a form-encoded body")
+        XCTAssertTrue(body.contains("token=01abff007f"), "Body: \(body)")
+        XCTAssertTrue(body.contains("operating_system=ios"), "Body: \(body)")
+        XCTAssertTrue(body.contains("locale=es-MX"), "Body: \(body)")
+        // The server upserts on every call and an omitted test_device resets the stored
+        // value to false — the param's *presence* on every request is contract, not just
+        // its value.
+        XCTAssertTrue(body.contains("test_device=false"), "Body: \(body)")
+    }
+
+    func testRegistration_flagsTestDevices() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true)
+
+        let body = try XCTUnwrap(capture.body)
+        XCTAssertTrue(body.contains("test_device=true"), "Body: \(body)")
+    }
+
+    func testRegistration_targetsRegionScopedURL() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false)
+
+        let url = try XCTUnwrap(capture.url)
+        XCTAssertTrue(
+            url.absoluteString.starts(with: "https://alerts.example.com/api/v2/regions/1/push_registrations"),
+            "URL: \(url.absoluteString)")
+    }
+
+    /// The server answers validation failures with a 422 — that must surface as an error.
+    func testRegistrationValidationFailureThrows() async throws {
+        _ = mockRegistrationPOST(statusCode: 422)
+
+        do {
+            try await obacoService.postPushRegistration(token: "", locale: "en-US", testDevice: false)
+            XCTFail("Expected postPushRegistration to throw APIError.requestFailure")
+        } catch let error as APIError {
+            guard case .requestFailure = error else {
+                XCTFail("Expected APIError.requestFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testSuccessfulUnregistration() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 204) { request in
+            request.httpMethod == "DELETE" &&
+            (request.url?.path.hasSuffix("/push_registrations") ?? false) &&
+            (request.url?.query?.contains("token=01abff007f") ?? false)
+        }
+
+        let (_, response) = try await obacoService.deletePushRegistration(token: "01abff007f")
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 204)
+    }
+
+    /// A 404 means the token was never registered — safe for callers to ignore, but the
+    /// service layer still surfaces it faithfully.
+    func testUnregistrationWith404Throws() async throws {
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: Data(), statusCode: 404) { request in
+            request.httpMethod == "DELETE" &&
+            (request.url?.path.hasSuffix("/push_registrations") ?? false)
+        }
+
+        do {
+            _ = try await obacoService.deletePushRegistration(token: "01abff007f")
+            XCTFail("Expected deletePushRegistration to throw APIError.requestNotFound")
+        } catch let error as APIError {
+            guard case .requestNotFound = error else {
+                XCTFail("Expected APIError.requestNotFound, got \(error)")
+                return
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the project and run the tests to verify they fail**
+
+```bash
+scripts/generate_project OneBusAway
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with `value of type 'ObacoAPIService' has no member 'postPushRegistration'` (compile error is the failing state for a new API).
+
+- [ ] **Step 3: Implement the endpoints**
+
+In `OBAKitCore/Network/ObacoAPIService.swift`, change the `regionID` declaration (~line 26) from:
+
+```swift
+    private let regionID: RegionIdentifier
+```
+
+to (Task 2's manager reads it cross-module to key its dedupe state on the region actually targeted):
+
+```swift
+    public nonisolated let regionID: RegionIdentifier
+```
+
+Then add after `deleteAlarm(url:)` (~line 160):
+
+```swift
+    // MARK: - Push Registrations
+
+    /// Registers — or refreshes — this device's APNs push token with the OBACloud server so the
+    /// region's transit agencies can send service-alert push notifications to it.
+    ///
+    /// The server upserts on `(region, token)`, so create and update are the same call. A
+    /// successful response is a bare `204 No Content`.
+    ///
+    /// - Parameters:
+    ///   - token: The hex-encoded APNs device token.
+    ///   - locale: The device's BCP-47 locale identifier (e.g. `"es-MX"`), used by the server to
+    ///     pick the alert translation. Sent as-reported; the server does its own mapping.
+    ///   - testDevice: Whether this device should receive "Test users only" sends. The server
+    ///     resets an omitted value to `false` on every upsert, so it is always sent explicitly.
+    public nonisolated func postPushRegistration(token: String, locale: String, testDevice: Bool) async throws {
+        let url = await buildURL(path: String(format: "/api/v2/regions/%d/push_registrations", regionID))
+        let urlRequest = NSMutableURLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
+        urlRequest.httpMethod = "POST"
+
+        let params: [String: Any] = [
+            "token": token,
+            "operating_system": "ios",
+            "locale": locale,
+            "test_device": testDevice ? "true" : "false"
+        ]
+
+        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
+
+        _ = try await data(for: urlRequest as URLRequest)
+    }
+
+    /// Removes this device's push registration from the OBACloud server.
+    ///
+    /// The token travels as a query item; the server is a Rails app whose `params` merge query
+    /// and body, and its own request spec exercises DELETE this way.
+    ///
+    /// Answers `204` on success and `404` if the token was never registered — the latter throws
+    /// `APIError.requestNotFound`, which callers may safely ignore.
+    @discardableResult
+    public nonisolated func deletePushRegistration(token: String) async throws -> (Data, URLResponse) {
+        let url = await buildURL(
+            path: String(format: "/api/v2/regions/%d/push_registrations", regionID),
+            queryItems: [URLQueryItem(name: "token", value: token)])
+        let request = NSMutableURLRequest(url: url)
+        request.httpMethod = "DELETE"
+        return try await data(for: request as URLRequest)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests/PushRegistrationModelOperationTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: `Test Suite 'PushRegistrationModelOperationTests' passed` — 6 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Network/ObacoAPIService.swift "OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift"
+git commit -m "Add OBACloud push_registrations API endpoints to ObacoAPIService (#1204)"
+```
+
+---
+
+### Task 2: `PushRegistrationManager`
+
+**Files:**
+- Create: `OBAKit/PushNotifications/PushRegistrationManager.swift`
+- Create: `OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift`
+
+**Interfaces:**
+- Consumes: `ObacoAPIService.postPushRegistration(token:locale:testDevice:)` and `ObacoAPIService.regionID` from Task 1; `Logger` from OBAKitCore.
+- Produces (Tasks 3–4 rely on these exact signatures):
+  - `@MainActor public final class PushRegistrationManager: NSObject`
+  - `public init(obacoServiceProvider:userDefaults:testDeviceProvider:currentRegionIdentifierProvider:authorizationStatusProvider:localeProvider:dateProvider:requestRemoteNotificationsRegistration:)` — last four have defaults
+  - `public func updateDeviceToken(_ token: String)` — stores only; side-effect free
+  - `public func registerIfNeeded() async` — POSTs iff something changed or the last POST is >24h old
+  - `public func refreshRegistration() async` — auth check → `registerForRemoteNotifications()` → `registerIfNeeded()`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift`:
+
+```swift
+//
+//  PushRegistrationManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import UserNotifications
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Tests for `PushRegistrationManager` (issue #1204): keeping the device's APNs token
+/// registered with the current region's OBACloud server — deduplicated, daily-refreshed,
+/// and gated on notification authorization.
+@MainActor
+class PushRegistrationManagerTests: OBATestCase {
+
+    /// Mutable state shared with the manager's injected closures. `@unchecked Sendable`
+    /// because tests mutate it only between awaited calls.
+    private final class Controls: @unchecked Sendable {
+        var authorizationStatus: UNAuthorizationStatus = .authorized
+        var locale = "en-US"
+        var testDevice = false
+        var currentRegionID: Int? = 1
+        var now = Date(timeIntervalSince1970: 1_752_800_000)
+        var remoteRegistrationRequests = 0
+        /// When true, the next auth-status check parks on `authGate` until the test resumes it —
+        /// lets the coalescing test hold a registration mid-flight deterministically.
+        var holdNextAuthCheck = false
+        var authGate: CheckedContinuation<Void, Never>?
+    }
+
+    private var controls: Controls!
+    private var dataLoader: MockDataLoader!
+    private var currentService: ObacoAPIService?
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        controls = Controls()
+        dataLoader = MockDataLoader(testName: name)
+        currentService = buildObacoService(dataLoader: dataLoader)
+        defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+    }
+
+    /// Mocks the `POST /push_registrations` response. Installed per-test rather than in
+    /// `setUp` because `MockDataLoader` matching is first-added-wins and the
+    /// failure-handling test needs a non-204 answer.
+    private func mockRegistrationResponse(statusCode: Int = 204) {
+        dataLoader.mock(data: Data(), statusCode: statusCode) { request in
+            request.httpMethod == "POST" && (request.url?.path.hasSuffix("/push_registrations") ?? false)
+        }
+    }
+
+    private func makeManager() -> PushRegistrationManager {
+        let controls = self.controls!
+        return PushRegistrationManager(
+            obacoServiceProvider: { [weak self] in self?.currentService },
+            userDefaults: defaults,
+            testDeviceProvider: { controls.testDevice },
+            currentRegionIdentifierProvider: { controls.currentRegionID },
+            authorizationStatusProvider: {
+                if controls.holdNextAuthCheck {
+                    controls.holdNextAuthCheck = false
+                    await withCheckedContinuation { controls.authGate = $0 }
+                }
+                return controls.authorizationStatus
+            },
+            localeProvider: { controls.locale },
+            dateProvider: { controls.now },
+            requestRemoteNotificationsRegistration: { controls.remoteRegistrationRequests += 1 }
+        )
+    }
+
+    private var registrationRequestCount: Int {
+        dataLoader.recordedRequestURLs.filter { $0.path.hasSuffix("/push_registrations") }.count
+    }
+
+    // MARK: - Registration
+
+    func test_registerIfNeeded_postsTokenOnce() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+
+        // Nothing changed: an immediate second call must not hit the network again.
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    func test_registerIfNeeded_withoutToken_doesNothing() async {
+        let manager = makeManager()
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    func test_registerIfNeeded_withoutAuthorization_doesNothing() async {
+        controls.authorizationStatus = .denied
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    /// Provisionally-authorized users receive quiet notifications — they count as opted in.
+    func test_registerIfNeeded_registersWithProvisionalAuthorization() async {
+        controls.authorizationStatus = .provisional
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    /// `CoreApplication.refreshObacoService()` leaves the previous region's service in place
+    /// when the user switches to a region without a sidecar — never register against a region
+    /// the user has left.
+    func test_registerIfNeeded_skipsWhenObacoServiceRegionIsStale() async {
+        controls.currentRegionID = 99
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    func test_registerIfNeeded_withoutObacoService_doesNothing() async {
+        currentService = nil
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+
+    // MARK: - Re-registration triggers
+
+    func test_registerIfNeeded_repostsWhenTokenRotates() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        manager.updateDeviceToken("cafed00d")
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenLocaleChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.locale = "es-MX"
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenTestDeviceFlagChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.testDevice = true
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    func test_registerIfNeeded_repostsWhenRegionChanges() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 1)
+
+        // Same host, different region — mirrors CoreApplication rebuilding obacoService
+        // after a region switch.
+        let config = APIServiceConfiguration(baseURL: obacoURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: 2)
+        currentService = ObacoAPIService(regionID: 2, delegate: nil, configuration: config, dataLoader: dataLoader)
+        controls.currentRegionID = 2
+
+        await manager.registerIfNeeded()
+        XCTAssertEqual(registrationRequestCount, 2)
+        XCTAssertTrue(dataLoader.recordedRequestURLs.contains { $0.path.hasSuffix("/regions/2/push_registrations") })
+    }
+
+    /// The server prunes tokens not seen for 180 days; an unchanged registration is
+    /// therefore re-POSTed once its age exceeds the refresh interval.
+    func test_registerIfNeeded_repostsWhenStale() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        controls.now = controls.now.addingTimeInterval(PushRegistrationManager.refreshInterval + 60)
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2)
+    }
+
+    /// Dedupe state persists across manager instances (i.e., app launches).
+    func test_registerIfNeeded_dedupeSurvivesRelaunch() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+
+        let relaunched = makeManager()
+        relaunched.updateDeviceToken("01abff007f")
+        await relaunched.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    // MARK: - Failure handling
+
+    /// A failed POST must not be recorded as a successful registration — the next call retries.
+    func test_registerIfNeeded_doesNotPersistOnServerError() async {
+        mockRegistrationResponse(statusCode: 422)
+
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+        await manager.registerIfNeeded()
+        await manager.registerIfNeeded()
+
+        XCTAssertEqual(registrationRequestCount, 2, "Expected a retry because the first POST failed")
+    }
+
+    // MARK: - Coalescing
+
+    /// On the first foreground after a permission grant, the becomeActive trigger and the
+    /// APNs token callback can both call `registerIfNeeded()` before either finishes — the
+    /// second caller must coalesce into the first instead of double-POSTing.
+    func test_registerIfNeeded_coalescesConcurrentCalls() async {
+        mockRegistrationResponse()
+        let manager = makeManager()
+        manager.updateDeviceToken("01abff007f")
+
+        // Hold the first registration at its auth check, mid-flight.
+        controls.holdNextAuthCheck = true
+        let first = Task { await manager.registerIfNeeded() }
+        while controls.authGate == nil { await Task.yield() }
+
+        // A second trigger arrives while the first is parked: it must return immediately
+        // after handing its work to the in-flight pass.
+        await manager.registerIfNeeded()
+
+        controls.authGate?.resume()
+        controls.authGate = nil
+        _ = await first.value
+
+        XCTAssertEqual(registrationRequestCount, 1)
+    }
+
+    // MARK: - refreshRegistration
+
+    func test_refreshRegistration_requestsAPNsRegistrationWhenAuthorized() async {
+        let manager = makeManager()
+        await manager.refreshRegistration()
+        XCTAssertEqual(controls.remoteRegistrationRequests, 1)
+    }
+
+    func test_refreshRegistration_skipsAPNsRegistrationWhenDenied() async {
+        controls.authorizationStatus = .denied
+        let manager = makeManager()
+        await manager.refreshRegistration()
+        XCTAssertEqual(controls.remoteRegistrationRequests, 0)
+        XCTAssertEqual(registrationRequestCount, 0)
+    }
+}
+```
+
+**Note for the implementer:** `OBATestCase` exposes `obacoURL`, `apiKey`, `uuid`, `appVersion`, and `buildObacoService(dataLoader:)` (see `OBAKitTests/Helpers/OBATestCase.swift:74-77`); `MockDataLoader.mock(data:statusCode:matcher:)` and `recordedRequestURLs` are at `OBAKitTests/Helpers/Mocks/MockDataLoader.swift:144` and `:61`.
+
+- [ ] **Step 2: Regenerate the project and verify the tests fail**
+
+```bash
+scripts/generate_project OneBusAway
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with `cannot find 'PushRegistrationManager' in scope`.
+
+- [ ] **Step 3: Implement `PushRegistrationManager`**
+
+Create `OBAKit/PushNotifications/PushRegistrationManager.swift`:
+
+```swift
+//
+//  PushRegistrationManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+import OBAKitCore
+
+/// Keeps this device's APNs push token registered with the current region's OBACloud server
+/// so transit agencies can send service-alert push notifications to it.
+///
+/// Historically the server only learned tokens as a side effect of alarm creation, which
+/// misses riders who never set an alarm, carries no locale for translated alert copy, and
+/// lets tokens age past the server's 180-day prune. This manager registers proactively:
+/// `Application` calls ``refreshRegistration()`` on every foreground, feeds rotated tokens in
+/// via ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, and calls ``registerIfNeeded()``
+/// again after a region change.
+///
+/// The last successful registration (token, region, locale, test-device flag, timestamp) is
+/// persisted to user defaults; an unchanged registration is re-POSTed only after
+/// ``refreshInterval`` elapses, which keeps traffic well under the server's rate limit while
+/// still refreshing `last_seen_at` ahead of the prune.
+@MainActor
+public final class PushRegistrationManager: NSObject {
+
+    public typealias AuthorizationStatusProvider = @Sendable () async -> UNAuthorizationStatus
+
+    /// The inputs that determine whether a new POST is needed, plus when the last one happened.
+    private struct Registration: Codable {
+        let token: String
+        let regionID: RegionIdentifier
+        let locale: String
+        let testDevice: Bool
+        let registeredAt: Date
+
+        /// Equivalence over everything except `registeredAt` — age is checked separately.
+        func isEquivalent(to other: Registration) -> Bool {
+            token == other.token &&
+            regionID == other.regionID &&
+            locale == other.locale &&
+            testDevice == other.testDevice
+        }
+    }
+
+    /// Re-POST an otherwise-unchanged registration this often so the server's 180-day
+    /// `last_seen_at` prune never drops this device.
+    nonisolated public static let refreshInterval: TimeInterval = 60 * 60 * 24
+
+    nonisolated static let lastRegistrationUserDefaultsKey = "PushRegistrationManager.lastRegistration"
+
+    private let obacoServiceProvider: () -> ObacoAPIService?
+    private let userDefaults: UserDefaults
+    private let testDeviceProvider: () -> Bool
+    private let currentRegionIdentifierProvider: () -> RegionIdentifier?
+    private let authorizationStatusProvider: AuthorizationStatusProvider
+    private let localeProvider: () -> String
+    private let dateProvider: () -> Date
+    private let requestRemoteNotificationsRegistration: () -> Void
+
+    private(set) var deviceToken: String?
+
+    /// Coalescing state: `registrationInProgress` is held for the duration of a registration
+    /// pass; a caller arriving mid-flight sets `needsAnotherPass` and returns, and the holder
+    /// loops once more (the dedupe check makes a redundant pass a no-op).
+    private var registrationInProgress = false
+    private var needsAnotherPass = false
+
+    /// - Parameters:
+    ///   - obacoServiceProvider: Resolves the current region's Obaco service on each call —
+    ///     the service is recreated whenever the region changes, so it must not be captured.
+    ///   - userDefaults: Backing store for the last-registration dedupe state.
+    ///   - testDeviceProvider: Whether this install should receive "Test users only" sends.
+    ///   - currentRegionIdentifierProvider: The user's current region. Guards against the
+    ///     stale-`obacoService` case: switching to a region without a sidecar leaves the old
+    ///     region's service in place, and we must never register against a region the user left.
+    ///   - authorizationStatusProvider: Injectable for tests; defaults to the real
+    ///     notification-center authorization status.
+    ///   - localeProvider: Injectable for tests; defaults to the device's BCP-47 identifier.
+    ///   - dateProvider: Injectable for tests; defaults to `Date()`.
+    ///   - requestRemoteNotificationsRegistration: Injectable for tests; defaults to
+    ///     `UIApplication.shared.registerForRemoteNotifications()`.
+    public init(
+        obacoServiceProvider: @escaping () -> ObacoAPIService?,
+        userDefaults: UserDefaults,
+        testDeviceProvider: @escaping () -> Bool,
+        currentRegionIdentifierProvider: @escaping () -> RegionIdentifier?,
+        authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        },
+        localeProvider: @escaping () -> String = { Locale.current.identifier(.bcp47) },
+        dateProvider: @escaping () -> Date = { Date() },
+        requestRemoteNotificationsRegistration: @escaping () -> Void = {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    ) {
+        self.obacoServiceProvider = obacoServiceProvider
+        self.userDefaults = userDefaults
+        self.testDeviceProvider = testDeviceProvider
+        self.currentRegionIdentifierProvider = currentRegionIdentifierProvider
+        self.authorizationStatusProvider = authorizationStatusProvider
+        self.localeProvider = localeProvider
+        self.dateProvider = dateProvider
+        self.requestRemoteNotificationsRegistration = requestRemoteNotificationsRegistration
+    }
+
+    /// Stores the latest hex-encoded APNs token. Side-effect free — follow with
+    /// ``registerIfNeeded()``. Called from the push provider's token callback, which fires on
+    /// every `registerForRemoteNotifications()` including token rotations.
+    public func updateDeviceToken(_ token: String) {
+        deviceToken = token
+    }
+
+    /// Asks the OS for a (possibly rotated) device token and registers whatever token is
+    /// already known. Call on every app foreground: the token callback re-enters via
+    /// ``updateDeviceToken(_:)`` + ``registerIfNeeded()``, so a rotated token is registered
+    /// as soon as APNs delivers it. No-ops unless notification permission is granted.
+    public func refreshRegistration() async {
+        guard await isAuthorized() else { return }
+        requestRemoteNotificationsRegistration()
+        await registerIfNeeded()
+    }
+
+    /// POSTs the current token to the current region's Obaco server — but only if the token,
+    /// region, locale, or test-device flag changed since the last successful POST, or that
+    /// POST is older than ``refreshInterval``. No-ops without a token, an Obaco service, or
+    /// notification permission. Concurrent calls coalesce: on the first foreground after a
+    /// permission grant, the becomeActive trigger and the APNs token callback can overlap,
+    /// and only one POST should result.
+    public func registerIfNeeded() async {
+        guard !registrationInProgress else {
+            // An in-flight pass will loop and re-read all inputs (including a token that
+            // rotated underneath it) — nothing is lost by returning here.
+            needsAnotherPass = true
+            return
+        }
+
+        registrationInProgress = true
+        defer { registrationInProgress = false }
+
+        repeat {
+            needsAnotherPass = false
+            await performRegistrationIfNeeded()
+        } while needsAnotherPass
+    }
+
+    private func performRegistrationIfNeeded() async {
+        guard
+            let deviceToken,
+            let obacoService = obacoServiceProvider(),
+            // Switching to a region without a sidecar leaves the previous region's service in
+            // place (CoreApplication.refreshObacoService early-returns) — never register
+            // against a region the user left.
+            obacoService.regionID == currentRegionIdentifierProvider(),
+            await isAuthorized()
+        else { return }
+
+        let candidate = Registration(
+            token: deviceToken,
+            regionID: obacoService.regionID,
+            locale: localeProvider(),
+            testDevice: testDeviceProvider(),
+            registeredAt: dateProvider())
+
+        if let last = lastRegistration,
+           last.isEquivalent(to: candidate),
+           candidate.registeredAt.timeIntervalSince(last.registeredAt) < Self.refreshInterval {
+            return
+        }
+
+        do {
+            try await obacoService.postPushRegistration(
+                token: candidate.token,
+                locale: candidate.locale,
+                testDevice: candidate.testDevice)
+            lastRegistration = candidate
+        } catch {
+            // Leave `lastRegistration` untouched so the next trigger retries.
+            Logger.error("Push registration failed: \(error)")
+        }
+    }
+
+    /// Provisional and ephemeral authorization still deliver notifications — those riders
+    /// count as opted in. Only `.denied`/`.notDetermined` block registration.
+    private func isAuthorized() async -> Bool {
+        switch await authorizationStatusProvider() {
+        case .authorized, .provisional, .ephemeral: return true
+        default: return false
+        }
+    }
+
+    private var lastRegistration: Registration? {
+        get {
+            guard let data = userDefaults.data(forKey: Self.lastRegistrationUserDefaultsKey) else { return nil }
+            return try? JSONDecoder().decode(Registration.self, from: data)
+        }
+        set {
+            guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
+                userDefaults.removeObject(forKey: Self.lastRegistrationUserDefaultsKey)
+                return
+            }
+            userDefaults.set(data, forKey: Self.lastRegistrationUserDefaultsKey)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests/PushRegistrationManagerTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: `Test Suite 'PushRegistrationManagerTests' passed` — 16 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/PushNotifications/PushRegistrationManager.swift OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+git commit -m "Add PushRegistrationManager with dedupe and daily refresh (#1204)"
+```
+
+---
+
+### Task 3: Thread token updates through the push service chain into `Application`
+
+**Files:**
+- Modify: `OBAKit/PushNotifications/PushService.swift` (protocol at lines 29-40, delegate at lines 44-48, init at lines 58-66)
+- Modify: `OBAKit/PushNotifications/OBACloudPushService.swift` (property near line 31, `didRegisterForRemoteNotifications` at lines 105-116)
+- Modify: `OBAKit/Orchestration/Application.swift` (push notifications section, lines 282-318)
+- Modify: `OBAKitTests/PushNotifications/PushServiceTests.swift` (mock provider at line 17, delegate recorder at line 38)
+- Modify: `OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift`
+- Modify: `OBAKitTests/Application/ApplicationTests.swift` (`MockPushServiceProvider` at line 723)
+
+**Interfaces:**
+- Consumes: `PushRegistrationManager` (Task 2), `PushManagerUserIDCallback` (existing typealias `(String) -> Void`).
+- Produces:
+  - `PushServiceProvider` gains `var deviceTokenUpdatedHandler: PushManagerUserIDCallback? { get set }`
+  - `PushServiceDelegate` gains `func pushService(_ pushService: PushService, receivedDeviceToken token: String)`
+  - `Application.pushRegistrationManager: PushRegistrationManager` (public, lazy)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift`, add inside the class:
+
+```swift
+    // MARK: - Token Update Handler
+
+    func test_didRegister_invokesDeviceTokenUpdatedHandlerOnEveryRegistration() {
+        var receivedTokens: [String] = []
+        service.deviceTokenUpdatedHandler = { receivedTokens.append($0) }
+
+        service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xBE, 0xEF]))
+        // Token rotation (restore/reinstall) re-fires the handler with the new token.
+        service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xCA, 0xFE]))
+
+        XCTAssertEqual(receivedTokens, ["beef", "cafe"])
+    }
+```
+
+In `OBAKitTests/PushNotifications/PushServiceTests.swift`, add a `receivedDeviceTokens` recorder and a test. In `PushServiceDelegateRecorder` (line 38), add:
+
+```swift
+    var receivedDeviceTokens: [String] = []
+
+    func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
+        receivedDeviceTokens.append(token)
+    }
+```
+
+In `RecordingPushServiceProvider` (line 17), add:
+
+```swift
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+```
+
+Then add this test to the test class body:
+
+```swift
+    func test_deviceTokenUpdates_areForwardedToDelegate() {
+        XCTAssertNotNil(provider.deviceTokenUpdatedHandler, "PushService must install the token handler during init")
+
+        provider.deviceTokenUpdatedHandler?("01abff007f")
+
+        XCTAssertEqual(delegate.receivedDeviceTokens, ["01abff007f"])
+    }
+```
+
+In `OBAKitTests/Application/ApplicationTests.swift`, `MockPushServiceProvider` (line 723), add the same property:
+
+```swift
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+```
+
+- [ ] **Step 2: Build to verify the failure**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** — the two new tests reference `deviceTokenUpdatedHandler`, which exists on neither `OBACloudPushService` nor the provider protocol yet. (The delegate recorder's extra method compiles fine on its own — an unmatched method is not an error — so the failure comes from the handler references.)
+
+- [ ] **Step 3: Implement the plumbing**
+
+In `OBAKit/PushNotifications/PushService.swift`:
+
+Add to the `PushServiceProvider` protocol (after the `errorHandler` requirement, line 37):
+
+```swift
+    /// Called with the hex-encoded APNs token every time the device (re-)registers with APNs,
+    /// including token rotations. Set by ``PushService`` during initialization.
+    var deviceTokenUpdatedHandler: PushManagerUserIDCallback? { get set }
+```
+
+Add to `PushServiceDelegate` (after `receivedDonationPrompt`, line 47):
+
+```swift
+    /// Called whenever APNs issues the device a (possibly rotated) push token.
+    func pushService(_ pushService: PushService, receivedDeviceToken token: String)
+```
+
+In `PushService.init` (after the `errorHandler` assignment, line 65):
+
+```swift
+        self.serviceProvider.deviceTokenUpdatedHandler = { [weak self] token in
+            guard let self else { return }
+            self.delegate?.pushService(self, receivedDeviceToken: token)
+        }
+```
+
+In `OBAKit/PushNotifications/OBACloudPushService.swift`:
+
+Add the property (after `errorHandler`, line 31):
+
+```swift
+    /// Called with the hex token on every successful APNs registration. Set by ``PushService`` during initialization.
+    public var deviceTokenUpdatedHandler: PushManagerUserIDCallback?
+```
+
+In `didRegisterForRemoteNotifications(withDeviceToken:)` (line 105), after `Logger.info("APNs device token: \(token)")` add:
+
+```swift
+        deviceTokenUpdatedHandler?(token)
+```
+
+In `OBAKit/Orchestration/Application.swift`, in the `// MARK: - Push Notifications` section (after the `pushService` property, line 285), add:
+
+```swift
+    /// Keeps this device's APNs token registered with the current region's OBACloud server so
+    /// agencies can send service-alert push notifications to it. See #1204.
+    public private(set) lazy var pushRegistrationManager = PushRegistrationManager(
+        obacoServiceProvider: { [weak self] in self?.obacoService },
+        userDefaults: userDefaults,
+        testDeviceProvider: { [weak self] in
+            // "Test users only" audience: agencies preview an alert push against flagged
+            // devices before sending it to everyone. Debug builds always qualify; release
+            // builds qualify via the hidden Debug Mode setting.
+            #if DEBUG
+            return true
+            #else
+            return self?.userDataStore.debugMode ?? false
+            #endif
+        },
+        currentRegionIdentifierProvider: { [weak self] in self?.currentRegionIdentifier }
+    )
+```
+
+And add the new delegate method next to the other `PushServiceDelegate` methods (after `pushService(_:received:)`, line 318):
+
+```swift
+    public func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
+        pushRegistrationManager.updateDeviceToken(token)
+        Task { await pushRegistrationManager.registerIfNeeded() }
+    }
+```
+
+**Note:** `Application` also implements `pushService(_:receivedDonationPrompt:)` somewhere below line 318 — placement next to the existing delegate methods is what matters, not the exact line. If a release-build warning appears for the unused `self` capture in the `#if DEBUG` branch of `testDeviceProvider`, leave it — the release path uses it.
+
+- [ ] **Step 4: Run the push notification test suites**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests/OBACloudPushServiceTests -only-testing:OBAKitTests/PushServiceTests -only-testing:OBAKitTests/ApplicationTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: all three suites pass, including the two new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/PushNotifications/PushService.swift OBAKit/PushNotifications/OBACloudPushService.swift OBAKit/Orchestration/Application.swift OBAKitTests/PushNotifications/PushServiceTests.swift OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift OBAKitTests/Application/ApplicationTests.swift
+git commit -m "Thread APNs token updates to PushRegistrationManager via PushService (#1204)"
+```
+
+---
+
+### Task 4: Lifecycle triggers, full verification
+
+**Files:**
+- Modify: `OBAKit/Orchestration/Application.swift` (`applicationDidBecomeActive` at line 428, `regionsService(_:updatedRegion:)` at line 658)
+
+**Interfaces:**
+- Consumes: `Application.pushRegistrationManager` (Task 3), `PushRegistrationManager.refreshRegistration()` / `.registerIfNeeded()` (Task 2).
+- Produces: nothing new — final wiring.
+
+**Testability note:** these triggers cannot be exercised by unit tests: `configurePushNotifications` early-returns under `#if targetEnvironment(simulator)`, so `pushService` is always nil in the simulator-hosted test suite. The behavior they invoke is fully covered by Task 2's manager tests; this task's verification is "full suite still green + lint clean," plus the on-device manual check below.
+
+- [ ] **Step 1: Add the foreground trigger**
+
+In `Application.applicationDidBecomeActive` (line 428), after `alertsStore.checkForUpdates()` (line 450), add:
+
+```swift
+        // Re-register the push token with OBACloud so the server's 180-day prune never drops
+        // this device, and so locale changes propagate. The manager dedupes, so this only
+        // hits the network when something changed or the last POST is a day old. Skipped on
+        // the Simulator, where pushService is never configured.
+        if pushService != nil {
+            Task { await pushRegistrationManager.refreshRegistration() }
+        }
+```
+
+- [ ] **Step 2: Add the region-change trigger**
+
+In `Application.regionsService(_:updatedRegion:)` (line 658), at the end of the method body (after the analytics block), add:
+
+```swift
+        // By the time updatedRegion fires, willUpdateToRegion has already rebuilt
+        // obacoService for the new region, so this registers the token there.
+        Task { await pushRegistrationManager.registerIfNeeded() }
+```
+
+- [ ] **Step 3: Run the full unit test suite and SwiftLint**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+scripts/swiftlint.sh
+```
+
+Expected: full `OBAKitTests` suite passes with 0 failures; SwiftLint reports no new violations in the touched files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OBAKit/Orchestration/Application.swift
+git commit -m "Register push token with OBACloud on foreground and region change (#1204)"
+```
+
+- [ ] **Step 5: On-device manual verification (requires a physical device + an OBACloud admin)**
+
+1. Run a Debug build on a device in a region whose `sidecarBaseURL` points at an OBACloud server; grant notification permission (the onboarding notifications step or alarm creation both trigger the prompt).
+2. Confirm via server logs/console that `POST /api/v2/regions/{id}/push_registrations` arrived with `test_device=true` (Debug builds always flag) and the device's BCP-47 locale.
+3. Background and re-foreground the app: no second POST (dedupe). Change the device language, re-foreground: a new POST with the new locale.
+4. Switch regions to another sidecar-backed region: a POST against the new region's ID.
+5. Have an OBACloud admin publish an alert with the "Test users only" audience — the device receives the push, and tapping it opens the app (plain title+body notification; no deep link expected).
+
+Record the results of each check in the PR description.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** register on launch/foreground (Task 4 step 1 → `refreshRegistration`), on token rotation (Task 3: `didRegisterForRemoteNotifications` → handler → delegate → `registerIfNeeded`), on region change (Task 4 step 2). `test_device` sent on every call (Task 1, pinned by test). Locale sent as BCP-47 (Task 2 default provider). Authorization gate includes `.provisional`/`.ephemeral` (tested). Unregister endpoint implemented + tested (Task 1) but intentionally unwired — no in-app opt-out exists today, matching the issue's conditional phrasing. 422/404/429 handling: 422 and 404 surface as `APIError` (tested); 429 surfaces as `requestFailure` and is made unlikely by dedupe + coalescing.
+- **Independent plan review (2026-07-18):** verified against the codebase and an empirical Swift 6 typecheck of the concurrency patterns — no blockers. Rework applied: provisional/ephemeral gate, stale-region guard (`currentRegionIdentifierProvider`), concurrent-call coalescing, DELETE query-param confirmed against the obacloud Rails spec, factual comment fixes.
+- **Type consistency:** `postPushRegistration(token:locale:testDevice:)`, `deletePushRegistration(token:)`, `regionID`, `updateDeviceToken(_:)`, `registerIfNeeded()`, `refreshRegistration()`, `deviceTokenUpdatedHandler`, and `pushService(_:receivedDeviceToken:)` are spelled identically at definition and every use site across Tasks 1–4.


### PR DESCRIPTION
Closes #1204.

## Summary

- Adds `POST`/`DELETE /api/v2/regions/{id}/push_registrations` to `ObacoAPIService` (form-encoded, mirroring the alarms API) and a new `PushRegistrationManager` that keeps the device's APNs token registered with the current region's OBACloud server — on every app foreground, on token rotation, and on region change — so agencies can send service-alert pushes to opted-in riders with the right locale.
- The manager owns all policy: authorization gating (`.authorized`/`.provisional`/`.ephemeral`), dedupe with a 24h refresh (keeps `last_seen_at` ahead of the server's inactivity prune without hammering the rate limit), single-flight coalescing of concurrent triggers, a stale-region guard, retry-without-poisoning-dedupe on failure, and Crashlytics reporting of server-side rejections. Token delivery is threaded through a new `deviceTokenUpdatedHandler` on `PushServiceProvider` → `PushService` → `PushServiceDelegate`.
- `test_device` is sent explicitly on **every** POST (the server upsert resets an omitted value to `false`); debug builds always flag it, release builds use the Debug Mode switch. Locale is the BCP-47 identifier, unnormalized, per the server contract.

## Test plan

- [x] 29 new unit tests: 6 API-contract tests (wire body captures pinning `token`/`operating_system`/`locale`/`test_device`, 204/422/404 handling), 21 manager tests (dedupe, staleness, relaunch persistence, auth gating incl. provisional, region change, stale-region skip, coalescing via a deterministic continuation gate, mid-flight token rotation, corrupted-persistence recovery, error reporting), 2 plumbing tests (provider → delegate forwarding). Full suite: **1365/1365**, SwiftLint 0 violations.
- [x] Simulator smoke: fresh-install cold launch and terminate/relaunch cycle verified clean (onboarding + notification prompt render, no crash reports, no new console errors). On the Simulator the feature is inert by design (`pushService` is nil), so both triggers were also verified as no-ops there.
- [ ] **On-device manual verification (pending — needs a physical device + an OBACloud admin):** register a debug build in a sidecar-backed region, confirm the POST arrives with `test_device=true` and the device locale; re-foreground (no duplicate POST), change device language (re-POST with new locale), switch regions (POST to new region); publish a "Test users only" alert and confirm delivery. ⚠️ Until OneBusAway/obacloud#983 lands, expect the preview push to a **debug** build to fail at production APNs — verify delivery with a TestFlight build, which holds a production token.

## Review notes

Five specialist review passes (code, tests, comments, silent failures, type design) plus a whole-branch architecture review ran before this PR; everything Critical/Important is addressed in the branch. Non-blocking items deliberately left for follow-up:

- **Server-side sandbox routing gap** — filed as OneBusAway/obacloud#983: the alert fan-out has no `apns_sandbox` routing and `push_tokens` has no sandbox column, so debug builds (the natural `test_device` audience) can't receive preview pushes until the server adds it. Client change afterwards is two lines.
- **`deletePushRegistration` is implemented + tested but unwired** (no in-app opt-out exists yet). Consequence: after a region switch, the old region's row lingers until the server's inactivity prune — a rider who moves can receive the old region's alerts for a while. Wiring a DELETE on region change (and/or an in-app opt-out) is a natural follow-up.
- **Stale `obacoService` root cause**: `CoreApplication.refreshObacoService()` leaves the previous region's service in place when the new region has no sidecar. This PR guards against it locally (and verified all other consumers handle nil safely) — nil-ing it at the source is a small follow-up that fixes the whole class of bug for alarms/live activities/donations too.
- **No backoff for permanently-rejected registrations**: a persistent 422 retries once per trigger (foreground/region change — user-paced, so bounded, and now visible in Crashlytics). If that ever shows up as noise, distinguishing 4xx-don't-retry from transient errors is the fix.
- Pre-existing behavior worth knowing: tapping a plain title+body push routes through `PushService`'s fallback and re-presents the alert body in an in-app dialog after opening. Not a regression; deep-linking to alert detail needs a server payload addition first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic registration of iOS push-notification device tokens with the active region, including proactive refresh on app foreground and re-registration when the region changes.
  * Handles rotated device tokens and safely deduplicates concurrent registration attempts; retries after failures without marking success.
  * Added a Debug-only “Test Device Name” field to control test-device labeling behavior.
* **Documentation**
  * Updated push-notifications specification covering registration, routing, staleness, and validation rules.
* **Tests**
  * Expanded test coverage for token update callbacks, deduplication/persistence, refresh timing, concurrency, and failure/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->