### PR TITLE
ci: pin third-party GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -18,10 +18,10 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     # Cache Swift Package Manager dependencies.
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-spm-
 
     # Cache Ruby gems (fastlane and its dependencies).
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -44,7 +44,7 @@ jobs:
     # resolved dependency graph, the XcodeGen project specs, or this workflow
     # change. The previous `**/*.yml` glob also matched vendored yml under
     # .build/checkouts and caused needless cache misses (→ full rebuilds).
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: deriveddata-cache
       with:
         path: DerivedData
@@ -75,7 +75,7 @@ jobs:
     # (see a1244c48). The trade-off is that the toolchain is no longer pinned, so a
     # new beta landing in the image can move the concurrency warning count below.
     - name: Setup Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: 'latest'
 
@@ -238,7 +238,7 @@ jobs:
     # writes a lighter summary to $GITHUB_STEP_SUMMARY instead. If test-retry flags
     # are ever added, broaden this to `always()` so flaky-but-passing runs still
     # surface which tests retried.
-    - uses: slidoapp/xcresulttool@v3.1.1
+    - uses: slidoapp/xcresulttool@0930e06ae335d8c5e2d2f311ee98d495889a6103 # v3.1.1
       continue-on-error: true
       if: failure()
       with:


### PR DESCRIPTION
## Summary

Pins all third-party and first-party GitHub Actions to immutable full-length commit SHAs instead of mutable tags (e.g. `@v4`), as requested in #1146.

## Problem

Using mutable version tags (e.g. `actions/checkout@v4`) leaves the repository exposed to supply chain attacks if an action's maintainer is compromised and a tag is force-moved to a malicious commit. This is especially sensitive for actions like `slidoapp/xcresulttool` which run with `checks: write` access.

## Solution

Following [GitHub's security hardening guidelines](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), all actions are now pinned to their current resolved commit SHAs. 

The version tags remain as comments for readability (e.g. `@11d5960a326750d5838078e36cf38b85af677262 # v4`).

Fixes #1146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned automated build, test, caching, and deployment actions to immutable versions.
  * Preserved existing workflow behavior while improving reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->