### PR TITLE
Bump OTPKit to 0.15.0

### DIFF
--- a/Apps/OneBusAway/Package.resolved
+++ b/Apps/OneBusAway/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneBusAway/otpkit.git",
       "state" : {
-        "revision" : "e8627740097323e9eae154e20e715efe679800cf",
-        "version" : "0.14.0"
+        "revision" : "b61353818b00a6d4666d52198f29fed914013b8a",
+        "version" : "0.15.0"
       }
     },
     {


### PR DESCRIPTION
Bumps the OneBusAway app's OTPKit pin from **0.14.0** to **0.15.0** (tag released upstream at [OneBusAway/otpkit@0.15.0](https://github.com/OneBusAway/otpkit/releases/tag/0.15.0)).

## Why
A plain package *resolve* keeps OTPKit at 0.14.0 because it still satisfies the `0.5.0 ..< 1.0.0` range in `Apps/Shared/app_shared.yml` — the lockfile pin has to be moved explicitly. This updates the committed `Apps/OneBusAway/Package.resolved` so the bump is reproducible and survives `scripts/generate_project`.

## Notes
- OTPKit's dependency graph is unchanged between 0.14.0 and 0.15.0 (SwiftUI-Flow + ViewInspector), so no new transitive pins were needed — just the OTPKit `revision`/`version`.
- `clean build-for-testing` passes on the iPhone 17 Pro simulator with 0.15.0 resolved.

## Test plan
- [x] `scripts/generate_project OneBusAway` seeds the workspace at 0.15.0
- [x] `xcodebuild clean build-for-testing -scheme 'App'` → **TEST BUILD SUCCEEDED**
- [x] `scripts/update_package_resolved OneBusAway` round-trips cleanly (only OTPKit moved)