### PR TITLE
Enable push notifications on the Simulator

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -311,16 +311,15 @@ public class Application: CoreApplication, PushServiceDelegate {
         }
     )
 
+    // Deliberately no Simulator carve-out: Simulators get real (sandbox) APNs tokens, so don't
+    // re-add a `#if targetEnvironment(simulator)` guard here. See docs/push-notifications.md §6
+    // for what a sandbox token does and doesn't receive.
     private func configurePushNotifications(launchOptions: [AnyHashable: Any]) {
         guard let pushServiceProvider = config.pushServiceProvider else { return }
 
-        #if targetEnvironment(simulator)
-            Logger.warn("Push notifications don't work on the Simulator. Run this app on a device instead!")
-            return
-        #else
-            self.pushService = PushService(serviceProvider: pushServiceProvider, delegate: self)
-            self.pushService?.start(launchOptions: launchOptions)
-        #endif
+        let pushService = PushService(serviceProvider: pushServiceProvider, delegate: self)
+        self.pushService = pushService
+        pushService.start(launchOptions: launchOptions)
     }
 
     public func pushServicePresentingController(_ pushService: PushService) -> UIViewController? {
@@ -484,8 +483,8 @@ public class Application: CoreApplication, PushServiceDelegate {
         // Re-register the push token with OBACloud so the server's inactivity prune never
         // drops this device, and so locale changes propagate. The manager dedupes, so this
         // only hits the network when something changed or the last POST is older than
-        // PushRegistrationManager.refreshInterval. Skipped on the Simulator and in apps
-        // without a configured push provider, where pushService is never set.
+        // PushRegistrationManager.refreshInterval. Skipped in apps without a configured
+        // push provider, where pushService is never set.
         if pushService != nil {
             Task { await pushRegistrationManager.refreshRegistration() }
         }

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -174,7 +174,7 @@ Three triggers feed `PushRegistrationManager`; all of them are safe to fire redu
 
 ```swift
 // 1. Every foreground (Application.applicationDidBecomeActive):
-if pushService != nil {                     // nil on Simulator / providerless apps
+if pushService != nil {                     // nil only in providerless (white-label) apps
     Task { await pushRegistrationManager.refreshRegistration() }
 }
 // refreshRegistration(): if authorized → registerForRemoteNotifications()
@@ -279,7 +279,9 @@ Implement the server contract directly:
 
 ## 6. Testing and the APNs sandbox
 
-- **Simulators get no real APNs tokens.** OBAKit skips push configuration entirely under `#if targetEnvironment(simulator)`. Test registration logic with unit tests (see `PushRegistrationManagerTests` — the dedupe, coalescing, and auth-gating behaviors are all covered with injected closures and a mock data loader; no network or notification center needed).
+- **Simulators do get real APNs tokens.** On an Apple silicon (or T2 Intel) Mac running macOS 13+ with an iOS 16+ runtime, the Simulator registers with APNs and receives remote pushes, so OBAKit configures push identically on Simulator and device — there is no `#if targetEnvironment(simulator)` carve-out. A Simulator token is a **sandbox** token, so it behaves exactly like a debug build's token in the two bullets below: alarms and Live Activities reach it, service-alert fan-out does not. To deliver a payload locally without involving a server at all, use `xcrun simctl push booted org.onebusaway.iphone payload.apns`. One knock-on effect: the notifications onboarding step is gated on `pushService != nil`, so it is now reachable on the Simulator — a clean install shows it, and granting or denying permission drops it from the flow.
+- **If no token ever arrives, check `apsd` before suspecting the app.** `xcrun simctl spawn booted log show --last 4m --style compact --predicate 'process == "apsd"'` should show the topic being enabled for the bundle ID and a token request against `sandbox.push.apple.com`. `Connected on 0 interfaces` plus `token: (null)` means the machine has no APNs connection — the app-side registration is fine and there is nothing to fix in this repo. App-side logging is an `os.Logger` on the bundle ID, and its `.info` lines (including `APNs device token: …`) are invisible to a default-level `log stream`; pass `--level debug --predicate 'subsystem == "org.onebusaway.iphone"'`.
+- **Registration logic is still best covered by unit tests.** See `PushRegistrationManagerTests` — the dedupe, coalescing, and auth-gating behaviors are all covered with injected closures and a mock data loader; no network or notification center needed.
 - **Debug builds hold *sandbox* tokens.** A debug-provisioned install registers with the APNs sandbox host; pushes sent through production APNs bounce off it. Alarms and Live Activities handle this by sending `apns_sandbox=1` from debug builds, which the server forwards to gorush as `development: true`.
 - **Setting up a test device:** since 2026-07-19 the server rejects `test_device=true` registrations without a non-blank `description` (`422`). To register this install as a test device: enable **Debug Mode** in Settings → Debug, fill in **Test Device Name** (e.g. "Aaron's iPhone 17"), then re-foreground the app so `PushRegistrationManager` picks up the change and re-POSTs. Until the name is set, the device silently registers as a regular device (`test_device=false`) instead of failing.
 - **⚠️ Known gap — sandbox routing for service alerts:** the `push_registrations` API has no `apns_sandbox` param and the alert fan-out always uses production APNs — so even once registered, a *debug* build **cannot receive** the preview push. Until [OneBusAway/obacloud#983](https://github.com/OneBusAway/obacloud/issues/983) lands, verify alert delivery with a **TestFlight** build (production token) flagged via the Debug Mode switch.


### PR DESCRIPTION
## Summary

- Removes the `#if targetEnvironment(simulator)` early-return from `Application.configurePushNotifications`. Simulators have gotten real APNs tokens since Xcode 14 / iOS 16 runtimes on Apple silicon and T2 Intel Macs; the guard dates to 2019, when it was accurate. Push is now configured identically on Simulator and device.
- Everything downstream already gates on `pushService != nil`, so this also makes the notifications onboarding step, trip alarms, and the Debug → Push ID row reachable in the Simulator. White-label apps without a push provider are unaffected — the `config.pushServiceProvider` guard still short-circuits.
- Updates `docs/push-notifications.md` §6, which asserted the opposite, and corrects a stale "Skipped on the Simulator" comment.

No entitlement changes were needed: `aps-environment: development` and `UIBackgroundModes: remote-notification` were already in `Apps/Shared/push_config.yml`.

## Test plan

- [x] `xcodebuild build-for-testing` clean; SwiftLint clean (one pre-existing `file_length` warning in `StopPageViewController.swift`)
- [x] Full unit suite: **1463 passed, 0 failed, 0 skipped** on iPhone 17 Pro / iOS 27.0
- [x] Fresh install on a Simulator → onboarding flow computes `["welcome", "location", "region", "notifications", "done"]`. The `notifications` step is gated on `pushService != nil`, so its presence is direct evidence the change took effect
- [x] Granted the system notification prompt in the Simulator → flow correctly drops back to `["welcome", "location", "region", "done"]`
- [x] Simulator `apsd` confirms the app reaches APNs: enables topic `org.onebusaway.iphone` in the `development` environment and requests a token from `sandbox.push.apple.com`
- [x] Re-ran build, suite, and the fresh-install check after post-review cleanup

## Review notes

- **No end-to-end push was delivered.** On my machine `apsd` reports `Connected on 0 interfaces` and `token: (null)`, so no token is ever minted and `didRegisterForRemoteNotificationsWithDeviceToken:` never fires. That looks like a machine/network condition rather than an app problem — the app-side path is verified right up to where `apsd` takes over — but it does mean actual push delivery on a Simulator is unproven here and worth a second check. I added a docs bullet on how to tell the two apart.
- **Sandbox routing still applies.** A Simulator token is a sandbox token, so alarms and Live Activities reach it (`apns_sandbox=1`) but the service-alert fan-out does not, per the existing gap in OneBusAway/obacloud#983.
- **Dev simulators will now register with OBACloud.** `refreshRegistration()` runs on foreground in the Simulator, so sim tokens will start appearing in the server's device registry for whichever region is selected. Happy to suppress that if you'd rather keep the registry device-only.
- `docs/superpowers/specs/2026-07-17-onboarding-rethink-design.md:86` still says the Simulator skips the notifications step, which is now false. Left alone as a dated design record — say the word if you want it amended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Push notifications now initialize consistently in Simulator and on physical devices when configured.
  - Supported iOS Simulators can receive real APNs sandbox tokens.

- **Documentation**
  - Clarified push notification configuration and simulator testing guidance.
  - Added troubleshooting steps for missing simulator tokens.
  - Recommended validating registration behavior with unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->