### PR TITLE
Run OBAKitTests CI on the xcode-27 runner image

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -8,8 +8,8 @@ on:
 
 # GitHub macOS Runner images are documented at:
 # https://github.com/actions/runner-images?tab=readme-ov-file
-# Installed versions of Xcode on macOS 15 are documented at:
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
+# The `xcode-27` image (arm64, public preview) is documented at:
+# https://github.com/actions/runner-images/blob/main/images/macos/xcode-27-Readme.md
 #
 # Performance note (figures observed 2026-06 — a dated snapshot, not an invariant;
 # they will drift as the suite, runner images, and Xcode change): the OBAKitTests
@@ -25,15 +25,15 @@ on:
 
 jobs:
   build:
-    runs-on: macos-26
+    runs-on: xcode-27
     permissions:
       checks: write
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -44,7 +44,7 @@ jobs:
     # resolved dependency graph, the XcodeGen project specs, or this workflow
     # change. The previous `**/*.yml` glob also matched vendored yml under
     # .build/checkouts and caused needless cache misses (→ full rebuilds).
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       id: deriveddata-cache
       with:
         path: DerivedData
@@ -64,18 +64,20 @@ jobs:
       if: steps.deriveddata-cache.outputs.cache-hit != 'true'
       run: rm -rf DerivedData/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules
 
-    # Pin Xcode deterministically so the set of bundled simulator runtimes is
-    # known, instead of relying on `xcode-select` against whatever the image ships.
-    # 26.6, not 26.2: the Swift 6 migration needs a compiler from the same
-    # generation as local development (Xcode 27 beta / Swift 6.4). Xcode 26.2's
-    # compiler emits implicitly-isolated deinits for MainActor-default classes
-    # whose runtime path double-frees in TaskLocal teardown, crashing the test
-    # suite regardless of simulator runtime (see docs/swift6-migration-plan.md,
-    # "Toolchain/runtime pairing caveat").
+    # The `xcode-27` image ships exactly one Xcode (27.0 beta), so this is close to
+    # a no-op today — it's here so that if the image ever carries a second Xcode,
+    # CI takes the newest one rather than whatever `xcode-select` defaults to.
+    # `latest`, not `latest-stable`: the only installed Xcode is a beta, and
+    # `latest-stable` filters betas out and fails. Following the image forward is
+    # deliberate — the Swift 6 migration needs a compiler of the same generation as
+    # local development (docs/swift6-migration-plan.md), which the older pinned
+    # Xcode 26.6 was not: it rejected code Xcode 27 accepts and turned main red
+    # (see a1244c48). The trade-off is that the toolchain is no longer pinned, so a
+    # new beta landing in the image can move the concurrency warning count below.
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.6'
+        xcode-version: 'latest'
 
     - name: Install xcodegen
       env:
@@ -83,22 +85,23 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: brew install xcodegen
 
-    # Make iOS runtime acquisition explicit and time-boxed. An iOS 26+ runtime is
-    # REQUIRED, not merely preferred: the runner image also ships older runtimes
-    # (e.g. iOS 18.5), and running the Swift 6 build's tests on those routes every
-    # MainActor class deinit through the isolated-deinit back-deployment shim,
-    # which double-frees in TaskLocal teardown under Xcode 26.2's compiler
-    # (crash: swift_task_deinitOnExecutorMainActorBackDeploy →
-    # BUG_IN_CLIENT_OF_LIBMALLOC, seen 2026-07-16). On an SDK-matched iOS 26
-    # runtime the native runtime entry point is used and the shim never runs.
+    # Make iOS runtime acquisition explicit and time-boxed. An SDK-matched runtime
+    # is REQUIRED, not merely preferred: on an older runtime every MainActor class
+    # deinit routes through the isolated-deinit back-deployment shim instead of the
+    # native runtime entry point, and that path double-freed in TaskLocal teardown
+    # under Xcode 26.2's codegen (crash:
+    # swift_task_deinitOnExecutorMainActorBackDeploy → BUG_IN_CLIENT_OF_LIBMALLOC,
+    # seen 2026-07-16). Xcode 27 no longer emits those implicit isolated deinits,
+    # but the 11 explicit `isolated deinit` sites still take the shim. The
+    # `xcode-27` image ships only iOS 27 runtimes, so this normally skips.
     - name: Download iOS platform (if needed)
       timeout-minutes: 30
       run: |
