### PR TITLE
 Prevent duplicate Live Activities for the same stop and route

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -218,6 +218,16 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
             regionID: application.currentRegion?.regionIdentifier ?? 0
         )
 
+        // Tapping Track again on a bookmark that is already tracked — or tracking
+        // the same trip from the stop page — would otherwise mint a second
+        // activity for one stop, leaving the user with duplicate Lock Screen
+        // cards and duplicate OBACloud push registrations.
+        if Activity<TripAttributes>.running(matching: staticData) != nil {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); not starting a duplicate.")
+            showLiveActivityStartedToast()
+            return
+        }
+
         guard let contentState = buildContentState(from: arrivalDepartures) else {
             // Shouldn't happen — the context menu only offers Track once arrival
             // data has loaded — but if data was cleared between the menu render
@@ -236,12 +246,19 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
             )
             trackLiveActivity(activity, arrivalDepartures: arrivalDepartures)
             Logger.info("Started Live Activity with ID: \(activity.id)")
-            let message = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Toast shown when a Live Activity starts on the Lock Screen")
-            ProgressHUD.showSuccessAndDismiss(message: message)
+            showLiveActivityStartedToast()
         } catch {
             Logger.error("Failed to start Live Activity: \(error)")
             showLiveActivityErrorAlert()
         }
