### PR TITLE
Fix illegible route name in reduced-colors stop badge

### DIFF
--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -64,19 +64,24 @@ struct RouteBadgeView: View {
     }
 
     /// Same frame as the standard badge so departure rows keep their column
-    /// alignment when the setting flips.
+    /// alignment when the setting flips. The thin color bar is drawn as a
+    /// leading overlay offset into the row's leading gap (negative leading), so
+    /// the route name keeps the full badge width instead of being squeezed by
+    /// the bar + spacing — otherwise `minimumScaleFactor` shrinks it to an
+    /// illegible size for names like "C Line".
     private var reducedBody: some View {
-        HStack(spacing: 6 * scale) {
-            Capsule(style: .continuous)
-                .fill(routeColor)
-                .frame(width: barWidth, height: size * scale)
-            Text(routeShortName)
-                .font(badgeFont)
-                .monospacedDigit()
-                .foregroundStyle(.primary)
-                .minimumScaleFactor(0.6)
-                .lineLimit(1)
-            Spacer(minLength: 0)
-        }
+        Text(routeShortName)
+            .font(badgeFont)
+            .monospacedDigit()
+            .foregroundStyle(.primary)
+            .minimumScaleFactor(0.6)
+            .lineLimit(1)
+            .frame(width: size * scale, height: size * scale, alignment: .leading)
+            .overlay(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(routeColor)
+                    .frame(width: barWidth, height: size * scale)
+                    .offset(x: -(barWidth + 6 * scale))
+            }
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
+++ b/OBAKit/Stops/StopPage/Shared/RouteBadgeView.swift
@@ -27,6 +27,7 @@ struct RouteBadgeView: View {
     @ScaledMetric(relativeTo: .body) private var scale: CGFloat = 1
     @ScaledMetric(relativeTo: .body) private var barWidth: CGFloat = 5
     @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(\.layoutDirection) private var layoutDirection
 
     private var resolvedTextColor: Color {
         RouteBadgeStyle.textColor(routeColor: routeColor, routeTextColor: routeTextColor, contrast: contrast)
@@ -70,7 +71,11 @@ struct RouteBadgeView: View {
     /// the bar + spacing — otherwise `minimumScaleFactor` shrinks it to an
     /// illegible size for names like "C Line".
     private var reducedBody: some View {
-        Text(routeShortName)
+        // `offset(x:)` is a physical shift, so the sign is flipped for RTL: the
+        // bar must move outward past the (right-hand) leading edge, not inward
+        // over the text.
+        let barOffset = (layoutDirection == .rightToLeft ? 1 : -1) * (barWidth + 6 * scale)
+        return Text(routeShortName)
             .font(badgeFont)
             .monospacedDigit()
             .foregroundStyle(.primary)
@@ -81,7 +86,7 @@ struct RouteBadgeView: View {
                 Capsule(style: .continuous)
                     .fill(routeColor)
                     .frame(width: barWidth, height: size * scale)
-                    .offset(x: -(barWidth + 6 * scale))
+                    .offset(x: barOffset)
             }
     }
 }


### PR DESCRIPTION
Follow-up to #1210. With **Settings ▸ Accessibility ▸ Reduce colors on stop page** enabled, route short names in the departure list rendered far too small to read (see below) — e.g. "C Line" shrank to ~8pt.

## Cause
`RouteBadgeView.reducedBody` laid out `[ color bar (5pt) + spacing (6pt) + route name ]` all inside the same fixed 44pt frame the standard badge uses. That left the route name only ~33pt, and `minimumScaleFactor(0.6)` then crushed multi-character names to an illegible size. The standard (non-reduced) badge gives the name the full 44pt.

## Fix
Draw the thin color bar as a **leading overlay offset ~11pt into the row's leading margin** (a negative-leading position), and give the route name the full 44pt badge width — the same space the standard badge provides. The row's default `.plain` list inset (~16pt) absorbs the offset with margin to spare, so nothing clips.

Result: reduced-colors legibility now matches the standard badge, and the headsign column position is unchanged (badge frame stays 44pt, so alignment is preserved when the setting flips).

## Test plan
- [x] `xcodebuild build -scheme 'App'` → **BUILD SUCCEEDED**
- [ ] Enable *Reduce colors on stop page*, open a stop, confirm route short names (e.g. "C Line") are legible and left-aligned with the standard-badge column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reduced-color route badges so route names have more available space.
  * Preserved the route-color indicator by adjusting the badge layout so the route text stays aligned and is not squeezed.
  * Improved right-to-left behavior for the route-color indicator positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->