-        if xcrun simctl runtime list 2>/dev/null | grep -qE "iOS (2[6-9]|[3-9][0-9])[0-9.]*.*\(Ready\)"; then
-          echo "An iOS 26+ simulator runtime is already installed; skipping download:"
+        if xcrun simctl runtime list 2>/dev/null | grep -qE "iOS (2[7-9]|[3-9][0-9])[0-9.]*.*\(Ready\)"; then
+          echo "An iOS 27+ simulator runtime is already installed; skipping download:"
           xcrun simctl runtime list | grep -E "iOS [0-9]" || true
         else
-          echo "No iOS 26+ simulator runtime found; downloading…"
+          echo "No iOS 27+ simulator runtime found; downloading…"
           xcodebuild -downloadPlatform iOS
         fi
 
@@ -113,11 +116,11 @@ jobs:
         xcodebuild -showsdks || true
 
     # Pick an iPhone simulator on the NEWEST installed iOS runtime and capture its
-    # UDID. Using `id=` in the destination (rather than `name=iPhone 16`) avoids the
-    # "multiple matching destinations" ambiguity. Newest-runtime matters: older
-    # runtimes on the image (iOS 18.x) crash the Swift 6 test suite in the
-    # isolated-deinit back-deploy shim (see the download step's note). Booting it
-    # here isolates first-boot cost from the test step.
+    # UDID. Using `id=` in the destination (rather than `name=iPhone 17 Pro`) avoids
+    # the "multiple matching destinations" ambiguity. Newest-runtime matters: should
+    # the image ever carry a pre-SDK runtime alongside iOS 27, the tests must not
+    # land on it — that's the isolated-deinit shim crash described in the download
+    # step's note. Booting it here isolates first-boot cost from the test step.
     - name: Prepare iOS Simulator
       run: |
         set -euo pipefail
@@ -159,9 +162,12 @@ jobs:
 
     # Swift 6 migration ratchet (docs/swift6-migration-plan.md): the number of
     # strict-concurrency warnings may only go down. Enforcing since 2026-07-16.
-    # The checked-in baseline (39) was measured on Xcode 27 beta 3; CI's Xcode
-    # 26.6 counts 37 for the same code, so the baseline is the max across the
-    # supported toolchains — don't "lower it to match CI" or local builds fail.
+    # The checked-in baseline (39) was measured on Xcode 27 beta 3, which is what
+    # the `xcode-27` image ships — so CI and local development now count the same
+    # code the same way. The baseline is still a ceiling across supported
+    # toolchains (the previously pinned Xcode 26.6 counted 37 for the same code),
+    # so don't lower it to match whatever a single toolchain reports, or builds on
+    # the others fail.
     # All remaining warnings are in OBAKitTests (pinned to Swift 5, see its
     # project.yml); every Swift 6 target is at zero and additionally locked by
     # SWIFT_WARNINGS_AS_ERRORS_GROUPS in Apps/Shared/app_shared.yml.