+    }
+
+    /// Shared by the start path and the already-tracking guard, so a duplicate
+    /// tap gets the same confirmation the first tap did rather than silently
+    /// appearing to do nothing.
+    private func showLiveActivityStartedToast() {
+        let message = OBALoc("live_activity.started.title", value: "Tracking on Lock Screen", comment: "Toast shown when a Live Activity starts on the Lock Screen")
+        ProgressHUD.showSuccessAndDismiss(message: message)
     }
 
     func updateRunningLiveActivities() {
@@ -249,10 +266,15 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
         for activity in activities {
             let staticData = activity.attributes.staticData
             let matchingBookmark = application.userDataStore.bookmarks.first(where: { bookmark in
+                // Delegates to the shared identity rule so this match can't
+                // drift from the start paths' duplicate guard.
                 let keys = Self.liveActivityKeys(for: bookmark)
-                return bookmark.stopID == staticData.stopID &&
-                       keys.routeShortName == staticData.routeShortName &&
-                       keys.routeHeadsign == staticData.routeHeadsign
+                let bookmarkIdentity = TripAttributes.StaticData(
+                    routeShortName: keys.routeShortName,
+                    routeHeadsign: keys.routeHeadsign,
+                    stopID: bookmark.stopID
+                )
+                return bookmarkIdentity.tracksSameTrip(as: staticData)
             })
             let arrivalDepartures = matchingBookmark.map { viewModel.arrivalDepartures(for: $0) } ?? []
 

--- a/OBAKit/Extensions/ProgressHUDExtensions.swift
+++ b/OBAKit/Extensions/ProgressHUDExtensions.swift
@@ -10,13 +10,20 @@
 import UIKit
 
 extension ProgressHUD {
+    /// The pending auto-dismiss from the most recent `showSuccessAndDismiss` call.
+    /// Superseded (cancelled) by each new call, so a HUD shown while a prior one
+    /// is still on screen gets its full display window instead of being hidden
+    /// early by the prior call's timer. MainActor-isolated via `ProgressHUD`.
+    private static var pendingDismiss: DispatchWorkItem?
+
     /// Displays the 'success' indicator with an optional message, and then dismisses the HUD `dismissAfter` seconds later.
     /// - Parameter message: Optional message to show the user. Defaults to `nil`.
     /// - Parameter dismissAfter: How many seconds until the HUD should be dismissed. Defaults to `3.0`.
     class func showSuccessAndDismiss(message: String? = nil, dismissAfter: TimeInterval = 3.0) {
+        pendingDismiss?.cancel()
         ProgressHUD.showSuccess(message, image: nil, interaction: false)
-        DispatchQueue.main.asyncAfter(deadline: .now() + dismissAfter) {
-            ProgressHUD.dismiss()
-        }
+        let dismiss = DispatchWorkItem { ProgressHUD.dismiss() }
+        pendingDismiss = dismiss
+        DispatchQueue.main.asyncAfter(deadline: .now() + dismissAfter, execute: dismiss)
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -406,6 +406,16 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
             regionID: application.currentRegion?.regionIdentifier ?? 0
         )
 
+        // The same trip can be started from here and from the bookmarks list, so
+        // this guard has to live on both start paths — otherwise one stop ends up
+        // with two Lock Screen cards and two OBACloud push registrations.
+        if Activity<TripAttributes>.running(matching: staticData) != nil {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); not starting a duplicate.")
+            // Re-show the confirmation rather than appearing to do nothing.
+            viewModel.signalLiveActivityStarted()
+            return
+        }
+
         guard let contentState = buildLiveActivityContentState(for: departure) else {
             Logger.error("Failed to build content state for Live Activity")
             return

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -133,6 +133,11 @@ class StopViewModel: ObservableObject {
     /// SwiftUI stop page to show a non-blocking toast. Auto-resets after 2 seconds.
     @Published private(set) var liveActivityStarted = false
 
+    /// The pending auto-dismiss for the Live Activity toast. Each new signal
+    /// supersedes (cancels) it so every confirmation gets its full display
+    /// window — see `signalLiveActivityStarted()`.
+    private var liveActivityToastDismissTask: Task<Void, Never>?
+
     /// Departure ids with an in-flight `setAlarm`, so a double-tap can't create a
     /// duplicate alarm while the first create is suspended (MainActor-serialized,
     /// so a plain `Set` needs no further synchronization).
@@ -703,12 +708,24 @@ class StopViewModel: ObservableObject {
 
     /// Briefly raises `liveActivityStarted` so the SwiftUI stop page can show a
     /// non-blocking toast. Called by `StopPageViewController` after a successful
-    /// `Activity.request()`.
+    /// `Activity.request()`, and again when a duplicate Track attempt is
+    /// short-circuited — either way the user gets the same confirmation.
+    ///
+    /// Each signal supersedes the pending dismiss rather than racing it: without
+    /// the cancellation, a signal arriving late in the previous toast's window
+    /// would inherit that toast's imminent dismissal and vanish almost
+    /// immediately — leaving the duplicate tap looking like it did nothing.
     func signalLiveActivityStarted() {
+        liveActivityToastDismissTask?.cancel()
         liveActivityStarted = true
-        Task {
-            try? await Task.sleep(for: .seconds(2))
-            liveActivityStarted = false
+        liveActivityToastDismissTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                // Superseded by a newer signal; that signal's task owns the dismissal.
+                return
+            }
+            self?.liveActivityStarted = false
         }
     }
 

--- a/OBAKitCore/LiveActivities/LiveActivityLookup.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityLookup.swift
@@ -1,0 +1,55 @@
+//
+//  LiveActivityLookup.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import ActivityKit
+
+extension TripAttributes.StaticData {
+
+    /// Whether two `StaticData` describe the same tracked trip: the same route,
+    /// with the same headsign, arriving at the same stop.
+    ///
+    /// This is the single definition of Live Activity identity — the start
+    /// paths' duplicate guards and the bookmark-reconciliation match all
+    /// delegate to it, so "the same tracked trip" can't quietly come to mean
+    /// two different things.
+    ///
+    /// `routeColorHex` and `regionID` are excluded on purpose. Both are
+    /// presentation/routing metadata rather than identity, and the colour in
+    /// particular is read from the first arrival payload — it is nil until
+    /// arrivals load. Folding it into identity would let a duplicate through in
+    /// exactly the case this guards against: a second tap before data arrives.
+    public func tracksSameTrip(as other: TripAttributes.StaticData) -> Bool {
+        stopID == other.stopID
+            && routeShortName == other.routeShortName
+            && routeHeadsign == other.routeHeadsign
+    }
+}
+
+extension Activity where Attributes == TripAttributes {
+
+    /// The Live Activity already running for `staticData`'s stop and route, if any.
+    ///
+    /// Every `Activity.request` mints a brand-new activity with a fresh id, and
+    /// nothing downstream dedupes by content: `LiveActivityTracker` and
+    /// `LiveActivityRegistry` are both keyed on `activity.id`. So a start path
+    /// that doesn't consult this leaves the user with two Lock Screen cards —
+    /// and two OBACloud push registrations — for a single trip.
+    ///
+    /// Only *live* activities count. ActivityKit keeps dismissed and ended
+    /// activities in `activities`, so presence in that array is not evidence the
+    /// user is still looking at one; a guard written against mere presence would
+    /// refuse to start an activity the user had already dismissed. See
+    /// `LiveActivityRegistry.isLive(_:)`.
+    public static func running(matching staticData: TripAttributes.StaticData) -> Activity<TripAttributes>? {
+        activities.first { activity in
+            LiveActivityRegistry.isLive(activity.activityState)
+                && activity.attributes.staticData.tracksSameTrip(as: staticData)
+        }
+    }
+}

--- a/OBAKitTests/Models/TripAttributesIdentityTests.swift
+++ b/OBAKitTests/Models/TripAttributesIdentityTests.swift
@@ -1,0 +1,99 @@
+//
+//  TripAttributesIdentityTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import OBAKitCore
+
+/// Covers the identity rule behind the duplicate-Live-Activity guard.
+///
+/// The guard itself (`Activity.running(matching:)`) can't be unit-tested —
+/// ActivityKit's static `activities` isn't injectable — so these tests pin the
+/// comparison it delegates to, which is where the actual decision lives.
+@MainActor
+class TripAttributesIdentityTests: XCTestCase {
+
+    private func staticData(
+        routeShortName: String = "49",
+        routeHeadsign: String = "Downtown",
+        stopID: String = "1_75403",
+        routeColorHex: String? = nil,
+        regionID: Int = 1
+    ) -> TripAttributes.StaticData {
+        TripAttributes.StaticData(
+            routeShortName: routeShortName,
+            routeHeadsign: routeHeadsign,
+            stopID: stopID,
+            routeColorHex: routeColorHex,
+            regionID: regionID
+        )
+    }
+
+    func testMatchesWhenStopRouteAndHeadsignAreEqual() {
+        XCTAssertTrue(staticData().tracksSameTrip(as: staticData()))
+    }
+
+    func testDoesNotMatchOnDifferentStop() {
+        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(stopID: "1_99999")))
+    }
+
+    func testDoesNotMatchOnDifferentRoute() {
+        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(routeShortName: "8")))
+    }
+
+    /// Two directions of the same route at one stop are different trips, so
+    /// tracking one must not suppress starting the other.
+    func testDoesNotMatchOnDifferentHeadsign() {
+        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(routeHeadsign: "University District")))
+    }
+
+    /// The route colour arrives with the first arrivals payload and is nil until
+    /// then. If it were part of identity, a second tap before data loaded would
+    /// be treated as a different trip and would start a duplicate — the exact
+    /// case the guard exists to prevent.
+    func testMatchesWhenOnlyRouteColorDiffers() {
+        XCTAssertTrue(staticData(routeColorHex: nil).tracksSameTrip(as: staticData(routeColorHex: "FF0000")))
+    }
+
+    /// `regionID` is routing metadata for the widget deep link, not identity —
+    /// and excluding it keeps this rule identical to the stop/route/headsign
+    /// match `updateRunningLiveActivities()` already uses.
+    func testMatchesWhenOnlyRegionDiffers() {
+        XCTAssertTrue(staticData(regionID: 1).tracksSameTrip(as: staticData(regionID: 5)))
+    }
+
+    /// Symmetry is pinned with concrete values in both directions — asserting
+    /// the two calls equal each other would also pass if both directions were
+    /// wrong in the same way.
+    func testIsSymmetric() {
+        let a = staticData()
+        let b = staticData(routeShortName: "8")
+        XCTAssertFalse(a.tracksSameTrip(as: b))
+        XCTAssertFalse(b.tracksSameTrip(as: a))
+
+        let plain = staticData(routeColorHex: nil)
+        let colored = staticData(routeColorHex: "FF0000")
+        XCTAssertTrue(plain.tracksSameTrip(as: colored))
+        XCTAssertTrue(colored.tracksSameTrip(as: plain))
+    }
+
+    /// Empty headsign is the fallback both start paths use when a bookmark or
+    /// departure has none, so it has to compare cleanly rather than being
+    /// treated as "unknown, therefore different".
+    func testMatchesWhenBothHeadsignsAreEmpty() {
+        XCTAssertTrue(staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "")))
+    }
+
+    /// A record with no stored headsign ("" after the `tripHeadsign ?? ""`
+    /// fallback) is deliberately not treated as the same trip as one with a
+    /// specific headsign — that's the boundary of the guard's cross-screen
+    /// dedupe, pinned here so it can't change silently.
+    func testDoesNotMatchWhenOneHeadsignIsEmpty() {
+        XCTAssertFalse(staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "Downtown")))
+    }
+}


