### PR TITLE
fix: make date strategy symmetric in RegionsFileStorage

### DIFF
--- a/OBAKitCore/Location/Regions/RegionsFileStorage.swift
+++ b/OBAKitCore/Location/Regions/RegionsFileStorage.swift
@@ -87,7 +87,7 @@ public final class RegionsFileStorage: RegionsFileStorageProtocol {
     public func saveDefaultRegions(_ regions: [Region]) throws {
         let url = try defaultRegionsFileURL()
         try createDirectoryIfNeeded(for: url)
-        let data = try JSONEncoder().encode(regions)
+        let data = try JSONEncoder.RESTEncoder().encode(regions)
         try data.write(to: url, options: .atomic)
     }
 
@@ -121,7 +121,7 @@ public final class RegionsFileStorage: RegionsFileStorageProtocol {
     public func saveCustomRegion(_ region: Region) throws {
         let url = try customRegionFileURL(identifier: region.regionIdentifier)
         try createDirectoryIfNeeded(for: url)
-        let data = try JSONEncoder().encode(region)
+        let data = try JSONEncoder.RESTEncoder().encode(region)
         try data.write(to: url, options: .atomic)
     }
 

--- a/OBAKitCore/Models/Helpers/InternalTypes.swift
+++ b/OBAKitCore/Models/Helpers/InternalTypes.swift
@@ -73,3 +73,11 @@ extension JSONDecoder {
         return decoder
     }
 }
+
+extension JSONEncoder {
+    class func RESTEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        return encoder
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the asymmetry in `RegionsFileStorage`'s date encoding/decoding strategies by introducing a `JSONEncoder.RESTEncoder()` helper and using it for serialization, as requested in #1152.

## Problem

`RegionsFileStorage` was saving regions with the default `JSONEncoder()` (which defaults to `.deferredToDate` / seconds since reference date). However, it loads them using `JSONDecoder.RESTDecoder()`, which explicitly sets `dateDecodingStrategy = .millisecondsSince1970`. 

While harmless today (because `Region` lacks any `Date` properties), this would silently break serialization round-tripping if a `Date` field is ever added to `Region`.

## Solution

1. Added `JSONEncoder.RESTEncoder()` to `InternalTypes.swift` (matching the existing `JSONDecoder.RESTDecoder()`) which configures `.millisecondsSince1970`.
2. Updated `RegionsFileStorage.saveDefaultRegions` and `saveCustomRegion` to use this new encoder.

Fixes #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when saving default and custom regions by using a consistent date format.
  * Region data is now encoded with millisecond-precision timestamps for more reliable persistence and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->