### PR TITLE
Fix: Sort filter routes lexicographically with numeric awareness (#1218)

### DIFF
--- a/OBAKitCore/Extensions/FoundationExtensions.swift
+++ b/OBAKitCore/Extensions/FoundationExtensions.swift
@@ -249,7 +249,7 @@ public extension Sequence where Element == String {
     /// - Returns: A localized, case-insensitive sorted Array.
     func localizedCaseInsensitiveSort() -> [Element] {
         return sorted { (s1, s2) -> Bool in
-            return s1.localizedCaseInsensitiveCompare(s2) == .orderedAscending
+            return s1.localizedStandardCompare(s2) == .orderedAscending
         }
     }
 }

--- a/OBAKitCore/Models/REST/References/Route.swift
+++ b/OBAKitCore/Models/REST/References/Route.swift
@@ -179,7 +179,7 @@ public extension Sequence where Element == Route {
     /// - Returns: A localized, case-insensitive sorted Array.
     func localizedCaseInsensitiveSort() -> [Element] {
         return sorted { (s1, s2) -> Bool in
-            return s1.shortName.localizedCaseInsensitiveCompare(s2.shortName) == .orderedAscending
+            return s1.shortName.localizedStandardCompare(s2.shortName) == .orderedAscending
         }
     }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
@@ -214,6 +214,19 @@ class RouteTests: OBATestCase {
         expect(sortedRoutes[1].shortName) == "m Route"
         expect(sortedRoutes[2].shortName) == "z Route"
     }
+
+    func test_arrayExtensionSort_numeric() {
+        let routeNames = ["10", "3", "11", "49", "Bellevue", "12"]
+        let routes = try! routeNames.enumerated().map { (index, name) -> Route in
+            let dict: [String: Any] = ["id": "route_\(index)", "agencyId": "1", "shortName": name, "type": 3]
+            return try Fixtures.dictionaryToModel(type: Route.self, dictionary: dict)
+        }
+
+        let sortedRoutes = routes.localizedCaseInsensitiveSort()
+        let sortedNames = sortedRoutes.map(\.shortName)
+
+        expect(sortedNames) == ["3", "10", "11", "12", "49", "Bellevue"]
+    }
 }
 
 // MARK: - Frequency Tests


### PR DESCRIPTION
## Summary
Fixes #1218.

This PR updates route list sorting (`localizedCaseInsensitiveSort()`) in `OBAKitCore` to use `localizedStandardCompare(_:)` instead of `localizedCaseInsensitiveCompare(_:)`.

### Behavior Change
- **Before:** Route numbers were sorted by alphabetical code-point comparison (`"10", "11", "12", "3", "49", "Bellevue"`).
- **After:** Route numbers are sorted with natural numeric awareness (`"3", "10", "11", "12", "49", "Bellevue"`).

### Changes
1. Updated `Sequence where Element == Route`'s `localizedCaseInsensitiveSort()` to use `localizedStandardCompare`.
2. Updated `Sequence where Element == String`'s `localizedCaseInsensitiveSort()` to use `localizedStandardCompare`.
3. Added unit test `test_arrayExtensionSort_numeric()` in `RouteTests.swift`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting for strings and route names by recognizing numeric values naturally.
  * Route lists now sort values such as “3” before “10” for more intuitive ordering.

* **Tests**
  * Added coverage to verify numeric-aware route sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->