### PR TITLE
Show the predicted arrival time, not just the scheduled one

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -42,8 +42,8 @@ struct DepartureRowView: View {
 
     private var showsAlarmAffordance: Bool { canAlarm || hasAlarm }
 
-    private var scheduledTimeText: String {
-        formatters.timeFormatter.string(from: departure.scheduledDate)
+    private var timeDisplay: DepartureTimeDisplay {
+        DepartureTimeDisplay(arrivalDeparture: departure, formatters: formatters)
     }
 
     var body: some View {
@@ -60,9 +60,8 @@ struct DepartureRowView: View {
                     countdown
                 }
                 headsignText
-                Text(scheduledTimeText)
+                DepartureTimeText(display: timeDisplay)
                     .font(.footnote)
-                    .monospacedDigit()
                     .foregroundStyle(.secondary)
                 statusText
                 occupancyBadge
@@ -72,9 +71,8 @@ struct DepartureRowView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         headsignText
                         HStack(spacing: 6) {
-                            Text(scheduledTimeText)
+                            DepartureTimeText(display: timeDisplay)
                                 .font(.footnote)
-                                .monospacedDigit()
                                 .foregroundStyle(.secondary)
                             Text("·").foregroundStyle(.tertiary)
                             statusText
@@ -164,7 +162,9 @@ struct DepartureRowView: View {
     }
 
     private var accessibilityText: String {
-        var clauses = [baseAccessibilityText]
+        // The clock time follows the countdown: VoiceOver can't perceive the
+        // strikethrough that carries this on screen.
+        var clauses = [baseAccessibilityText, timeDisplay.accessibilityTimeDescription]
 
         if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
             clauses.append(OccupancyBadge.localizedDescription(occupancy))

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -349,19 +349,24 @@ struct GroupedListView: View {
     /// headsign, minutes, live/scheduled status, and occupancy when present.
     private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
-        var label = String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
-        // The strikethrough that carries this on screen is inaudible.
-        label += ", " + timeDisplay(departure).accessibilityTimeDescription
+        // Same clause list as `DepartureRowView.accessibilityText`; the clock
+        // time is spoken because the strikethrough carrying it is inaudible.
+        var clauses = [
+            String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription),
+            timeDisplay(departure).accessibilityTimeDescription
+        ]
         if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
-            label += ", " + OccupancyBadge.localizedDescription(occupancy)
+            clauses.append(OccupancyBadge.localizedDescription(occupancy))
         }
-        return label
+        return clauses.joined(separator: ", ")
     }
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
         let label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
-        // The strikethrough that carries this on screen is inaudible.
+        // Appended after the sentence rather than comma-joined like the row
+        // labels: this format string ends in a full stop, and VoiceOver's pause
+        // there keeps the time attached to the card rather than to the count.
         return label + " " + timeDisplay(group.next).accessibilityTimeDescription
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -55,6 +55,10 @@ struct GroupedListView: View {
         canAlarm(departure) || alarmLookup(departure) != nil
     }
 
+    private func timeDisplay(_ departure: ArrivalDeparture) -> DepartureTimeDisplay {
+        DepartureTimeDisplay(arrivalDeparture: departure, formatters: formatters)
+    }
+
     var body: some View {
         // One Section per route — the Section IS the card. Identity is the
         // stable RouteID; the accordion toggle lives INSIDE the Section so the
@@ -127,8 +131,8 @@ struct GroupedListView: View {
                     CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
                 }
                 headsignText(next)
-                Text(formatters.timeFormatter.string(from: next.scheduledDate))
-                    .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                DepartureTimeText(display: timeDisplay(next))
+                    .font(.footnote).foregroundStyle(.secondary)
                 Text(status.label)
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(Color(uiColor: status.color))
@@ -138,8 +142,8 @@ struct GroupedListView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         headsignText(next)
                         HStack(spacing: 6) {
-                            Text(formatters.timeFormatter.string(from: next.scheduledDate))
-                                .font(.footnote).monospacedDigit().foregroundStyle(.secondary)
+                            DepartureTimeText(display: timeDisplay(next))
+                                .font(.footnote).foregroundStyle(.secondary)
                             Text("·").foregroundStyle(.tertiary)
                             Text(status.label)
                                 .font(.footnote.weight(.semibold))
@@ -262,8 +266,8 @@ struct GroupedListView: View {
                         CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
                         tripChevron(departure)
                     }
-                    Text(formatters.timeFormatter.string(from: departure.scheduledDate))
-                        .font(.subheadline.weight(.semibold)).monospacedDigit()
+                    DepartureTimeText(display: timeDisplay(departure))
+                        .font(.subheadline.weight(.semibold))
                     Text(status.label)
                         .font(.subheadline)
                         .foregroundStyle(Color(uiColor: status.color))
@@ -275,8 +279,8 @@ struct GroupedListView: View {
                         alarmIcon(for: departure)
                         VStack(alignment: .leading, spacing: 2) {
                             HStack(spacing: 4) {
-                                Text(formatters.timeFormatter.string(from: departure.scheduledDate))
-                                    .font(.subheadline.weight(.semibold)).monospacedDigit()
+                                DepartureTimeText(display: timeDisplay(departure))
+                                    .font(.subheadline.weight(.semibold))
                                 Text("· \(status.label)")
                                     .font(.subheadline)
                                     .foregroundStyle(Color(uiColor: status.color))
@@ -346,6 +350,8 @@ struct GroupedListView: View {
     private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
         var label = String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+        // The strikethrough that carries this on screen is inaudible.
+        label += ", " + timeDisplay(departure).accessibilityTimeDescription
         if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
             label += ", " + OccupancyBadge.localizedDescription(occupancy)
         }
@@ -354,6 +360,8 @@ struct GroupedListView: View {
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
-        return String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+        let label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+        // The strikethrough that carries this on screen is inaudible.
+        return label + " " + timeDisplay(group.next).accessibilityTimeDescription
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/DepartureTimeDisplay.swift
+++ b/OBAKit/Stops/StopPage/Shared/DepartureTimeDisplay.swift
@@ -11,13 +11,18 @@ import OBAKitCore
 /// off its timetable the row shows both: the scheduled time struck through, then
 /// the time the rider should actually act on.
 ///
-/// The two are compared *as formatted strings* rather than as dates. A prediction
-/// twenty seconds off the timetable is a different `Date` but the same clock
-/// minute, and rendering "10:42 AM 10:42 AM" with one struck through reads as a
-/// bug. Comparing after formatting also catches the case `ScheduleStatus` misses:
-/// a deviation inside its ±1.5 minute "on time" band still lands on a different
+/// The two are compared *as formatted strings* rather than as dates, because the
+/// question being answered is "would these render identically?", not "are these
+/// the same minute?". A prediction twenty seconds off the timetable is a
+/// different `Date` but the same clock text, and rendering "10:42 AM 10:42 AM"
+/// with one struck through reads as a bug. The rule therefore tracks whatever
+/// `Formatters.timeFormatter` renders, deliberately — if that ever coarsens, the
+/// strikethrough should disappear along with the visible difference.
+///
+/// Comparing after formatting also catches the case `ScheduleStatus` misses: a
+/// deviation inside its ±1.5 minute "on time" band still lands on a different
 /// minute, and the rider still needs the corrected time.
-struct DepartureTimeDisplay {
+struct DepartureTimeDisplay: Equatable {
     /// The time the rider should act on: the prediction when there is one,
     /// the timetable otherwise.
     let expectedTimeText: String
@@ -26,32 +31,25 @@ struct DepartureTimeDisplay {
     /// Rendered struck through, ahead of the expected time.
     let scheduledTimeText: String?
 
-    /// Spoken equivalent of the strikethrough, which VoiceOver cannot perceive.
-    let accessibilityTimeDescription: String
-
     init(scheduledDate: Date, expectedDate: Date, isRealTime: Bool, formatters: Formatters) {
-        let expected = formatters.timeFormatter.string(from: isRealTime ? expectedDate : scheduledDate)
+        // `isRealTime` gates on the feed's own `predicted` flag rather than on the
+        // two dates differing: a payload can carry a prediction while declaring
+        // itself unpredicted, and `DepartureStatus` refuses to trust that too.
+        // When it's false the prediction is ignored outright, so there is nothing
+        // to strike through and one format call answers both properties. Equal
+        // dates necessarily format alike, so that case short-circuits here as
+        // well without disturbing the compare-as-rendered rule above.
+        guard isRealTime, expectedDate != scheduledDate else {
+            self.expectedTimeText = formatters.timeFormatter.string(from: scheduledDate)
+            self.scheduledTimeText = nil
+            return
+        }
+
+        let expected = formatters.timeFormatter.string(from: expectedDate)
         let scheduled = formatters.timeFormatter.string(from: scheduledDate)
 
         self.expectedTimeText = expected
-        self.scheduledTimeText = (isRealTime && scheduled != expected) ? scheduled : nil
-
-        if let scheduledTimeText {
-            let fmt = OBALoc(
-                "stop_page.time.a11y_rescheduled_fmt",
-                value: "scheduled %1$@, now expected %2$@",
-                comment: "VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time."
-            )
-            self.accessibilityTimeDescription = String(format: fmt, scheduledTimeText, expected)
-        }
-        else {
-            let fmt = OBALoc(
-                "stop_page.time.a11y_at_fmt",
-                value: "at %@",
-                comment: "VoiceOver clause naming the clock time of a departure. %@ is the time."
-            )
-            self.accessibilityTimeDescription = String(format: fmt, expected)
-        }
+        self.scheduledTimeText = scheduled == expected ? nil : scheduled
     }
 
     init(arrivalDeparture: ArrivalDeparture, formatters: Formatters) {
@@ -62,6 +60,29 @@ struct DepartureTimeDisplay {
             formatters: formatters
         )
     }
+
+    /// Spoken equivalent of the strikethrough, which VoiceOver cannot perceive.
+    ///
+    /// Computed rather than stored: the render path never reads it, and building
+    /// it eagerly would charge every row a bundle lookup for a string most
+    /// people never hear.
+    var accessibilityTimeDescription: String {
+        guard let scheduledTimeText else {
+            let fmt = OBALoc(
+                "stop_page.time.a11y_at_fmt",
+                value: "at %@",
+                comment: "VoiceOver clause naming the clock time of a departure. %@ is the time."
+            )
+            return String(format: fmt, expectedTimeText)
+        }
+
+        let fmt = OBALoc(
+            "stop_page.time.a11y_rescheduled_fmt",
+            value: "scheduled %1$@, now expected %2$@",
+            comment: "VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time."
+        )
+        return String(format: fmt, scheduledTimeText, expectedTimeText)
+    }
 }
 
 /// Renders a `DepartureTimeDisplay`: one clock time, or the struck-through
@@ -69,49 +90,28 @@ struct DepartureTimeDisplay {
 ///
 /// Deliberately styling-free apart from the strikethrough and the recessive
 /// tint on the scheduled time — font and foreground style are inherited, so the
-/// five call sites keep the type scale they already had.
+/// call sites keep the type scale they already had. Concatenated `Text` rather
+/// than a stack so the pair wraps as ordinary text at large Dynamic Type sizes.
 struct DepartureTimeText: View {
     let display: DepartureTimeDisplay
 
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
     var body: some View {
-        // Unary root so the enclosing List rows keep their fast path.
-        Group {
-            if let scheduledTimeText = display.scheduledTimeText {
-                // Two times don't fit side by side once the text is large enough,
-                // so stack them the way the rows themselves stack.
-                if dynamicTypeSize.isAccessibilitySize {
-                    VStack(alignment: .leading, spacing: 1) {
-                        scheduled(scheduledTimeText)
-                        expected
-                    }
-                }
-                else {
-                    HStack(spacing: 4) {
-                        scheduled(scheduledTimeText)
-                        expected
-                    }
-                }
-            }
-            else {
-                expected
-            }
+        time
+            .monospacedDigit()
+            // Every consumer speaks `accessibilityTimeDescription` in its own
+            // combined label (those parents use `children: .ignore`, which drops
+            // child labels outright), and a strikethrough is inaudible, so
+            // leaving this visible would announce two unrelated bare times.
+            .accessibilityHidden(true)
+    }
+
+    private var time: Text {
+        guard let scheduledTimeText = display.scheduledTimeText else {
+            return Text(display.expectedTimeText)
         }
-        .monospacedDigit()
-        // Every consumer speaks `accessibilityTimeDescription` in its own
-        // combined label; a strikethrough is inaudible, so leaving these
-        // visible would announce two bare times with no relationship.
-        .accessibilityHidden(true)
-    }
 
-    private var expected: Text {
-        Text(display.expectedTimeText)
-    }
-
-    private func scheduled(_ text: String) -> some View {
-        Text(text)
-            .strikethrough()
-            .foregroundStyle(.secondary)
+        return Text(scheduledTimeText).strikethrough().foregroundStyle(.secondary)
+            + Text(" ")
+            + Text(display.expectedTimeText)
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/DepartureTimeDisplay.swift
+++ b/OBAKit/Stops/StopPage/Shared/DepartureTimeDisplay.swift
@@ -1,0 +1,117 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// The clock time(s) shown on a departure row. When real-time data moves a trip
+/// off its timetable the row shows both: the scheduled time struck through, then
+/// the time the rider should actually act on.
+///
+/// The two are compared *as formatted strings* rather than as dates. A prediction
+/// twenty seconds off the timetable is a different `Date` but the same clock
+/// minute, and rendering "10:42 AM 10:42 AM" with one struck through reads as a
+/// bug. Comparing after formatting also catches the case `ScheduleStatus` misses:
+/// a deviation inside its ±1.5 minute "on time" band still lands on a different
+/// minute, and the rider still needs the corrected time.
+struct DepartureTimeDisplay {
+    /// The time the rider should act on: the prediction when there is one,
+    /// the timetable otherwise.
+    let expectedTimeText: String
+
+    /// The timetable time, present only when it differs from `expectedTimeText`.
+    /// Rendered struck through, ahead of the expected time.
+    let scheduledTimeText: String?
+
+    /// Spoken equivalent of the strikethrough, which VoiceOver cannot perceive.
+    let accessibilityTimeDescription: String
+
+    init(scheduledDate: Date, expectedDate: Date, isRealTime: Bool, formatters: Formatters) {
+        let expected = formatters.timeFormatter.string(from: isRealTime ? expectedDate : scheduledDate)
+        let scheduled = formatters.timeFormatter.string(from: scheduledDate)
+
+        self.expectedTimeText = expected
+        self.scheduledTimeText = (isRealTime && scheduled != expected) ? scheduled : nil
+
+        if let scheduledTimeText {
+            let fmt = OBALoc(
+                "stop_page.time.a11y_rescheduled_fmt",
+                value: "scheduled %1$@, now expected %2$@",
+                comment: "VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time."
+            )
+            self.accessibilityTimeDescription = String(format: fmt, scheduledTimeText, expected)
+        }
+        else {
+            let fmt = OBALoc(
+                "stop_page.time.a11y_at_fmt",
+                value: "at %@",
+                comment: "VoiceOver clause naming the clock time of a departure. %@ is the time."
+            )
+            self.accessibilityTimeDescription = String(format: fmt, expected)
+        }
+    }
+
+    init(arrivalDeparture: ArrivalDeparture, formatters: Formatters) {
+        self.init(
+            scheduledDate: arrivalDeparture.scheduledDate,
+            expectedDate: arrivalDeparture.arrivalDepartureDate,
+            isRealTime: arrivalDeparture.predicted,
+            formatters: formatters
+        )
+    }
+}
+
+/// Renders a `DepartureTimeDisplay`: one clock time, or the struck-through
+/// scheduled time followed by the corrected one.
+///
+/// Deliberately styling-free apart from the strikethrough and the recessive
+/// tint on the scheduled time — font and foreground style are inherited, so the
+/// five call sites keep the type scale they already had.
+struct DepartureTimeText: View {
+    let display: DepartureTimeDisplay
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        // Unary root so the enclosing List rows keep their fast path.
+        Group {
+            if let scheduledTimeText = display.scheduledTimeText {
+                // Two times don't fit side by side once the text is large enough,
+                // so stack them the way the rows themselves stack.
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 1) {
+                        scheduled(scheduledTimeText)
+                        expected
+                    }
+                }
+                else {
+                    HStack(spacing: 4) {
+                        scheduled(scheduledTimeText)
+                        expected
+                    }
+                }
+            }
+            else {
+                expected
+            }
+        }
+        .monospacedDigit()
+        // Every consumer speaks `accessibilityTimeDescription` in its own
+        // combined label; a strikethrough is inaudible, so leaving these
+        // visible would announce two bare times with no relationship.
+        .accessibilityHidden(true)
+    }
+
+    private var expected: Text {
+        Text(display.expectedTimeText)
+    }
+
+    private func scheduled(_ text: String) -> some View {
+        Text(text)
+            .strikethrough()
+            .foregroundStyle(.secondary)
+    }
+}

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "بيانات الجدول";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "في %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "حسب الجدول %1$@، والمتوقع الآن %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d مواقف";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1199,6 +1199,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "schedule data";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "at %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "scheduled %1$@, now expected %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d stops";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "datos de horario";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "a las %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "según el horario a las %1$@, ahora se espera a las %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "data ng iskedyul";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "nang %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "nakatakda nang %1$@, inaasahan na ngayon nang %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d hintuan";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horaire théorique";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "à %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "initialement prévu à %1$@, maintenant attendu à %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d arrêts";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dati di orario";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "alle %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "da orario alle %1$@, ora previsto alle %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d fermate";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "시간표 기준";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "시각 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "예정 시각 %1$@, 현재 예상 시각 %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "정류장 %d개";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dane rozkładowe";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "o %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "według rozkładu %1$@, przewidywana godzina %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d przyst.";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horário programado";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "às %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "programado para %1$@, agora previsto para %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "по расписанию";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "в %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "по расписанию %1$@, сейчас ожидается в %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d ост.";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dữ liệu lịch trình";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "lúc %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "theo lịch trình lúc %1$@, hiện dự kiến lúc %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d điểm dừng";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "时刻表数据";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "时间 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "原定 %1$@，现预计 %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d个车站";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1197,6 +1197,12 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "時刻表資料";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"stop_page.time.a11y_at_fmt" = "時間 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"stop_page.time.a11y_rescheduled_fmt" = "原定 %1$@，現預計 %2$@";
+
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d 站";
 

--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -302,8 +302,12 @@ public final class ArrivalDeparture: NSObject, Identifiable, Decodable, HasRefer
     }
 
     /// A more precise (but maybe not as useful?) calculation of the deviation of this trip from schedule.
+    ///
+    /// - Note: Measured against `scheduledDate` so that arrivals compare against
+    ///         `scheduledArrival`. Using `scheduledDeparture` unconditionally reports a
+    ///         late arrival as early by the length of the layover.
     private var rawDeviationFromScheduleInMinutes: Double {
-        return (arrivalDepartureDate.timeIntervalSinceNow - scheduledDeparture.timeIntervalSinceNow) / 60.0
+        return (arrivalDepartureDate.timeIntervalSinceNow - scheduledDate.timeIntervalSinceNow) / 60.0
     }
 
     /// Is this trip early, on time, delayed, or of an unknown status?

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -56,6 +56,45 @@ class Fixtures {
         return apiResponse.list
     }
 
+    /// Builds an `ArrivalDeparture` from timestamps, defaulting the ~15 keys of
+    /// decoder boilerplate that no test cares about. Times are seconds since the
+    /// epoch; pass the predicted ones as `nil` to model a schedule-only trip.
+    ///
+    /// `stopSequence` selects `arrivalDepartureStatus`: 0 is `.departing`,
+    /// anything else `.arriving`.
+    class func arrivalDeparture(
+        predicted: Bool = true,
+        scheduledArrival: Int = 1_700_000_000,
+        predictedArrival: Int? = nil,
+        scheduledDeparture: Int = 1_700_000_000,
+        predictedDeparture: Int? = nil,
+        stopSequence: Int = 5
+    ) throws -> ArrivalDeparture {
+        var dictionary: [String: Any] = [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": scheduledArrival,
+            "numberOfStopsAway": 1,
+            "predicted": predicted,
+            "routeId": "route_1",
+            "scheduledArrivalTime": scheduledArrival,
+            "scheduledDepartureTime": scheduledDeparture,
+            "serviceDate": scheduledArrival,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_1",
+            "stopSequence": stopSequence,
+            "tripId": "trip_1",
+            "vehicleId": "vehicle_1"
+        ]
+        if let predictedArrival { dictionary["predictedArrivalTime"] = predictedArrival }
+        if let predictedDeparture { dictionary["predictedDepartureTime"] = predictedDeparture }
+
+        return try dictionaryToModel(type: ArrivalDeparture.self, dictionary: dictionary)
+    }
+
     class func loadAlarm(id: String = "1234567890", region: String = "1") throws -> Alarm {
         return try dictionaryToModel(type: Alarm.self, dictionary: ["url": String(format: "https://alerts.example.com/regions/%@/alarms/%@", region, id)])
     }

--- a/OBAKitTests/Mapping/StopAnnotationCalloutTests.swift
+++ b/OBAKitTests/Mapping/StopAnnotationCalloutTests.swift
@@ -18,6 +18,12 @@ import Nimble
 /// chevron that pushes the stop — so a regression here silently breaks that screen's entry point.
 class StopAnnotationCalloutTests: OBATestCase {
 
+    /// `@MainActor` because `StopIconFactory` is: OBAKit builds with
+    /// `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` while OBAKitTests is `nonisolated`
+    /// (see `Apps/Shared/app_shared.yml` and `OBAKitTests/project.yml`). A nested type
+    /// doesn't inherit the enclosing `OBATestCase`'s isolation, so without this the
+    /// `iconFactory` default value can't be evaluated in the stub's nonisolated init.
+    @MainActor
     private final class StopAnnotationDelegateStub: NSObject, StopAnnotationDelegate {
         var showsStopAnnotationCallouts: Bool
         var shouldHideExtraStopAnnotationData = false

--- a/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
@@ -381,4 +381,52 @@ class ArrivalDepartureTests: OBATestCase {
             try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: incompleteData)
         }.to(throwError())
     }
+
+    // MARK: - Schedule deviation
+
+    /// Builds a trip that sits at the stop for a ten minute layover and runs
+    /// three minutes late, so that measuring the deviation against the wrong
+    /// scheduled field produces a visibly different answer.
+    private func layoverArrivalDeparture(stopSequence: Int) throws -> ArrivalDeparture {
+        try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": 1_700_000_000,
+            "numberOfStopsAway": 1,
+            "predicted": true,
+            "scheduledArrivalTime": 1_700_000_000,
+            "predictedArrivalTime": 1_700_000_180,   // 3 min after scheduled arrival
+            "scheduledDepartureTime": 1_700_000_600, // 10 min layover
+            "predictedDepartureTime": 1_700_000_780, // 3 min after scheduled departure
+            "routeId": "route_layover",
+            "serviceDate": 1_700_000_000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_layover",
+            "stopSequence": stopSequence,
+            "tripId": "trip_layover",
+            "vehicleId": "vehicle_layover"
+        ])
+    }
+
+    func test_deviation_forArrivingTrip_measuresAgainstScheduledArrival() throws {
+        // A non-zero stopSequence means `.arriving`, so the comparable baseline
+        // is scheduledArrival — not scheduledDeparture on the far side of the
+        // layover, which would report this late trip as 7 minutes early.
+        let arrival = try layoverArrivalDeparture(stopSequence: 5)
+
+        expect(arrival.arrivalDepartureStatus) == .arriving
+        expect(arrival.deviationFromScheduleInMinutes) == 3
+        expect(arrival.scheduleStatus) == .delayed
+    }
+
+    func test_deviation_forDepartingTrip_measuresAgainstScheduledDeparture() throws {
+        let departure = try layoverArrivalDeparture(stopSequence: 0)
+
+        expect(departure.arrivalDepartureStatus) == .departing
+        expect(departure.deviationFromScheduleInMinutes) == 3
+        expect(departure.scheduleStatus) == .delayed
+    }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
@@ -388,27 +388,13 @@ class ArrivalDepartureTests: OBATestCase {
     /// three minutes late, so that measuring the deviation against the wrong
     /// scheduled field produces a visibly different answer.
     private func layoverArrivalDeparture(stopSequence: Int) throws -> ArrivalDeparture {
-        try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
-            "arrivalEnabled": true,
-            "blockTripSequence": 1,
-            "departureEnabled": true,
-            "distanceFromStop": 100.0,
-            "lastUpdateTime": 1_700_000_000,
-            "numberOfStopsAway": 1,
-            "predicted": true,
-            "scheduledArrivalTime": 1_700_000_000,
-            "predictedArrivalTime": 1_700_000_180,   // 3 min after scheduled arrival
-            "scheduledDepartureTime": 1_700_000_600, // 10 min layover
-            "predictedDepartureTime": 1_700_000_780, // 3 min after scheduled departure
-            "routeId": "route_layover",
-            "serviceDate": 1_700_000_000,
-            "situationIds": [],
-            "status": "SCHEDULED",
-            "stopId": "stop_layover",
-            "stopSequence": stopSequence,
-            "tripId": "trip_layover",
-            "vehicleId": "vehicle_layover"
-        ])
+        try Fixtures.arrivalDeparture(
+            scheduledArrival: 1_700_000_000,
+            predictedArrival: 1_700_000_180,    // 3 min after scheduled arrival
+            scheduledDeparture: 1_700_000_600,  // 10 min layover
+            predictedDeparture: 1_700_000_780,  // 3 min after scheduled departure
+            stopSequence: stopSequence
+        )
     }
 
     func test_deviation_forArrivingTrip_measuresAgainstScheduledArrival() throws {

--- a/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
@@ -1,0 +1,160 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import OBAKitCore
+@testable import OBAKit
+
+@MainActor
+final class DepartureTimeDisplayTests: XCTestCase {
+
+    private let formatters = Formatters(
+        locale: Locale(identifier: "en_US"),
+        calendar: Calendar(identifier: .gregorian),
+        themeColors: ThemeColors.shared
+    )
+
+    /// Deliberately aligned to :00 seconds. The same-minute and different-minute
+    /// cases below reason about which clock minute an offset lands in, which is
+    /// only predictable from a minute boundary.
+    private let scheduled = Date(timeIntervalSinceReferenceDate: 699_999_960)
+
+    private func display(expectedOffset: TimeInterval, isRealTime: Bool = true) -> DepartureTimeDisplay {
+        DepartureTimeDisplay(
+            scheduledDate: scheduled,
+            expectedDate: scheduled.addingTimeInterval(expectedOffset),
+            isRealTime: isRealTime,
+            formatters: formatters
+        )
+    }
+
+    private func formatted(_ offset: TimeInterval) -> String {
+        formatters.timeFormatter.string(from: scheduled.addingTimeInterval(offset))
+    }
+
+    // MARK: - Which time is shown
+
+    func test_noRealTime_showsScheduledTimeAloneWithNoStrikethrough() {
+        // Without a prediction there is nothing to correct, so a struck-through
+        // time would imply a change that never happened.
+        let display = display(expectedOffset: 0, isRealTime: false)
+
+        XCTAssertEqual(display.expectedTimeText, formatted(0))
+        XCTAssertNil(display.scheduledTimeText)
+    }
+
+    func test_late_showsPredictedTimeAndStrikesTheScheduledOne() {
+        let display = display(expectedOffset: 3 * 60)
+
+        XCTAssertEqual(display.expectedTimeText, formatted(3 * 60))
+        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+    }
+
+    func test_early_showsPredictedTimeAndStrikesTheScheduledOne() {
+        let display = display(expectedOffset: -4 * 60)
+
+        XCTAssertEqual(display.expectedTimeText, formatted(-4 * 60))
+        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+    }
+
+    // MARK: - The "on time" band
+
+    func test_sameMinute_showsOneTimeOnly() {
+        // A 20 second deviation formats to the same clock minute; showing
+        // "10:42 AM 10:42 AM" with one struck through would be nonsense.
+        let display = display(expectedOffset: 20)
+
+        XCTAssertEqual(display.expectedTimeText, formatted(0))
+        XCTAssertNil(display.scheduledTimeText)
+    }
+
+    func test_differentMinuteInsideOnTimeBand_stillShowsBothTimes() {
+        // scheduleStatus calls anything inside ±1.5 min "on time", but the rider
+        // still needs the corrected clock time — this is the bug in issue #1214
+        // that a "strike through only when late" rule would leave unfixed.
+        let display = display(expectedOffset: 80)
+
+        XCTAssertEqual(display.expectedTimeText, formatted(80))
+        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+    }
+
+    // MARK: - VoiceOver
+
+    func test_accessibility_speaksBothTimesWhenTheyDiffer() {
+        // Strikethrough is invisible to VoiceOver, so the correction has to be
+        // carried by words.
+        let display = display(expectedOffset: 3 * 60)
+
+        XCTAssertEqual(
+            display.accessibilityTimeDescription,
+            "scheduled \(formatted(0)), now expected \(formatted(3 * 60))"
+        )
+    }
+
+    func test_accessibility_speaksOneTimeWhenTheyMatch() {
+        let display = display(expectedOffset: 0, isRealTime: false)
+
+        XCTAssertEqual(display.accessibilityTimeDescription, "at \(formatted(0))")
+    }
+
+    // MARK: - Model bridge
+
+    func test_initFromArrivalDeparture_usesPredictedTimeAsExpected() throws {
+        let arrivalDeparture = try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": 1_700_000_000,
+            "numberOfStopsAway": 1,
+            "predicted": true,
+            "scheduledArrivalTime": 1_700_000_000,
+            "predictedArrivalTime": 1_700_000_180,
+            "scheduledDepartureTime": 1_700_000_000,
+            "predictedDepartureTime": 1_700_000_180,
+            "routeId": "route_1",
+            "serviceDate": 1_700_000_000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_1",
+            "stopSequence": 5,
+            "tripId": "trip_1",
+            "vehicleId": "vehicle_1"
+        ])
+
+        let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
+
+        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate))
+        XCTAssertEqual(display.scheduledTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+    }
+
+    func test_initFromArrivalDeparture_withoutPrediction_showsNoStrikethrough() throws {
+        let arrivalDeparture = try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": 1_700_000_000,
+            "numberOfStopsAway": 1,
+            "predicted": false,
+            "scheduledArrivalTime": 1_700_000_000,
+            "scheduledDepartureTime": 1_700_000_000,
+            "routeId": "route_1",
+            "serviceDate": 1_700_000_000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_1",
+            "stopSequence": 5,
+            "tripId": "trip_1",
+            "vehicleId": "vehicle_1"
+        ])
+
+        let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
+
+        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+        XCTAssertNil(display.scheduledTimeText)
+    }
+}

--- a/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
@@ -103,27 +103,10 @@ final class DepartureTimeDisplayTests: XCTestCase {
     // MARK: - Model bridge
 
     func test_initFromArrivalDeparture_usesPredictedTimeAsExpected() throws {
-        let arrivalDeparture = try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
-            "arrivalEnabled": true,
-            "blockTripSequence": 1,
-            "departureEnabled": true,
-            "distanceFromStop": 100.0,
-            "lastUpdateTime": 1_700_000_000,
-            "numberOfStopsAway": 1,
-            "predicted": true,
-            "scheduledArrivalTime": 1_700_000_000,
-            "predictedArrivalTime": 1_700_000_180,
-            "scheduledDepartureTime": 1_700_000_000,
-            "predictedDepartureTime": 1_700_000_180,
-            "routeId": "route_1",
-            "serviceDate": 1_700_000_000,
-            "situationIds": [],
-            "status": "SCHEDULED",
-            "stopId": "stop_1",
-            "stopSequence": 5,
-            "tripId": "trip_1",
-            "vehicleId": "vehicle_1"
-        ])
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predictedArrival: 1_700_000_180,
+            predictedDeparture: 1_700_000_180
+        )
 
         let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
 
@@ -131,26 +114,25 @@ final class DepartureTimeDisplayTests: XCTestCase {
         XCTAssertEqual(display.scheduledTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
     }
 
+    func test_initFromArrivalDeparture_ignoresPredictionWhenFeedSaysNotPredicted() throws {
+        // A payload can carry predicted times while declaring `predicted: false`.
+        // `arrivalDepartureDate` hands back the prediction anyway, so the display
+        // has to gate on the flag or it would strike through a time the feed
+        // just told us not to trust.
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predicted: false,
+            predictedArrival: 1_700_000_180,
+            predictedDeparture: 1_700_000_180
+        )
+
+        let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
+
+        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+        XCTAssertNil(display.scheduledTimeText)
+    }
+
     func test_initFromArrivalDeparture_withoutPrediction_showsNoStrikethrough() throws {
-        let arrivalDeparture = try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
-            "arrivalEnabled": true,
-            "blockTripSequence": 1,
-            "departureEnabled": true,
-            "distanceFromStop": 100.0,
-            "lastUpdateTime": 1_700_000_000,
-            "numberOfStopsAway": 1,
-            "predicted": false,
-            "scheduledArrivalTime": 1_700_000_000,
-            "scheduledDepartureTime": 1_700_000_000,
-            "routeId": "route_1",
-            "serviceDate": 1_700_000_000,
-            "situationIds": [],
-            "status": "SCHEDULED",
-            "stopId": "stop_1",
-            "stopSequence": 5,
-            "tripId": "trip_1",
-            "vehicleId": "vehicle_1"
-        ])
+        let arrivalDeparture = try Fixtures.arrivalDeparture(predicted: false)
 
         let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
 


### PR DESCRIPTION
Fixes #1214.

## Summary

- The new Stop page printed `scheduledDate` at all five of its clock-time sites while feeding the countdown `arrivalDepartureMinutes`, which is prediction-derived. A late bus rendered `7m` beside `10:42 AM` with nothing to say which to trust, so riders read the timetable time and missed the bus. Departures now show the corrected time with the scheduled time struck through beside it.
- The strikethrough decision compares the **formatted strings**, not the dates. That avoids rendering `10:42 AM 10:42 AM` for a prediction seconds off the timetable, and it also fixes a case a "strike through only when late" rule would miss: `ScheduleStatus` calls anything inside ±1.5 min "on time", but such a trip still lands on a different clock minute and still needs its time corrected.
- VoiceOver can't perceive a strikethrough, so the chronological rows and both grouped-card labels now speak "scheduled X, now expected Y". Two new strings, translated into all 12 non-English locales.
- Also fixes the schedule-deviation baseline in `ArrivalDeparture`: it measured against `scheduledDeparture` even for arrivals, reporting a late arrival as *early* by the length of the layover. Showing both times side by side would have made that disagreement visible on screen.

Only the new Stop page was affected. The old page, bookmarks, and `Formatters` already displayed `arrivalDepartureDate`.

## Test plan

- [x] `OBAKitTests` — 1452 tests, 0 failures
- [x] New `DepartureTimeDisplayTests` (10): late, early, same-minute, different-minute-inside-the-on-time-band, schedule-only, and a feed that carries predicted times while declaring `predicted: false`
- [x] New `ArrivalDepartureTests` deviation tests pin both the arriving and departing branch of the layover fix
- [x] Locale key parity across all 13 locales; `plutil -lint` clean on each
- [x] Rendered every state through `ImageRenderer` at default size and at `accessibility3`, confirming the two times wrap one-per-line at large type
- [x] SwiftLint clean (one pre-existing `file_length` violation in `StopPageViewController.swift`, untouched here)

## Review notes

Non-blocking findings from the cleanup pass that I deliberately left out of scope:

1. **`DepartureTimeDisplay` lives in OBAKit, so the widget and Live Activity can't adopt it.** They import only `OBAKitCore`. I left it in place because neither surface exhibits #1214 today — `BookmarkCardView` and `TripActivityPresenter` already render `arrivalDepartureDate` — and moving the two strings between framework bundles is a separate risk worth its own change. Tracked in #1225.
2. **`BookmarkCardView` still renders a bare time with no strikethrough.** Migrating it is a one-liner but it's a product decision about bookmark cards, not part of this issue.
3. **These values are rebuilt per render rather than per data refresh.** `StopPageListBuilder` is the natural home if it ever shows up in a profile; after the cleanup commit the render path costs one or two `DateFormatter` calls and no bundle lookups, close to what it cost before.
4. **Pre-existing, old stop page:** `Formatters.formattedScheduleDeviation` picks its wording from `deviationFromScheduleInMinutes == 0` while the color comes from `scheduleStatus`'s ±1.5 min band, so a 1-minute-late trip renders a green "arrives 1 min late".
5. **Pre-existing, localization:** `stop_page.status.late_fmt` / `early_fmt` have no `.stringsdict` plural rules, and OBAKitCore has no stringsdict at all, so "1 min late" is ungrammatical in several locales.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved stop-page departure time presentation to clearly show scheduled vs predicted (expected) times, including strikethrough when rescheduled.
  * Enhanced VoiceOver labeling for departure times, including localized, rescheduled-time phrasing.
* **Bug Fixes**
  * Schedule deviation calculations now correctly measure deviation for arriving vs departing services. 
* **Tests**
  * Added coverage for departure time display behavior and schedule deviation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

