### PR TITLE
Fix route badge contrast (WCAG AA) and add reduced-color stop page mode

### DIFF
--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -64,7 +64,8 @@ class SettingsViewController: FormViewController {
             debugModeEnabled: application.userDataStore.debugMode,
             alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops,
             walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
-            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit
+            walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
+            stopUIReducedColorsTag: application.userDataStore.stopUIReducedColors
         ])
     }
 
@@ -108,6 +109,10 @@ class SettingsViewController: FormViewController {
 
         if let debugEnabled = values[debugModeEnabled] as? Bool {
             application.userDataStore.debugMode = debugEnabled
+        }
+
+        if let reducedColors = values[stopUIReducedColorsTag] as? Bool {
+            application.userDataStore.stopUIReducedColors = reducedColors
         }
 
         if let alwaysShowSurveys = values[alwaysShowSurveysOnStops] as? Bool {
@@ -217,6 +222,11 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc("settings_controller.accessibility_section.show_stop_annotation_labels", value: "Show route labels on the map", comment: "Settings > Accessibility section > Show route labels on the map")
         }
 
+        section <<< SwitchRow {
+            $0.tag = stopUIReducedColorsTag
+            $0.title = OBALoc("settings_controller.accessibility_section.reduce_stop_colors", value: "Reduce colors on stop page", comment: "Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square")
+        }
+
         return section
     }()
 
