### PR TITLE
Default the scheme picker to App, not OBAKit

### DIFF
--- a/OBAKit/project.yml
+++ b/OBAKit/project.yml
@@ -1,3 +1,21 @@
+# Declared here rather than as `scheme:` on the OBAKit target below, purely so the
+# scheme's name differs from the target's.
+#
+# The generated project is `OBAKit.xcodeproj` (see `name:` in
+# Apps/Shared/app_shared.yml), and when Xcode opens a project with no saved user
+# state it selects the scheme whose name matches the project's. A target-generated
+# `OBAKit` scheme therefore won `App` every time a developer regenerated the project
+# — which `scripts/generate_project` does routinely, wiping the xcuserdata that
+# would otherwise remember the choice. Nothing selects this scheme by name (CI,
+# scripts/docs, and CLAUDE.md all use `App`), so only the display name moves.
+schemes:
+  OBAKit Framework:
+    build:
+      targets:
+        OBAKit: all
+    test:
+      gatherCoverageData: true
+
 targets:
   OBAKit:
     type: framework
@@ -23,8 +41,6 @@ targets:
       - path: "../scripts/swiftlint.sh"
         name: Swiftlint
         basedOnDependencyAnalysis: false
-    scheme:
-      gatherCoverageData: true
     info:
       path: "Info.plist"
       properties:


### PR DESCRIPTION
## Problem

Opening `OBAKit.xcodeproj` always selects the **OBAKit** framework scheme instead of **App**.

## Root cause

Two things combine:

1. When Xcode opens a project with no saved user state, it selects the scheme whose name matches the project name. Our project is `OBAKit.xcodeproj` (`name: OBAKit` in `Apps/Shared/app_shared.yml`), and the `OBAKit` framework target's `scheme:` block generated a scheme with exactly that name.
2. `scripts/generate_project` does `rm -rf OBAKit.xcodeproj` and regenerates, so the `xcuserdata` that would otherwise remember your last choice is destroyed every time. The default gets re-applied constantly.

Scheme *ordering* isn't the lever — `App` already has `orderHint 0` and sits at the top of the picker. It's specifically the name collision.

I verified this by regenerating the project, deleting `OBAKit.xcscheme` before first open, and reading the archived active scheme out of `UserInterfaceState.xcuserstate`: it flipped from `OBAKit` to `App`. Pre-seeding `xcschememanagement.plist` with `App` at `orderHint 0` before first open made no difference, confirming order isn't what's consulted.

## Fix

Move the framework scheme from a target-level `scheme:` block to a top-level `schemes:` entry named **`OBAKit Framework`**, so no scheme name matches the project name. The target is untouched.

## Verification

- Regenerated and opened cold: active scheme is now `App` (`IDENameStringSApp` in the archived UI state).
- The generated scheme is identical to the previous `OBAKit.xcscheme` apart from two empty `<CommandLineArguments>` elements; `gatherCoverageData` is preserved.
- Nothing selects this scheme by name — CI (`.github/workflows/obakittests.yml`), `scripts/docs`, and `CLAUDE.md` all pass `-scheme App` — so only the display name changes.
- Both app variants (`OneBusAway`, `KiedyBus`) generate cleanly.
- `xcodebuild build` succeeds for both `App` and `OBAKit Framework`.

## Note

The deeper oddity is that the white-label workspace is named after one of its framework targets. Renaming the project would be the root fix, but it moves `OBAKit.xcodeproj` for every script, workflow, doc, and developer's DerivedData — a much larger change than this bug warrants. Flagging it rather than doing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an explicit OBAKit Framework build scheme.
  * Enabled test coverage data collection for the framework’s test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->