### PR TITLE
Fix main-thread hang warning from CLLocationManager.locationServicesEnabled()

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -476,6 +476,11 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     @MainActor @objc public func applicationDidBecomeActive(_ application: UIApplication) {
+        // Runs before the gate below: the user may have re-enabled Location
+        // Services while they were away, which leaves `isLocationUseAuthorized`
+        // false until we probe for it.
+        locationService.retryIfLocationServicesDenied()
+
         if locationService.isLocationUseAuthorized {
             locationService.startUpdates()
         }
@@ -566,9 +571,9 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     @objc public func applicationWillResignActive(_ application: UIApplication) {
-        if locationService.isLocationUseAuthorized {
-            locationService.stopUpdates()
-        }
+        // Unconditional: stopping is always safe, and gating it on authorization
+        // would strand a manager we started before access was revoked.
+        locationService.stopUpdates()
 
         hyperconnectivityCancellable?.cancel()
     }

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -476,9 +476,11 @@ public class Application: CoreApplication, PushServiceDelegate {
     }
 
     @MainActor @objc public func applicationDidBecomeActive(_ application: UIApplication) {
-        // Runs before the gate below: the user may have re-enabled Location
-        // Services while they were away, which leaves `isLocationUseAuthorized`
-        // false until we probe for it.
+        // The user may have re-enabled Location Services while they were away,
+        // which leaves `isLocationUseAuthorized` false until we probe for it.
+        // The probe is asynchronous, so the gate below still sees the pre-probe
+        // state — recovery is not this call's job. `LocationService` starts
+        // updates itself when the probe clears the latch.
         locationService.retryIfLocationServicesDenied()
 
         if locationService.isLocationUseAuthorized {

--- a/OBAKitCore/Extensions/CoreLocationExtensions.swift
+++ b/OBAKitCore/Extensions/CoreLocationExtensions.swift
@@ -28,6 +28,15 @@ extension CLAuthorizationStatus: @retroactive LosslessStringConvertible {
     }
 }
 
+public extension CLAuthorizationStatus {
+    /// Whether this status grants the app location access, foreground or always.
+    /// The single definition of the "is this authorized?" predicate that both
+    /// the per-app and effective status checks share.
+    var isAuthorized: Bool {
+        self == .authorizedWhenInUse || self == .authorizedAlways
+    }
+}
+
 public extension CLLocationDirection {
 
     /// Creates an affine transform from the specified rotation, and allows for an

--- a/OBAKitCore/Location/Location/LocationManagerProtocol.swift
+++ b/OBAKitCore/Location/Location/LocationManagerProtocol.swift
@@ -25,11 +25,6 @@ public protocol LocationManager {
     /// to try to mock class functions.
     var authorizationStatus: CLAuthorizationStatus { get }
 
-    /// Replaces the CLLocationManager class func of the same name. This is used
-    /// to facilitate easier testing on a per-instance basis instead of having
-    /// to try to mock class functions.
-    var isLocationServicesEnabled: Bool { get }
-
     @available(iOS 14, *)
     var accuracyAuthorization: CLAccuracyAuthorization { get }
 
@@ -52,10 +47,6 @@ public protocol LocationManager {
 
 extension CLLocationManager: LocationManager {
     // nop. CLLocationManager already implements all of the protocol methods.
-
-    public var isLocationServicesEnabled: Bool {
-        return CLLocationManager.locationServicesEnabled()
-    }
 
     public var isHeadingAvailable: Bool {
         return CLLocationManager.headingAvailable()

--- a/OBAKitCore/Location/Location/LocationManagerProtocol.swift
+++ b/OBAKitCore/Location/Location/LocationManagerProtocol.swift
@@ -25,6 +25,19 @@ public protocol LocationManager {
     /// to try to mock class functions.
     var authorizationStatus: CLAuthorizationStatus { get }
 
+    /// Whether Location Services are enabled system-wide.
+    ///
+    /// Wraps `CLLocationManager.locationServicesEnabled()`, which Apple documents
+    /// as a synchronous, potentially long-blocking call that must not run on the
+    /// main thread. This is `async` so the real implementation can hop the read
+    /// off-main; it is the authoritative signal for the system-wide switch, which
+    /// per-app authorization and `didFailWithError` only approximate.
+    ///
+    /// `@MainActor` because the only caller is the main-actor `LocationService`
+    /// and the mocks hold main-actor state — the off-main hop happens *inside*
+    /// the real implementation, not at this boundary.
+    @MainActor func locationServicesEnabled() async -> Bool
+
     @available(iOS 14, *)
     var accuracyAuthorization: CLAccuracyAuthorization { get }
 
@@ -47,6 +60,15 @@ public protocol LocationManager {
 
 extension CLLocationManager: LocationManager {
     // nop. CLLocationManager already implements all of the protocol methods.
+
+    /// Reads the class-level `locationServicesEnabled()` off the main thread.
+    /// The call is a blocking XPC round-trip; hopping to a detached task keeps
+    /// it from hanging the main thread (the whole point of this method). The
+    /// method is `@MainActor` per the protocol, but its work runs on the
+    /// detached task, so awaiting it never blocks the main thread.
+    @MainActor public func locationServicesEnabled() async -> Bool {
+        await Task.detached { CLLocationManager.locationServicesEnabled() }.value
+    }
 
     public var isHeadingAvailable: Bool {
         return CLLocationManager.headingAvailable()

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -148,6 +148,21 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         }
     }
 
+    /// Latched when Core Location reports a `denied` error. This can happen even
+    /// while `authorizationStatus` still reads as authorized — most commonly when
+    /// the user switches Location Services off system-wide, which does not change
+    /// the app's per-app authorization. While set, `isLocationUseAuthorized`
+    /// reports `false` so the UI hides location affordances (locate button, user
+    /// dot) that would otherwise appear active but never produce a fix. It is
+    /// cleared on the next authorization callback, when the user may have
+    /// re-enabled access.
+    private var locationServicesDenied = false {
+        didSet {
+            guard locationServicesDenied != oldValue else { return }
+            notifyDelegatesAuthorizationChanged(authorizationStatus)
+        }
+    }
+
     /// This is true when the app is in a state such that the user can/should be
     /// prompted for location services authorization. In other words: the app has
     /// not been denied or approved, and the user also has not generally restricted
@@ -181,9 +196,16 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     }
 
     /// Answers the question of whether the device GPS can be consulted for location data.
+    ///
+    /// This is derived from `authorizationStatus` plus the `locationServicesDenied`
+    /// latch. We deliberately avoid `CLLocationManager.locationServicesEnabled()`
+    /// because it performs a blocking, synchronous XPC call that Apple warns can
+    /// hang the main thread. When location services are disabled system-wide,
+    /// attempts to start updates fail via `locationManager(_:didFailWithError:)`
+    /// with a `denied` error, which we latch here — the pattern Apple recommends.
     public var isLocationUseAuthorized: Bool {
-        return locationManager.isLocationServicesEnabled &&
-            (authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways)
+        guard !locationServicesDenied else { return false }
+        return authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways
     }
 
     @available(iOS 14, *)
@@ -249,11 +271,17 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     @available(iOS, introduced: 4.2, deprecated: 14.0)
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        // A fresh authorization callback means access was re-evaluated, so clear
+        // any latched denial before recomputing derived state.
+        locationServicesDenied = false
         authorizationStatus = status
     }
 
     @available(iOS 14, *)
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        // A fresh authorization callback means access was re-evaluated, so clear
+        // any latched denial before recomputing derived state.
+        locationServicesDenied = false
         authorizationStatus = manager.authorizationStatus
 
         // Accuracy can change while the coarse status stays put (e.g. "Allow
@@ -297,6 +325,16 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     }
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // A `denied` error means location is currently unavailable even if
+        // `authorizationStatus` still reads as authorized (e.g. Location Services
+        // switched off system-wide). Apple recommends stopping updates in this
+        // case; we also latch the state so `isLocationUseAuthorized` reports the
+        // location as unusable and the UI can hide its location affordances.
+        if let clError = error as? CLError, clError.code == .denied {
+            locationManager.stopUpdatingLocation()
+            locationServicesDenied = true
+        }
+
         notifyDelegatesErrorReceived(error)
     }
 

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -160,6 +160,16 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         didSet {
             guard locationServicesDenied != oldValue else { return }
             notifyDelegatesAuthorizationChanged(authorizationStatus)
+
+            // When the latch clears while the app is still authorized, resume
+            // updates ourselves. The `authorizationStatus` didSet only restarts
+            // them when the coarse status *value* changes, which it often does
+            // not on recovery (e.g. it stays `.authorizedWhenInUse`), so relying
+            // on it alone would leave the stream stopped until the next app
+            // foreground.
+            if !locationServicesDenied, isLocationUseAuthorized {
+                startUpdates()
+            }
         }
     }
 
@@ -269,19 +279,23 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Delegate
 
+    /// A fresh authorization callback means access was re-evaluated by the user
+    /// or system, so any latched `denied` state is stale. Clearing it before we
+    /// recompute `authorizationStatus` lets derived state (and any resumed
+    /// updates) reflect the new reality.
+    private func resetDeniedLatchForAuthorizationChange() {
+        locationServicesDenied = false
+    }
+
     @available(iOS, introduced: 4.2, deprecated: 14.0)
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        // A fresh authorization callback means access was re-evaluated, so clear
-        // any latched denial before recomputing derived state.
-        locationServicesDenied = false
+        resetDeniedLatchForAuthorizationChange()
         authorizationStatus = status
     }
 
     @available(iOS 14, *)
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        // A fresh authorization callback means access was re-evaluated, so clear
-        // any latched denial before recomputing derived state.
-        locationServicesDenied = false
+        resetDeniedLatchForAuthorizationChange()
         authorizationStatus = manager.authorizationStatus
 
         // Accuracy can change while the coarse status stays put (e.g. "Allow
@@ -330,8 +344,11 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         // switched off system-wide). Apple recommends stopping updates in this
         // case; we also latch the state so `isLocationUseAuthorized` reports the
         // location as unusable and the UI can hide its location affordances.
+        //
+        // Stop first (while still authorized, so the guards in `stopUpdates()`
+        // pass and both location and heading are torn down), then latch.
         if let clError = error as? CLError, clError.code == .denied {
-            locationManager.stopUpdatingLocation()
+            stopUpdates()
             locationServicesDenied = true
         }
 

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -304,8 +304,15 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Heading
 
+    /// Guarded on authorization as well as availability. `isHeadingAvailable`
+    /// wraps `CLLocationManager.headingAvailable()`, which reports whether the
+    /// *device* has a magnetometer — it says nothing about whether we may use it.
+    /// Without the authorization guard, `startUpdates()` would start heading even
+    /// when starting location had just synchronously latched a `denied` error and
+    /// torn the manager down, leaving the magnetometer powered for the rest of
+    /// the process.
     public func startUpdatingHeading() {
-        guard locationManager.isHeadingAvailable else {
+        guard isLocationUseAuthorized, locationManager.isHeadingAvailable else {
             return
         }
 
@@ -336,16 +343,32 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     /// The read is a blocking XPC call, hence off the main thread; the result is
     /// applied back on the main actor. It reconciles both directions, so a single
     /// call covers "services came back on" and "services are off."
+    /// The in-flight probe, if any.
+    ///
+    /// Probes are single-flight by cancel-and-replace. Three call sites can start
+    /// one — the authorization callback, `retryIfLocationServicesDenied()`, and
+    /// foregrounding by way of the latter — and unstructured tasks have no
+    /// ordering guarantee at the `await`, so an older read could land after a
+    /// newer one and clobber the latch with stale state. Cancelling the previous
+    /// probe makes the newest read the only one that applies.
+    private var servicesProbeTask: Task<Void, Never>?
+
     private func refreshLocationServicesEnabled() {
         // The latch is only meaningful while the app is itself authorized; when it
         // isn't, `authorizationStatus` reports the raw status directly and there is
         // nothing to reconcile.
         guard isPerAppAuthorized else { return }
 
-        Task { [weak self] in
+        servicesProbeTask?.cancel()
+        servicesProbeTask = Task { [weak self] in
             guard let self else { return }
             let enabled = await self.locationManager.locationServicesEnabled()
-            guard self.isPerAppAuthorized else { return }
+
+            // Cancellation cannot interrupt the blocking read itself, so a
+            // superseded probe resumes here with an answer it must not apply.
+            guard !Task.isCancelled, self.isPerAppAuthorized else { return }
+
+            self.servicesProbeTask = nil
             self.applyAuthorizationState(rawStatus: self.rawAuthorizationStatus, servicesDenied: !enabled)
         }
     }

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -164,7 +164,7 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     }
 
     private var isPerAppAuthorized: Bool {
-        rawAuthorizationStatus == .authorizedWhenInUse || rawAuthorizationStatus == .authorizedAlways
+        rawAuthorizationStatus.isAuthorized
     }
 
     /// The current *effective* authorization state of the app.
@@ -182,32 +182,40 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         return .denied
     }
 
-    /// The single funnel for both inputs to `authorizationStatus`. It applies
-    /// the new values and *then* reacts once to the effective transition.
+    /// The single funnel for both inputs to `authorizationStatus`. It applies the
+    /// new values, reconciles the manager's running state to match, and notifies
+    /// delegates once on an effective transition.
     ///
     /// Property observers on the two inputs can't do this correctly: whichever
-    /// one is assigned first sees the other's stale value, and both firing
-    /// means delegates get notified twice for one logical change.
+    /// one is assigned first sees the other's stale value, and both firing means
+    /// delegates get notified twice for one logical change.
+    ///
+    /// Reconciliation is unconditional (not gated on the transition) and relies on
+    /// `startUpdates()`/`stopUpdates()` being idempotent. That is deliberate: Core
+    /// Location fires an authorization callback carrying an *unchanged* status the
+    /// moment the delegate is assigned, and an already-authorized app must start
+    /// its first fix from it. Reconciling here means there is a single place that
+    /// starts updates — no separate post-funnel start path that would fire a
+    /// second time on a real grant (and, with services off, produce two failed
+    /// probes and two error callbacks).
     private func applyAuthorizationState(rawStatus: CLAuthorizationStatus, servicesDenied: Bool) {
         let oldStatus = authorizationStatus
-        let wasAuthorized = isLocationUseAuthorized
 
         rawAuthorizationStatus = rawStatus
         locationServicesDenied = servicesDenied
 
-        guard authorizationStatus != oldStatus else { return }
-
-        notifyDelegatesAuthorizationChanged(authorizationStatus)
-
+        // Reconcile running state to the effective authorization. When access is
+        // revoked this is what tears the manager down — nobody else will, and a
+        // `CLLocationManager` left running keeps the location-usage indicator lit
+        // and the magnetometer powered for the rest of the process.
         if isLocationUseAuthorized {
             startUpdates()
-        } else if wasAuthorized {
-            // Access was revoked. Tear the manager down here — nobody else will,
-            // and a `CLLocationManager` left running keeps the location-usage
-            // indicator lit and the magnetometer powered for the rest of the
-            // process.
+        } else {
             stopUpdates()
         }
+
+        guard authorizationStatus != oldStatus else { return }
+        notifyDelegatesAuthorizationChanged(authorizationStatus)
     }
 
     /// This is true when the app is in a state such that the user can/should be
@@ -251,7 +259,7 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     /// updates fail via `locationManager(_:didFailWithError:)` with a `denied`
     /// error, which we latch — the pattern Apple recommends.
     public var isLocationUseAuthorized: Bool {
-        return authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways
+        return authorizationStatus.isAuthorized
     }
 
     @available(iOS 14, *)
@@ -314,61 +322,79 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Delegate
 
-    /// Attempts to resume location updates after a latched `denied` error.
+    /// Reconciles the denied latch against the system-wide Location Services
+    /// switch, read off the main thread.
+    ///
+    /// This is the authoritative signal the latch approximates. `didFailWithError`
+    /// (a `denied` error) and `didUpdateLocations` (a fix) are the async proxies
+    /// we also honor between probes, but each has a blind spot: toggling Location
+    /// Services back on delivers no authorization callback and, indoors, no fix
+    /// either — so a latch cleared only by those signals could stay stuck for a
+    /// whole session. Reading the real switch recovers regardless, and latches a
+    /// services-off launch without waiting for the first `denied` error to arrive.
+    ///
+    /// The read is a blocking XPC call, hence off the main thread; the result is
+    /// applied back on the main actor. It reconciles both directions, so a single
+    /// call covers "services came back on" and "services are off."
+    private func refreshLocationServicesEnabled() {
+        // The latch is only meaningful while the app is itself authorized; when it
+        // isn't, `authorizationStatus` reports the raw status directly and there is
+        // nothing to reconcile.
+        guard isPerAppAuthorized else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+            let enabled = await self.locationManager.locationServicesEnabled()
+            guard self.isPerAppAuthorized else { return }
+            self.applyAuthorizationState(rawStatus: self.rawAuthorizationStatus, servicesDenied: !enabled)
+        }
+    }
+
+    /// Attempts to recover from a latched `denied` error, e.g. when the app
+    /// returns to the foreground after the user visited Settings.
     ///
     /// Toggling Location Services back on system-wide does not change the app's
     /// per-app authorization, so Core Location may deliver no authorization
     /// callback at all — nothing would otherwise clear the latch, and the locate
-    /// button and user dot would stay hidden until the app was force-quit. The
-    /// app calls this when it returns to the foreground, which is where the user
-    /// lands after visiting Settings.
+    /// button and user dot would stay hidden until the app was force-quit.
     ///
-    /// This probes rather than assumes: the latch stays set until we have an
-    /// answer, so the UI does not flash location affordances on and back off.
-    /// A fix clears the latch (see `locationManager(_:didUpdateLocations:)`);
-    /// another `denied` error leaves it exactly as it was.
+    /// Recovery goes through the off-main `locationServicesEnabled` probe rather
+    /// than optimistically restarting updates: the latch stays set until the probe
+    /// answers, so the UI never flashes location affordances on and back off, and
+    /// the probe clears the latch even when no GPS fix will arrive (indoors).
     public func retryIfLocationServicesDenied() {
         guard locationServicesDenied, isPerAppAuthorized else { return }
-        locationManager.startUpdatingLocation()
+        refreshLocationServicesEnabled()
     }
 
     @available(iOS 14, *)
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        // A *change* of per-app authorization means the user just made a fresh
-        // decision, so any latched `denied` state is stale evidence and we
-        // re-arm optimistically. A callback that leaves the status untouched
-        // carries no new information — Core Location fires one whenever a
-        // delegate is assigned — so it must not clear the latch, or every
-        // spurious callback would restart updates against a location subsystem
-        // that is still off.
-        //
         // Read the status from the injected manager, not from `manager`, so the
         // path under test is the path that ships.
+        //
+        // Clear the latch only when the transition crosses *into* authorization:
+        // a fresh grant (e.g. `.notDetermined`/`.denied` → `.authorizedWhenInUse`)
+        // is genuinely new evidence, so re-arm optimistically. A change between two
+        // authorized values (WhenInUse → Always) does *not* cross in, so it can't
+        // clear a latch while services are still off — that would flicker the
+        // locate button and user dot. The system-wide toggle, which delivers no
+        // authorization callback at all, is handled by the off-main probe below.
         let newStatus = locationManager.authorizationStatus
-        let statusChanged = newStatus != rawAuthorizationStatus
-        applyAuthorizationState(rawStatus: newStatus, servicesDenied: statusChanged ? false : locationServicesDenied)
+        let crossesIntoAuthorization = !rawAuthorizationStatus.isAuthorized && newStatus.isAuthorized
+        applyAuthorizationState(rawStatus: newStatus, servicesDenied: crossesIntoAuthorization ? false : locationServicesDenied)
 
-        // Core Location delivers a callback as soon as the delegate is assigned,
-        // carrying an *unchanged* status. That is the app's earliest signal that
-        // it is authorized, and it is where location updates have always been
-        // started from — early enough that the first fix lands before the map
-        // settles. `applyAuthorizationState` deliberately reacts only to
-        // transitions, so starting updates has to happen outside of it or a
-        // relaunch of an already-authorized app would wait for the next
-        // foreground. Both calls below are idempotent.
-        if isLocationUseAuthorized {
-            startUpdates()
-        } else {
-            // Same reasoning for a latch seeded from the previous launch: probe
-            // it now rather than making the user wait for a foreground event.
-            retryIfLocationServicesDenied()
-        }
+        // Reconcile the latch against the system-wide switch. Core Location fires
+        // this callback the moment the delegate is assigned, so this is also where
+        // a latch seeded from the previous launch — or a fresh, services-off
+        // authorization — is resolved, without waiting for a foreground event.
+        refreshLocationServicesEnabled()
 
         // Accuracy can change while the coarse status stays put (e.g. "Allow
         // Once" elevates a reduced-accuracy session to full). That leaves the
-        // `authorizationStatus` didSet silent, so detect and forward the
-        // accuracy transition on its own channel.
-        let newAccuracy = manager.accuracyAuthorization
+        // effective `authorizationStatus` unchanged, so detect and forward the
+        // accuracy transition on its own channel — reading from the injected
+        // manager, for the same testability reason as the status above.
+        let newAccuracy = locationManager.accuracyAuthorization
         if newAccuracy != lastAccuracyAuthorization {
             lastAccuracyAuthorization = newAccuracy
             notifyDelegatesAccuracyAuthorizationChanged(newAccuracy)
@@ -413,13 +439,17 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         // A `denied` error means location is currently unavailable even if the
         // per-app authorization still reads as authorized (e.g. Location
         // Services switched off system-wide). Latching it flips the effective
-        // `authorizationStatus` to `.denied`, which stops updates as Apple
-        // recommends and lets the UI explain the situation.
-        if let clError = error as? CLError, clError.code == .denied {
-            // Unconditional, as Apple recommends: a probe that re-confirms an
-            // already-latched denial must still leave the manager stopped, and
-            // `applyAuthorizationState` only reacts to state *transitions*.
-            stopUpdates()
+        // `authorizationStatus` to `.denied`, which stops updates (the funnel
+        // reconciles the manager down, as Apple recommends) and lets the UI
+        // explain the situation.
+        //
+        // Only latch while the app is itself authorized. A `denied` error that
+        // arrives while the raw status is `.denied`/`.notDetermined` would be
+        // masked by `authorizationStatus` anyway, but persisting it there means a
+        // later grant (made while the app wasn't running) launches with a stale
+        // latch that no status-change callback clears — the app would wrongly show
+        // "Location Services Off" until a fix happened to arrive.
+        if let clError = error as? CLError, clError.code == .denied, isPerAppAuthorized {
             applyAuthorizationState(rawStatus: rawAuthorizationStatus, servicesDenied: true)
         }
 

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -40,11 +40,18 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     public init(userDefaults: UserDefaults, locationManager: LocationManager) {
         self.locationManager = locationManager
-        authorizationStatus = locationManager.authorizationStatus
+        rawAuthorizationStatus = locationManager.authorizationStatus
         lastAccuracyAuthorization = locationManager.accuracyAuthorization
         currentLocation = locationManager.location
 
         self.userDefaults = userDefaults
+
+        // Seed the latch from the last session. Location Services being off
+        // system-wide survives an app relaunch, but nothing tells us so at
+        // launch: the per-app authorization still reads as authorized and no
+        // `denied` error has arrived yet. Without this seed the first frames
+        // would advertise location as available and then retract it.
+        locationServicesDenied = userDefaults.bool(forKey: UserDefaultsKeys.locationServicesDenied)
 
         super.init()
 
@@ -59,6 +66,7 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     private struct UserDefaultsKeys {
         static let promptUserForLocationPermission = "LocationService.promptUserForLocationPermission"
+        static let locationServicesDenied = "LocationService.locationServicesDenied"
     }
 
     private func registerDefaults() {
@@ -137,39 +145,68 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Authorization
 
-    /// The current authorization state of the app.
-    public private(set) var authorizationStatus: CLAuthorizationStatus {
-        didSet {
-            notifyDelegatesAuthorizationChanged(authorizationStatus)
+    /// The app's own authorization, exactly as Core Location reports it.
+    private var rawAuthorizationStatus: CLAuthorizationStatus
 
-            if isLocationUseAuthorized {
-                startUpdates()
-            }
+    /// Latched when Core Location reports a `denied` error. This happens even
+    /// while `rawAuthorizationStatus` still reads as authorized — most commonly
+    /// when the user switches Location Services off system-wide, which does not
+    /// change the app's per-app authorization.
+    ///
+    /// Persisted, because that system-wide state outlives the app process while
+    /// the per-app authorization that masks it does not. See the seeding comment
+    /// in `init(userDefaults:locationManager:)`.
+    private var locationServicesDenied: Bool {
+        didSet {
+            guard locationServicesDenied != oldValue else { return }
+            userDefaults.set(locationServicesDenied, forKey: UserDefaultsKeys.locationServicesDenied)
         }
     }
 
-    /// Latched when Core Location reports a `denied` error. This can happen even
-    /// while `authorizationStatus` still reads as authorized — most commonly when
-    /// the user switches Location Services off system-wide, which does not change
-    /// the app's per-app authorization. While set, `isLocationUseAuthorized`
-    /// reports `false` so the UI hides location affordances (locate button, user
-    /// dot) that would otherwise appear active but never produce a fix. It is
-    /// cleared on the next authorization callback, when the user may have
-    /// re-enabled access.
-    private var locationServicesDenied = false {
-        didSet {
-            guard locationServicesDenied != oldValue else { return }
-            notifyDelegatesAuthorizationChanged(authorizationStatus)
+    private var isPerAppAuthorized: Bool {
+        rawAuthorizationStatus == .authorizedWhenInUse || rawAuthorizationStatus == .authorizedAlways
+    }
 
-            // When the latch clears while the app is still authorized, resume
-            // updates ourselves. The `authorizationStatus` didSet only restarts
-            // them when the coarse status *value* changes, which it often does
-            // not on recovery (e.g. it stays `.authorizedWhenInUse`), so relying
-            // on it alone would leave the stream stopped until the next app
-            // foreground.
-            if !locationServicesDenied, isLocationUseAuthorized {
-                startUpdates()
-            }
+    /// The current *effective* authorization state of the app.
+    ///
+    /// When the `locationServicesDenied` latch is set, this reports `.denied`
+    /// even though the per-app authorization still reads as authorized. That is
+    /// deliberate: consumers switch on this value to decide what to show
+    /// (`MapViewModel.topPillState`, `MapStatusView.state(for:)`), and a user
+    /// whose location is unusable needs the "Location Services Off / Turn On in
+    /// Settings" pill, not a silent absence of the locate button. The latch is
+    /// ignored while the app is not itself authorized, so `.notDetermined`
+    /// survives and the app can still prompt.
+    public var authorizationStatus: CLAuthorizationStatus {
+        guard locationServicesDenied, isPerAppAuthorized else { return rawAuthorizationStatus }
+        return .denied
+    }
+
+    /// The single funnel for both inputs to `authorizationStatus`. It applies
+    /// the new values and *then* reacts once to the effective transition.
+    ///
+    /// Property observers on the two inputs can't do this correctly: whichever
+    /// one is assigned first sees the other's stale value, and both firing
+    /// means delegates get notified twice for one logical change.
+    private func applyAuthorizationState(rawStatus: CLAuthorizationStatus, servicesDenied: Bool) {
+        let oldStatus = authorizationStatus
+        let wasAuthorized = isLocationUseAuthorized
+
+        rawAuthorizationStatus = rawStatus
+        locationServicesDenied = servicesDenied
+
+        guard authorizationStatus != oldStatus else { return }
+
+        notifyDelegatesAuthorizationChanged(authorizationStatus)
+
+        if isLocationUseAuthorized {
+            startUpdates()
+        } else if wasAuthorized {
+            // Access was revoked. Tear the manager down here — nobody else will,
+            // and a `CLLocationManager` left running keeps the location-usage
+            // indicator lit and the magnetometer powered for the rest of the
+            // process.
+            stopUpdates()
         }
     }
 
@@ -207,14 +244,13 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Answers the question of whether the device GPS can be consulted for location data.
     ///
-    /// This is derived from `authorizationStatus` plus the `locationServicesDenied`
-    /// latch. We deliberately avoid `CLLocationManager.locationServicesEnabled()`
-    /// because it performs a blocking, synchronous XPC call that Apple warns can
-    /// hang the main thread. When location services are disabled system-wide,
-    /// attempts to start updates fail via `locationManager(_:didFailWithError:)`
-    /// with a `denied` error, which we latch here — the pattern Apple recommends.
+    /// Derived from the effective `authorizationStatus`. We deliberately avoid
+    /// `CLLocationManager.locationServicesEnabled()` because it performs a
+    /// blocking, synchronous XPC call that Apple warns can hang the main thread.
+    /// When location services are disabled system-wide, attempts to start
+    /// updates fail via `locationManager(_:didFailWithError:)` with a `denied`
+    /// error, which we latch — the pattern Apple recommends.
     public var isLocationUseAuthorized: Bool {
-        guard !locationServicesDenied else { return false }
         return authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways
     }
 
@@ -251,11 +287,10 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         locationManager.startUpdatingLocation()
     }
 
+    /// Unlike its `start` counterpart this is unguarded: stopping is always safe,
+    /// and gating it on authorization would make a manager we started before
+    /// access was revoked impossible to ever turn off.
     public func stopUpdatingLocation() {
-        guard isLocationUseAuthorized else {
-            return
-        }
-
         locationManager.stopUpdatingLocation()
     }
 
@@ -279,24 +314,55 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     // MARK: - Delegate
 
-    /// A fresh authorization callback means access was re-evaluated by the user
-    /// or system, so any latched `denied` state is stale. Clearing it before we
-    /// recompute `authorizationStatus` lets derived state (and any resumed
-    /// updates) reflect the new reality.
-    private func resetDeniedLatchForAuthorizationChange() {
-        locationServicesDenied = false
-    }
-
-    @available(iOS, introduced: 4.2, deprecated: 14.0)
-    public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        resetDeniedLatchForAuthorizationChange()
-        authorizationStatus = status
+    /// Attempts to resume location updates after a latched `denied` error.
+    ///
+    /// Toggling Location Services back on system-wide does not change the app's
+    /// per-app authorization, so Core Location may deliver no authorization
+    /// callback at all — nothing would otherwise clear the latch, and the locate
+    /// button and user dot would stay hidden until the app was force-quit. The
+    /// app calls this when it returns to the foreground, which is where the user
+    /// lands after visiting Settings.
+    ///
+    /// This probes rather than assumes: the latch stays set until we have an
+    /// answer, so the UI does not flash location affordances on and back off.
+    /// A fix clears the latch (see `locationManager(_:didUpdateLocations:)`);
+    /// another `denied` error leaves it exactly as it was.
+    public func retryIfLocationServicesDenied() {
+        guard locationServicesDenied, isPerAppAuthorized else { return }
+        locationManager.startUpdatingLocation()
     }
 
     @available(iOS 14, *)
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        resetDeniedLatchForAuthorizationChange()
-        authorizationStatus = manager.authorizationStatus
+        // A *change* of per-app authorization means the user just made a fresh
+        // decision, so any latched `denied` state is stale evidence and we
+        // re-arm optimistically. A callback that leaves the status untouched
+        // carries no new information — Core Location fires one whenever a
+        // delegate is assigned — so it must not clear the latch, or every
+        // spurious callback would restart updates against a location subsystem
+        // that is still off.
+        //
+        // Read the status from the injected manager, not from `manager`, so the
+        // path under test is the path that ships.
+        let newStatus = locationManager.authorizationStatus
+        let statusChanged = newStatus != rawAuthorizationStatus
+        applyAuthorizationState(rawStatus: newStatus, servicesDenied: statusChanged ? false : locationServicesDenied)
+
+        // Core Location delivers a callback as soon as the delegate is assigned,
+        // carrying an *unchanged* status. That is the app's earliest signal that
+        // it is authorized, and it is where location updates have always been
+        // started from — early enough that the first fix lands before the map
+        // settles. `applyAuthorizationState` deliberately reacts only to
+        // transitions, so starting updates has to happen outside of it or a
+        // relaunch of an already-authorized app would wait for the next
+        // foreground. Both calls below are idempotent.
+        if isLocationUseAuthorized {
+            startUpdates()
+        } else {
+            // Same reasoning for a latch seeded from the previous launch: probe
+            // it now rather than making the user wait for a foreground event.
+            retryIfLocationServicesDenied()
+        }
 
         // Accuracy can change while the coarse status stays put (e.g. "Allow
         // Once" elevates a reduced-accuracy session to full). That leaves the
@@ -314,6 +380,11 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let newLocation = locations.last else {
             return
+        }
+
+        // A fix is proof that location is usable again, whatever we last latched.
+        if locationServicesDenied {
+            applyAuthorizationState(rawStatus: rawAuthorizationStatus, servicesDenied: false)
         }
 
         guard let currentLocation = currentLocation else {
@@ -339,17 +410,17 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     }
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        // A `denied` error means location is currently unavailable even if
-        // `authorizationStatus` still reads as authorized (e.g. Location Services
-        // switched off system-wide). Apple recommends stopping updates in this
-        // case; we also latch the state so `isLocationUseAuthorized` reports the
-        // location as unusable and the UI can hide its location affordances.
-        //
-        // Stop first (while still authorized, so the guards in `stopUpdates()`
-        // pass and both location and heading are torn down), then latch.
+        // A `denied` error means location is currently unavailable even if the
+        // per-app authorization still reads as authorized (e.g. Location
+        // Services switched off system-wide). Latching it flips the effective
+        // `authorizationStatus` to `.denied`, which stops updates as Apple
+        // recommends and lets the UI explain the situation.
         if let clError = error as? CLError, clError.code == .denied {
+            // Unconditional, as Apple recommends: a probe that re-confirms an
+            // already-latched denial must still leave the manager stopped, and
+            // `applyAuthorizationState` only reacts to state *transitions*.
             stopUpdates()
-            locationServicesDenied = true
+            applyAuthorizationState(rawStatus: rawAuthorizationStatus, servicesDenied: true)
         }
 
         notifyDelegatesErrorReceived(error)

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -42,10 +42,6 @@ public class LocationManagerMock: NSObject, LocationManager {
         return .notDetermined
     }
 
-    public var isLocationServicesEnabled: Bool {
-        return true
-    }
-
     @available(iOS 14, *)
     public var accuracyAuthorization: CLAccuracyAuthorization {
         return .fullAccuracy

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -74,9 +74,16 @@ public class LocationManagerMock: NSObject, LocationManager {
         }
     }
 
-    public var isHeadingAvailable: Bool {
-        return authorizationStatus.isAuthorized
-    }
+    /// Whether the device has a magnetometer, matching what the real
+    /// `isHeadingAvailable` reports (`CLLocationManager.headingAvailable()`).
+    ///
+    /// Stored and default-`true`, like `MockAuthorizedLocationManager`'s. It used
+    /// to derive from `authorizationStatus`, which conflated capability with
+    /// permission: revoking authorization made it flip to `false`, and since
+    /// `LocationService.stopUpdatingHeading()` guards on it, the stop was skipped
+    /// and the mock reported heading as still running. Real hardware capability
+    /// does not change with authorization, so neither does this.
+    public var isHeadingAvailable = true
 
     public func startUpdatingHeading() {
         headingUpdatesStarted = true
@@ -121,8 +128,23 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
     /// reports `false`.
     public var simulatesLocationServicesOff = false
 
+    /// When true, `locationServicesEnabled()` parks each call instead of
+    /// answering from `simulatesLocationServicesOff`. The test then resumes the
+    /// parked calls in whatever order it likes, which is the only deterministic
+    /// way to reproduce two probes completing out of order.
+    public var parksProbes = false
+
+    /// Parked `locationServicesEnabled()` calls, oldest first.
+    public private(set) var pendingProbes: [CheckedContinuation<Bool, Never>] = []
+
     public override func locationServicesEnabled() async -> Bool {
-        return !simulatesLocationServicesOff
+        guard parksProbes else { return !simulatesLocationServicesOff }
+        return await withCheckedContinuation { pendingProbes.append($0) }
+    }
+
+    /// Answers the parked probe at `index` (0 is the oldest).
+    public func answerProbe(at index: Int, enabled: Bool) {
+        pendingProbes[index].resume(returning: enabled)
     }
 
     public override func startUpdatingLocation() {
@@ -139,11 +161,20 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
         }
     }
 
+    /// Mirrors `startUpdatingLocation()`: with Location Services off system-wide,
+    /// no heading is delivered.
+    ///
+    /// `super` is still called — deliberately. Real Core Location *accepts*
+    /// `startUpdatingHeading()` with services off (there is no error return, and
+    /// the magnetometer is powered); it simply never delivers data. So
+    /// `headingUpdatesStarted` must stay a faithful record of "the call reached
+    /// the manager." Skipping `super` here would model the leak out of existence
+    /// and let a service that wrongly starts heading after latching denial pass.
     public override func startUpdatingHeading() {
         super.startUpdatingHeading()
-        if authorizationStatus.isAuthorized {
-            heading = updateHeading
-        }
+        guard authorizationStatus.isAuthorized, !simulatesLocationServicesOff else { return }
+
+        heading = updateHeading
     }
 }
 

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -42,6 +42,10 @@ public class LocationManagerMock: NSObject, LocationManager {
         return .notDetermined
     }
 
+    public func locationServicesEnabled() async -> Bool {
+        return true
+    }
+
     @available(iOS 14, *)
     public var accuracyAuthorization: CLAccuracyAuthorization {
         return .fullAccuracy
@@ -71,7 +75,7 @@ public class LocationManagerMock: NSObject, LocationManager {
     }
 
     public var isHeadingAvailable: Bool {
-        return authorizationStatus == .authorizedWhenInUse
+        return authorizationStatus.isAuthorized
     }
 
     public func startUpdatingHeading() {
@@ -113,12 +117,20 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
 
     /// Simulates Location Services being switched off system-wide: the app's own
     /// authorization is untouched, but every attempt to start updates comes back
-    /// as `CLError.denied` instead of a fix.
+    /// as `CLError.denied` instead of a fix, and `locationServicesEnabled()`
+    /// reports `false`.
     public var simulatesLocationServicesOff = false
+
+    public override func locationServicesEnabled() async -> Bool {
+        return !simulatesLocationServicesOff
+    }
 
     public override func startUpdatingLocation() {
         super.startUpdatingLocation()
-        guard authorizationStatus == .authorizedWhenInUse else { return }
+        // Guard on either authorized status, not just `.authorizedWhenInUse`, so
+        // the `.authorizedAlways` path actually delivers fixes/errors instead of
+        // returning here and letting Always-authorized tests pass vacuously.
+        guard authorizationStatus.isAuthorized else { return }
 
         if simulatesLocationServicesOff {
             delegate?.locationManager?(CLLocationManager(), didFailWithError: CLError(.denied))
@@ -129,7 +141,7 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
 
     public override func startUpdatingHeading() {
         super.startUpdatingHeading()
-        if authorizationStatus == .authorizedWhenInUse {
+        if authorizationStatus.isAuthorized {
             heading = updateHeading
         }
     }

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -89,7 +89,12 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
     var updateHeading: OBAMockHeading
     public var _authorizationStatus: CLAuthorizationStatus = .notDetermined {
         didSet {
-            delegate?.locationManager?(CLLocationManager(), didChangeAuthorization: _authorizationStatus)
+            // The modern callback, not the iOS 14-deprecated
+            // `didChangeAuthorization:`. With an iOS 18 deployment target that
+            // deprecated overload is never invoked on device, so a mock that
+            // called it would exercise a path that doesn't ship. The service
+            // reads the status off this mock, so the argument is unused.
+            delegate?.locationManagerDidChangeAuthorization?(CLLocationManager())
         }
     }
 
@@ -106,9 +111,18 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
         return _authorizationStatus
     }
 
+    /// Simulates Location Services being switched off system-wide: the app's own
+    /// authorization is untouched, but every attempt to start updates comes back
+    /// as `CLError.denied` instead of a fix.
+    public var simulatesLocationServicesOff = false
+
     public override func startUpdatingLocation() {
         super.startUpdatingLocation()
-        if authorizationStatus == .authorizedWhenInUse {
+        guard authorizationStatus == .authorizedWhenInUse else { return }
+
+        if simulatesLocationServicesOff {
+            delegate?.locationManager?(CLLocationManager(), didFailWithError: CLError(.denied))
+        } else {
             location = updateLocation
         }
     }

--- a/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
+++ b/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
@@ -52,7 +52,6 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
     }
 
     var authorizationStatus: CLAuthorizationStatus = .authorizedWhenInUse
-    var isLocationServicesEnabled: Bool = true
 
     /// Stored so tests can toggle reduced accuracy without needing a separate
     /// mock class. Kept as `CLAccuracyAuthorization` even though it's only

--- a/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
+++ b/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
@@ -53,6 +53,11 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
 
     var authorizationStatus: CLAuthorizationStatus = .authorizedWhenInUse
 
+    var locationServicesEnabledValue = true
+    func locationServicesEnabled() async -> Bool {
+        return locationServicesEnabledValue
+    }
+
     /// Stored so tests can toggle reduced accuracy without needing a separate
     /// mock class. Kept as `CLAccuracyAuthorization` even though it's only
     /// touched under iOS 14+ — the availability gate lives on the protocol

--- a/OBAKitTests/Helpers/Mocks/OBAMockHeading.swift
+++ b/OBAKitTests/Helpers/Mocks/OBAMockHeading.swift
@@ -51,4 +51,13 @@ public final nonisolated class OBAMockHeading: CLHeading, @unchecked Sendable {
     public override var debugDescription: String {
         return "wtf is wrong with this class?"
     }
+
+    /// `CLHeading`'s own `description` reads the raw magnetometer components
+    /// (`x`/`y`/`z`), which this mock does not implement — reaching it segfaults.
+    /// Swift Testing reflects the values in a *failing* `#expect`, so without
+    /// this override any assertion that touches a mock heading turns a clean
+    /// test failure into a crashed test run.
+    public override var description: String {
+        return "OBAMockHeading(magnetic: \(_magneticHeading), true: \(_trueHeading))"
+    }
 }

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -131,4 +131,64 @@ final class LocationServiceTests {
 
         #expect(delError == err)
     }
+
+    // MARK: - Denied error handling
+
+    /// A `denied` error means location is unusable even though `authorizationStatus`
+    /// still reads as authorized (e.g. Location Services switched off system-wide).
+    /// The service should latch that, report location unavailable, stop updates, and
+    /// re-notify delegates so the UI can hide its location affordances.
+    func test_deniedError_marksLocationUnavailable() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let del = LocDelegate()
+        service.addDelegate(del)
+
+        service.requestInUseAuthorization()
+        expect(service.isLocationUseAuthorized).to(beTrue())
+        expect(locationManagerMock.locationUpdatesStarted).to(beTrue())
+
+        del.status = nil
+
+        service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+
+        // Per-app authorization is unchanged, but location is now reported unavailable.
+        expect(service.authorizationStatus) == .authorizedWhenInUse
+        expect(service.isLocationUseAuthorized).to(beFalse())
+        // Delegates were re-notified so UI (locate button, user dot) can update.
+        expect(del.status).toNot(beNil())
+        // The raw error is still forwarded to delegates.
+        expect((del.error as? CLError)?.code) == .denied
+        // Updates were stopped, as Apple recommends for a denied error.
+        expect(locationManagerMock.locationUpdatesStarted).to(beFalse())
+    }
+
+    /// A subsequent authorization callback (the user re-enabling access) clears the
+    /// latch so location becomes usable again.
+    func test_deniedError_clearedByAuthorizationChange() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+
+        service.requestInUseAuthorization()
+        service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+        expect(service.isLocationUseAuthorized).to(beFalse())
+
+        service.locationManager(CLLocationManager(), didChangeAuthorization: .authorizedWhenInUse)
+
+        expect(service.isLocationUseAuthorized).to(beTrue())
+    }
+
+    /// Only a `denied` error latches unavailability; transient errors such as
+    /// `locationUnknown` must not disable location.
+    func test_nonDeniedError_doesNotMarkUnavailable() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+
+        service.requestInUseAuthorization()
+        expect(service.isLocationUseAuthorized).to(beTrue())
+
+        service.locationManager(CLLocationManager(), didFailWithError: CLError(.locationUnknown))
+
+        expect(service.isLocationUseAuthorized).to(beTrue())
+    }
 }

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -147,6 +147,7 @@ final class LocationServiceTests {
         service.requestInUseAuthorization()
         expect(service.isLocationUseAuthorized).to(beTrue())
         expect(locationManagerMock.locationUpdatesStarted).to(beTrue())
+        expect(locationManagerMock.headingUpdatesStarted).to(beTrue())
 
         del.status = nil
 
@@ -159,12 +160,14 @@ final class LocationServiceTests {
         expect(del.status).toNot(beNil())
         // The raw error is still forwarded to delegates.
         expect((del.error as? CLError)?.code) == .denied
-        // Updates were stopped, as Apple recommends for a denied error.
+        // Both location and heading updates were stopped, as Apple recommends.
         expect(locationManagerMock.locationUpdatesStarted).to(beFalse())
+        expect(locationManagerMock.headingUpdatesStarted).to(beFalse())
     }
 
     /// A subsequent authorization callback (the user re-enabling access) clears the
-    /// latch so location becomes usable again.
+    /// latch so location becomes usable again *and* updates resume, even though the
+    /// coarse authorization status is unchanged.
     func test_deniedError_clearedByAuthorizationChange() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
@@ -172,10 +175,34 @@ final class LocationServiceTests {
         service.requestInUseAuthorization()
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
         expect(service.isLocationUseAuthorized).to(beFalse())
+        expect(locationManagerMock.locationUpdatesStarted).to(beFalse())
 
+        // Status stays `.authorizedWhenInUse`, so recovery must come from the latch
+        // clearing rather than an `authorizationStatus` value change.
         service.locationManager(CLLocationManager(), didChangeAuthorization: .authorizedWhenInUse)
 
         expect(service.isLocationUseAuthorized).to(beTrue())
+        expect(locationManagerMock.locationUpdatesStarted).to(beTrue())
+    }
+
+    /// A repeated `denied` error must not re-notify delegates — the latch only
+    /// fires on a real state transition.
+    func test_deniedError_repeated_doesNotReNotify() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let del = LocDelegate()
+        service.addDelegate(del)
+
+        service.requestInUseAuthorization()
+        service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+        expect(service.isLocationUseAuthorized).to(beFalse())
+
+        del.status = nil
+        service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+
+        // Still latched, but no authorization notification for the no-op transition.
+        expect(service.isLocationUseAuthorized).to(beFalse())
+        expect(del.status).to(beNil())
     }
 
     /// Only a `denied` error latches unavailability; transient errors such as

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -16,6 +16,12 @@ import Testing
 @MainActor
 @Suite(.serialized)
 final class LocationServiceTests {
+    /// An isolated defaults suite. The denied latch is persisted, so these tests
+    /// must not read or write each other's (or the standard suite's) state.
+    private func freshDefaults() -> UserDefaults {
+        return UserDefaults(suiteName: "LocationServiceTests.\(UUID().uuidString)")!
+    }
+
     // MARK: - Authorization
 
     @Test func `Authorization default value is not determined`() {
@@ -132,90 +138,242 @@ final class LocationServiceTests {
         #expect(delError == err)
     }
 
+    /// Core Location delivers an authorization callback as soon as the delegate
+    /// is assigned, carrying an unchanged status. An already-authorized app must
+    /// start updates from it: that is what gets the first fix in before the map
+    /// settles, and without it the map opens zoomed out and jumps once the fix
+    /// finally arrives at the next foreground event.
+    @Test func `Authorization callback starts updates when already authorized`() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        #expect(!locationManagerMock.locationUpdatesStarted)
+
+        service.locationManagerDidChangeAuthorization(CLLocationManager())
+
+        #expect(locationManagerMock.locationUpdatesStarted)
+        #expect(locationManagerMock.headingUpdatesStarted)
+        #expect(service.currentLocation == TestData.mockSeattleLocation)
+    }
+
+    /// The same callback must *not* start updates when the app isn't authorized.
+    @Test func `Authorization callback does not start updates when unauthorized`() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        locationManagerMock._authorizationStatus = .denied
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+
+        service.locationManagerDidChangeAuthorization(CLLocationManager())
+
+        #expect(!service.isLocationUseAuthorized)
+        #expect(!locationManagerMock.locationUpdatesStarted)
+    }
+
+    /// A latch seeded from the previous launch is probed at app init rather than
+    /// waiting for a foreground event, so a stale one resolves as early as possible.
+    @Test func `Seeded latch is probed on authorization callback`() {
+        let userDefaults = freshDefaults()
+
+        let firstLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let firstLaunch = LocationService(userDefaults: userDefaults, locationManager: firstLaunchManager)
+        firstLaunch.requestInUseAuthorization()
+        firstLaunch.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+        #expect(!firstLaunch.isLocationUseAuthorized)
+
+        // Relaunch, with Location Services back on system-wide.
+        let secondLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        secondLaunchManager._authorizationStatus = .authorizedWhenInUse
+        let secondLaunch = LocationService(userDefaults: userDefaults, locationManager: secondLaunchManager)
+        #expect(secondLaunch.authorizationStatus == .denied)
+
+        secondLaunch.locationManagerDidChangeAuthorization(CLLocationManager())
+
+        #expect(secondLaunch.authorizationStatus == .authorizedWhenInUse)
+        #expect(secondLaunch.currentLocation == TestData.mockSeattleLocation)
+    }
+
     // MARK: - Denied error handling
 
-    /// A `denied` error means location is unusable even though `authorizationStatus`
-    /// still reads as authorized (e.g. Location Services switched off system-wide).
-    /// The service should latch that, report location unavailable, stop updates, and
-    /// re-notify delegates so the UI can hide its location affordances.
-    func test_deniedError_marksLocationUnavailable() {
+    /// A `denied` error means location is unusable even though the app's own
+    /// authorization is untouched (e.g. Location Services switched off system-wide).
+    /// The service should latch that, report `.denied` so the UI can explain the
+    /// situation, stop updates, and re-notify delegates.
+    @Test func `Denied error marks location unavailable`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
         let del = LocDelegate()
         service.addDelegate(del)
 
         service.requestInUseAuthorization()
-        expect(service.isLocationUseAuthorized).to(beTrue())
-        expect(locationManagerMock.locationUpdatesStarted).to(beTrue())
-        expect(locationManagerMock.headingUpdatesStarted).to(beTrue())
+        #expect(service.isLocationUseAuthorized)
+        #expect(locationManagerMock.locationUpdatesStarted)
+        #expect(locationManagerMock.headingUpdatesStarted)
 
         del.status = nil
 
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
 
-        // Per-app authorization is unchanged, but location is now reported unavailable.
-        expect(service.authorizationStatus) == .authorizedWhenInUse
-        expect(service.isLocationUseAuthorized).to(beFalse())
-        // Delegates were re-notified so UI (locate button, user dot) can update.
-        expect(del.status).toNot(beNil())
+        // The per-app authorization is unchanged, but the *effective* status must
+        // read `.denied`: consumers switch on this value to decide whether to show
+        // the "Location Services Off / Turn On in Settings" pill.
+        #expect(service.authorizationStatus == .denied)
+        #expect(!service.isLocationUseAuthorized)
+        // Delegates were re-notified, and with the denied-like status — not the
+        // stale `.authorizedWhenInUse`, which would hide the pill.
+        #expect(del.status == .denied)
         // The raw error is still forwarded to delegates.
-        expect((del.error as? CLError)?.code) == .denied
+        #expect((del.error as? CLError)?.code == .denied)
         // Both location and heading updates were stopped, as Apple recommends.
-        expect(locationManagerMock.locationUpdatesStarted).to(beFalse())
-        expect(locationManagerMock.headingUpdatesStarted).to(beFalse())
+        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!locationManagerMock.headingUpdatesStarted)
     }
 
-    /// A subsequent authorization callback (the user re-enabling access) clears the
-    /// latch so location becomes usable again *and* updates resume, even though the
-    /// coarse authorization status is unchanged.
-    func test_deniedError_clearedByAuthorizationChange() {
+    /// An authorization callback whose status actually *changed* means the user
+    /// made a fresh decision, so the latch is stale evidence and access is
+    /// re-armed optimistically.
+    @Test func `Denied error cleared by authorization status change`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
 
         service.requestInUseAuthorization()
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
-        expect(service.isLocationUseAuthorized).to(beFalse())
-        expect(locationManagerMock.locationUpdatesStarted).to(beFalse())
+        #expect(!service.isLocationUseAuthorized)
+        #expect(!locationManagerMock.locationUpdatesStarted)
 
-        // Status stays `.authorizedWhenInUse`, so recovery must come from the latch
-        // clearing rather than an `authorizationStatus` value change.
-        service.locationManager(CLLocationManager(), didChangeAuthorization: .authorizedWhenInUse)
+        // The user re-enabled Location Services and promoted the app to Always.
+        locationManagerMock._authorizationStatus = .authorizedAlways
 
-        expect(service.isLocationUseAuthorized).to(beTrue())
-        expect(locationManagerMock.locationUpdatesStarted).to(beTrue())
+        #expect(service.authorizationStatus == .authorizedAlways)
+        #expect(service.isLocationUseAuthorized)
+        #expect(locationManagerMock.locationUpdatesStarted)
+    }
+
+    /// Core Location fires an authorization callback whenever a delegate is
+    /// assigned. One that leaves the status untouched carries no new evidence, so
+    /// it must not clear the latch — doing so would re-arm location against a
+    /// still-disabled subsystem and flicker the locate button and user dot.
+    @Test func `Denied error survives redundant authorization callback`() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        locationManagerMock.simulatesLocationServicesOff = true
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let del = LocDelegate()
+        service.addDelegate(del)
+
+        service.requestInUseAuthorization()
+        #expect(service.authorizationStatus == .denied)
+
+        del.status = nil
+        service.locationManagerDidChangeAuthorization(CLLocationManager())
+
+        // The callback probes instead of assuming. Location Services are still
+        // off, so the probe re-fails and nothing the user can see changes.
+        #expect(service.authorizationStatus == .denied)
+        #expect(!service.isLocationUseAuthorized)
+        #expect(del.status == nil)
+        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!locationManagerMock.headingUpdatesStarted)
+    }
+
+    /// Toggling Location Services back on system-wide does not change the app's
+    /// per-app authorization, so no authorization callback need arrive. The
+    /// foreground retry probes for a fix, and a successful one clears the latch.
+    @Test func `Denied error cleared by foreground retry`() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        locationManagerMock.simulatesLocationServicesOff = true
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let del = LocDelegate()
+        service.addDelegate(del)
+
+        service.requestInUseAuthorization()
+        #expect(service.authorizationStatus == .denied)
+        #expect(!locationManagerMock.locationUpdatesStarted)
+
+        // Still off: the probe re-fails, and the UI is not disturbed by it.
+        del.status = nil
+        service.retryIfLocationServicesDenied()
+        #expect(service.authorizationStatus == .denied)
+        #expect(del.status == nil)
+        #expect(!locationManagerMock.locationUpdatesStarted)
+
+        // The user turned Location Services back on; now the probe yields a fix.
+        locationManagerMock.simulatesLocationServicesOff = false
+        service.retryIfLocationServicesDenied()
+
+        #expect(service.authorizationStatus == .authorizedWhenInUse)
+        #expect(service.isLocationUseAuthorized)
+        #expect(del.status == .authorizedWhenInUse)
+        #expect(service.currentLocation == TestData.mockSeattleLocation)
+        #expect(locationManagerMock.locationUpdatesStarted)
+        #expect(locationManagerMock.headingUpdatesStarted)
+    }
+
+    /// Location Services being off system-wide outlives the app process, but the
+    /// per-app authorization that masks it reads as authorized on the next launch.
+    /// The latch is persisted so a cold start doesn't advertise location as
+    /// available and then retract it.
+    @Test func `Denied latch persists across launches`() {
+        let userDefaults = freshDefaults()
+
+        let firstLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let firstLaunch = LocationService(userDefaults: userDefaults, locationManager: firstLaunchManager)
+        firstLaunch.requestInUseAuthorization()
+        firstLaunch.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+        #expect(!firstLaunch.isLocationUseAuthorized)
+
+        // Relaunch: the app is still authorized as far as Core Location is concerned.
+        let secondLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        secondLaunchManager._authorizationStatus = .authorizedWhenInUse
+        let secondLaunch = LocationService(userDefaults: userDefaults, locationManager: secondLaunchManager)
+
+        #expect(secondLaunch.authorizationStatus == .denied)
+        #expect(!secondLaunch.isLocationUseAuthorized)
+    }
+
+    /// Revoking authorization must tear the manager down. Nothing else will, and a
+    /// running `CLLocationManager` keeps the location-usage indicator lit.
+    @Test func `Authorization revoked stops updates`() {
+        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+
+        service.requestInUseAuthorization()
+        #expect(locationManagerMock.locationUpdatesStarted)
+
+        locationManagerMock._authorizationStatus = .denied
+
+        #expect(!service.isLocationUseAuthorized)
+        #expect(!locationManagerMock.locationUpdatesStarted)
     }
 
     /// A repeated `denied` error must not re-notify delegates — the latch only
     /// fires on a real state transition.
-    func test_deniedError_repeated_doesNotReNotify() {
+    @Test func `Repeated denied error does not re-notify`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
         let del = LocDelegate()
         service.addDelegate(del)
 
         service.requestInUseAuthorization()
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
-        expect(service.isLocationUseAuthorized).to(beFalse())
+        #expect(!service.isLocationUseAuthorized)
 
         del.status = nil
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
 
         // Still latched, but no authorization notification for the no-op transition.
-        expect(service.isLocationUseAuthorized).to(beFalse())
-        expect(del.status).to(beNil())
+        #expect(!service.isLocationUseAuthorized)
+        #expect(del.status == nil)
     }
 
     /// Only a `denied` error latches unavailability; transient errors such as
     /// `locationUnknown` must not disable location.
-    func test_nonDeniedError_doesNotMarkUnavailable() {
+    @Test func `Non-denied error does not mark unavailable`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
+        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
 
         service.requestInUseAuthorization()
-        expect(service.isLocationUseAuthorized).to(beTrue())
+        #expect(service.isLocationUseAuthorized)
 
         service.locationManager(CLLocationManager(), didFailWithError: CLError(.locationUnknown))
 
-        expect(service.isLocationUseAuthorized).to(beTrue())
+        #expect(service.isLocationUseAuthorized)
     }
 }

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -250,6 +250,28 @@ final class LocationServiceTests {
 
     // MARK: - Denied error handling
 
+    /// `startUpdates()` starts location then heading, and starting location can
+    /// synchronously deliver the `denied` error that latches and tears both down.
+    /// Heading must not then start anyway on the way back out: `isHeadingAvailable`
+    /// is a device-capability check (`CLLocationManager.headingAvailable()`), not
+    /// an authorization one, so nothing else stops it — and a magnetometer left
+    /// powered outlives the denial for the rest of the process.
+    @Test func `Synchronous denial during startUpdates leaves heading stopped`() {
+        let (mock, service) = makeService(servicesOff: true)
+        let del = LocDelegate()
+        service.addDelegate(del)
+
+        // Synchronous throughout: no probe has run yet, so this observes the
+        // state `startUpdates()` itself leaves behind.
+        service.requestInUseAuthorization()
+
+        #expect(service.authorizationStatus == .denied)
+        #expect(!mock.locationUpdatesStarted)
+        #expect(!mock.headingUpdatesStarted)
+        #expect(service.currentHeading == nil)
+        #expect(del.heading == nil)
+    }
+
     /// A `denied` error means location is unusable even though the app's own
     /// authorization is untouched (e.g. Location Services switched off system-wide).
     /// The service should latch that, report `.denied` so the UI can explain the
@@ -381,6 +403,48 @@ final class LocationServiceTests {
         #expect(mock.headingUpdatesStarted)
     }
 
+    /// Probes are unstructured tasks with no ordering guarantee at the `await`,
+    /// and three call sites can start one. A probe that started earlier — and so
+    /// read an older system state — must not clobber the latch when it resumes
+    /// after a newer one. Cancel-and-replace is what makes the newest read win.
+    @Test func `Stale probe does not clobber a newer one`() async {
+        let (mock, service) = makeService(servicesOff: true)
+
+        // Let the authorization callback's own probe run to completion first, so
+        // the only parked probes below are the two this test starts.
+        service.requestInUseAuthorization()
+        await spin(0.05)
+        #expect(service.authorizationStatus == .denied)
+
+        mock.parksProbes = true
+
+        // Two probes in flight, started one at a time so their parked order is
+        // known: the first read the switch while it was still off, the second
+        // after the user turned it back on.
+        service.retryIfLocationServicesDenied()
+        await poll(until: { mock.pendingProbes.count == 1 },
+                   "the first probe should have parked")
+
+        service.retryIfLocationServicesDenied()
+        await poll(until: { mock.pendingProbes.count == 2 },
+                   "the second probe should have parked")
+
+        // The user turned Location Services back on between the two probes, so
+        // the newer one sees `true` and the restarted manager delivers a fix.
+        mock.simulatesLocationServicesOff = false
+
+        // Resume newest-first, so the stale answer lands last.
+        mock.answerProbe(at: 1, enabled: true)
+        await poll(until: { service.isLocationUseAuthorized },
+                   "the newer probe never cleared the latch")
+
+        mock.answerProbe(at: 0, enabled: false)
+        await spin(0.05)
+
+        #expect(service.authorizationStatus == .authorizedWhenInUse)
+        #expect(service.isLocationUseAuthorized)
+    }
+
     /// Location Services being off system-wide outlives the app process, but the
     /// per-app authorization that masks it reads as authorized on the next launch.
     /// The latch is persisted so a cold start doesn't advertise location as
@@ -411,6 +475,10 @@ final class LocationServiceTests {
 
         #expect(!service.isLocationUseAuthorized)
         #expect(!mock.locationUpdatesStarted)
+        // Heading too, not just location: revocation must power the magnetometer
+        // down as well, and `stopUpdatingHeading()`'s availability guard is a
+        // device-capability check that does not relax when authorization goes away.
+        #expect(!mock.headingUpdatesStarted)
     }
 
     /// A repeated `denied` error must not re-notify delegates — the latch only

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -16,10 +16,45 @@ import Testing
 @MainActor
 @Suite(.serialized)
 final class LocationServiceTests {
+    /// Suite names handed out by `freshDefaults()`, torn down in `deinit` so the
+    /// test host doesn't accumulate a plist per run.
+    private var createdDefaultsSuites: [String] = []
+
     /// An isolated defaults suite. The denied latch is persisted, so these tests
     /// must not read or write each other's (or the standard suite's) state.
     private func freshDefaults() -> UserDefaults {
-        return UserDefaults(suiteName: "LocationServiceTests.\(UUID().uuidString)")!
+        let suiteName = "LocationServiceTests.\(UUID().uuidString)"
+        createdDefaultsSuites.append(suiteName)
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    deinit {
+        for suiteName in createdDefaultsSuites {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+    }
+
+    /// Builds an authorizable mock and a service wired to it, with a fresh,
+    /// isolated defaults suite by default. Collapses the mock + service pair that
+    /// every test below would otherwise spell out.
+    ///
+    /// - Parameters:
+    ///   - defaults: An explicit suite, for tests that simulate two launches
+    ///     sharing persisted state.
+    ///   - servicesOff: Simulates Location Services being off system-wide.
+    ///   - initialStatus: The mock's authorization *before* the service is
+    ///     constructed, so the service seeds its raw status from it (as it would
+    ///     on a real relaunch).
+    private func makeService(
+        defaults: UserDefaults? = nil,
+        servicesOff: Bool = false,
+        initialStatus: CLAuthorizationStatus = .notDetermined
+    ) -> (AuthorizableLocationManagerMock, LocationService) {
+        let mock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
+        mock.simulatesLocationServicesOff = servicesOff
+        mock._authorizationStatus = initialStatus
+        let service = LocationService(userDefaults: defaults ?? freshDefaults(), locationManager: mock)
+        return (mock, service)
     }
 
     // MARK: - Authorization
@@ -144,51 +179,73 @@ final class LocationServiceTests {
     /// settles, and without it the map opens zoomed out and jumps once the fix
     /// finally arrives at the next foreground event.
     @Test func `Authorization callback starts updates when already authorized`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        locationManagerMock._authorizationStatus = .authorizedWhenInUse
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        let (mock, service) = makeService(initialStatus: .authorizedWhenInUse)
+        #expect(!mock.locationUpdatesStarted)
 
         service.locationManagerDidChangeAuthorization(CLLocationManager())
 
-        #expect(locationManagerMock.locationUpdatesStarted)
-        #expect(locationManagerMock.headingUpdatesStarted)
+        #expect(mock.locationUpdatesStarted)
+        #expect(mock.headingUpdatesStarted)
         #expect(service.currentLocation == TestData.mockSeattleLocation)
     }
 
     /// The same callback must *not* start updates when the app isn't authorized.
     @Test func `Authorization callback does not start updates when unauthorized`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        locationManagerMock._authorizationStatus = .denied
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let (mock, service) = makeService(initialStatus: .denied)
 
         service.locationManagerDidChangeAuthorization(CLLocationManager())
 
         #expect(!service.isLocationUseAuthorized)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
     }
 
     /// A latch seeded from the previous launch is probed at app init rather than
-    /// waiting for a foreground event, so a stale one resolves as early as possible.
-    @Test func `Seeded latch is probed on authorization callback`() {
+    /// waiting for a foreground event, so a stale one resolves as early as
+    /// possible. Recovery goes through the off-main `locationServicesEnabled`
+    /// probe, so it is asynchronous.
+    @Test func `Seeded latch is probed on authorization callback`() async {
         let userDefaults = freshDefaults()
 
-        let firstLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let firstLaunch = LocationService(userDefaults: userDefaults, locationManager: firstLaunchManager)
+        // First launch: Location Services off system-wide, so the app latches.
+        let (_, firstLaunch) = makeService(defaults: userDefaults, servicesOff: true)
         firstLaunch.requestInUseAuthorization()
-        firstLaunch.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
         #expect(!firstLaunch.isLocationUseAuthorized)
 
-        // Relaunch, with Location Services back on system-wide.
-        let secondLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        secondLaunchManager._authorizationStatus = .authorizedWhenInUse
-        let secondLaunch = LocationService(userDefaults: userDefaults, locationManager: secondLaunchManager)
+        // Relaunch, with Location Services back on system-wide. The per-app
+        // authorization still reads as authorized, so the seeded latch masks it.
+        let (_, secondLaunch) = makeService(defaults: userDefaults, initialStatus: .authorizedWhenInUse)
         #expect(secondLaunch.authorizationStatus == .denied)
 
+        // The init-time authorization callback probes the seeded latch and, with
+        // services back on, clears it.
         secondLaunch.locationManagerDidChangeAuthorization(CLLocationManager())
+        await poll(until: { secondLaunch.isLocationUseAuthorized },
+                   "seeded latch was never cleared by the probe")
 
         #expect(secondLaunch.authorizationStatus == .authorizedWhenInUse)
         #expect(secondLaunch.currentLocation == TestData.mockSeattleLocation)
+    }
+
+    /// A transition that crosses *into* authorization is a fresh grant, so it
+    /// clears a stale latch synchronously — without waiting for the off-main probe.
+    @Test func `Latch cleared when authorization crosses into authorized`() {
+        let userDefaults = freshDefaults()
+
+        // Prior session latched (services off) while authorized; the latch persists.
+        let (_, firstLaunch) = makeService(defaults: userDefaults, servicesOff: true)
+        firstLaunch.requestInUseAuthorization()
+        #expect(!firstLaunch.isLocationUseAuthorized)
+
+        // Relaunch not-yet-authorized: the persisted latch is masked by the raw
+        // `.notDetermined` status.
+        let (mock, secondLaunch) = makeService(defaults: userDefaults, initialStatus: .notDetermined)
+        #expect(secondLaunch.authorizationStatus == .notDetermined)
+
+        // The user grants access. Crossing into authorization clears the stale
+        // latch right away.
+        mock._authorizationStatus = .authorizedWhenInUse
+        #expect(secondLaunch.authorizationStatus == .authorizedWhenInUse)
+        #expect(secondLaunch.isLocationUseAuthorized)
     }
 
     // MARK: - Denied error handling
@@ -198,15 +255,14 @@ final class LocationServiceTests {
     /// The service should latch that, report `.denied` so the UI can explain the
     /// situation, stop updates, and re-notify delegates.
     @Test func `Denied error marks location unavailable`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let (mock, service) = makeService()
         let del = LocDelegate()
         service.addDelegate(del)
 
         service.requestInUseAuthorization()
         #expect(service.isLocationUseAuthorized)
-        #expect(locationManagerMock.locationUpdatesStarted)
-        #expect(locationManagerMock.headingUpdatesStarted)
+        #expect(mock.locationUpdatesStarted)
+        #expect(mock.headingUpdatesStarted)
 
         del.status = nil
 
@@ -223,38 +279,54 @@ final class LocationServiceTests {
         // The raw error is still forwarded to delegates.
         #expect((del.error as? CLError)?.code == .denied)
         // Both location and heading updates were stopped, as Apple recommends.
-        #expect(!locationManagerMock.locationUpdatesStarted)
-        #expect(!locationManagerMock.headingUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
+        #expect(!mock.headingUpdatesStarted)
     }
 
-    /// An authorization callback whose status actually *changed* means the user
-    /// made a fresh decision, so the latch is stale evidence and access is
-    /// re-armed optimistically.
-    @Test func `Denied error cleared by authorization status change`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+    /// A `denied` error is not latched while the app isn't itself authorized:
+    /// the effective status would mask it anyway, and persisting it there means a
+    /// grant made while the app was not running launches wrongly showing
+    /// "Location Services Off."
+    @Test func `Denied error while unauthorized is not latched`() {
+        let userDefaults = freshDefaults()
+
+        // A denied error arrives while the app is only `.notDetermined`.
+        let (_, firstLaunch) = makeService(defaults: userDefaults, initialStatus: .notDetermined)
+        firstLaunch.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
+
+        // Nothing was persisted, so a later launch that is authorized (the user
+        // granted access while the app was dead) is not masked as denied.
+        let (_, secondLaunch) = makeService(defaults: userDefaults, initialStatus: .authorizedWhenInUse)
+        #expect(secondLaunch.authorizationStatus == .authorizedWhenInUse)
+        #expect(secondLaunch.isLocationUseAuthorized)
+    }
+
+    /// An authorization callback triggers the off-main probe, which clears the
+    /// latch once Location Services are back on — even a callback that only
+    /// changes between two authorized values (WhenInUse → Always).
+    @Test func `Denied latch cleared by probe on authorization callback`() async {
+        let (mock, service) = makeService(servicesOff: true)
 
         service.requestInUseAuthorization()
-        service.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
-        #expect(!service.isLocationUseAuthorized)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(service.authorizationStatus == .denied)
+        #expect(!mock.locationUpdatesStarted)
 
         // The user re-enabled Location Services and promoted the app to Always.
-        locationManagerMock._authorizationStatus = .authorizedAlways
+        mock.simulatesLocationServicesOff = false
+        mock._authorizationStatus = .authorizedAlways
 
+        await poll(until: { service.isLocationUseAuthorized },
+                   "probe never cleared the latch after services came back on")
         #expect(service.authorizationStatus == .authorizedAlways)
-        #expect(service.isLocationUseAuthorized)
-        #expect(locationManagerMock.locationUpdatesStarted)
+        #expect(mock.locationUpdatesStarted)
     }
 
     /// Core Location fires an authorization callback whenever a delegate is
     /// assigned. One that leaves the status untouched carries no new evidence, so
     /// it must not clear the latch — doing so would re-arm location against a
     /// still-disabled subsystem and flicker the locate button and user dot.
-    @Test func `Denied error survives redundant authorization callback`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        locationManagerMock.simulatesLocationServicesOff = true
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+    @Test func `Denied error survives redundant authorization callback`() async {
+        let (mock, service) = makeService(servicesOff: true)
         let del = LocDelegate()
         service.addDelegate(del)
 
@@ -265,45 +337,48 @@ final class LocationServiceTests {
         service.locationManagerDidChangeAuthorization(CLLocationManager())
 
         // The callback probes instead of assuming. Location Services are still
-        // off, so the probe re-fails and nothing the user can see changes.
+        // off, so the probe confirms the denial and nothing the user can see
+        // changes. Let the async probe run before asserting it changed nothing.
+        await spin(0.05)
         #expect(service.authorizationStatus == .denied)
         #expect(!service.isLocationUseAuthorized)
         #expect(del.status == nil)
-        #expect(!locationManagerMock.locationUpdatesStarted)
-        #expect(!locationManagerMock.headingUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
+        #expect(!mock.headingUpdatesStarted)
     }
 
     /// Toggling Location Services back on system-wide does not change the app's
     /// per-app authorization, so no authorization callback need arrive. The
-    /// foreground retry probes for a fix, and a successful one clears the latch.
-    @Test func `Denied error cleared by foreground retry`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        locationManagerMock.simulatesLocationServicesOff = true
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+    /// foreground retry probes the system-wide switch, and finding it back on
+    /// clears the latch.
+    @Test func `Denied error cleared by foreground retry`() async {
+        let (mock, service) = makeService(servicesOff: true)
         let del = LocDelegate()
         service.addDelegate(del)
 
         service.requestInUseAuthorization()
         #expect(service.authorizationStatus == .denied)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
 
-        // Still off: the probe re-fails, and the UI is not disturbed by it.
+        // Still off: the probe re-confirms the denial, and the UI is not disturbed.
         del.status = nil
         service.retryIfLocationServicesDenied()
+        await spin(0.05)
         #expect(service.authorizationStatus == .denied)
         #expect(del.status == nil)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
 
-        // The user turned Location Services back on; now the probe yields a fix.
-        locationManagerMock.simulatesLocationServicesOff = false
+        // The user turned Location Services back on; now the probe clears the latch.
+        mock.simulatesLocationServicesOff = false
         service.retryIfLocationServicesDenied()
 
+        await poll(until: { service.isLocationUseAuthorized },
+                   "foreground retry never cleared the latch")
         #expect(service.authorizationStatus == .authorizedWhenInUse)
-        #expect(service.isLocationUseAuthorized)
         #expect(del.status == .authorizedWhenInUse)
         #expect(service.currentLocation == TestData.mockSeattleLocation)
-        #expect(locationManagerMock.locationUpdatesStarted)
-        #expect(locationManagerMock.headingUpdatesStarted)
+        #expect(mock.locationUpdatesStarted)
+        #expect(mock.headingUpdatesStarted)
     }
 
     /// Location Services being off system-wide outlives the app process, but the
@@ -313,16 +388,12 @@ final class LocationServiceTests {
     @Test func `Denied latch persists across launches`() {
         let userDefaults = freshDefaults()
 
-        let firstLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let firstLaunch = LocationService(userDefaults: userDefaults, locationManager: firstLaunchManager)
+        let (_, firstLaunch) = makeService(defaults: userDefaults, servicesOff: true)
         firstLaunch.requestInUseAuthorization()
-        firstLaunch.locationManager(CLLocationManager(), didFailWithError: CLError(.denied))
         #expect(!firstLaunch.isLocationUseAuthorized)
 
         // Relaunch: the app is still authorized as far as Core Location is concerned.
-        let secondLaunchManager = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        secondLaunchManager._authorizationStatus = .authorizedWhenInUse
-        let secondLaunch = LocationService(userDefaults: userDefaults, locationManager: secondLaunchManager)
+        let (_, secondLaunch) = makeService(defaults: userDefaults, initialStatus: .authorizedWhenInUse)
 
         #expect(secondLaunch.authorizationStatus == .denied)
         #expect(!secondLaunch.isLocationUseAuthorized)
@@ -331,23 +402,21 @@ final class LocationServiceTests {
     /// Revoking authorization must tear the manager down. Nothing else will, and a
     /// running `CLLocationManager` keeps the location-usage indicator lit.
     @Test func `Authorization revoked stops updates`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let (mock, service) = makeService()
 
         service.requestInUseAuthorization()
-        #expect(locationManagerMock.locationUpdatesStarted)
+        #expect(mock.locationUpdatesStarted)
 
-        locationManagerMock._authorizationStatus = .denied
+        mock._authorizationStatus = .denied
 
         #expect(!service.isLocationUseAuthorized)
-        #expect(!locationManagerMock.locationUpdatesStarted)
+        #expect(!mock.locationUpdatesStarted)
     }
 
     /// A repeated `denied` error must not re-notify delegates — the latch only
     /// fires on a real state transition.
     @Test func `Repeated denied error does not re-notify`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let (_, service) = makeService()
         let del = LocDelegate()
         service.addDelegate(del)
 
@@ -366,8 +435,7 @@ final class LocationServiceTests {
     /// Only a `denied` error latches unavailability; transient errors such as
     /// `locationUnknown` must not disable location.
     @Test func `Non-denied error does not mark unavailable`() {
-        let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
-        let service = LocationService(userDefaults: freshDefaults(), locationManager: locationManagerMock)
+        let (_, service) = makeService()
 
         service.requestInUseAuthorization()
         #expect(service.isLocationUseAuthorized)


### PR DESCRIPTION
## Problem

The debugger surfaced this warning:

> This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the `-locationManagerDidChangeAuthorization:` callback and checking `authorizationStatus` first.

It traced to `LocationManager.isLocationServicesEnabled`, which called `CLLocationManager.locationServicesEnabled()` — a **synchronous, blocking XPC round-trip to `locationd`**. That call was hit on the main thread every time `LocationService.isLocationUseAuthorized` was evaluated (~10 UI call sites: `MapViewController`, `MapRegionManager`, `TripViewController`, `MapPanelRootView`, `OnboardingFlowView`, `Application`, plus internally on every authorization change).

## Fix

Follow Apple's recommended pattern: stop proactively polling the global toggle and rely on `authorizationStatus`, letting a failed location start report the "services off" case via the delegate.

1. **Removed** `isLocationServicesEnabled` from the `LocationManager` protocol and its `CLLocationManager.locationServicesEnabled()` implementation.
2. **`isLocationUseAuthorized`** is now derived from `authorizationStatus`.
3. **Handle `CLError.denied`** — because iOS keeps a per-app status of `.authorizedWhenInUse` even when Location Services is off system-wide, the service now latches a `locationServicesDenied` flag when Core Location reports a `denied` error, folds it into `isLocationUseAuthorized`, stops updates (per Apple guidance), and re-notifies delegates so the UI hides the locate button and user dot. The latch clears on the next authorization callback, so access recovers automatically.

## UI behavior (no consumer changes required)

- `MapRegionManager` turns off `showsUserLocation` on the auth-change notification.
- `MapViewModel`'s `@Published locationAuthStatus` re-fires (no dedupe), driving `MapViewController.renderMapStatus()` to hide the locate button.

## Tests

Added to `LocationServiceTests`:
- `test_deniedError_marksLocationUnavailable` — denied error → unavailable, delegates re-notified, updates stopped, raw error still forwarded.
- `test_deniedError_clearedByAuthorizationChange` — a later auth callback restores availability.
- `test_nonDeniedError_doesNotMarkUnavailable` — transient `locationUnknown` does not disable location.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location permission handling using an effective authorization state that respects system-wide Location Services being off, including a persisted “denied” latch across launches.
  * Location updates now stop reliably when moving to the background.
  * Added a foreground retry so location availability can automatically recover after Location Services are re-enabled.
* **Tests**
  * Expanded coverage for denied-latch persistence, relaunch/foreground recovery, and correct behavior for non-denial errors.
  * Updated mocks and scenarios to match the new effective authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->