--- a/docs/swift6-migration-plan.md
+++ b/docs/swift6-migration-plan.md
@@ -2,9 +2,11 @@
 
 *Written 2026-07-16, revised same day after an adversarial documentation review.
 Measurements taken on `main` @ `0ae45cb3` with Xcode 27.0 beta 3 (Swift 6.4
-toolchain). CI runs Xcode 26.6 — see the toolchain caveat in the Phase 4
-status section: Xcode 26.2's compiler crashes the Swift 6 test suite at
-runtime. Contributors need a recent Xcode 26.4+ / 27 toolchain.*
+toolchain). CI runs the same toolchain as of 2026-07-25 — the `xcode-27`
+runner image ships Xcode 27.0 beta 3 — having previously been pinned to Xcode
+26.6; see the toolchain caveat in the Phase 4 status section: Xcode 26.2's
+compiler crashes the Swift 6 test suite at runtime. Contributors need a recent
+Xcode 26.4+ / 27 toolchain.*
 
 ## Where we started (2026-07-16; see the Sequencing summary for current status)
 
@@ -368,8 +370,9 @@ classes, and that path double-frees when objects deallocate inside tasks
 carrying task-locals (XCTest's async lifecycle guarantees exactly that). It
 reproduces on both iOS 18.5 and iOS 26.2 simulators, so it's codegen, not
 the runtime. Xcode 27 beta 3 (Swift 6.4) does not emit implicit isolated
-deinits and is unaffected — CI is pinned to Xcode 26.6, the newest
-same-generation compiler on GitHub's runner images. Watch the 11 explicit
+deinits and is unaffected — and as of 2026-07-25 CI builds with it too, on the
+`xcode-27` runner image (previously pinned to Xcode 26.6, the newest
+same-generation compiler on the GA images). Watch the 11 explicit
 `isolated deinit` sites on iOS 18 devices regardless: they use the
 back-deploy shim compiled by whatever Xcode builds the release.
 


### PR DESCRIPTION
## Why

CI was pinned to Xcode 26.6 — the newest same-generation compiler on GitHub's GA runner images — while local development is on Xcode 27. That gap has a cost: 26.6 rejected a nested test stub whose default value calls a `@MainActor` initializer (code Xcode 27 accepts), which turned `main` red after #1223 landed and needed a1244c48 to unstick.

GitHub now offers an [`xcode-27` image](https://github.com/actions/runner-images/blob/main/images/macos/xcode-27-Readme.md) (arm64, [public preview](https://github.com/actions/runner-images/issues/14404)). It ships Xcode 27.0 beta 3 — precisely the toolchain the concurrency ratchet baseline of 39 was measured on — and only iOS 27 simulator runtimes.

## What

- `runs-on: macos-26` → `xcode-27`, closing the CI/local toolchain gap.
- Drops the `xcode-version: '26.6'` pin for `'latest'`. `latest-stable` is not an option here: the image's only Xcode is a beta, and `latest-stable` filters betas out and fails. `latest` includes them.
- `actions/checkout` v4 → v7, `actions/cache` v4 → v6.
- Tightens the runtime-detection grep from iOS 26+ to iOS 27+ so it agrees with the message it prints.
- Refreshes the comments (and two migration-plan passages) that documented the 26.6 pin, the image's iOS 18.x runtimes, and the per-toolchain warning counts — all three are false on this image.

The old pin's runtime hazard goes away rather than being ignored: it existed because the `macos-26` image shipped iOS 18.5 alongside iOS 26, and landing the Swift 6 tests on a pre-SDK runtime routed every MainActor deinit through the isolated-deinit back-deploy shim. `xcode-27` ships iOS 27 runtimes only, so the download step should simply skip.

## Trade-off worth a second opinion

`latest` means the toolchain is no longer pinned. When the image picks up beta 4 or an RC, the strict-concurrency warning count can move, and the ratchet fails closed if it moves up. I left it as `latest` deliberately — pinning `'27.0'` would break the day the image replaces the beta — but it is a real change in CI determinism, flagged inline next to the ratchet it affects.

## Verification

Config-only, so the PR's own CI run is the test. Checked before pushing: workflow YAML parses; `actions/checkout@v7` and `actions/cache@v6` both exist upstream; `xcode-27` is a valid label per runner-images; `latest` vs `latest-stable` beta semantics confirmed in setup-xcode's README; the tightened grep matches iOS 27.0 and rejects 18.5/26.2.