### PR TITLE
Read region-id from the add-region deep link

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -660,11 +660,16 @@ public class Application: CoreApplication, PushServiceDelegate {
 
                     // Construct Region from URL data. umamiAnalytics applies the
                     // both-or-nothing rule; no rule logic lives here.
+                    //
+                    // regionIdentifier must come from the link: Region falls back to a
+                    // random id when it's nil, and every Obaco call for the region then
+                    // 404s against an id the sidecar has never heard of.
                     let currentRegion = Region(
                         name: regionData.name,
                         OBABaseURL: regionData.obaURL,
                         coordinateRegion: adjustedRegionCoordinate,
                         contactEmail: "example@example.com",
+                        regionIdentifier: regionData.regionID,
                         openTripPlannerURL: regionData.otpURL,
                         sidecarBaseURL: regionData.sidecarURL,
                         umamiAnalytics: regionData.umamiAnalytics)

--- a/OBAKitCore/DeepLinks/URLSchemeRouter.swift
+++ b/OBAKitCore/DeepLinks/URLSchemeRouter.swift
@@ -21,6 +21,10 @@ public struct StopURLData {
 ///
 /// - Parameters:
 ///   - name: The name of the region to be added. This is a human-readable string that identifies the region.
+///   - regionID: The region's identifier on the Obaco sidecar. Optional, because links generated before
+///               `region-id` was emitted omit it — but every sidecar-backed feature (alerts, alarms, push
+///               registration, surveys) 404s when it's missing, since `Region` then falls back to a random
+///               identifier the sidecar has never heard of.
 ///   - obaURL: The URL to the OneBusAway (OBA) server for the region. This URL is used to access transit data.
 ///   - otpURL: An optional URL to the OpenTripPlanner (OTP) server, used for trip planning.
 ///   - sidecarURL: An optional base URL for the Obaco sidecar server.
@@ -30,6 +34,7 @@ public struct StopURLData {
 ///              invalid URL); use `umamiAnalytics`.
 public struct AddRegionURLData {
     public let name: String
+    public let regionID: Int?
     public let obaURL: URL
     public let otpURL: URL?
     public let sidecarURL: URL?
@@ -118,8 +123,8 @@ public class URLSchemeRouter: NSObject {
 
     // MARK: - Add Region URLs
     /// Decodes an `AddRegionURLData` from `add-region` URL components. `name` and a valid
-    /// `oba-url` are required; `otp-url`, `sidecar-url`, `umami-url`, and `umami-id` are
-    /// optional, and invalid optional values degrade to `nil`.
+    /// `oba-url` are required; `region-id`, `otp-url`, `sidecar-url`, `umami-url`, and
+    /// `umami-id` are optional, and invalid optional values degrade to `nil`.
     private func decodeAddRegion(from components: URLComponents) -> URLType? {
         guard
             let name = components.queryItem(named: "name")?.value,
@@ -134,8 +139,16 @@ public class URLSchemeRouter: NSObject {
             umamiID = trimmed.isEmpty ? nil : trimmed
         }
 
+        // A malformed region-id degrades to nil rather than rejecting the link:
+        // the region is still worth adding, it just loses sidecar features.
+        var regionID: Int?
+        if let rawRegionID = components.queryItem(named: "region-id")?.value {
+            regionID = Int(rawRegionID.strip())
+        }
+
         return .addRegion(AddRegionURLData(
             name: name,
+            regionID: regionID,
             obaURL: obaURL,
             otpURL: optionalURL(named: "otp-url", in: components),
             sidecarURL: optionalURL(named: "sidecar-url", in: components),

--- a/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
@@ -115,7 +115,81 @@ class URLSchemeRouterTests: XCTestCase {
     }
     
     // MARK: - Add Region URL Tests
-    
+
+    func test_decodeURLType_addRegion_decodesRegionID() {
+        var components = URLComponents()
+        components.scheme = "onebusaway"
+        components.host = "add-region"
+        components.queryItems = [
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "region-id", value: "19"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com")
+        ]
+
+        guard let url = components.url else {
+            fail("Failed to create URL")
+            return
+        }
+
+        switch router.decodeURLType(from: url) {
+        case .addRegion(let data):
+            expect(data?.regionID) == 19
+        default:
+            fail("Expected addRegion URLType")
+        }
+    }
+
+    // Links generated before region-id was emitted must still add the region.
+    func test_decodeURLType_addRegion_regionIDIsNilWhenAbsent() {
+        var components = URLComponents()
+        components.scheme = "onebusaway"
+        components.host = "add-region"
+        components.queryItems = [
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com")
+        ]
+
+        guard let url = components.url else {
+            fail("Failed to create URL")
+            return
+        }
+
+        switch router.decodeURLType(from: url) {
+        case .addRegion(let data):
+            expect(data).toNot(beNil())
+            expect(data?.regionID).to(beNil())
+        default:
+            fail("Expected addRegion URLType")
+        }
+    }
+
+    // A junk region-id costs sidecar features, but the region is still worth
+    // adding — so it degrades to nil rather than rejecting the whole link.
+    func test_decodeURLType_addRegion_malformedRegionIDDegradesToNil() {
+        var components = URLComponents()
+        components.scheme = "onebusaway"
+        components.host = "add-region"
+        components.queryItems = [
+            URLQueryItem(name: "name", value: "Test Region"),
+            URLQueryItem(name: "region-id", value: "not-a-number"),
+            URLQueryItem(name: "oba-url", value: "https://oba.example.com")
+        ]
+
+        guard let url = components.url else {
+            fail("Failed to create URL")
+            return
+        }
+
+        switch router.decodeURLType(from: url) {
+        case .addRegion(let data):
+            expect(data).toNot(beNil())
+            expect(data?.name) == "Test Region"
+            expect(data?.regionID).to(beNil())
+        default:
+            fail("Expected addRegion URLType")
+        }
+    }
+
     func test_decodeURLType_addRegion_decodesValidURLWithOTPURL() {
         var components = URLComponents()
         components.scheme = "onebusaway"


### PR DESCRIPTION
Companion to OneBusAway/obacloud#1040, which starts emitting `region-id`. Either can merge first — the param is optional on both ends.

## The bug

A region added via `onebusaway://add-region` had no identifier to work from, so `Region` fell back to:

```swift
// OBAKitCore/Models/Region.swift:214
self.regionIdentifier = regionIdentifier ?? 1000 + Int.random(in: 0...999)
```

`Application.swift`'s `case .addRegion` constructed the `Region` without passing `regionIdentifier:`, so every custom region got a random 1000–1999 id. `ObacoAPIService` then formats `/api/v1/regions/%d/alerts.pb` with it and the sidecar 404s. Observed right after adding a region:

> 404 Not found (https://sidecar.onebusaway.org/api/v1/regions/1957/alerts.pb?version=2&key=org.onebusaway.iphone&app_ver=26.3.0&...)

Verified against the live sidecar: the region's real identifier (19) returns 200, `1957` returns 404.

Alerts is just the first sidecar call to fire — alarms, push registration, surveys and vehicles fail the same way. This has never worked for any deep-link-added region.

## This change

- `AddRegionURLData` gains `regionID: Int?`.
- `decodeAddRegion` parses `region-id`.
- `Application.swift` passes it as `regionIdentifier:`.

Two deliberate choices, both covered by tests:

- **Optional**, so links generated before obacloud emitted `region-id` still add the region (just without sidecar features), rather than breaking existing QR codes.
- **A malformed value degrades to nil** instead of rejecting the link, matching how the other optional params behave — the region is still worth adding.

## Note

Installs that already added a region keep their random identifier until the region is removed and re-added; this only fixes regions added from here on.

## Verification

- `URLSchemeRouterTests`: 34 tests, 0 failures (3 new: valid id, absent id, malformed id)
- Full `OBAKitTests`: 1520 tests, 0 failures
- SwiftLint: only the 2 pre-existing `file_length` violations in files this PR doesn't touch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “add region” links so links without a region ID continue to work.
  * Invalid region IDs no longer prevent valid links from opening.
  * Regions added through links now retain the intended region ID, preventing follow-up service requests from targeting an unknown region.
* **Tests**
  * Added coverage for valid, missing, and malformed region IDs in add-region links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->