### PR TITLE
test: injectable Plausible client seam and typed prop-value tests

### DIFF
--- a/Apps/Shared/Analytics/PlausibleAnalytics.swift
+++ b/Apps/Shared/Analytics/PlausibleAnalytics.swift
@@ -1,13 +1,56 @@
+//
+//  PlausibleAnalytics.swift
+//  App
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
 import Foundation
 import OBAKit
 import AviaryInsights
 
+/// Seam for posting Plausible events. Production uses `AviaryInsights.Plausible`;
+/// tests inject a recording double (#1199).
+///
+/// Explicitly `nonisolated`: App's default MainActor isolation would otherwise
+/// make this protocol MainActor-bound, which blocks both `Plausible` (a plain
+/// Sendable struct) and actor-based test doubles from conforming (CI Xcode 27).
+nonisolated protocol PlausibleEventClient: Sendable {
+    func postEvent(_ event: Event) async throws
+}
+
+extension Plausible: PlausibleEventClient {}
+
 class PlausibleAnalytics: NSObject {
-    private let client: Plausible
+    private let client: any PlausibleEventClient
     private var defaultProperties: [String: (any Sendable)?] = [:]
 
     init(defaultDomainURL: URL, analyticsServerURL: URL) {
         self.client = Plausible(defaultDomain: defaultDomainURL.host!, serverURL: analyticsServerURL)
+    }
+
+    /// Test / alternate-transport entry point. Prefer the URL-based init in production.
+    init(client: any PlausibleEventClient) {
+        self.client = client
+    }
+
+    /// Coerces an `@objc Analytics` `Any?` value into a Plausible-safe `Sendable` prop.
+    ///
+    /// String and `NSNumber` (Int/Double/Bool via the ObjC bridge) pass through typed so
+    /// server-side prop filters keep working; everything else is stringified.
+    static func sendablePropValue(from value: Any?) -> (any Sendable)? {
+        switch value {
+        case nil:
+            return nil
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number
+        default:
+            return value.map { String(describing: $0) }
+        }
     }
 
     private func postEvent(pageURL: String, props: [String: (any Sendable)?]) async {
@@ -20,21 +63,7 @@ class PlausibleAnalytics: NSObject {
     }
 
     func reportEvent(pageURL: String, label: String, value: Any?) async {
-        // The Analytics protocol is @objc, so `value` arrives as Any?; Plausible's
-        // client requires Sendable props. Pass the known scalar types through
-        // typed (numbers must stay numbers for server-side prop filtering) and
-        // stringify only as a last resort.
-        let sendableValue: (any Sendable)?
-        switch value {
-        case nil:
-            sendableValue = nil
-        case let string as String:
-            sendableValue = string
-        case let number as NSNumber:
-            sendableValue = number
-        default:
-            sendableValue = value.map { String(describing: $0) }
-        }
+        let sendableValue = Self.sendablePropValue(from: value)
         await postEvent(pageURL: pageURL, props: [label: sendableValue])
     }
 

--- a/OBAKitTests/Analytics/PlausibleAnalyticsTests.swift
+++ b/OBAKitTests/Analytics/PlausibleAnalyticsTests.swift
@@ -1,0 +1,124 @@
+//
+//  PlausibleAnalyticsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import AviaryInsights
+@testable import App
+
+/// Records Plausible events so `PlausibleAnalytics` can be tested without a network.
+private actor RecordingPlausibleClient: PlausibleEventClient {
+    private(set) var events: [Event] = []
+
+    func postEvent(_ event: Event) async throws {
+        events.append(event)
+    }
+}
+
+@Suite(.serialized)
+final class PlausibleAnalyticsTests: OBATestCase {
+
+    // MARK: - sendablePropValue coercion
+    //
+    // Mirrors the @objc Analytics bridge: Int/Double/Bool arrive as NSNumber;
+    // unknown types stringify. Matches UmamiAnalyticsTests JSON-value coercion
+    // in spirit, for Plausible's Sendable prop path (#1199).
+
+    @Test func `Sendable prop value passes String through`() {
+        let value = PlausibleAnalytics.sendablePropValue(from: "hello")
+        #expect(value as? String == "hello")
+    }
+
+    @Test func `Sendable prop value passes NSNumber through`() {
+        #expect(
+            PlausibleAnalytics.sendablePropValue(from: NSNumber(value: 42)) as? NSNumber
+                == NSNumber(value: 42)
+        )
+        #expect(
+            PlausibleAnalytics.sendablePropValue(from: NSNumber(value: 3.5)) as? NSNumber
+                == NSNumber(value: 3.5)
+        )
+        #expect(
+            PlausibleAnalytics.sendablePropValue(from: NSNumber(value: true)) as? NSNumber
+                == NSNumber(value: true)
+        )
+    }
+
+    @Test func `Sendable prop value nil stays nil`() {
+        #expect(PlausibleAnalytics.sendablePropValue(from: nil) == nil)
+    }
+
+    @Test func `Sendable prop value unknown types stringify`() {
+        struct Token: CustomStringConvertible {
+            var description: String { "token-42" }
+        }
+        #expect(PlausibleAnalytics.sendablePropValue(from: Token()) as? String == "token-42")
+    }
+
+    // MARK: - Injectable client seam
+
+    @Test func `Report event posts typed props to client`() async {
+        let client = RecordingPlausibleClient()
+        let analytics = PlausibleAnalytics(client: client)
+
+        await analytics.reportEvent(pageURL: "app://localhost/map", label: "count", value: NSNumber(value: 7))
+
+        let events = await client.events
+        #expect(events.count == 1)
+        let event = events[0]
+        #expect(event.url == "app://localhost/map")
+        #expect(event.props?["count"] as? NSNumber == NSNumber(value: 7))
+    }
+
+    @Test func `Report search query posts string prop`() async {
+        let client = RecordingPlausibleClient()
+        let analytics = PlausibleAnalytics(client: client)
+
+        await analytics.reportSearchQuery("downtown")
+
+        let events = await client.events
+        #expect(events.count == 1)
+        #expect(events[0].url == "app://localhost/search")
+        #expect(events[0].props?["query"] as? String == "downtown")
+    }
+
+    /// Production `reportStopViewed` posts `id` and `distance` and silently
+    /// discards `name` — assert the props that ship, not the unused parameter.
+    @Test func `Report stop viewed posts id and distance`() async {
+        let client = RecordingPlausibleClient()
+        let analytics = PlausibleAnalytics(client: client)
+
+        await analytics.reportStopViewed(name: "Pine St", id: "1_75403", stopDistance: "near")
+
+        let events = await client.events
+        #expect(events.count == 1)
+        #expect(events[0].url == "app://localhost/stop")
+        #expect(events[0].props?["id"] as? String == "1_75403")
+        #expect(events[0].props?["distance"] as? String == "near")
+        // `name` is intentionally not forwarded today.
+        #expect(events[0].props?["name"] == nil)
+        #expect(!(events[0].props?.keys.contains("name") ?? false))
+    }
+
+    @Test func `Default properties merge into posted event`() async {
+        let client = RecordingPlausibleClient()
+        let analytics = PlausibleAnalytics(client: client)
+        analytics.setUserProperty(key: "RegionName", value: "Puget Sound")
+
+        await analytics.reportEvent(pageURL: "app://localhost/map", label: "tap", value: nil)
+
+        let events = await client.events
+        #expect(events.count == 1)
+        #expect(events[0].props?["RegionName"] as? String == "Puget Sound")
+        // A nil event value still keeps the label key present (AviaryInsights
+        // boxes Optional.none). Dictionary subscript can't tell "nil value"
+        // from "missing key" — assert presence instead.
+        #expect(events[0].props?.keys.contains("tap") == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `PlausibleEventClient` seam (production: `AviaryInsights.Plausible`; tests: recording actor) so `PlausibleAnalytics` can post without the network.
- Extracts `sendablePropValue(from:)` and locks the #1192 typing contract: String and `NSNumber` (Int/Double/Bool via the `@objc` bridge) pass through typed; unknown types stringify.
- Adds `PlausibleAnalyticsTests` covering coercion, event posting, stop/search helpers, and default-property merge.

Closes #1199

### Out of scope
Issue item 3 (“align Firebase / Umami / Plausible value handling”) is left as a follow-up — the backends intentionally have different contracts today (raw `Any?` vs coerced Sendable), and unifying them is a broader change than this coverage seam.

## Test plan
- [x] `xcodebuild build-for-testing -scheme App` (iOS Simulator)
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/PlausibleAnalyticsTests` — **8 tests, 0 failures**
- [ ] CI `OBAKitTests` green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved analytics event handling with more reliable property conversion and event delivery.
  * Added support for configurable analytics event clients, including test environments.

* **Bug Fixes**
  * Analytics events now preserve typed values, search queries, stop-view details, and merged user properties more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->