### PR TITLE
Fix natural sorting in route filters

### DIFF
--- a/OBAKitCore/Models/REST/References/Route.swift
+++ b/OBAKitCore/Models/REST/References/Route.swift
@@ -174,12 +174,12 @@ public class Route: NSObject, Identifiable, Codable, HasReferences {
 
 public extension Sequence where Element == Route {
 
-    /// Performs a localized case insensitive sort on the receiver.
+    /// Performs a localized, natural sort on route short names.
     ///
-    /// - Returns: A localized, case-insensitive sorted Array.
+    /// - Returns: A localized, case-insensitive Array with numeric route names in natural order.
     func localizedCaseInsensitiveSort() -> [Element] {
         return sorted { (s1, s2) -> Bool in
-            return s1.shortName.localizedCaseInsensitiveCompare(s2.shortName) == .orderedAscending
+            return s1.shortName.localizedStandardCompare(s2.shortName) == .orderedAscending
         }
     }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
@@ -198,21 +198,25 @@ class RouteTests: OBATestCase {
     }
     
     func test_arrayExtensionSort() {
-        let route1Data: [String: Any] = ["id": "route1", "agencyId": "1", "shortName": "z Route", "type": 3]
-        let route2Data: [String: Any] = ["id": "route2", "agencyId": "1", "shortName": "A Route", "type": 3]
-        let route3Data: [String: Any] = ["id": "route3", "agencyId": "1", "shortName": "m Route", "type": 3]
+        let route1Data: [String: Any] = ["id": "route1", "agencyId": "1", "shortName": "49", "type": 3]
+        let route2Data: [String: Any] = ["id": "route2", "agencyId": "1", "shortName": "10", "type": 3]
+        let route3Data: [String: Any] = ["id": "route3", "agencyId": "1", "shortName": "3", "type": 3]
+        let route4Data: [String: Any] = ["id": "route4", "agencyId": "1", "shortName": "Bellevue", "type": 3]
+        let route5Data: [String: Any] = ["id": "route5", "agencyId": "1", "shortName": "11", "type": 3]
+        let route6Data: [String: Any] = ["id": "route6", "agencyId": "1", "shortName": "12", "type": 3]
         
         let routes = try! [
             Fixtures.dictionaryToModel(type: Route.self, dictionary: route1Data),
             Fixtures.dictionaryToModel(type: Route.self, dictionary: route2Data),
-            Fixtures.dictionaryToModel(type: Route.self, dictionary: route3Data)
+            Fixtures.dictionaryToModel(type: Route.self, dictionary: route3Data),
+            Fixtures.dictionaryToModel(type: Route.self, dictionary: route4Data),
+            Fixtures.dictionaryToModel(type: Route.self, dictionary: route5Data),
+            Fixtures.dictionaryToModel(type: Route.self, dictionary: route6Data)
         ]
         
         let sortedRoutes = routes.localizedCaseInsensitiveSort()
         
-        expect(sortedRoutes[0].shortName) == "A Route"
-        expect(sortedRoutes[1].shortName) == "m Route"
-        expect(sortedRoutes[2].shortName) == "z Route"
+        expect(sortedRoutes.map(\.shortName)) == ["3", "10", "11", "12", "49", "Bellevue"]
     }
 }
 


### PR DESCRIPTION
## Summary
- sort route short names with `localizedStandardCompare` so numeric route names use natural order
- add regression coverage for the reported `3, 10, 11, 12, 49, Bellevue` sequence

Closes #1218

## Validation
- `swift -e` assertion for the exact natural-sort sequence
- `git diff --check`
- XcodeGen project generation succeeded with XcodeGen 2.46.0

The focused XCTest could not run locally because this machine has no available iOS Simulator runtime; the project CI can execute `OBAKitTests/RouteTests`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route sorting to use natural numeric ordering, producing more intuitive results for route names containing numbers.
  * Maintained localized, case-insensitive sorting behavior.

* **Tests**
  * Expanded route sorting coverage with numeric and named route examples.
  * Added validation for the complete sorted result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->