### PR TITLE
ui: improve arrival time badge contrast in light mode

### DIFF
--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -132,14 +132,15 @@ public final class ThemeColors: NSObject, @unchecked Sendable {
         departureEarly = .systemRed
         departureEarlyBackground = .systemRed
 
-        // Hex #129900 is better visibility for small text in light mode.
+        // Hex #007300 (red: 0.00, green: 0.45, blue: 0.00) has a 6.1:1 contrast ratio against white in
+        // light mode, clearing the WCAG AA minimum of 4.5:1 for normal-size text.
         // UIColor.systemGreen is better visibility for small text in dark mode.
-        // See #506 and #508 for user feedback.
+        // See #506, #508, and #599 for user feedback.
         let departureOnTimeColor = UIColor { traitCollection in
             if traitCollection.userInterfaceStyle == .dark {
                 return UIColor.systemGreen
             } else {
-                return UIColor(red: 0.07, green: 0.60, blue: 0.00, alpha: 1.00)
+                return UIColor(red: 0.00, green: 0.45, blue: 0.00, alpha: 1.00)
             }
         }
         departureOnTime = departureOnTimeColor

--- a/OBAKitTests/Extensions/UIColorWCAGTests.swift
+++ b/OBAKitTests/Extensions/UIColorWCAGTests.swift
@@ -79,4 +79,17 @@ struct UIColorWCAGTests {
         let midGray = UIColor(red: 127.0/255.0, green: 127.0/255.0, blue: 127.0/255.0, alpha: 1.0)
         #expect(midGray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
     }
+
+    // MARK: - ThemeColors on-time green (#599)
+
+    /// Light-mode `departureOnTime` (#007300) must clear WCAG AA (4.5:1) against
+    /// white — the solid capsule and tinted walk-pill both put white or green
+    /// text on this color. Identity checks on `DepartureStatus` would pass for
+    /// any ThemeColors value; this locks the actual contrast.
+    @Test func `On time color meets WCAG AA in light mode`() {
+        let light = ThemeColors.shared.departureOnTime.resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: .light)
+        )
+        #expect(light.wcagContrastRatio(against: .white) >= 4.5)
+    }
 }


### PR DESCRIPTION
## Summary

Improves the contrast of the `departureOnTimeColor` (green) in Light Mode to meet WCAG AA standards, as requested in #599.

## Problem

The previous custom green color used for "on time" badges in Light Mode (`#129900`) had a contrast ratio of roughly `3.76:1` against white text (inside the badge). This is below the WCAG AA minimum contrast ratio of `4.5:1`, making it difficult to read for users without perfect vision.

## Solution

I've darkened the Light Mode green from `#129900` (red: 0.07, green: 0.60, blue: 0.0) to **`#007300`** (red: 0.00, green: 0.45, blue: 0.00).

* **Contrast Ratio against White:** ~6.1:1 (clears WCAG AA for normal-size text; also clears AA for the walk-pill tint use at ~4.9:1).
* The text is now comfortably legible without requiring the user to explicitly enable the "Increase Contrast" accessibility flag.
* Dark mode is unaffected (it continues to use `.systemGreen` which contrasts well against a dark background).

Fixes #599

## Review follow-up

* Corrected the comment/PR claims that previously overstated the ratio as >7:1 / AAA.
* Added `test_onTimeColor_meetsWCAGAAInLightMode` to lock the AA contrast win.
* Left the always-dark `StopPageHeaderView` colorScheme follow-up for a separate issue, per review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the visibility of on-time departure indicators in light mode with a darker green color meeting WCAG AA contrast requirements.

* **Bug Fixes**
  * Added regression coverage to help ensure the improved contrast remains available in future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->