### PR TITLE
Route notification taps correctly when userInfo includes aps

### DIFF
--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -68,11 +68,13 @@ public class PushService: NSObject {
     // MARK: - PushServiceProvider Callbacks
 
     private func notificationReceivedHandler(message: String, additionalData: [AnyHashable: Any]?) {
-        guard
-            let additionalData = additionalData,
-            additionalData.keys.count == 1,
-            let key = additionalData.keys.first as? String
-        else {
+        // Remote-notification `userInfo` always includes an `aps` entry alongside
+        // any custom data key (see OBACloudPushService.userNotificationCenter(_:didReceive:...),
+        // which forwards the entire UNNotificationContent.userInfo). Routing must
+        // therefore count only the custom keys, ignoring `aps`, rather than requiring
+        // the whole dictionary to contain exactly one key.
+        let customKeys = (additionalData ?? [:]).keys.compactMap { $0 as? String }.filter { $0 != "aps" }
+        guard let additionalData, customKeys.count == 1, let key = customKeys.first else {
             displayMessage(message)
 
             return

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -142,6 +142,29 @@ class PushServiceTests: OBATestCase {
         XCTAssertTrue(delegate.receivedAlarms.isEmpty)
     }
 
+    /// Real remote notifications always include `aps` alongside the custom
+    /// data key (see `OBACloudPushService.userNotificationCenter(_:didReceive:...)`,
+    /// which forwards the entire `UNNotificationContent.userInfo`). This
+    /// mirrors that wire shape to guard against regressing to a strict
+    /// single-key count.
+    func test_alarmPayloadWithAPSSibling_isDecodedAndForwardedToDelegate() {
+        provider.notificationReceivedHandler("Your bus is arriving soon!", [
+            "aps": ["alert": ["body": "Your bus is arriving soon!"]],
+            "arrival_and_departure": validAlarmPayload
+        ])
+
+        XCTAssertEqual(delegate.receivedAlarms.count, 1)
+
+        let alarm = delegate.receivedAlarms[0]
+        XCTAssertEqual(alarm.tripID, "1_604387101")
+        XCTAssertEqual(alarm.stopID, "1_75403")
+        XCTAssertEqual(alarm.regionID, 1)
+        XCTAssertEqual(alarm.vehicleID, "1_4361")
+        XCTAssertEqual(alarm.stopSequence, 7)
+        XCTAssertEqual(alarm.serviceDateEpochTimestamp, 1717027200000)
+        XCTAssertEqual(alarm.serviceDate, Date(timeIntervalSince1970: 1717027200))
+    }
+
     // MARK: - Donation Payloads
 
     func test_donationPayload_forwardsTestIDToDelegate() {
@@ -156,6 +179,19 @@ class PushServiceTests: OBATestCase {
 
         XCTAssertEqual(delegate.receivedDonationPromptIDs.count, 1)
         XCTAssertNil(delegate.receivedDonationPromptIDs[0])
+    }
+
+    /// Real remote notifications always include `aps` alongside the custom
+    /// data key. Mirrors the wire shape delivered by
+    /// `OBACloudPushService.userNotificationCenter(_:didReceive:...)`.
+    func test_donationPayloadWithAPSSibling_forwardsTestIDToDelegate() {
+        provider.notificationReceivedHandler("Please donate", [
+            "aps": ["alert": ["body": "Please donate"]],
+            "donation": "experiment-42"
+        ])
+
+        XCTAssertEqual(delegate.receivedDonationPromptIDs.count, 1)
+        XCTAssertEqual(delegate.receivedDonationPromptIDs[0], "experiment-42")
     }
 
     // MARK: - Fallback Paths
@@ -176,6 +212,30 @@ class PushServiceTests: OBATestCase {
 
     func test_unknownSingleKeyPayload_doesNotRouteToAlarmOrDonation() {
         provider.notificationReceivedHandler("Hello", ["unknown_key": "whatever"])
+
+        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
+        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+    }
+
+    /// A plain service alert notification has no custom data key at all —
+    /// just the standard `aps` payload — and should fall through to display.
+    func test_apsOnlyPayload_doesNotRouteToAlarmOrDonation() {
+        provider.notificationReceivedHandler("Service alert", [
+            "aps": ["alert": ["body": "Service alert"]]
+        ])
+
+        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
+        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+    }
+
+    /// Two custom keys alongside `aps` is an ambiguous payload; it should
+    /// still fall through to display rather than guessing which key wins.
+    func test_twoCustomKeysWithAPSSibling_doesNotRouteToAlarmOrDonation() {
+        provider.notificationReceivedHandler("Hello", [
+            "aps": ["alert": ["body": "Hello"]],
+            "arrival_and_departure": validAlarmPayload,
+            "donation": "experiment-42"
+        ])
 
         XCTAssertTrue(delegate.receivedAlarms.isEmpty)
         XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)


### PR DESCRIPTION
## Summary

- Fixes a pre-existing bug (introduced with the OneSignal → direct-APNs migration) where tapping a trip-alarm or donation push showed a generic in-app dialog instead of routing: `PushService.notificationReceivedHandler` required `userInfo` to contain exactly **one** key, but a real remote notification's `userInfo` always carries `aps` alongside the custom key, so every real tap failed the guard and fell through to `displayMessage`.
- The guard now counts only custom keys (filtering out `aps`) before switching on the single custom key. Plain title+body pushes (service alerts) and ambiguous multi-key payloads still fall through to the dialog, as before.
- Surfaced during the documentation review for #1205 (`docs/push-notifications.md` documents this as a known issue — that caveat can be dropped once this merges).

## Test plan

- [x] TDD: two new tests using the real wire shape (`aps` + custom key) failed against the old guard (`XCTAssertEqual failed: ("0") is not equal to ("1")`), pass after the fix.
- [x] Four new tests total: alarm-with-`aps` routes to the alarm delegate; donation-with-`aps` routes to the donation delegate; `aps`-only falls through to display; two-custom-keys-plus-`aps` falls through to display.
- [x] Full `PushServiceTests` suite 16/16 — pre-existing tests (payloads without `aps`, matching the old OneSignal-stripped shape) still pass. SwiftLint: 0 violations.
- [ ] On-device: create a trip alarm, let it fire, tap the notification → app navigates to the stop.

## Review notes

- Based on `main`, independent of #1205; both touch `PushService.swift` in non-overlapping hunks, so merge order shouldn't matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Push notifications now correctly process custom payloads when accompanied by the standard `aps` data.
  - Notifications with no custom data or multiple custom keys safely fall back without triggering an incorrect destination.

- **Tests**
  - Added coverage for alarm and donation notifications containing `aps` data.
  - Added fallback scenarios for missing or ambiguous custom payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->