### PR TITLE
Service alert fixes: APNs sandbox registration flag, test-alert settings, alarm lead time

### DIFF
--- a/OBAKit/Donations/DonationsManager.swift
+++ b/OBAKit/Donations/DonationsManager.swift
@@ -17,15 +17,18 @@ public class DonationsManager {
     ///   - bundle: The application bundle. Usually, `Bundle.main`
     ///   - userDefaults: The user defaults object.
     ///   - analytics: The Analytics object.
+    ///   - appLaunchCount: Returns the number of times the app has been launched.
     public init(
         bundle: Bundle,
         userDefaults: UserDefaults,
         obacoService: ObacoAPIService?,
-        analytics: Analytics?
+        analytics: Analytics?,
+        appLaunchCount: @escaping () -> Int
     ) {
         self.bundle = bundle
         self.userDefaults = userDefaults
         self.analytics = analytics
+        self.appLaunchCount = appLaunchCount
     }
 
     // MARK: - Data
@@ -33,6 +36,7 @@ public class DonationsManager {
     private let bundle: Bundle
     var obacoService: ObacoAPIService?
     private let analytics: Analytics?
+    private let appLaunchCount: () -> Int
 
     // MARK: - User Defaults
 
@@ -80,9 +84,14 @@ public class DonationsManager {
         bundle.donationsEnabled && obacoService != nil
     }
 
+    /// The minimum number of app launches required before donation requests are shown.
+    private static let minimumAppLaunchesBeforeRequestingDonations = 3
+
     /// When true, it means the app should show an inline donation request UI.
     public var shouldRequestDonations: Bool {
         if !bundle.donationsEnabled { return false }
+
+        if appLaunchCount() < DonationsManager.minimumAppLaunchesBeforeRequestingDonations { return false }
 
         if let donationRequestReminderDate = donationRequestReminderDate, donationRequestReminderDate.timeIntervalSinceNow > 0 {
             return false

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -74,7 +74,8 @@ public class Application: CoreApplication, PushServiceDelegate {
         bundle: applicationBundle,
         userDefaults: userDefaults,
         obacoService: obacoService,
-        analytics: analytics
+        analytics: analytics,
+        appLaunchCount: { [userDataStore] in userDataStore.appLaunchCount }
     )
 
     /// Responsible for figuring out how to navigate between view controllers.

--- a/OBAKit/PushNotifications/PushRegistrationManager.swift
+++ b/OBAKit/PushNotifications/PushRegistrationManager.swift
@@ -57,7 +57,9 @@ public final class PushRegistrationManager {
 
     nonisolated static let lastRegistrationUserDefaultsKey = "PushRegistrationManager.lastRegistration"
 
-    nonisolated static let testDeviceDescriptionDefaultsKey = "PushRegistrationManager.testDeviceDescription"
+    /// Canonical key lives in OBAKitCore so `AgencyAlertsStore.shouldDisplayTestAlerts`
+    /// can read the same value; this alias keeps existing call sites working.
+    nonisolated static let testDeviceDescriptionDefaultsKey = AgencyAlertsStore.UserDefaultKeys.testDeviceDescription
 
     private let obacoServiceProvider: () -> ObacoAPIService?
     private let userDefaults: UserDefaults

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -320,6 +320,17 @@ class SettingsViewController: FormViewController {
     // MARK: - Debug Section
 
     private let debugModeEnabled = "debugModeEnabled"
+
+    /// Hides a row unless the Debug Mode switch is on.
+    ///
+    /// Captures only the tag string: a `Condition` is stored on its row for the lifetime
+    /// of the form the controller owns, so capturing `self` in one retains the controller
+    /// in a cycle and it never deallocates after dismissal.
+    private static func hiddenUnlessDebugMode(_ debugModeTag: String) -> Condition {
+        Condition.function([debugModeTag]) { form in
+            !((form.rowBy(tag: debugModeTag) as? SwitchRow)?.value ?? false)
+        }
+    }
     private let crashAppKey = "crashAppKey"
     private let pushIDKey = "pushIDKey"
     private let testDeviceDescriptionKey = "testDeviceDescriptionKey"
@@ -349,16 +360,14 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey
             $0.title = OBALoc("settings_controller.debug_section.always_refresh_regions", value: "Refresh regions on every launch", comment: "Settings > Debug section > Refresh regions on every launch")
-            $0.hidden = Condition.function([debugModeEnabled], { form in
-                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
-            })
+            $0.hidden = Self.hiddenUnlessDebugMode(debugModeEnabled)
         }
 
         section <<< LabelRow {
             $0.tag = crashAppKey
             $0.title = OBALoc("more_controller.debug_section.crash_row", value: "Crash the app", comment: "Title for a button that will crash the app.")
-            $0.hidden = Condition.function([debugModeEnabled], { form in
-                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false) && self.application.shouldShowCrashButton
+            $0.hidden = Condition.function([debugModeEnabled], { [debugModeEnabled, application] form in
+                return !((form.rowBy(tag: debugModeEnabled) as? SwitchRow)?.value ?? false) && application.shouldShowCrashButton
             })
             $0.onCellSelection { [weak self] _, _ in
                 guard let self else { return }
@@ -374,9 +383,7 @@ class SettingsViewController: FormViewController {
             $0.tag = pushIDKey
             $0.title = OBALoc("more_controller.debug_section.push_id.title", value: "Push ID", comment: "Title for the Push Notification ID row in the More Controller")
             $0.value = application.pushService?.pushUserID ?? OBALoc("more_controller.debug_section.push_id.not_available", value: "Not available", comment: "This is displayed instead of the user's push ID if the value is not available.")
-            $0.hidden = Condition.function([debugModeEnabled], { form in
-                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
-            })
+            $0.hidden = Self.hiddenUnlessDebugMode(debugModeEnabled)
             $0.disabled = true
             $0.onCellSelection { [weak self] _, row in
                 guard let self, let pushUserID = application.pushService?.pushUserID else { return }
@@ -402,9 +409,7 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc("settings_controller.debug_section.test_device_description", value: "Test Device Name", comment: "Settings > Debug section > Name identifying this device for test push notifications")
             $0.placeholder = OBALoc("settings_controller.debug_section.test_device_description.placeholder", value: "e.g. Aaron's iPhone", comment: "Placeholder example for the test device name field")
             $0.value = application.userDefaults.string(forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
-            $0.hidden = Condition.function([debugModeEnabled], { form in
-                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
-            })
+            $0.hidden = Self.hiddenUnlessDebugMode(debugModeEnabled)
             $0.onChange { [weak self] row in
                 guard let self else { return }
                 application.userDefaults.set(row.value, forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
@@ -420,13 +425,11 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts
             $0.title = OBALoc("settings_controller.alerts_section.display_test_alerts", value: "Display test alerts", comment: "Settings > Debug section > Display test alerts")
-            $0.hidden = Condition.function([debugModeEnabled], { form in
-                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
-            })
+            $0.hidden = Self.hiddenUnlessDebugMode(debugModeEnabled)
             // Test alerts only display for a named test device (see
             // AgencyAlertsStore.shouldDisplayTestAlerts), so the switch is inert without a name.
-            $0.disabled = Condition.function([testDeviceDescriptionKey], { form in
-                let name = (form.rowBy(tag: self.testDeviceDescriptionKey) as? TextRow)?.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            $0.disabled = Condition.function([testDeviceDescriptionKey], { [testDeviceDescriptionKey] form in
+                let name = (form.rowBy(tag: testDeviceDescriptionKey) as? TextRow)?.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 return name.isEmpty
             })
         }
@@ -447,9 +450,7 @@ class SettingsViewController: FormViewController {
             }
         }
 
-        section.hidden = application.hasDataToMigrate ? false : Condition.function([debugModeEnabled], { form in
-            return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
-        })
+        section.hidden = application.hasDataToMigrate ? false : Self.hiddenUnlessDebugMode(debugModeEnabled)
 
         return section
     }()

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -38,7 +38,6 @@ class SettingsViewController: FormViewController {
         form
             +++ mapSection
             +++ experimentalSection
-            +++ alertsSection
             +++ accessibilitySection
             +++ walkingSpeedSection
             +++ surveySection
@@ -288,19 +287,6 @@ class SettingsViewController: FormViewController {
         return section
     }()
 
-    // MARK: - Agency Alerts
-
-    private lazy var alertsSection: Section = {
-        let section = Section(OBALoc("settings_controller.alerts_section.title", value: "Agency Alerts", comment: "Settings > Alerts section title"))
-
-        section <<< SwitchRow {
-            $0.tag = AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts
-            $0.title = OBALoc("settings_controller.alerts_section.display_test_alerts", value: "Display test alerts", comment: "Settings > Alerts section > Display test alerts")
-        }
-
-        return section
-    }()
-
    // MARK: - Privacy
 
     private let privacySectionReportingEnabled = "privacySectionReportingEnabled"
@@ -348,9 +334,15 @@ class SettingsViewController: FormViewController {
             $0.tag = debugModeEnabled
             $0.title = OBALoc("settings_controller.debug_section.debug_mode", value: "Debug Mode", comment: "Settings > Debug section > Debug mode")
             $0.onChange { [weak self] row in
-                guard let self, let refreshRegionsRow = form.rowBy(tag: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey) as? SwitchRow, let value = row.value, value == false else { return }
+                guard let self, let value = row.value, value == false else { return }
 
-                refreshRegionsRow.value = false
+                // Turning Debug Mode off also turns off the debug-only behaviors it exposed.
+                if let refreshRegionsRow = form.rowBy(tag: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey) as? SwitchRow {
+                    refreshRegionsRow.value = false
+                }
+                if let testAlertsRow = form.rowBy(tag: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts) as? SwitchRow {
+                    testAlertsRow.value = false
+                }
             }
         }
 
@@ -414,8 +406,29 @@ class SettingsViewController: FormViewController {
                 return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
             })
             $0.onChange { [weak self] row in
-                self?.application.userDefaults.set(row.value, forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
+                guard let self else { return }
+                application.userDefaults.set(row.value, forKey: PushRegistrationManager.testDeviceDescriptionDefaultsKey)
+
+                // Clearing the name revokes test-device status, so test alerts go with it.
+                let trimmed = row.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if trimmed.isEmpty, let testAlertsRow = form.rowBy(tag: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts) as? SwitchRow {
+                    testAlertsRow.value = false
+                }
             }
+        }
+
+        section <<< SwitchRow {
+            $0.tag = AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts
+            $0.title = OBALoc("settings_controller.alerts_section.display_test_alerts", value: "Display test alerts", comment: "Settings > Debug section > Display test alerts")
+            $0.hidden = Condition.function([debugModeEnabled], { form in
+                return !((form.rowBy(tag: self.debugModeEnabled) as? SwitchRow)?.value ?? false)
+            })
+            // Test alerts only display for a named test device (see
+            // AgencyAlertsStore.shouldDisplayTestAlerts), so the switch is inert without a name.
+            $0.disabled = Condition.function([testDeviceDescriptionKey], { form in
+                let name = (form.rowBy(tag: self.testDeviceDescriptionKey) as? TextRow)?.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return name.isEmpty
+            })
         }
 
         return section

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -65,8 +65,7 @@ class SettingsViewController: FormViewController {
             debugModeEnabled: application.userDataStore.debugMode,
             alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops,
             walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
-            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
-            defaultAlarmLeadTimeMinutesKey: application.userDataStore.defaultAlarmLeadTimeMinutes
+            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit
         ])
     }
 
@@ -138,10 +137,6 @@ class SettingsViewController: FormViewController {
     private func saveAlertsValues(_ values: [String: Any?]) {
         if let testAlerts = values[AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts] as? Bool {
             application.userDefaults.set(testAlerts, forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
-        }
-
-        if let alarmLeadTime = values[defaultAlarmLeadTimeMinutesKey] as? Int {
-            application.userDataStore.defaultAlarmLeadTimeMinutes = alarmLeadTime
         }
     }
 
@@ -295,24 +290,12 @@ class SettingsViewController: FormViewController {
 
     // MARK: - Agency Alerts
 
-    private let defaultAlarmLeadTimeMinutesKey = "defaultAlarmLeadTimeMinutes"
-
     private lazy var alertsSection: Section = {
         let section = Section(OBALoc("settings_controller.alerts_section.title", value: "Agency Alerts", comment: "Settings > Alerts section title"))
 
         section <<< SwitchRow {
             $0.tag = AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts
             $0.title = OBALoc("settings_controller.alerts_section.display_test_alerts", value: "Display test alerts", comment: "Settings > Alerts section > Display test alerts")
-        }
-
-        section <<< SegmentedRow<Int> {
-            $0.tag = defaultAlarmLeadTimeMinutesKey
-            $0.title = OBALoc("settings_controller.alerts_section.default_alarm_lead_time", value: "Default alarm lead time", comment: "Settings > Alerts section > default minutes-before for one-tap departure alarms")
-            $0.options = [2, 5, 10]
-            $0.displayValueFor = { minutes in
-                guard let minutes else { return nil }
-                return String(format: OBALoc("settings_controller.alerts_section.lead_time_fmt", value: "%d min", comment: "Lead-time segment label. %d is minutes."), minutes)
-            }
         }
 
         return section

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "تسهيلات الاستخدام";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "مهلة التذكير الافتراضية";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "عرض التنبيهات التجريبية";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d د";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "تنبيهات هيئات النقل";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "تسهيلات الاستخدام";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "عرض التنبيهات التجريبية";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "تنبيهات هيئات النقل";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "تحديث المناطق عند كل تشغيل";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibility";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Display test alerts";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Agency Alerts";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Refresh regions on every launch";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibility";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Default alarm lead time";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Display test alerts";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Agency Alerts";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accesibilidad";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Anticipación predeterminada de la alarma";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Mostrar alertas de prueba";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Alertas de Agencias";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accesibilidad";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Mostrar alertas de prueba";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Alertas de Agencias";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Actualizar las regiones al inicio";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibility";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Default na lead time ng paalala";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Ipakita ang mga test alert";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Mga Alerto ng Ahensya";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibility";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Ipakita ang mga test alert";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Mga Alerto ng Ahensya";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "I-refresh ang mga rehiyon sa bawat paglunsad";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibilité";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Afficher les alertes de test";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Alertes des agences";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Actualiser les régions à chaque lancement";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibilité";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Délai de rappel par défaut";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Afficher les alertes de test";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Alertes des agences";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibilità";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Anticipo predefinito della sveglia";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Mostra avvisi di test";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Avvisi degli enti";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Accessibilità";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Mostra avvisi di test";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Avvisi degli enti";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Aggiorna area a ogni avvio";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "손쉬운 사용";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "기본 미리 알림 시간";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "테스트 알림 표시";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d분";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "운영 기관 알림";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "손쉬운 사용";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "테스트 알림 표시";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "운영 기관 알림";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "실행할 때마다 지역 새로고침";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Dostępność";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Wyświetl testowe alerty";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Alerty przewoźnika";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Odśwież regiony przy każdym uruchomieniu";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Dostępność";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Domyślne wyprzedzenie alarmu";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Wyświetl testowe alerty";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Alerty przewoźnika";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Acessibilidade";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Exibir alertas de teste";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Alertas das Agências";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Atualizar regiões a cada inicialização";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Acessibilidade";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Antecedência padrão do lembrete";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Exibir alertas de teste";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d min";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Alertas das Agências";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Универсальный доступ";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Время напоминания по умолчанию";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Показывать тестовые оповещения";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d мин";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Оповещения агентств";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Универсальный доступ";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Показывать тестовые оповещения";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Оповещения агентств";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Обновлять регионы при каждом запуске";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Trợ năng";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Hiển thị cảnh báo thử nghiệm";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "Cảnh báo từ đơn vị vận tải";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Làm mới khu vực mỗi lần khởi chạy";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "Trợ năng";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "Thời gian nhắc trước mặc định";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "Hiển thị cảnh báo thử nghiệm";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d phút";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "Cảnh báo từ đơn vị vận tải";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "辅助功能";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "显示测试通知";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "公交公司通知";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "启动应用时刷新地区信息";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "辅助功能";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "默认闹钟提前时间";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "显示测试通知";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d分钟";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "公交公司通知";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -939,11 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "輔助使用";
 
-/* Settings > Alerts section > Display test alerts */
+/* Settings > Debug section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "顯示測試警示";
-
-/* Settings > Alerts section title */
-"settings_controller.alerts_section.title" = "營運機構警示";
 
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "每次啟動時重新整理區域";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -939,14 +939,8 @@
 /* Settings > Accessibility section title */
 "settings_controller.accessibility_section.title" = "輔助使用";
 
-/* Settings > Alerts section > default minutes-before for one-tap departure alarms */
-"settings_controller.alerts_section.default_alarm_lead_time" = "預設提醒提前時間";
-
 /* Settings > Alerts section > Display test alerts */
 "settings_controller.alerts_section.display_test_alerts" = "顯示測試警示";
-
-/* Lead-time segment label. %d is minutes. */
-"settings_controller.alerts_section.lead_time_fmt" = "%d 分鐘";
 
 /* Settings > Alerts section title */
 "settings_controller.alerts_section.title" = "營運機構警示";

--- a/OBAKitCore/Models/AgencyAlertsStore.swift
+++ b/OBAKitCore/Models/AgencyAlertsStore.swift
@@ -37,7 +37,23 @@ public class AgencyAlertsStore: NSObject, @unchecked Sendable {
 
     public struct UserDefaultKeys {
         public static let displayRegionalTestAlerts = "displayRegionalTestAlerts"
+        /// Human-readable name identifying this test device to OBACloud admins. Written by
+        /// the Test Device Name field in Settings > Debug; read by push registration (OBAKit's
+        /// `PushRegistrationManager`) and by ``AgencyAlertsStore/shouldDisplayTestAlerts(userDefaults:)``.
+        /// The literal string predates this key living here — changing it would orphan saved names.
+        public static let testDeviceDescription = "PushRegistrationManager.testDeviceDescription"
         static let readAgencyAlertIDs = "readAgencyAlertIDs"
+    }
+
+    /// Whether regional test alerts should be shown: the "Display test alerts" switch must be
+    /// on *and* a Test Device Name must be set. Test alerts are a preview channel for named
+    /// test devices, mirroring how push registration only sends `test_device=true` once the
+    /// device is named.
+    public static func shouldDisplayTestAlerts(userDefaults: UserDefaults) -> Bool {
+        guard userDefaults.bool(forKey: UserDefaultKeys.displayRegionalTestAlerts) else { return false }
+        let name = userDefaults.string(forKey: UserDefaultKeys.testDeviceDescription)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return !(name?.isEmpty ?? true)
     }
 
     @MainActor

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -301,9 +301,9 @@ public protocol UserDataStore: NSObjectProtocol {
 
     // MARK: - Alarm Lead Time
 
-    /// The user's preferred alarm lead time in minutes for one-tap alarms on
-    /// the Stop page. Adjustable per-alarm afterward. Defaults to 5.
-    var defaultAlarmLeadTimeMinutes: Int { get set }
+    /// The alarm lead time in minutes for one-tap alarms on the Stop page.
+    /// Adjustable per-alarm afterward.
+    var defaultAlarmLeadTimeMinutes: Int { get }
 
 }
 
@@ -367,7 +367,7 @@ public protocol StopPreferencesStore: NSObjectProtocol {
 public enum UserDataStoreDefaults {
     /// Default lead time in minutes for one-tap alarms on the Stop page.
     /// Referenced by OBAKit's `AlarmLeadTime.defaultMinutes`.
-    public static let alarmLeadTimeMinutes = 5
+    public static let alarmLeadTimeMinutes = 10
 }
 
 // MARK: - UserDefaultsStore
@@ -408,9 +408,12 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         self.userDefaults.register(defaults: [
             UserDefaultsKeys.debugMode: false,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
-            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue,
-            UserDefaultsKeys.defaultAlarmLeadTimeMinutes: UserDataStoreDefaults.alarmLeadTimeMinutes
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
         ])
+
+        // The alarm lead time used to be user-configurable; the setting has been removed
+        // and everyone gets `UserDataStoreDefaults.alarmLeadTimeMinutes` now.
+        self.userDefaults.removeObject(forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes)
     }
 
     // MARK: - Debug Mode
@@ -1094,12 +1097,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     // MARK: - Alarm Lead Time
 
     public var defaultAlarmLeadTimeMinutes: Int {
-        get {
-            userDefaults.integer(forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes)
-        }
-        set {
-            userDefaults.set(newValue, forKey: UserDefaultsKeys.defaultAlarmLeadTimeMinutes)
-        }
+        UserDataStoreDefaults.alarmLeadTimeMinutes
     }
 
     // MARK: - Private Helpers

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -137,15 +137,7 @@ public actor ObacoAPIService: @preconcurrency APIService {
             params["vehicle_id"] = vehicleID
         }
 
-        #if DEBUG
-        // A debug build is provisioned with the development APNs entitlement, so the
-        // token APNs issues us is only valid against the APNs sandbox host. The server
-        // pushes to production APNs by config, which rejects a sandbox token — the alarm
-        // just never arrives. Flagging the alarm at registration tells the server to route
-        // this one push through the sandbox instead. (The alarm fires minutes later, from
-        // a job, so the flag has to be persisted server-side rather than sent at push time.)
-        params["apns_sandbox"] = "1"
-        #endif
+        stampAPNsSandboxFlag(&params)
 
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 
@@ -158,6 +150,32 @@ public actor ObacoAPIService: @preconcurrency APIService {
         request.httpMethod = "DELETE"
 
         return try await data(for: request as URLRequest)
+    }
+
+    // MARK: - APNs Environment
+
+    /// Stamps `apns_sandbox=1` onto a token-registering request in debug builds.
+    ///
+    /// A debug build is provisioned with the development APNs entitlement, so every token
+    /// it registers — alarm, service-alert registration, or Live Activity — is only valid
+    /// against the APNs sandbox host. The server persists the flag and routes that token's
+    /// pushes through the sandbox; without it they bounce with `BadDeviceToken`. Omission
+    /// means production: release builds send nothing, and on upsert-style endpoints the
+    /// next unflagged registration clears any previously stored flag.
+    ///
+    /// Every Obaco request that registers a push token MUST call this — the flag was
+    /// originally implemented per-endpoint and the endpoint that got missed shipped
+    /// exactly that bug.
+    ///
+    /// Caveat: DEBUG is a proxy for the `aps-environment` entitlement, not the
+    /// entitlement itself. A Release-configuration build signed with a development
+    /// provisioning profile (e.g. Xcode's Profile action) holds a sandbox token but
+    /// sends no flag, so its pushes bounce. The entitlement isn't runtime-readable,
+    /// so this is the best available signal.
+    private nonisolated func stampAPNsSandboxFlag(_ params: inout [String: Any]) {
+        #if DEBUG
+        params["apns_sandbox"] = "1"
+        #endif
     }
 
     // MARK: - Push Registrations
@@ -193,6 +211,8 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let description, !description.isEmpty {
             params["description"] = description
         }
+
+        stampAPNsSandboxFlag(&params)
 
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 
@@ -252,13 +272,10 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let vehicleID { params["vehicle_id"] = vehicleID }
         if let stopSequence { params["stop_sequence"] = stopSequence }
 
-        #if DEBUG
-        // A debug build's ActivityKit push token is a sandbox token. The server
-        // persists this flag and uses it for every update and end push over the
-        // activity's lifetime. Without it, pushes bounce with BadDeviceToken and
-        // the server retires the subscription.
-        params["apns_sandbox"] = "1"
-        #endif
+        // The stakes are highest here: an unflagged Live Activity doesn't just go
+        // quiet — its pushes bounce with BadDeviceToken and the server retires the
+        // subscription outright.
+        stampAPNsSandboxFlag(&params)
 
         urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -119,7 +119,7 @@ open class CoreApplication: NSObject,
     // MARK: - Agency Alerts
 
     public var shouldDisplayRegionalTestAlerts: Bool {
-        return userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
+        return AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: userDefaults)
     }
 
     public lazy var alertsStore = AgencyAlertsStore(userDefaults: userDefaults, regionsService: regionsService)

--- a/OBAKitTests/Donations/DonationsManagerTests.swift
+++ b/OBAKitTests/Donations/DonationsManagerTests.swift
@@ -1,0 +1,96 @@
+//
+//  DonationsManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// A `Bundle` whose `OBAKitConfig` reports a configurable `Donations.Enabled`
+/// value, so these tests don't depend on the host app's Info.plist. Each
+/// instance is backed by a unique temporary directory because `Bundle` caches
+/// instances by path and would otherwise return a previously-created fake.
+private class DonationsConfigBundle: Bundle {
+    var donationsEnabledValue = true
+
+    override func object(forInfoDictionaryKey key: String) -> Any? {
+        if key == "OBAKitConfig" {
+            return ["Donations": ["Enabled": donationsEnabledValue]]
+        }
+        return super.object(forInfoDictionaryKey: key)
+    }
+
+    static func create(donationsEnabled: Bool) throws -> DonationsConfigBundle {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let bundle = try XCTUnwrap(DonationsConfigBundle(path: dir.path))
+        bundle.donationsEnabledValue = donationsEnabled
+        return bundle
+    }
+}
+
+class DonationsManagerTests: OBATestCase {
+
+    private func buildManager(appLaunchCount: Int, donationsEnabled: Bool = true) throws -> DonationsManager {
+        DonationsManager(
+            bundle: try DonationsConfigBundle.create(donationsEnabled: donationsEnabled),
+            userDefaults: userDefaults,
+            obacoService: obacoService,
+            analytics: nil,
+            appLaunchCount: { appLaunchCount }
+        )
+    }
+
+    // MARK: - Launch Count Gating
+
+    func test_shouldRequestDonations_firstLaunch_isFalse() throws {
+        let manager = try buildManager(appLaunchCount: 1)
+        expect(manager.shouldRequestDonations) == false
+    }
+
+    func test_shouldRequestDonations_secondLaunch_isFalse() throws {
+        let manager = try buildManager(appLaunchCount: 2)
+        expect(manager.shouldRequestDonations) == false
+    }
+
+    func test_shouldRequestDonations_thirdLaunch_isTrue() throws {
+        let manager = try buildManager(appLaunchCount: 3)
+        expect(manager.shouldRequestDonations) == true
+    }
+
+    func test_shouldRequestDonations_laterLaunches_isTrue() throws {
+        let manager = try buildManager(appLaunchCount: 100)
+        expect(manager.shouldRequestDonations) == true
+    }
+
+    // MARK: - Composition with Other Gates
+
+    func test_shouldRequestDonations_thirdLaunch_dismissed_isFalse() throws {
+        let manager = try buildManager(appLaunchCount: 3)
+        manager.dismissDonationsRequests()
+        expect(manager.shouldRequestDonations) == false
+    }
+
+    func test_shouldRequestDonations_thirdLaunch_futureReminder_isFalse() throws {
+        let manager = try buildManager(appLaunchCount: 3)
+        manager.remindUserLater()
+        expect(manager.shouldRequestDonations) == false
+    }
+
+    func test_shouldRequestDonations_thirdLaunch_pastReminder_isTrue() throws {
+        let manager = try buildManager(appLaunchCount: 3)
+        manager.donationRequestReminderDate = Date(timeIntervalSinceNow: -3600)
+        expect(manager.shouldRequestDonations) == true
+    }
+
+    func test_shouldRequestDonations_donationsDisabled_isFalse() throws {
+        let manager = try buildManager(appLaunchCount: 3, donationsEnabled: false)
+        expect(manager.shouldRequestDonations) == false
+    }
+}

--- a/OBAKitTests/Modeling/AgencyAlertsTestDeviceGatingTests.swift
+++ b/OBAKitTests/Modeling/AgencyAlertsTestDeviceGatingTests.swift
@@ -1,0 +1,66 @@
+//
+//  AgencyAlertsTestDeviceGatingTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Test alerts are a preview channel for OBACloud admins: displaying them requires
+/// both the "Display test alerts" switch *and* a Test Device Name, mirroring how
+/// push registration only sends `test_device=true` once the device is named.
+class AgencyAlertsTestDeviceGatingTests: OBATestCase {
+
+    private func setTestDeviceName(_ name: String?) {
+        userDefaults.set(name, forKey: AgencyAlertsStore.UserDefaultKeys.testDeviceDescription)
+    }
+
+    private func setDisplayTestAlerts(_ enabled: Bool) {
+        userDefaults.set(enabled, forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
+    }
+
+    func test_switchOff_noName_doesNotDisplay() {
+        setDisplayTestAlerts(false)
+
+        expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults)) == false
+    }
+
+    func test_switchOn_noName_doesNotDisplay() {
+        setDisplayTestAlerts(true)
+
+        expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults)) == false
+    }
+
+    func test_switchOn_whitespaceOnlyName_doesNotDisplay() {
+        setDisplayTestAlerts(true)
+        setTestDeviceName("   \n")
+
+        expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults)) == false
+    }
+
+    func test_switchOff_withName_doesNotDisplay() {
+        setDisplayTestAlerts(false)
+        setTestDeviceName("Aaron's iPhone")
+
+        expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults)) == false
+    }
+
+    func test_switchOn_withName_displays() {
+        setDisplayTestAlerts(true)
+        setTestDeviceName("Aaron's iPhone")
+
+        expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults)) == true
+    }
+
+    func test_keyMatchesPushRegistrationManagersKey() {
+        // The gate reads the same defaults entry that the Settings form writes and
+        // PushRegistrationManager reads — if these diverge, the gate silently breaks.
+        expect(AgencyAlertsStore.UserDefaultKeys.testDeviceDescription) == PushRegistrationManager.testDeviceDescriptionDefaultsKey
+    }
+}

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -66,6 +66,15 @@ class PushRegistrationModelOperationTests: OBATestCase {
         XCTAssertTrue(body.contains("description=Aarons%20iPhone"), "Body: \(body)")
     }
 
+    func testRegistration_flagsApnsSandboxInDebugBuilds() async throws {
+        let capture = mockRegistrationPOST()
+
+        try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true, description: "Aarons iPhone")
+
+        let body = try XCTUnwrap(capture.body)
+        XCTAssertTrue(body.contains("apns_sandbox=1"), "Expected a debug build to flag its registration for the APNs sandbox — its token is only valid there, so an unflagged test push bounces with BadDeviceToken. Body: \(body)")
+    }
+
     /// A blank/omitted description must never reach the wire — the server treats an empty
     /// `description` param the same as a missing one, and `test_device=false` doesn't
     /// require one at all.

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -309,14 +309,17 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Default Alarm Lead Time
 
-    func test_defaultAlarmLeadTime_defaultValueAndRoundTrip() {
-        expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes) == 5
-
-        userDefaultsStore.defaultAlarmLeadTimeMinutes = 10
+    func test_defaultAlarmLeadTime_is10Minutes() {
         expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes) == 10
+    }
+
+    func test_defaultAlarmLeadTime_ignoresAndClearsLegacyStoredValue() {
+        userDefaults.set(2, forKey: "UserDataStore.defaultAlarmLeadTimeMinutes")
 
         let newStore = UserDefaultsStore(userDefaults: userDefaults)
+
         expect(newStore.defaultAlarmLeadTimeMinutes) == 10
+        expect(self.userDefaults.object(forKey: "UserDataStore.defaultAlarmLeadTimeMinutes")).to(beNil())
     }
 
 }

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -196,7 +196,7 @@ Task { await pushRegistrationManager.registerIfNeeded() }
 Two subtleties worth knowing before you touch this code:
 
 - **Stale-region guard:** switching to a region *without* a sidecar leaves the previous region's `obacoService` in place (`CoreApplication.refreshObacoService()` early-returns). The manager compares `obacoService.regionID` against the current region and refuses to register against a region the user left.
-- **`test_device` gating:** debug builds and Debug-Mode-enabled release builds only register as test devices once a **Test Device Name** is set in Settings → Debug; without one, they downgrade to a regular registration (`test_device=false`, no `description` sent) rather than POST a guaranteed 422. Agencies use the "Test users only" audience to preview an alert push before sending it to everyone.
+- **`test_device` gating:** debug builds and Debug-Mode-enabled release builds only register as test devices once a **Test Device Name** is set in Settings → Debug; without one, they downgrade to a regular registration (`test_device=false`, no `description` sent) rather than POST a guaranteed 422. Agencies use the "Test users only" audience to preview an alert push before sending it to everyone. The same name also gates the **Display test alerts** switch (Settings → Debug): regional test alerts are only fetched and shown once the switch is on *and* a name is set (`AgencyAlertsStore.shouldDisplayTestAlerts`).
 
 ### 4.3 Receiving notifications
 


### PR DESCRIPTION
## Summary
- **Flag push registrations for the APNs sandbox in debug builds**: `postPushRegistration` was the one token-registering Obaco endpoint that didn't send `apns_sandbox=1` from debug builds, so the server registered sandbox tokens as production and test pushes bounced with `BadDeviceToken` (server side: OneBusAway/obacloud#986). The three per-endpoint `#if DEBUG` blocks are consolidated into one `stampAPNsSandboxFlag` helper called from `postAlarm`, `postPushRegistration`, and `postLiveActivity`, with the canonical doc (including the DEBUG-vs-`aps-environment`-entitlement caveat) in one place.
- Pre-existing work on this branch: Display-test-alerts moved into Debug settings gated on Test Device Name; alarm lead-time setting removed (fixed at 10 minutes); donation prompts gated behind 3 app launches.

## Test plan
- [x] `PushRegistrationModelOperationTests`, `AlarmModelOperationTests`, `LiveActivityModelOperationTests` — 15 test cases, `** TEST SUCCEEDED **` on iPhone 17 Pro Max simulator
- [x] New `testRegistration_flagsApnsSandboxInDebugBuilds` pins `apns_sandbox=1` on the registration wire body; existing alarm/Live Activity tests pin the other two call sites after the helper extraction

## Notes
- Deploy pairing: obacloud#986 backfills `apns_sandbox = true` for existing iOS test devices, but this build needs to reach test devices before that assumption stops mattering — releases clear the flag automatically on their next registration upsert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Donation requests are now available starting with the third app launch.
  * “Display test alerts” is now located under **Settings > Debug**.
* **Changes**
  * Alarm lead time is now fixed at **10 minutes** (no longer user-configurable).
  * Regional test alerts require **Debug Mode enabled**, the **Display test alerts** switch on, and a **non-blank (trimmed) Test Device Name**.
* **Documentation**
  * Updated push-notification guidance for when test alerts are eligible to show.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->