### PR TITLE
Generate Xcode 16 buildable folders instead of explicit file references

### DIFF
--- a/Apps/KiedyBus/project.yml
+++ b/Apps/KiedyBus/project.yml
@@ -11,6 +11,9 @@ targets:
       - path: Apps/KiedyBus
         name: App
         group: KiedyBus
+        # gpx files are simulated-location fixtures for schemes, not app
+        # resources; keep them out of the bundle.
+        excludes: ["gpx_files"]
       - path: Apps/Shared/CommonClient
         name: Common
         group: KiedyBus

--- a/Apps/OneBusAway/project.yml
+++ b/Apps/OneBusAway/project.yml
@@ -11,6 +11,9 @@ targets:
       - path: Apps/OneBusAway
         name: App
         group: OneBusAway
+        # gpx files are simulated-location fixtures for schemes, not app
+        # resources; keep them out of the bundle.
+        excludes: ["gpx_files"]
       - path: Apps/Shared/CommonClient
         name: Common
         group: OneBusAway

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -26,7 +26,13 @@ settings:
     SWIFT_WARNINGS_AS_ERRORS_GROUPS: "ActorIsolatedCall SendableClosureCaptures RegionIsolation ConformanceIsolation MutableGlobalVariable"
 
 options:
-  minimumXcodeGenVersion: 2.42
+  # Directory sources generate Xcode 16 buildable folders
+  # (PBXFileSystemSynchronizedRootGroup): the pbxproj records only the folder
+  # path and target membership follows the file system, so adding/removing
+  # files no longer touches the project file. Requires XcodeGen >= 2.45 for
+  # excludes -> membership exceptions and automatic Info.plist exclusion.
+  minimumXcodeGenVersion: 2.45.4
+  defaultSourceDirectoryType: syncedFolder
   generateEmptyDirectories: true
   groupSortPosition: top
   deploymentTarget:

--- a/OBAKit/project.yml
+++ b/OBAKit/project.yml
@@ -2,7 +2,14 @@ targets:
   OBAKit:
     type: framework
     platform: iOS
-    sources: ["."]
+    sources:
+      # XcodeGen's synced folders can't mark headers public, so the umbrella
+      # header is carved out of the buildable folder and added as an explicit
+      # public header.
+      - path: "."
+        excludes: ["OBAKit.h"]
+      - path: OBAKit.h
+        headerVisibility: public
     dependencies:
       - target: OBAKitCore
       - package: BLTNBoard

--- a/OBAKitCore/project.yml
+++ b/OBAKitCore/project.yml
@@ -2,7 +2,16 @@ targets:
   OBAKitCore:
     type: framework
     platform: iOS
-    sources: ["."]
+    sources:
+      # XcodeGen's synced folders can't mark headers public, so the umbrella
+      # header is carved out of the buildable folder and added as an explicit
+      # public header.
+      - path: "."
+        # The .proto schema is source material for pre-generated Swift, not a
+        # target member; without the exclusion Xcode tries to compile it.
+        excludes: ["OBAKitCore.h", "Models/Protobuf/gtfs-realtime.proto"]
+      - path: OBAKitCore.h
+        headerVisibility: public
     dependencies:
       - package: SwiftProtobuf
       - package: GRDB


### PR DESCRIPTION
## Summary

Switches XcodeGen project generation from explicit per-file references to Xcode 16 **buildable folders** (`PBXFileSystemSynchronizedRootGroup`) via `options.defaultSourceDirectoryType: syncedFolder`. The pbxproj now records only folder paths — target membership follows the file system — so adding, removing, or renaming files no longer touches the project file. The generated pbxproj shrinks from ~4,600 to ~1,450 lines.

## Toolchain requirement

**XcodeGen ≥ 2.45.4** (was 2.42), enforced via `minimumXcodeGenVersion`. Versions before 2.45 lack `excludes` → membership exceptions, automatic Info.plist exclusion from synced folders, and multi-target dedup. If generation fails after this merges, run `brew upgrade xcodegen`. CI installs the current Homebrew formula (2.46.0) and needs no changes.

## Carve-outs (behavior parity)

- **Umbrella headers** (`OBAKit.h`, `OBAKitCore.h`) remain explicit file sources with `headerVisibility: public`. XcodeGen's synced-folder exception sets can't mark headers public, so inside a buildable folder they would silently lose their `Public` attribute and break Objective-C consumers of the frameworks.
- **`gpx_files`** are excluded from both app targets. They're simulated-location fixtures referenced by schemes; previously phase-less, the buildable folder was copying all of them into the app bundle.
- **`gtfs-realtime.proto`** is excluded from OBAKitCore. The buildable folder placed it in Compile Sources, producing a `no rule to process` warning; the Swift it generates is already checked in.

## Verification

- Clean `build-for-testing` succeeds; **all 1,401 OBAKitTests pass** (iPhone 17 Pro simulator)
- All 13 localizations present in the built app and both framework bundles
- Umbrella headers retain the `Public` attribute in the Headers phase
- No gpx/entitlements leaked into the app bundle; `project.yml`/`Package.resolved` copied as resources exactly as before (pre-existing behavior, unchanged)
- Both `scripts/generate_project OneBusAway` and `scripts/generate_project KiedyBus` generate cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved app packaging by excluding simulated-location test fixtures from production bundles.
  * Updated project-generation requirements and defaults for more consistent build configuration.
  * Refined header handling to ensure public framework headers are packaged correctly while preventing internal and generated files from being compiled unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->