@@ -224,6 +234,7 @@ class SettingsViewController: FormViewController {
 
     private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
     private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"
+    private let stopUIReducedColorsTag = "stopUIReducedColors"
 
     private func snapToPreset(_ speed: Double) -> Double {
         WalkingSpeedPreset.nearest(to: speed).rawValue

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -234,7 +234,7 @@ class SettingsViewController: FormViewController {
 
     private let walkingSpeedMetersPerSecondKey = "walkingSpeedMetersPerSecond"
     private let walkingSpeedUseHealthKitKey = "walkingSpeedUseHealthKit"
-    private let stopUIReducedColorsTag = "stopUIReducedColors"
+    private let stopUIReducedColorsTag = UserDefaultsStore.stopUIReducedColorsKey
 
     private func snapToPreset(_ speed: Double) -> Double {
         WalkingSpeedPreset.nearest(to: speed).rawValue

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -36,7 +36,7 @@ struct DepartureRowView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.obaFormatters) private var formatters
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
-    @AppStorage("stopUIReducedColors") private var reducedColors = false
+    @AppStorage(UserDefaultsStore.stopUIReducedColorsKey) private var reducedColors = false
 
     private var dimmed: Bool { style == .past }
 

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -36,6 +36,7 @@ struct DepartureRowView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.obaFormatters) private var formatters
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
+    @AppStorage("stopUIReducedColors") private var reducedColors = false
 
     private var dimmed: Bool { style == .past }
 
@@ -109,7 +110,8 @@ struct DepartureRowView: View {
         RouteBadgeView(
             routeShortName: departure.routeShortName,
             routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand),
-            routeTextColor: departure.route.textColor.map { Color(uiColor: $0) }
+            routeTextColor: departure.route.textColor.map { Color(uiColor: $0) },
+            reducedColors: reducedColors
         )
     }
 

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -108,7 +108,8 @@ struct DepartureRowView: View {
     private var routeBadge: some View {
         RouteBadgeView(
             routeShortName: departure.routeShortName,
-            routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand)
+            routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand),
+            routeTextColor: departure.route.textColor.map { Color(uiColor: $0) }
         )
     }
 

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -41,7 +41,7 @@ struct GroupedListView: View {
 
     @Environment(\.obaFormatters) private var formatters
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @AppStorage("stopUIReducedColors") private var reducedColors = false
+    @AppStorage(UserDefaultsStore.stopUIReducedColorsKey) private var reducedColors = false
 
     /// At accessibility sizes the card layouts "stack" (the guide's committed
     /// layout): badge + countdown become glance tokens on the first line and
@@ -122,7 +122,7 @@ struct GroupedListView: View {
         VStack(alignment: .leading, spacing: 3) {
             if isAccessibilitySize {
                 HStack(alignment: .center) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48, reducedColors: reducedColors)
+                    routeBadge(for: next, routeColor: routeColor)
                     Spacer(minLength: 8)
                     CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
                 }
@@ -134,7 +134,7 @@ struct GroupedListView: View {
                     .foregroundStyle(Color(uiColor: status.color))
             } else {
                 HStack(alignment: .center, spacing: 13) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48, reducedColors: reducedColors)
+                    routeBadge(for: next, routeColor: routeColor)
                     VStack(alignment: .leading, spacing: 3) {
                         headsignText(next)
                         HStack(spacing: 6) {
@@ -151,6 +151,16 @@ struct GroupedListView: View {
                 }
             }
         }
+    }
+
+    private func routeBadge(for next: ArrivalDeparture, routeColor: Color) -> some View {
+        RouteBadgeView(
+            routeShortName: next.routeShortName,
+            routeColor: routeColor,
+            routeTextColor: next.route.textColor.map { Color(uiColor: $0) },
+            size: 48,
+            reducedColors: reducedColors
+        )
     }
 
     /// Clamped to two lines at every size (the guide's committed "clamp + tap"

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -121,7 +121,7 @@ struct GroupedListView: View {
         VStack(alignment: .leading, spacing: 3) {
             if isAccessibilitySize {
                 HStack(alignment: .center) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48)
                     Spacer(minLength: 8)
                     CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
                 }
@@ -133,7 +133,7 @@ struct GroupedListView: View {
                     .foregroundStyle(Color(uiColor: status.color))
             } else {
                 HStack(alignment: .center, spacing: 13) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, size: 48)
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48)
                     VStack(alignment: .leading, spacing: 3) {
                         headsignText(next)
                         HStack(spacing: 6) {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -41,6 +41,7 @@ struct GroupedListView: View {
 
     @Environment(\.obaFormatters) private var formatters
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @AppStorage("stopUIReducedColors") private var reducedColors = false
 
     /// At accessibility sizes the card layouts "stack" (the guide's committed
     /// layout): badge + countdown become glance tokens on the first line and
@@ -121,7 +122,7 @@ struct GroupedListView: View {
         VStack(alignment: .leading, spacing: 3) {
             if isAccessibilitySize {
                 HStack(alignment: .center) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48)
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48, reducedColors: reducedColors)
                     Spacer(minLength: 8)
                     CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
                 }
@@ -133,7 +134,7 @@ struct GroupedListView: View {
                     .foregroundStyle(Color(uiColor: status.color))
             } else {
                 HStack(alignment: .center, spacing: 13) {
-                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48)
+                    RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48, reducedColors: reducedColors)
                     VStack(alignment: .leading, spacing: 3) {
                         headsignText(next)
                         HStack(spacing: 6) {

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -31,17 +31,11 @@ struct RouteBadgeView: View {
     @Environment(\.colorSchemeContrast) private var contrast
 
     private var resolvedTextColor: Color {
-        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
-        let background = UIColor(routeColor)
-        let preferred = routeTextColor.map { UIColor($0) }
-        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+        RouteBadgeStyle.textColor(routeColor: routeColor, routeTextColor: routeTextColor, contrast: contrast)
     }
 
-    /// The gradient's luminance ramp is a small, intentional deviation from
-    /// the flat color the ratio is computed against; Increase Contrast goes
-    /// flat so the strict 7:1 tier has no ambiguity.
     private var backgroundStyle: AnyShapeStyle {
-        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+        RouteBadgeStyle.backgroundStyle(routeColor: routeColor, contrast: contrast)
     }
 
     private var badgeFont: Font {

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -21,8 +21,13 @@ struct RouteBadgeView: View {
     let routeColor: Color
     var routeTextColor: Color?
     var size: CGFloat = 44
+    /// When true (Settings > Accessibility > "Reduce colors on stop page"),
+    /// route color shrinks to a thin vertical bar and the route number uses
+    /// the standard label color — same information, minimal color area.
+    var reducedColors: Bool = false
 
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @ScaledMetric(relativeTo: .body) private var barWidth: CGFloat = 5
     @Environment(\.colorSchemeContrast) private var contrast
 
     private var resolvedTextColor: Color {
@@ -39,15 +44,47 @@ struct RouteBadgeView: View {
         contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
     }
 
+    private var badgeFont: Font {
+        .system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy)
+    }
+
     var body: some View {
+        Group {
+            if reducedColors {
+                reducedBody
+            } else {
+                standardBody
+            }
+        }
+        .frame(width: size * scale, height: size * scale)
+        .accessibilityHidden(true) // route name is in the row's combined label
+    }
+
+    private var standardBody: some View {
         Text(routeShortName)
-            .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
+            .font(badgeFont)
             .monospacedDigit()
             .foregroundStyle(resolvedTextColor)
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .frame(width: size * scale, height: size * scale)
             .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
-            .accessibilityHidden(true) // route name is in the row's combined label
+    }
+
+    /// Same frame as the standard badge so departure rows keep their column
+    /// alignment when the setting flips.
+    private var reducedBody: some View {
+        HStack(spacing: 6 * scale) {
+            Capsule(style: .continuous)
+                .fill(routeColor)
+                .frame(width: barWidth, height: size * scale)
+            Text(routeShortName)
+                .font(badgeFont)
+                .monospacedDigit()
+                .foregroundStyle(.primary)
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -9,13 +9,11 @@ import OBAKitCore
 
 /// Rounded-square route identity badge — the only place route color appears in
 /// the departure list rows; the trip panel separately uses it for the vehicle
-/// glyph and approach timeline. Spec §4.3 still holds: route color never tints
-/// countdowns or adherence text.
+/// glyph and approach timeline. The stop-page-rethink spec's §4.3 still holds:
+/// route color never tints countdowns or adherence text.
 ///
-/// Text color is WCAG-aware: the agency's `route_text_color` is honored when
-/// it clears the contrast threshold, else black/white is computed. Under
-/// system Increase Contrast the gradient flattens and the threshold rises to
-/// 7:1 (see docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md).
+/// Text color and fill are decided by `RouteBadgeStyle` (WCAG-aware; see
+/// docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md).
 struct RouteBadgeView: View {
     let routeShortName: String
     let routeColor: Color

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -5,27 +5,49 @@
 //
 
 import SwiftUI
+import OBAKitCore
 
 /// Rounded-square route identity badge — the only place route color appears in
 /// the departure list rows; the trip panel separately uses it for the vehicle
 /// glyph and approach timeline. Spec §4.3 still holds: route color never tints
 /// countdowns or adherence text.
+///
+/// Text color is WCAG-aware: the agency's `route_text_color` is honored when
+/// it clears the contrast threshold, else black/white is computed. Under
+/// system Increase Contrast the gradient flattens and the threshold rises to
+/// 7:1 (see docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md).
 struct RouteBadgeView: View {
     let routeShortName: String
     let routeColor: Color
+    var routeTextColor: Color?
     var size: CGFloat = 44
 
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    private var resolvedTextColor: Color {
+        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+    }
+
+    /// The gradient's luminance ramp is a small, intentional deviation from
+    /// the flat color the ratio is computed against; Increase Contrast goes
+    /// flat so the strict 7:1 tier has no ambiguity.
+    private var backgroundStyle: AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+    }
 
     var body: some View {
         Text(routeShortName)
             .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
             .monospacedDigit()
-            .foregroundStyle(.white)
+            .foregroundStyle(resolvedTextColor)
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .frame(width: size * scale, height: size * scale)
-            .background(routeColor.gradient, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
             .accessibilityHidden(true) // route name is in the row's combined label
     }
 }

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "استجابة لمسية عند إعادة التحميل";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "تقليل الألوان في صفحة الموقف";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "إظهار تسميات الخطوط على الخريطة";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Haptic feedback on reload";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Reduce colors on stop page";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Show route labels on the map";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Retroalimentación táctil al actualizar";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Reducir los colores en la página de la parada";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Mostrar las etiquetas de la ruta en el mapa";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Haptic feedback kapag nag-reload";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Bawasan ang mga kulay sa pahina ng hintuan";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Ipakita ang mga label ng ruta sa mapa";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Retour haptique lors de l'actualisation";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Réduire les couleurs sur la page de l'arrêt";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Afficher les noms des lignes sur la carte";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Ricarica pagina con feedback tattile";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Riduci i colori nella pagina della fermata";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Mostra le etichette del percorso sulla mappa";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "새로고침 시 햅틱 피드백";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "정류장 페이지에서 색상 줄이기";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "지도에 노선 레이블 표시";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Haptyczna informacja zwrotna po przeładowaniu";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Zmniejsz liczbę kolorów na stronie przystanku";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Pokaż etykiety tras na mapie";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Resposta tátil ao recarregar";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Reduzir as cores na página da parada";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Mostrar nomes das linhas no mapa";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Тактильный отклик при обновлении";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Уменьшать количество цветов на странице остановки";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Показывать названия маршрутов на карте";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "Phản hồi rung khi tải lại";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "Giảm màu sắc trên trang điểm dừng";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "Hiển thị nhãn tuyến trên bản đồ";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "重新加载时发送手机振动";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "在车站页面上减少颜色";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "在地图上显示线路标签";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -933,6 +933,9 @@
 /* Settings > Accessibility section > Haptic feedback on reload */
 "settings_controller.accessibility_section.enable_reload_haptic" = "重新整理時提供觸覺回饋";
 
+/* Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square */
+"settings_controller.accessibility_section.reduce_stop_colors" = "在站牌頁面上減少顏色";
+
 /* Settings > Accessibility section > Show route labels on the map */
 "settings_controller.accessibility_section.show_stop_annotation_labels" = "在地圖上顯示路線標籤";
 

--- a/OBAKitCore/Extensions/UIColor+WCAG.swift
+++ b/OBAKitCore/Extensions/UIColor+WCAG.swift
@@ -13,12 +13,16 @@ public extension UIColor {
 
     /// WCAG 2.1 relative luminance: 0 (black) … 1 (white), with piecewise
     /// sRGB linearization.
+    ///
+    /// Assumes an RGB-convertible color (pattern colors degrade to luminance
+    /// 0); alpha is ignored — colors are treated as opaque.
     var wcagRelativeLuminance: CGFloat {
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
         getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         func linearize(_ channel: CGFloat) -> CGFloat {
-            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+            let clamped = min(max(channel, 0), 1)
+            return clamped <= 0.03928 ? clamped / 12.92 : pow((clamped + 0.055) / 1.055, 2.4)
         }
 
         return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)

--- a/OBAKitCore/Extensions/UIColor+WCAG.swift
+++ b/OBAKitCore/Extensions/UIColor+WCAG.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+
+// WCAG 2.1 contrast math (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance).
+// Distinct from `isLightColor`/`contrastingTextColor` in UIKitExtensions.swift,
+// which use a perceived-luminance heuristic unsuitable for contrast-ratio checks.
+public extension UIColor {
+
+    /// WCAG 2.1 relative luminance: 0 (black) … 1 (white), with piecewise
+    /// sRGB linearization.
+    var wcagRelativeLuminance: CGFloat {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        func linearize(_ channel: CGFloat) -> CGFloat {
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+
+        return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)
+    }
+
+    /// WCAG 2.1 contrast ratio between the receiver and `other`:
+    /// 1 (identical) … 21 (black/white). Symmetric.
+    func wcagContrastRatio(against other: UIColor) -> CGFloat {
+        let lighter = max(wcagRelativeLuminance, other.wcagRelativeLuminance)
+        let darker = min(wcagRelativeLuminance, other.wcagRelativeLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    /// Text color for content drawn over the receiver. Honors `preferred`
+    /// (e.g. the agency's GTFS `route_text_color`) when it clears
+    /// `minimumRatio`; otherwise returns black or white, whichever contrasts
+    /// more. Guarantees the best achievable contrast when no candidate
+    /// clears the bar.
+    func badgeTextColor(preferring preferred: UIColor?, minimumRatio: CGFloat) -> UIColor {
+        if let preferred, preferred.wcagContrastRatio(against: self) >= minimumRatio {
+            return preferred
+        }
+
+        let blackRatio = UIColor.black.wcagContrastRatio(against: self)
+        let whiteRatio = UIColor.white.wcagContrastRatio(against: self)
+        return blackRatio >= whiteRatio ? .black : .white
+    }
+}

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -412,8 +412,8 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     /// page's `@AppStorage` readers and the Settings form reference the same
     /// string. Deliberately dot-free, unlike its `UserDataStore.`-prefixed
     /// neighbors: `@AppStorage` observes the key via KVO, which treats dots
-    /// as key-path separators and silently never fires. See the
-    /// accessibility spec.
+    /// as key-path separators and silently never fires. See
+    /// docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md §3.
     public static let stopUIReducedColorsKey = "stopUIReducedColors"
 
     public init(userDefaults: UserDefaults) {

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -405,11 +405,16 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
         static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
-        // Deliberately dot-free, unlike its neighbors: the stop page observes
-        // this key via @AppStorage, whose KVO treats dots as key-path
-        // separators and silently never fires. See the accessibility spec.
-        static let stopUIReducedColors = "stopUIReducedColors"
+        static let stopUIReducedColors = UserDefaultsStore.stopUIReducedColorsKey
     }
+
+    /// The defaults key backing `stopUIReducedColors`, public so the stop
+    /// page's `@AppStorage` readers and the Settings form reference the same
+    /// string. Deliberately dot-free, unlike its `UserDataStore.`-prefixed
+    /// neighbors: `@AppStorage` observes the key via KVO, which treats dots
+    /// as key-path separators and silently never fires. See the
+    /// accessibility spec.
+    public static let stopUIReducedColorsKey = "stopUIReducedColors"
 
     public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -36,6 +36,11 @@ public protocol UserDataStore: NSObjectProtocol {
 
     var debugMode: Bool { get set }
 
+    /// Whether the stop page renders route badges in reduced-color form
+    /// (thin route-color bar + label-colored text). Surfaced in
+    /// Settings > Accessibility.
+    var stopUIReducedColors: Bool { get set }
+
     // MARK: - Bookmark Groups
 
     /// Retrieves a list of `BookmarkGroup` objects.
@@ -400,6 +405,10 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
         static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
+        // Deliberately dot-free, unlike its neighbors: the stop page observes
+        // this key via @AppStorage, whose KVO treats dots as key-path
+        // separators and silently never fires. See the accessibility spec.
+        static let stopUIReducedColors = "stopUIReducedColors"
     }
 
     public init(userDefaults: UserDefaults) {
@@ -407,6 +416,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
 
         self.userDefaults.register(defaults: [
             UserDefaultsKeys.debugMode: false,
+            UserDefaultsKeys.stopUIReducedColors: false,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
             UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
         ])
@@ -424,6 +434,17 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             userDefaults.set(newValue, forKey: UserDefaultsKeys.debugMode)
+        }
+    }
+
+    // MARK: - Stop UI Reduced Colors
+
+    public var stopUIReducedColors: Bool {
+        get {
+            return userDefaults.bool(forKey: UserDefaultsKeys.stopUIReducedColors)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.stopUIReducedColors)
         }
     }
 

--- a/OBAKitCore/UI/RouteBadgeStyle.swift
+++ b/OBAKitCore/UI/RouteBadgeStyle.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// The shared visual policy for route badges: which text color to draw over
+/// the route color (agency `route_text_color` when it clears the WCAG bar,
+/// else computed black/white) and whether the fill keeps its gradient. One
+/// home so the stop page badge and the public widget badge cannot drift.
+public enum RouteBadgeStyle {
+
+    /// AA (4.5:1) for the standard presentation; AAA (7:1) once the user
+    /// asks the system for more contrast.
+    private static func minimumRatio(for contrast: ColorSchemeContrast) -> CGFloat {
+        contrast == .increased ? 7.0 : 4.5
+    }
+
+    public static func textColor(routeColor: Color, routeTextColor: Color?, contrast: ColorSchemeContrast) -> Color {
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio(for: contrast)))
+    }
+
+    /// The gradient's luminance ramp is a small, intentional deviation from
+    /// the flat color the ratio is computed against; Increase Contrast goes
+    /// flat so the strict 7:1 tier has no ambiguity.
+    public static func backgroundStyle(routeColor: Color, contrast: ColorSchemeContrast) -> AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+    }
+}

--- a/OBAKitCore/UI/RouteBadgeStyle.swift
+++ b/OBAKitCore/UI/RouteBadgeStyle.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// The shared visual policy for route badges: which text color to draw over
 /// the route color (agency `route_text_color` when it clears the WCAG bar,
 /// else computed black/white) and whether the fill keeps its gradient. One
-/// home so the stop page badge and the public widget badge cannot drift.
+/// home so the stop page's badge and OBAKitCore's public `RouteBadgeView`
+/// (bookmark cards, trip Live Activity) cannot drift.
 public enum RouteBadgeStyle {
 
     /// AA (4.5:1) for the standard presentation; AAA (7:1) once the user

--- a/OBAKitCore/UI/RouteBadgeView.swift
+++ b/OBAKitCore/UI/RouteBadgeView.swift
@@ -8,12 +8,14 @@ import SwiftUI
 
 /// Rounded-square route identity badge. Public so the widget extension can use it.
 ///
-/// Text color is WCAG-aware (same decision as the stop page's internal
-/// `RouteBadgeView`): agency text color when it clears the threshold, else
-/// computed black/white; Increase Contrast flattens the gradient and raises
-/// the threshold to 7:1. Note: in `accented`/`vibrant` widget rendering modes
-/// the system tints everything and this logic is moot; it matters in
-/// `fullColor` rendering.
+/// Text color and fill are decided by `RouteBadgeStyle` (WCAG-aware; see
+/// docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md).
+/// Currently consumed by the trip Live Activity and in-app bookmark cards,
+/// neither of which is subject to widget `accented`/`vibrant` tinting; if
+/// this badge is ever placed in a timeline widget, the color logic only
+/// matters in `fullColor` rendering. Neither current consumer passes
+/// `routeTextColor`, so the agency-color path is exercised only by the stop
+/// page's separate badge.
 public struct RouteBadgeView: View {
     public let routeShortName: String
     public let routeColor: Color

--- a/OBAKitCore/UI/RouteBadgeView.swift
+++ b/OBAKitCore/UI/RouteBadgeView.swift
@@ -31,14 +31,11 @@ public struct RouteBadgeView: View {
     }
 
     private var resolvedTextColor: Color {
-        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
-        let background = UIColor(routeColor)
-        let preferred = routeTextColor.map { UIColor($0) }
-        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+        RouteBadgeStyle.textColor(routeColor: routeColor, routeTextColor: routeTextColor, contrast: contrast)
     }
 
     private var backgroundStyle: AnyShapeStyle {
-        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+        RouteBadgeStyle.backgroundStyle(routeColor: routeColor, contrast: contrast)
     }
 
     public var body: some View {

--- a/OBAKitCore/UI/RouteBadgeView.swift
+++ b/OBAKitCore/UI/RouteBadgeView.swift
@@ -7,28 +7,49 @@
 import SwiftUI
 
 /// Rounded-square route identity badge. Public so the widget extension can use it.
+///
+/// Text color is WCAG-aware (same decision as the stop page's internal
+/// `RouteBadgeView`): agency text color when it clears the threshold, else
+/// computed black/white; Increase Contrast flattens the gradient and raises
+/// the threshold to 7:1. Note: in `accented`/`vibrant` widget rendering modes
+/// the system tints everything and this logic is moot; it matters in
+/// `fullColor` rendering.
 public struct RouteBadgeView: View {
     public let routeShortName: String
     public let routeColor: Color
+    public var routeTextColor: Color?
     public var size: CGFloat = 44
 
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @Environment(\.colorSchemeContrast) private var contrast
 
-    public init(routeShortName: String, routeColor: Color, size: CGFloat = 44) {
+    public init(routeShortName: String, routeColor: Color, routeTextColor: Color? = nil, size: CGFloat = 44) {
         self.routeShortName = routeShortName
         self.routeColor = routeColor
+        self.routeTextColor = routeTextColor
         self.size = size
+    }
+
+    private var resolvedTextColor: Color {
+        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+    }
+
+    private var backgroundStyle: AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
     }
 
     public var body: some View {
         Text(routeShortName)
             .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
             .monospacedDigit()
-            .foregroundStyle(.white)
+            .foregroundStyle(resolvedTextColor)
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .frame(width: size * scale, height: size * scale)
-            .background(routeColor.gradient, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
             .accessibilityHidden(true)
     }
 }

--- a/OBAKitTests/Extensions/UIColorWCAGTests.swift
+++ b/OBAKitTests/Extensions/UIColorWCAGTests.swift
@@ -72,4 +72,11 @@ struct UIColorWCAGTests {
         #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 4.5) == UIColor.white)
         #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
     }
+
+    /// #7F7F7F under the 7:1 tier: white ≈ 3.6:1, black ≈ 5.8:1 — neither
+    /// clears the bar, so the decision must fall back to the better one.
+    @Test func whenNothingClearsTheBarTheHigherContrastFallbackWins() {
+        let midGray = UIColor(red: 127.0/255.0, green: 127.0/255.0, blue: 127.0/255.0, alpha: 1.0)
+        #expect(midGray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
+    }
 }

--- a/OBAKitTests/Extensions/UIColorWCAGTests.swift
+++ b/OBAKitTests/Extensions/UIColorWCAGTests.swift
@@ -1,0 +1,75 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Testing
+import UIKit
+@testable import OBAKitCore
+
+struct UIColorWCAGTests {
+
+    // MARK: - Relative luminance
+
+    @Test func luminanceOfBlackIsZero() {
+        #expect(abs(UIColor.black.wcagRelativeLuminance - 0.0) < 0.0001)
+    }
+
+    @Test func luminanceOfWhiteIsOne() {
+        #expect(abs(UIColor.white.wcagRelativeLuminance - 1.0) < 0.0001)
+    }
+
+    // MARK: - Contrast ratio
+
+    @Test func whiteOnBlackIs21ToOne() {
+        #expect(abs(UIColor.white.wcagContrastRatio(against: .black) - 21.0) < 0.01)
+    }
+
+    @Test func ratioIsSymmetric() {
+        let yellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        let a = UIColor.white.wcagContrastRatio(against: yellow)
+        let b = yellow.wcagContrastRatio(against: .white)
+        #expect(abs(a - b) < 0.0001)
+    }
+
+    /// #767676 is the canonical WCAG AA boundary gray: white text over it is
+    /// almost exactly 4.5:1.
+    @Test func whiteOn767676IsTheAABoundary() {
+        let gray = UIColor(red: 118.0/255.0, green: 118.0/255.0, blue: 118.0/255.0, alpha: 1.0)
+        let ratio = UIColor.white.wcagContrastRatio(against: gray)
+        #expect(abs(ratio - 4.54) < 0.01)
+    }
+
+    // MARK: - Badge text color decision
+
+    /// The reported bug: Metro's yellow with white text is ~1.8:1. The
+    /// decision must reject white and return black (~11:1).
+    @Test func metroYellowGetsBlackText() {
+        let metroYellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        let chosen = metroYellow.badgeTextColor(preferring: .white, minimumRatio: 4.5)
+        #expect(chosen == UIColor.black)
+    }
+
+    @Test func darkBlueKeepsAgencyWhiteText() {
+        let darkBlue = UIColor(red: 0.05, green: 0.15, blue: 0.45, alpha: 1.0)
+        let chosen = darkBlue.badgeTextColor(preferring: .white, minimumRatio: 4.5)
+        #expect(chosen == UIColor.white)
+    }
+
+    @Test func nilPreferredComputesBlackOrWhite() {
+        let metroYellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        #expect(metroYellow.badgeTextColor(preferring: nil, minimumRatio: 4.5) == UIColor.black)
+
+        let darkBlue = UIColor(red: 0.05, green: 0.15, blue: 0.45, alpha: 1.0)
+        #expect(darkBlue.badgeTextColor(preferring: nil, minimumRatio: 4.5) == UIColor.white)
+    }
+
+    /// A preferred color passing 4.5 but failing 7.0 must be rejected at the
+    /// Increase Contrast threshold. White on #767676 is ~4.54:1.
+    @Test func strictThresholdRejectsBorderlinePreferred() {
+        let gray = UIColor(red: 118.0/255.0, green: 118.0/255.0, blue: 118.0/255.0, alpha: 1.0)
+        #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 4.5) == UIColor.white)
+        #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
+    }
+}

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -201,6 +201,21 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(newStore.debugMode).to(beTrue())
     }
 
+    // MARK: - Stop UI Reduced Colors
+
+    func test_stopUIReducedColors_defaultValue() {
+        expect(self.userDefaultsStore.stopUIReducedColors).to(beFalse())
+    }
+
+    func test_stopUIReducedColors_setValue_persistsUnderTheAppStorageKey() {
+        userDefaultsStore.stopUIReducedColors = true
+        expect(self.userDefaultsStore.stopUIReducedColors).to(beTrue())
+        // The @AppStorage readers and the Eureka form must see the same key,
+        // and it must stay dot-free or KVO observation silently stops firing.
+        expect(UserDefaultsStore.stopUIReducedColorsKey) == "stopUIReducedColors"
+        expect(self.userDefaultsStore.userDefaults.bool(forKey: UserDefaultsStore.stopUIReducedColorsKey)).to(beTrue())
+    }
+
     // MARK: - Survey Properties
 
     func test_surveyUserIdentifier_generatesUUID() {

--- a/OBAKitTests/UI/RouteBadgeStyleTests.swift
+++ b/OBAKitTests/UI/RouteBadgeStyleTests.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Testing
+import SwiftUI
+@testable import OBAKitCore
+
+struct RouteBadgeStyleTests {
+
+    /// #767676 is the canonical WCAG AA boundary gray: white text over it is
+    /// ~4.54:1 — above the standard 4.5 tier, below the increased 7.0 tier.
+    /// One color, two contrast settings, two different outcomes proves the
+    /// tier wiring (the WCAG tests all pass minimumRatio explicitly and
+    /// cannot catch a mis-wired threshold).
+    @Test @MainActor func increasedContrastRaisesTheThreshold() {
+        let gray = Color(red: 118.0/255.0, green: 118.0/255.0, blue: 118.0/255.0)
+
+        // UIColor(Color) round-trips through a different color space than a
+        // directly-constructed UIColor.white/.black, so `==` isn't reliable
+        // here; compare the channel average instead.
+        func averageChannel(_ color: Color) -> CGFloat {
+            var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+            UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+            return (red + green + blue) / 3
+        }
+
+        #expect(averageChannel(RouteBadgeStyle.textColor(routeColor: gray, routeTextColor: .white, contrast: .standard)) > 0.99)
+        #expect(averageChannel(RouteBadgeStyle.textColor(routeColor: gray, routeTextColor: .white, contrast: .increased)) < 0.01)
+    }
+}

--- a/docs/superpowers/plans/2026-07-20-stop-ui-accessibility.md
+++ b/docs/superpowers/plans/2026-07-20-stop-ui-accessibility.md
@@ -1,0 +1,703 @@
+# Stop UI Accessibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the stop page's route badges WCAG-AA readable (fixing white-on-yellow), honor system Increase Contrast, and add an opt-in reduced-color badge presentation.
+
+**Architecture:** WCAG 2.1 contrast math lives in a new OBAKitCore `UIColor` extension so both `RouteBadgeView` copies (stop page + widget) share one text-color decision. The stop page's copy additionally gains a reduced-color variant (vertical route-color bar + primary-label text) driven by a dot-free `@AppStorage` key that a new `UserDataStore` property and Eureka `SwitchRow` write.
+
+**Tech Stack:** Swift, SwiftUI (stop page), Eureka (settings form), Swift Testing (new tests), XcodeGen project generation.
+
+**Spec:** `docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md`
+
+## Global Constraints
+
+- iOS 18.0+ deployment target; Swift 5/6 language modes; modern syntax is fine.
+- OBAKitCore must remain application-extension safe (no UIApplication, no app-only API).
+- Run `scripts/generate_project OneBusAway` after adding any file, before building.
+- Build/test destination: `platform=iOS Simulator,name=iPhone 17 Pro` (iPhone 16 is NOT installed).
+- Test command shape: `xcodebuild test-without-building -only-testing:OBAKitTests/<ClassOrSuite> -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — build first with `xcodebuild build-for-testing -scheme 'App' -destination '…'`. Use `set -o pipefail` if piping through `tail`; a failed build leaves stale products the simulator refuses to launch.
+- User-facing strings use `OBALoc("key", value:, comment:)`.
+- The reduced-colors defaults key MUST be the dot-free string `stopUIReducedColors` (KVO/@AppStorage constraint — see spec §3).
+- WCAG thresholds: 4.5:1 normal, 7.0:1 under Increase Contrast. Never special-case by text size.
+- Commit after each task.
+
+---
+
+### Task 1: WCAG contrast math + badge text-color decision (OBAKitCore)
+
+**Files:**
+- Create: `OBAKitCore/Extensions/UIColor+WCAG.swift`
+- Test: `OBAKitTests/Extensions/UIColorWCAGTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (used by Tasks 2–3):
+  - `UIColor.wcagRelativeLuminance: CGFloat`
+  - `UIColor.wcagContrastRatio(against other: UIColor) -> CGFloat`
+  - `UIColor.badgeTextColor(preferring preferred: UIColor?, minimumRatio: CGFloat) -> UIColor`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OBAKitTests/Extensions/UIColorWCAGTests.swift`. Swift Testing (there is precedent in `OBAKitTests/Strings/LocalizationTests.swift`); most old tests are XCTest but new tests use Swift Testing.
+
+```swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Testing
+import UIKit
+@testable import OBAKitCore
+
+struct UIColorWCAGTests {
+
+    // MARK: - Relative luminance
+
+    @Test func luminanceOfBlackIsZero() {
+        #expect(abs(UIColor.black.wcagRelativeLuminance - 0.0) < 0.0001)
+    }
+
+    @Test func luminanceOfWhiteIsOne() {
+        #expect(abs(UIColor.white.wcagRelativeLuminance - 1.0) < 0.0001)
+    }
+
+    // MARK: - Contrast ratio
+
+    @Test func whiteOnBlackIs21ToOne() {
+        #expect(abs(UIColor.white.wcagContrastRatio(against: .black) - 21.0) < 0.01)
+    }
+
+    @Test func ratioIsSymmetric() {
+        let yellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        let a = UIColor.white.wcagContrastRatio(against: yellow)
+        let b = yellow.wcagContrastRatio(against: .white)
+        #expect(abs(a - b) < 0.0001)
+    }
+
+    /// #767676 is the canonical WCAG AA boundary gray: white text over it is
+    /// almost exactly 4.5:1.
+    @Test func whiteOn767676IsTheAABoundary() {
+        let gray = UIColor(red: 118.0/255.0, green: 118.0/255.0, blue: 118.0/255.0, alpha: 1.0)
+        let ratio = UIColor.white.wcagContrastRatio(against: gray)
+        #expect(abs(ratio - 4.54) < 0.01)
+    }
+
+    // MARK: - Badge text color decision
+
+    /// The reported bug: Metro's yellow with white text is ~1.8:1. The
+    /// decision must reject white and return black (~11:1).
+    @Test func metroYellowGetsBlackText() {
+        let metroYellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        let chosen = metroYellow.badgeTextColor(preferring: .white, minimumRatio: 4.5)
+        #expect(chosen == UIColor.black)
+    }
+
+    @Test func darkBlueKeepsAgencyWhiteText() {
+        let darkBlue = UIColor(red: 0.05, green: 0.15, blue: 0.45, alpha: 1.0)
+        let chosen = darkBlue.badgeTextColor(preferring: .white, minimumRatio: 4.5)
+        #expect(chosen == UIColor.white)
+    }
+
+    @Test func nilPreferredComputesBlackOrWhite() {
+        let metroYellow = UIColor(red: 0.96, green: 0.71, blue: 0.20, alpha: 1.0)
+        #expect(metroYellow.badgeTextColor(preferring: nil, minimumRatio: 4.5) == UIColor.black)
+
+        let darkBlue = UIColor(red: 0.05, green: 0.15, blue: 0.45, alpha: 1.0)
+        #expect(darkBlue.badgeTextColor(preferring: nil, minimumRatio: 4.5) == UIColor.white)
+    }
+
+    /// A preferred color passing 4.5 but failing 7.0 must be rejected at the
+    /// Increase Contrast threshold. White on #767676 is ~4.54:1.
+    @Test func strictThresholdRejectsBorderlinePreferred() {
+        let gray = UIColor(red: 118.0/255.0, green: 118.0/255.0, blue: 118.0/255.0, alpha: 1.0)
+        #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 4.5) == UIColor.white)
+        #expect(gray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+scripts/generate_project OneBusAway
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+```
+
+Expected: **build FAILS** — `value of type 'UIColor' has no member 'wcagRelativeLuminance'`. (Compile failure is this ecosystem's "red": the API doesn't exist yet.)
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKitCore/Extensions/UIColor+WCAG.swift`:
+
+```swift
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+
+// WCAG 2.1 contrast math (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance).
+// Distinct from `isLightColor`/`contrastingTextColor` in UIKitExtensions.swift,
+// which use a perceived-luminance heuristic unsuitable for contrast-ratio checks.
+public extension UIColor {
+
+    /// WCAG 2.1 relative luminance: 0 (black) … 1 (white), with piecewise
+    /// sRGB linearization.
+    var wcagRelativeLuminance: CGFloat {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        func linearize(_ channel: CGFloat) -> CGFloat {
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+
+        return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)
+    }
+
+    /// WCAG 2.1 contrast ratio between the receiver and `other`:
+    /// 1 (identical) … 21 (black/white). Symmetric.
+    func wcagContrastRatio(against other: UIColor) -> CGFloat {
+        let lighter = max(wcagRelativeLuminance, other.wcagRelativeLuminance)
+        let darker = min(wcagRelativeLuminance, other.wcagRelativeLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    /// Text color for content drawn over the receiver. Honors `preferred`
+    /// (e.g. the agency's GTFS `route_text_color`) when it clears
+    /// `minimumRatio`; otherwise returns black or white, whichever contrasts
+    /// more. Guarantees the best achievable contrast when no candidate
+    /// clears the bar.
+    func badgeTextColor(preferring preferred: UIColor?, minimumRatio: CGFloat) -> UIColor {
+        if let preferred, preferred.wcagContrastRatio(against: self) >= minimumRatio {
+            return preferred
+        }
+
+        let blackRatio = UIColor.black.wcagContrastRatio(against: self)
+        let whiteRatio = UIColor.white.wcagContrastRatio(against: self)
+        return blackRatio >= whiteRatio ? .black : .white
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests/UIColorWCAGTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: build succeeds; all 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Extensions/UIColor+WCAG.swift OBAKitTests/Extensions/UIColorWCAGTests.swift
+git commit -m "Add WCAG 2.1 contrast math and badge text-color decision"
+```
+
+---
+
+### Task 2: Contrast-aware stop-page badge (OBAKit RouteBadgeView + call sites)
+
+**Files:**
+- Modify: `OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift`
+- Modify: `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift:108-113`
+- Modify: `OBAKit/Stops/StopPage/Departures/GroupedListView.swift:120-153`
+
+**Interfaces:**
+- Consumes (Task 1): `UIColor.badgeTextColor(preferring:minimumRatio:)`.
+- Produces: `RouteBadgeView(routeShortName:routeColor:routeTextColor:size:)` — new optional `routeTextColor: Color? = nil` parameter, existing call sites without it still compile. Task 4 adds another parameter to this same view.
+
+- [ ] **Step 1: Rewrite the badge with contrast-aware text and Increase Contrast support**
+
+Replace the body of `OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift` (keep the license header comment) with:
+
+```swift
+import SwiftUI
+import OBAKitCore
+
+/// Rounded-square route identity badge — the only place route color appears in
+/// the departure list rows; the trip panel separately uses it for the vehicle
+/// glyph and approach timeline. Spec §4.3 still holds: route color never tints
+/// countdowns or adherence text.
+///
+/// Text color is WCAG-aware: the agency's `route_text_color` is honored when
+/// it clears the contrast threshold, else black/white is computed. Under
+/// system Increase Contrast the gradient flattens and the threshold rises to
+/// 7:1 (see docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md).
+struct RouteBadgeView: View {
+    let routeShortName: String
+    let routeColor: Color
+    var routeTextColor: Color?
+    var size: CGFloat = 44
+
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    private var resolvedTextColor: Color {
+        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+    }
+
+    /// The gradient's luminance ramp is a small, intentional deviation from
+    /// the flat color the ratio is computed against; Increase Contrast goes
+    /// flat so the strict 7:1 tier has no ambiguity.
+    private var backgroundStyle: AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+    }
+
+    var body: some View {
+        Text(routeShortName)
+            .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
+            .monospacedDigit()
+            .foregroundStyle(resolvedTextColor)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size * scale, height: size * scale)
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .accessibilityHidden(true) // route name is in the row's combined label
+    }
+}
+```
+
+Note: `import OBAKitCore` may already be implied via other imports but add it explicitly; `badgeTextColor` lives there.
+
+- [ ] **Step 2: Pass the agency text color from DepartureRowView**
+
+In `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift`, replace the `routeBadge` computed property:
+
+```swift
+    private var routeBadge: some View {
+        RouteBadgeView(
+            routeShortName: departure.routeShortName,
+            routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand),
+            routeTextColor: departure.route.textColor.map { Color(uiColor: $0) }
+        )
+    }
+```
+
+- [ ] **Step 3: Pass the agency text color from GroupedListView**
+
+In `OBAKit/Stops/StopPage/Departures/GroupedListView.swift`, both `RouteBadgeView` calls inside `headerPrimaryRow(next:status:routeColor:)` (lines 124 and 136) become:
+
+```swift
+RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48)
+```
+
+(Other `RouteBadgeView` call sites — `BookmarkCardView`, `TripLiveActivityCardView` — are intentionally untouched: with `routeTextColor` nil they now get computed black/white instead of hardcoded white, which is the always-on fix, and wiring their agency color is out of scope.)
+
+- [ ] **Step 4: Build and run the full stop-page-adjacent test suite**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: build succeeds, OBAKitTests PASS (no existing test asserts white badge text; if one does, update it to the new decision and say so in the commit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift OBAKit/Stops/StopPage/Departures/DepartureRowView.swift OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+git commit -m "Make stop page route badge text WCAG contrast-aware"
+```
+
+---
+
+### Task 3: Contrast-aware widget badge (OBAKitCore RouteBadgeView)
+
+**Files:**
+- Modify: `OBAKitCore/UI/RouteBadgeView.swift`
+- Modify: `OBAKitCore/UI/TripLiveActivityCardView.swift:46-50` (no signature change — verify only)
+
+**Interfaces:**
+- Consumes (Task 1): `UIColor.badgeTextColor(preferring:minimumRatio:)`.
+- Produces: `RouteBadgeView(routeShortName:routeColor:routeTextColor:size:)` (public, OBAKitCore) — new optional `routeTextColor: Color? = nil` init parameter; existing callers compile unchanged.
+
+- [ ] **Step 1: Mirror the contrast logic in the public badge**
+
+Replace the struct in `OBAKitCore/UI/RouteBadgeView.swift` (keep the license header):
+
+```swift
+import SwiftUI
+
+/// Rounded-square route identity badge. Public so the widget extension can use it.
+///
+/// Text color is WCAG-aware (same decision as the stop page's internal
+/// `RouteBadgeView`): agency text color when it clears the threshold, else
+/// computed black/white; Increase Contrast flattens the gradient and raises
+/// the threshold to 7:1. Note: in `accented`/`vibrant` widget rendering modes
+/// the system tints everything and this logic is moot; it matters in
+/// `fullColor` rendering.
+public struct RouteBadgeView: View {
+    public let routeShortName: String
+    public let routeColor: Color
+    public var routeTextColor: Color?
+    public var size: CGFloat = 44
+
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    public init(routeShortName: String, routeColor: Color, routeTextColor: Color? = nil, size: CGFloat = 44) {
+        self.routeShortName = routeShortName
+        self.routeColor = routeColor
+        self.routeTextColor = routeTextColor
+        self.size = size
+    }
+
+    private var resolvedTextColor: Color {
+        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+    }
+
+    private var backgroundStyle: AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+    }
+
+    public var body: some View {
+        Text(routeShortName)
+            .font(.system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy))
+            .monospacedDigit()
+            .foregroundStyle(resolvedTextColor)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size * scale, height: size * scale)
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+            .accessibilityHidden(true)
+    }
+}
+```
+
+- [ ] **Step 2: Verify `TripLiveActivityCardView` still compiles unchanged**
+
+It calls `RouteBadgeView(routeShortName:routeColor:size:)`; the new parameter defaults to nil, so no edit. Confirm by building.
+
+- [ ] **Step 3: Build for testing (includes OBAKitCore and extensions)**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+```
+
+Expected: build succeeds. (Extension-safety: the new code touches only UIColor/SwiftUI — safe.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OBAKitCore/UI/RouteBadgeView.swift
+git commit -m "Make shared/widget route badge text WCAG contrast-aware"
+```
+
+---
+
+### Task 4: Reduced-color badge variant (stop page only)
+
+**Files:**
+- Modify: `OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift` (as written by Task 2)
+- Modify: `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift` (as written by Task 2)
+- Modify: `OBAKit/Stops/StopPage/Departures/GroupedListView.swift` (as written by Task 2)
+
+**Interfaces:**
+- Consumes: Task 2's `RouteBadgeView` (stop-page copy).
+- Produces: `RouteBadgeView` gains `var reducedColors: Bool = false`. Call sites read `@AppStorage("stopUIReducedColors")` — the literal key string Task 5's setting writes. The stop page root already applies `.defaultAppStorage(application.userDefaults)` (see `StopPageViewController.swift:22`), so plain `@AppStorage` hits the right suite.
+
+- [ ] **Step 1: Add the reduced-color rendering to the stop-page badge**
+
+In `OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift`, add the property and split the body (full struct after the edit; doc comment gains one line):
+
+```swift
+struct RouteBadgeView: View {
+    let routeShortName: String
+    let routeColor: Color
+    var routeTextColor: Color?
+    var size: CGFloat = 44
+    /// When true (Settings > Accessibility > "Reduce colors on stop page"),
+    /// route color shrinks to a thin vertical bar and the route number uses
+    /// the standard label color — same information, minimal color area.
+    var reducedColors: Bool = false
+
+    @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
+    @ScaledMetric(relativeTo: .body) private var barWidth: CGFloat = 5
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    private var resolvedTextColor: Color {
+        let minimumRatio: CGFloat = contrast == .increased ? 7.0 : 4.5
+        let background = UIColor(routeColor)
+        let preferred = routeTextColor.map { UIColor($0) }
+        return Color(uiColor: background.badgeTextColor(preferring: preferred, minimumRatio: minimumRatio))
+    }
+
+    private var backgroundStyle: AnyShapeStyle {
+        contrast == .increased ? AnyShapeStyle(routeColor) : AnyShapeStyle(routeColor.gradient)
+    }
+
+    private var badgeFont: Font {
+        .system(size: (routeShortName.count <= 2 ? 18 : 13) * scale, weight: .heavy)
+    }
+
+    var body: some View {
+        Group {
+            if reducedColors {
+                reducedBody
+            } else {
+                standardBody
+            }
+        }
+        .frame(width: size * scale, height: size * scale)
+        .accessibilityHidden(true) // route name is in the row's combined label
+    }
+
+    private var standardBody: some View {
+        Text(routeShortName)
+            .font(badgeFont)
+            .monospacedDigit()
+            .foregroundStyle(resolvedTextColor)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size * scale, height: size * scale)
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: size * scale * 0.28, style: .continuous))
+    }
+
+    /// Same frame as the standard badge so departure rows keep their column
+    /// alignment when the setting flips.
+    private var reducedBody: some View {
+        HStack(spacing: 6 * scale) {
+            Capsule(style: .continuous)
+                .fill(routeColor)
+                .frame(width: barWidth, height: size * scale)
+            Text(routeShortName)
+                .font(badgeFont)
+                .monospacedDigit()
+                .foregroundStyle(.primary)
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+    }
+}
+```
+
+(Note `barWidth` is itself a `@ScaledMetric`, so the bar tracks Dynamic Type per the spec. `standardBody` keeps its own inner `.frame` so the rounded-rect background hugs the square exactly as before; the outer shared frame is a no-op for it.)
+
+- [ ] **Step 2: Drive it from the departure row**
+
+In `OBAKit/Stops/StopPage/Departures/DepartureRowView.swift`, add alongside the other property wrappers (after line 38's `@ScaledMetric`):
+
+```swift
+    @AppStorage("stopUIReducedColors") private var reducedColors = false
+```
+
+and update `routeBadge`:
+
+```swift
+    private var routeBadge: some View {
+        RouteBadgeView(
+            routeShortName: departure.routeShortName,
+            routeColor: Color(uiColor: departure.route.color ?? ThemeColors.shared.brand),
+            routeTextColor: departure.route.textColor.map { Color(uiColor: $0) },
+            reducedColors: reducedColors
+        )
+    }
+```
+
+- [ ] **Step 3: Drive it from the grouped list**
+
+In `OBAKit/Stops/StopPage/Departures/GroupedListView.swift`, add the same `@AppStorage` property to the view struct containing `headerPrimaryRow` (top of the struct, near its other `@Environment` properties):
+
+```swift
+    @AppStorage("stopUIReducedColors") private var reducedColors = false
+```
+
+and both badge calls become:
+
+```swift
+RouteBadgeView(routeShortName: next.routeShortName, routeColor: routeColor, routeTextColor: next.route.textColor.map { Color(uiColor: $0) }, size: 48, reducedColors: reducedColors)
+```
+
+(Parameter order: `reducedColors` is declared after `size`, so this label order matches the memberwise initializer.)
+
+- [ ] **Step 4: Build, test, and eyeball both modes**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS. Visual verification of the reduced mode happens in Task 5 step 4, once the Settings toggle exists to flip it — don't hand-write app-group defaults here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift OBAKit/Stops/StopPage/Departures/DepartureRowView.swift OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+git commit -m "Add reduced-color route badge variant to the stop page"
+```
+
+---
+
+### Task 5: The setting — UserDataStore property + Settings switch
+
+**Files:**
+- Modify: `OBAKitCore/Models/UserData/UserDataStore.swift` (protocol ~line 37; keys struct lines 380-403; `register(defaults:)` lines 408-412; new property after `debugMode` lines 421-428)
+- Modify: `OBAKit/Settings/SettingsViewController.swift` (`form.setValues` lines 53-68; `saveFormValues` lines 79-124; `accessibilitySection` lines 202-221)
+
+**Interfaces:**
+- Consumes: nothing from other tasks at compile time; at runtime the key string must match Task 4's `@AppStorage("stopUIReducedColors")` exactly.
+- Produces: `UserDataStore.stopUIReducedColors: Bool { get set }` (protocol + `UserDefaultsStore` implementation).
+
+- [ ] **Step 1: Add the property to the UserDataStore protocol**
+
+In `OBAKitCore/Models/UserData/UserDataStore.swift`, directly below `var debugMode: Bool { get set }` (line 37):
+
+```swift
+    /// Whether the stop page renders route badges in reduced-color form
+    /// (thin route-color bar + label-colored text). Surfaced in
+    /// Settings > Accessibility.
+    var stopUIReducedColors: Bool { get set }
+```
+
+- [ ] **Step 2: Add the key, default, and implementation to UserDefaultsStore**
+
+In the `UserDefaultsKeys` struct (after line 402):
+
+```swift
+        // Deliberately dot-free, unlike its neighbors: the stop page observes
+        // this key via @AppStorage, whose KVO treats dots as key-path
+        // separators and silently never fires. See the accessibility spec.
+        static let stopUIReducedColors = "stopUIReducedColors"
+```
+
+In `init(userDefaults:)`, extend `register(defaults:)`:
+
+```swift
+        self.userDefaults.register(defaults: [
+            UserDefaultsKeys.debugMode: false,
+            UserDefaultsKeys.stopUIReducedColors: false,
+            UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
+        ])
+```
+
+After the `debugMode` property (line 428), add:
+
+```swift
+    // MARK: - Stop UI Reduced Colors
+
+    public var stopUIReducedColors: Bool {
+        get {
+            return userDefaults.bool(forKey: UserDefaultsKeys.stopUIReducedColors)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.stopUIReducedColors)
+        }
+    }
+```
+
+Check for other `UserDataStore` conformers before building: `grep -rn ': UserDataStore' OBAKit* Apps` — if a test mock conforms, add the property there too (a plain stored `var stopUIReducedColors = false` suffices in a mock).
+
+- [ ] **Step 3: Add the switch to Settings > Accessibility**
+
+In `OBAKit/Settings/SettingsViewController.swift`:
+
+Near the other tag constants (e.g. below line 226's `walkingSpeedUseHealthKitKey`):
+
+```swift
+    private let stopUIReducedColorsTag = "stopUIReducedColors"
+```
+
+In `accessibilitySection` (before `return section`, line 220):
+
+```swift
+        section <<< SwitchRow {
+            $0.tag = stopUIReducedColorsTag
+            $0.title = OBALoc("settings_controller.accessibility_section.reduce_stop_colors", value: "Reduce colors on stop page", comment: "Settings > Accessibility section > Toggle that renders stop page route badges as a thin color bar beside plain text instead of a colored square")
+        }
+```
+
+In `form.setValues([...])` (line 53-68), add:
+
+```swift
+            stopUIReducedColorsTag: application.userDataStore.stopUIReducedColors,
+```
+
+In `saveFormValues()` (near the `debugEnabled` block, line 109-111), add:
+
+```swift
+        if let reducedColors = values[stopUIReducedColorsTag] as? Bool {
+            application.userDataStore.stopUIReducedColors = reducedColors
+        }
+```
+
+- [ ] **Step 4: Build, test, and verify end-to-end in the simulator**
+
+```bash
+set -o pipefail
+xcodebuild build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS. Then run the app: More tab > Settings > Accessibility > flip "Reduce colors on stop page" > open a stop. Badges must render as bar + plain text. Flip back; colored squares return. If a stop page is left open behind Settings, it must update live on return (this is the dot-free-key guarantee).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Models/UserData/UserDataStore.swift OBAKit/Settings/SettingsViewController.swift
+git commit -m "Add 'Reduce colors on stop page' accessibility setting"
+```
+
+---
+
+### Task 6: Visual verification pass + SwiftLint
+
+**Files:**
+- No new files. Screenshots go to the session scratchpad, not the repo.
+
+**Interfaces:** none — this is the ship-gate check for the whole feature.
+
+- [ ] **Step 1: SwiftLint**
+
+```bash
+scripts/swiftlint.sh
+```
+
+Expected: no new violations in touched files.
+
+- [ ] **Step 2: Contrast scenarios in the simulator**
+
+Run the app on 'iPhone 17 Pro' against a region with colored routes (Puget Sound default; Metro route 48 is yellow). Verify, with screenshots at each step:
+
+1. Default: yellow badges show **black** route numbers (the bug fix — compare against the user report's white-on-yellow).
+2. Dark route colors still show white/agency text.
+3. Settings > Accessibility > Increase Contrast (simulator: Settings app > Accessibility > Display & Text Size > Increase Contrast): badges go flat (no gradient) and text still passes visually.
+4. Reduce Motion ON: header "Updated" dot and skeleton pulses are static (pre-existing behavior — regression check only).
+5. Reduced-colors toggle ON: vertical bar + plain text in both chronological and by-route (grouped) modes, rows still aligned; accessibility Dynamic Type size scales the bar and text.
+
+- [ ] **Step 3: Report**
+
+Summarize pass/fail per scenario with the screenshots. Any failure loops back to the owning task before proceeding.
+
+- [ ] **Step 4: Final commit (only if fixes were needed)**
+
+```bash
+git add -A && git commit -m "Fix visual issues found in accessibility verification"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 always-on contrast → Tasks 1-3; §2 Increase Contrast → Tasks 2-3, Reduce Motion verified-only → Task 6 step 2.4, Reduce Transparency / Differentiate Without Color → no-change per spec; §3 reduced-color mode → Tasks 4-5; spec Testing section → Tasks 1 and 6.
+- **Key-string consistency:** `"stopUIReducedColors"` appears in Task 4 (`@AppStorage` ×2), Task 5 (`UserDefaultsKeys`, tag constant). All four must be the identical dot-free literal.
+- **Signature consistency:** `badgeTextColor(preferring:minimumRatio:)` (Tasks 1→2→3); `RouteBadgeView(routeShortName:routeColor:routeTextColor:size:)` + stop-page-only `reducedColors:` (Tasks 2→4; memberwise label order `routeTextColor` before `size`, `reducedColors` last).

--- a/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
+++ b/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
@@ -1,0 +1,142 @@
+# Stop UI Accessibility: Route Badge Contrast & Reduced-Color Mode
+
+**Date:** 2026-07-20
+**Branch:** `stop-accessibility`
+**Status:** Approved
+
+## Background
+
+A rider with low vision reported that the new stop page's route badges are
+unreadable: the badge renders the route short name in hardcoded white over the
+agency-provided route color, which for King County Metro's yellow produces a
+contrast ratio far below the WCAG 2.1 AA minimum. Distinguishing route 43 from
+route 48 determines which stop she uses; this is a real navigation failure, not
+a cosmetic issue.
+
+Root cause: `RouteBadgeView` (two near-duplicate copies —
+`OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift` for the stop page and
+`OBAKitCore/UI/RouteBadgeView.swift` for the widget) uses
+`.foregroundStyle(.white)` unconditionally over `routeColor.gradient`. The GTFS
+feed's `route_text_color` (`Route.textColor`) is decoded but ignored. No WCAG
+contrast math exists in the codebase (only a perceived-luminance heuristic,
+`UIColor.contrastingTextColor`, used by legacy/widget code). The stop page
+reads no contrast-related accessibility environment values.
+
+## Goals
+
+1. Route badge text always meets WCAG 2.1 AA contrast against its background,
+   with no user action required.
+2. The stop page respects system accessibility settings: Increase Contrast and
+   Reduce Motion.
+3. An opt-in "reduced colors" presentation replaces the colored badge with a
+   thin vertical route-color bar beside the route number in standard label
+   color.
+
+## Non-Goals
+
+- The legacy UIKit `StopViewController` / `StopArrivalView`.
+- Map route labels or any screen other than the new stop page (plus the shared
+  badge used by the widget, which inherits the contrast fix for free).
+- Changing the green/red/blue departure-status colors. The words "on time" /
+  "early" / "delayed" already carry that information redundantly in text.
+- Merging the two `RouteBadgeView` copies into one view.
+
+## Design
+
+### 1. Always-on contrast fix
+
+**New WCAG helpers** in OBAKitCore (extension-safe), as a `UIColor` extension
+in a new file (e.g. `OBAKitCore/Extensions/UIColor+WCAG.swift`):
+
+- `wcagRelativeLuminance` — WCAG 2.1 relative luminance with proper sRGB
+  linearization (piecewise `c/12.92` vs `((c+0.055)/1.055)^2.4`), not the
+  existing `0.299/0.587/0.114` quick heuristic.
+- `wcagContrastRatio(with:)` — `(L1 + 0.05) / (L2 + 0.05)`.
+
+**One shared decision function** (also OBAKitCore, so the stop page and widget
+badges use identical logic):
+
+```
+badgeTextColor(background: UIColor,
+               agencyTextColor: UIColor?,
+               minimumRatio: CGFloat) -> UIColor
+```
+
+Rules:
+- If `agencyTextColor` is provided and its contrast ratio against
+  `background` is ≥ `minimumRatio`, use it (respects agency branding).
+- Otherwise return black or white, whichever has the higher ratio against
+  `background`.
+
+**Badge wiring** (both `RouteBadgeView` copies):
+- Gain an optional `routeTextColor` parameter; `DepartureRowView` and the
+  widget pass `route.textColor` through.
+- Normal presentation: `minimumRatio` = 4.5 (AA). Background keeps the
+  existing `.gradient` fill; the ratio is computed against the flat base
+  color.
+- Under system Increase Contrast (`@Environment(\.colorSchemeContrast) ==
+  .increased`): the badge uses a flat fill (no gradient) and raises
+  `minimumRatio` to 7.0 (AAA) before falling back to computed black/white.
+
+Result for the reported case: black text on Metro's yellow (~11:1) instead of
+white (~1.8:1).
+
+### 2. System accessibility settings
+
+- **Reduce Motion:** gate the three ungated `repeatForever` pulse animations
+  on `@Environment(\.accessibilityReduceMotion)`, matching the existing
+  `RealtimeGlyph` precedent (`RealtimeGlyph.swift:26`):
+  - `StopPageHeaderView.swift:201`
+  - `StopPageHeaderView.swift:235`
+  - `TripDetailPanelView.swift:193`
+
+  When reduce motion is on, the affected element renders in its static state
+  (no pulse). One-shot layout transitions (`withAnimation(.snappy)` toggles)
+  are unchanged — Apple's guidance targets continuous/large motion.
+- **Increase Contrast:** covered in §1 (flat fill + 7:1 threshold).
+- **Reduce Transparency:** no change needed; the page's `.ultraThinMaterial`
+  is a system material that adapts automatically.
+- **Differentiate Without Color:** no change needed; every color-coded fact on
+  the page (route identity, schedule status) is already duplicated in text.
+
+### 3. Opt-in reduced-color mode
+
+**Setting storage:** new `Bool` property on `UserDataStore`, key
+`UserDataStore.stopUIReducedColors`, registered default `false`, following the
+existing `debugMode` pattern.
+
+**Settings UI:** a `SwitchRow` in the existing **Accessibility** section of
+`SettingsViewController` ("Reduce colors on stop page"), seeded in
+`form.setValues` and persisted in the save path like its neighbors.
+
+**Presentation:** when enabled, the stop page's `RouteBadgeView` renders as:
+- a vertical capsule bar in the route color, ~5 pt wide × badge height, and
+- the route short name in `.primary` label color beside it,
+- inside the same fixed frame width as the standard badge, so the departure
+  rows keep their column alignment.
+
+The mode is read by the SwiftUI stop page via the app's `UserDefaults` suite
+(the same suite `UserDataStore` writes to) so the page updates when the
+setting changes. The widget keeps the standard badge; this mode is app-only.
+
+Scope: route badge only. Status colors are untouched (see Non-Goals).
+
+## Testing
+
+Unit tests in `OBAKitTests`:
+- Relative luminance and contrast ratio against known WCAG reference values
+  (e.g. white/black = 21:1, white on #767676 ≈ 4.54:1).
+- Decision function: white-on-yellow rejected → black chosen; agency text
+  color honored when passing; rejected when failing; 7:1 threshold behavior.
+
+Manual verification in the simulator: standard badge with a yellow route,
+Increase Contrast on/off, Reduce Motion on/off, and the reduced-color toggle.
+
+## Decisions Log
+
+- Agency `route_text_color` is respected when it passes WCAG, otherwise
+  computed black/white — always-on, not behind a setting. (Approved)
+- Reduced-color mode affects the badge only, not status colors. (Approved)
+- Reduced-color mode is a manual toggle only; it does not auto-engage from
+  Differentiate Without Color. Increase Contrast independently hardens the
+  standard badge. (Approved)

--- a/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
+++ b/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
@@ -36,7 +36,9 @@ reads no contrast-related accessibility environment values.
 
 - The legacy UIKit `StopViewController` / `StopArrivalView`.
 - Map route labels or any screen other than the new stop page (plus the shared
-  badge used by the widget, which inherits the contrast fix for free).
+  badge used by the widget, which inherits the contrast fix in `fullColor`
+  rendering; in `accented`/`vibrant` widget modes the system's own tinting
+  overrides both the route color and the text color, so the fix is moot there).
 - Changing the green/red/blue departure-status colors. The words "on time" /
   "early" / "delayed" already carry that information redundantly in text.
 - Merging the two `RouteBadgeView` copies into one view.
@@ -72,8 +74,14 @@ Rules:
 - Gain an optional `routeTextColor` parameter; `DepartureRowView` and the
   widget pass `route.textColor` through.
 - Normal presentation: `minimumRatio` = 4.5 (AA). Background keeps the
-  existing `.gradient` fill; the ratio is computed against the flat base
-  color.
+  existing `.gradient` fill; the ratio is intentionally computed against the
+  flat base color, an approximation — the gradient's lighter band has
+  marginally lower contrast, and the Increase Contrast branch removes the
+  ambiguity where it matters by going flat.
+- Threshold note: WCAG large text (≥14 pt bold) and Apple's Accessibility
+  Inspector (bold → 3:1 at all sizes) would accept 3:1 for the heavy badge
+  text, but the badge can render as small as 13 pt, so we hold the stricter
+  4.5:1 floor everywhere rather than special-casing by size.
 - Under system Increase Contrast (`@Environment(\.colorSchemeContrast) ==
   .increased`): the badge uses a flat fill (no gradient) and raises
   `minimumRatio` to 7.0 (AAA) before falling back to computed black/white.
@@ -92,7 +100,11 @@ white (~1.8:1).
 
   When reduce motion is on, the affected element renders in its static state
   (no pulse). One-shot layout transitions (`withAnimation(.snappy)` toggles)
-  are unchanged — Apple's guidance targets continuous/large motion.
+  are unchanged: Apple's mandatory guidance covers automatic and repetitive
+  motion (the pulses), while de-motioning transitions is a best practice we
+  partially meet already — `.snappy` is a stiff, low-bounce spring, and none
+  of the gated toggles animate large positional or scale changes.
+  Implementation should verify that last point per call site.
 - **Increase Contrast:** covered in §1 (flat fill + 7:1 threshold).
 - **Reduce Transparency:** no change needed; the page's `.ultraThinMaterial`
   is a system material that adapts automatically.
@@ -112,8 +124,12 @@ existing `debugMode` pattern.
 **Presentation:** when enabled, the stop page's `RouteBadgeView` renders as:
 - a vertical capsule bar in the route color, ~5 pt wide × badge height, and
 - the route short name in `.primary` label color beside it,
-- inside the same fixed frame width as the standard badge, so the departure
-  rows keep their column alignment.
+- inside the same frame width as the standard badge, so the departure rows
+  keep their column alignment.
+
+Both the bar width and the frame scale with Dynamic Type via `@ScaledMetric`,
+matching the standard badge's existing scaling — fixed points would undercut
+the low-vision users this mode serves.
 
 The mode is read by the SwiftUI stop page via the app's `UserDefaults` suite
 (the same suite `UserDataStore` writes to) so the page updates when the

--- a/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
+++ b/docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md
@@ -91,15 +91,15 @@ white (~1.8:1).
 
 ### 2. System accessibility settings
 
-- **Reduce Motion:** gate the three ungated `repeatForever` pulse animations
-  on `@Environment(\.accessibilityReduceMotion)`, matching the existing
-  `RealtimeGlyph` precedent (`RealtimeGlyph.swift:26`):
-  - `StopPageHeaderView.swift:201`
-  - `StopPageHeaderView.swift:235`
-  - `TripDetailPanelView.swift:193`
-
-  When reduce motion is on, the affected element renders in its static state
-  (no pulse). One-shot layout transitions (`withAnimation(.snappy)` toggles)
+- **Reduce Motion:** verified already handled — implementation review found
+  all three `repeatForever` pulse sites (`StopPageHeaderView.swift:201,235`,
+  `TripDetailPanelView.swift:193`) are already gated on
+  `@Environment(\.accessibilityReduceMotion)` with `guard !reduceMotion`
+  plus static-opacity fallbacks, matching the `RealtimeGlyph` precedent
+  (`RealtimeGlyph.swift:26`). An earlier grep saw the `repeatForever` calls
+  but missed the surrounding guards. No code change required; the
+  implementation plan keeps a verification-only check.
+  One-shot layout transitions (`withAnimation(.snappy)` toggles)
   are unchanged: Apple's mandatory guidance covers automatic and repetitive
   motion (the pulses), while de-motioning transitions is a best practice we
   partially meet already — `.snappy` is a stiff, low-bounce spring, and none
@@ -113,9 +113,14 @@ white (~1.8:1).
 
 ### 3. Opt-in reduced-color mode
 
-**Setting storage:** new `Bool` property on `UserDataStore`, key
-`UserDataStore.stopUIReducedColors`, registered default `false`, following the
-existing `debugMode` pattern.
+**Setting storage:** new `Bool` property on `UserDataStore`, registered
+default `false`, following the existing `debugMode` pattern — but with the
+deliberately dot-free defaults key `stopUIReducedColors` (not
+`UserDataStore.stopUIReducedColors`): the stop page reads it via
+`@AppStorage`, which observes UserDefaults through KVO, and KVO treats dots
+in a key as key-path separators, silently breaking live updates. The page
+already uses dot-free `@AppStorage` keys for this reason
+(`stopViewShowsServiceAlerts`).
 
 **Settings UI:** a `SwitchRow` in the existing **Accessibility** section of
 `SettingsViewController` ("Reduce colors on stop page"), seeded in


### PR DESCRIPTION
## Summary

Responds to a rider report that the new stop page's route badges are unreadable for low-vision users (white text on King County Metro's yellow routes 43/48 — roughly 1.8:1 contrast, far below the WCAG 2.1 AA minimum this rider correctly cited).

- **Always-on contrast fix**: route badge text is now chosen by WCAG 2.1 contrast math (new `UIColor+WCAG` helpers + shared `RouteBadgeStyle` policy in OBAKitCore). The agency's GTFS `route_text_color` — previously decoded but ignored — is honored when it clears 4.5:1; otherwise black/white is computed, whichever contrasts more. Metro's yellow 48 now renders **black-on-yellow (~11.5:1)** instead of white (~1.8:1).
- **System accessibility settings**: under Increase Contrast the badge drops its gradient for a flat fill and raises the threshold to 7:1 (AAA). Reduce Motion was audited — all stop-page pulse animations were already gated; verified, no change needed. Reduce Transparency and Differentiate Without Color need no changes (system materials adapt automatically; all color-coded facts are duplicated in text).
- **Opt-in reduced-color mode**: Settings > Accessibility > "Reduce colors on stop page" (localized in all 13 locales) renders badges as a thin vertical route-color bar beside the route number in standard label color — same information, minimal color area. Rows keep column alignment; bar and text scale with Dynamic Type. Backed by a `UserDataStore` property on a deliberately dot-free defaults key (`@AppStorage`'s KVO observation breaks on dotted keys) shared via one public constant.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] 9 new WCAG unit tests anchored to published reference values (21:1 black/white, #767676 ≈ 4.54:1 AA boundary; the Metro-yellow regression case is a named test)
- [x] `RouteBadgeStyle` threshold-wiring test (same gray flips white→black between standard and increased contrast) + best-achievable-fallback test when nothing clears 7:1
- [x] `UserDataStore` setting default/persistence tests, including the dot-free key contract
- [x] Full suite: 1390 XCTest + 11 Swift Testing, 0 failures; SwiftLint 0 violations in 430 files
- [x] Visual verification via `ImageRenderer` with pixel assertions: yellow-48/43 → black text, dark-blue-49 → white preserved, reduced-color bar variant, standard/reduced column alignment
- [ ] Live-app tap-through (Settings toggle → open stop → badges update): **blocked in my sandbox** (simulator UI automation unavailable) — worth a 2-minute manual check on device/simulator

## Review notes

Multi-agent review ran clean (0 critical / 0 important). Non-blocking observations for the reviewer:

- The contrast fix intentionally also applies to OBAKitCore's public `RouteBadgeView` — **bookmark cards and the trip Live Activity badges change appearance too** (black text on light route colors instead of white). Those call sites don't pass `route_text_color`; wiring the agency color there is a possible follow-up.
- The reduced-color mode is stop-page only by design (widget/live activity keep the standard badge).
- WCAG luminance treats colors as opaque and assumes RGB-convertible colors — fine for hex-decoded GTFS colors; documented in the extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Accessibility setting to reduce colors on stop pages.
  * Route badges can now display a thin color bar beside route text instead of colored squares.
  * Improved badge text and background contrast, including support for increased-contrast display settings.
  * Added localized labels for the new setting.

* **Tests**
  * Added coverage for contrast calculations, badge styling, and preference persistence.

* **Documentation**
  * Added design and implementation documentation for stop-page accessibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->