### PR TITLE
Fix URLSchemeRouter doc comment: parameters are stopID/regionID, not stop_id/region_id

### DIFF
--- a/OBAKitCore/DeepLinks/URLSchemeRouter.swift
+++ b/OBAKitCore/DeepLinks/URLSchemeRouter.swift
@@ -57,7 +57,7 @@ public enum URLType {
 }
 /// Provides support for deep linking into the app by way of a custom URL scheme.
 ///
-/// Custom URL scheme deep linking (e.g. `onebusaway://view-stop?region_id=1&stop_id=12345`)
+/// Custom URL scheme deep linking (e.g. `onebusaway://view-stop?stopID=12345&regionID=1`)
 /// is the most reliable way to perform deep linking into the iOS app from an extension like the Today View.
 /// The only reason we don't use it everywhere is because the URLs generated are completely useless unless
 /// their recipient has a compatible version of OneBusAway installed on their device.


### PR DESCRIPTION
The doc comment on `URLSchemeRouter` shows

    onebusaway://view-stop?region_id=1&stop_id=12345

but `decodeViewStop` only reads the camelCase names (`stopID`, `regionID`), so a link built from the comment's example fails to decode and the app just opens to wherever it was. I integrated the scheme in my own app from the comment's example and hit exactly that.

Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the custom URL scheme deep-link example to use the current `stopID` and `regionID` query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->