### PR DESCRIPTION

## Summary

Partially addresses #1189 (Problem 1).

Tapping **Track** on a bookmark that was already being tracked — or starting the same trip from both the bookmarks list and the stop page — created a second, independent Live Activity for the same stop. The result was two Lock Screen cards and two OBACloud push registrations for a single bus.

## Root cause

Neither start path checked whether an activity was already running before calling `Activity.request(...)`. Every request minted a fresh `activity.id`, and nothing downstream deduplicates by content — `LiveActivityTracker` and `LiveActivityRegistry` are both keyed on that id. This PR adds the missing check.

## What changed

- **`TripAttributes.StaticData.tracksSameTrip(as:)` (new)** — the single definition of Live Activity identity: matching `stopID`, `routeShortName`, and `routeHeadsign`. `routeColorHex` and `regionID` are deliberately excluded, since color is `nil` until arrivals load and including it would let a fast second tap slip through.
- **`Activity<TripAttributes>.running(matching:)` (new)** — finds an already-running activity for a given identity, filtered through `LiveActivityRegistry.isLive(_:)` so a *dismissed* activity can still be re-tracked.
- **Guard added to both start paths** — `BookmarksViewController` and `StopPageViewController` now check before calling `Activity.request(...)`. A duplicate tap re-shows the "Tracking on Lock Screen" confirmation rather than silently doing nothing.
- **`updateRunningLiveActivities()` now delegates to `tracksSameTrip(as:)`** instead of hand-rolling the same three-field comparison, so the reconciliation match and the new guard can't drift apart.
- **Toast/HUD dismissals are now cancellable** — both the `StopViewModel` dismiss task and the `ProgressHUD.showSuccessAndDismiss` timer. Previously, a second tap late in an existing toast's window inherited the first toast's imminent dismissal and vanished almost immediately: exactly the "looks like nothing happened" case this fix is about.

## Before / After

<table>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
<tr>
<td><video src="https://github.com/user-attachments/assets/2a644d22-1ef5-4834-85fb-6f13dd8f743c"></video></td>
<td><video src="https://github.com/user-attachments/assets/b392d497-0437-4a76-b793-9685fa474caa"></video></td>
</tr>
<tr>
<td>Tracking the same bookmark twice → two Live Activities on the Lock Screen.</td>
<td>The second tap is a no-op, one Live Activity remains, and the confirmation still shows.</td>
</tr>
</table>

## Out of scope

This PR covers Problem 1 of #1189 only. Problem 2 (the Dynamic Island not switching to the newest tracked trip) is a separate change — it needs `relevanceScore` on both the app and the OBACloud push side — so it is intentionally left out.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Live Activity trip matching to prevent duplicate Lock Screen cards and registrations.
  - Matching now consistently identifies trips using stop, route, and destination details.

- **Bug Fixes**
  - Prevented earlier success notifications from dismissing newer ones prematurely.
  - Stabilized Live Activity confirmation messages when duplicate start requests occur.
  - Added coverage for trip identity matching, including route color, region, and destination edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->