### PR TITLE
Move DepartureTimeDisplay into OBAKitCore so every surface shows corrected departure times

### DIFF
--- a/OBAKit/Bookmarks/BookmarkCardView.swift
+++ b/OBAKit/Bookmarks/BookmarkCardView.swift
@@ -124,9 +124,13 @@ struct BookmarkCardView: View {
     }
 
     private func timeText(for departure: ArrivalDeparture) -> some View {
-        Text(formatters.timeFormatter.string(from: departure.arrivalDepartureDate))
+        // Shared corrected-time component (#1225): when a prediction moves the
+        // trip off its timetable, the scheduled time renders struck through
+        // ahead of the time the rider should act on. The spoken equivalent is
+        // appended in `Formatters.accessibilityValue(for:)` — this card's label
+        // uses `children: .ignore`, so the visual view can't carry it.
+        DepartureTimeText(display: DepartureTimeDisplay(arrivalDeparture: departure, formatters: formatters))
             .font(.footnote)
-            .monospacedDigit()
             .foregroundStyle(.secondary)
     }
 

--- a/OBAKit/Bookmarks/Formatters+BookmarkArrival.swift
+++ b/OBAKit/Bookmarks/Formatters+BookmarkArrival.swift
@@ -39,6 +39,22 @@ extension Formatters {
 
         var value = self.accessibilityValue(for: firstArrivalDeparture)
 
+        // The visual card renders the corrected time with the schedule struck
+        // through (`DepartureTimeText`); a strikethrough is inaudible, so the
+        // correction is carried here in words. Only the corrected case is
+        // spoken: the base value above already names the expected clock time,
+        // so the plain "at %@" clause would merely repeat it. Appended as its
+        // own sentence — the base value ends with terminal punctuation, so a
+        // comma join would read "…at 9:57 PM., scheduled…". The joiner and
+        // period are code-level rather than a localized sentence-form key on
+        // purpose: this string is only ever spoken, punctuation surfaces as a
+        // pause, and a second key would force all 13 locales to re-adjudicate
+        // punctuation for translations that carried over verbatim (#1225).
+        let timeDisplay = DepartureTimeDisplay(arrivalDeparture: firstArrivalDeparture, formatters: self)
+        if timeDisplay.scheduledTimeText != nil {
+            value += " " + timeDisplay.accessibilityTimeDescription + "."
+        }
+
         if arrivalDepartures.count >= 2 {
             let textToAppend: String
             let secondArrivalDeparture = arrivalDepartures[1]

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "بيانات الجدول";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "في %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "حسب الجدول %1$@، والمتوقع الآن %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d مواقف";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1238,12 +1238,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "schedule data";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "at %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "scheduled %1$@, now expected %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d stops";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "datos de horario";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "a las %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "según el horario a las %1$@, ahora se espera a las %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "data ng iskedyul";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "nang %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "nakatakda nang %1$@, inaasahan na ngayon nang %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d hintuan";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horaire théorique";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "à %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "initialement prévu à %1$@, maintenant attendu à %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d arrêts";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dati di orario";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "alle %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "da orario alle %1$@, ora previsto alle %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d fermate";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "시간표 기준";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "시각 %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "예정 시각 %1$@, 현재 예상 시각 %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "정류장 %d개";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dane rozkładowe";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "o %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "według rozkładu %1$@, przewidywana godzina %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d przyst.";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horário programado";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "às %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "programado para %1$@, agora previsto para %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "по расписанию";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "в %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "по расписанию %1$@, сейчас ожидается в %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d ост.";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dữ liệu lịch trình";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "lúc %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "theo lịch trình lúc %1$@, hiện dự kiến lúc %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d điểm dừng";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "时刻表数据";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "时间 %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "原定 %1$@，现预计 %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d个车站";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1236,12 +1236,6 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "時刻表資料";
 
-/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
-"stop_page.time.a11y_at_fmt" = "時間 %@";
-
-/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
-"stop_page.time.a11y_rescheduled_fmt" = "原定 %1$@，現預計 %2$@";
-
 /* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "stop_page.timeline.skipped_stops_fmt" = "%d 站";
 

--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "المركبات";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "في %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "حسب الجدول %1$@، والمتوقع الآن %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "وصلت قبل %d د";
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Vehicles";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "at %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "scheduled %1$@, now expected %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Arrived %d min ago";
 

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Vehículos";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "a las %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "según el horario a las %1$@, ahora se espera a las %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Llegó hace %dmin";
 

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Mga Sasakyan";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "nang %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "nakatakda nang %1$@, inaasahan na ngayon nang %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Dumating %d min ang nakalipas";
 

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Véhicules";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "à %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "initialement prévu à %1$@, maintenant attendu à %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Arrivé il y a %d min";
 

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Veicoli";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "alle %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "da orario alle %1$@, ora previsto alle %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Arrivato %d min fa";
 

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "차량";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "시각 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "예정 시각 %1$@, 현재 예상 시각 %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "%d분 전 도착";
 

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Pojazdy";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "o %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "według rozkładu %1$@, przewidywana godzina %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Przyejchał %d min temu";
 

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Veículos";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "às %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "programado para %1$@, agora previsto para %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Chegou há %d min";
 

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Транспорт";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "в %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "по расписанию %1$@, сейчас ожидается в %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Прибыл %d мин. назад";
 

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "Phương tiện";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "lúc %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "theo lịch trình lúc %1$@, hiện dự kiến lúc %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "Đã đến %d phút trước";
 

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "车辆";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "时间 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "原定 %1$@，现预计 %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "%d分钟前已到站";
 

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -205,6 +205,12 @@
 /* The title of the Vehicles tab showing real-time vehicle positions on a map. */
 "common.vehicles" = "車輛";
 
+/* VoiceOver clause naming the clock time of a departure. %@ is the time. */
+"departure_time.a11y_at_fmt" = "時間 %@";
+
+/* VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time. */
+"departure_time.a11y_rescheduled_fmt" = "原定 %1$@，現預計 %2$@";
+
 /* Use for vehicles that arrived X minutes ago. */
 "formatters.arrived_x_min_ago_fmt" = "%d 分鐘前到站";
 

--- a/OBAKitCore/UI/DepartureTimeDisplay.swift
+++ b/OBAKitCore/UI/DepartureTimeDisplay.swift
@@ -5,7 +5,6 @@
 //
 
 import SwiftUI
-import OBAKitCore
 
 /// The clock time(s) shown on a departure row. When real-time data moves a trip
 /// off its timetable the row shows both: the scheduled time struck through, then
@@ -22,16 +21,16 @@ import OBAKitCore
 /// Comparing after formatting also catches the case `ScheduleStatus` misses: a
 /// deviation inside its ±1.5 minute "on time" band still lands on a different
 /// minute, and the rider still needs the corrected time.
-struct DepartureTimeDisplay: Equatable {
+public struct DepartureTimeDisplay: Equatable {
     /// The time the rider should act on: the prediction when there is one,
     /// the timetable otherwise.
-    let expectedTimeText: String
+    public let expectedTimeText: String
 
     /// The timetable time, present only when it differs from `expectedTimeText`.
     /// Rendered struck through, ahead of the expected time.
-    let scheduledTimeText: String?
+    public let scheduledTimeText: String?
 
-    init(scheduledDate: Date, expectedDate: Date, isRealTime: Bool, formatters: Formatters) {
+    public init(scheduledDate: Date, expectedDate: Date, isRealTime: Bool, formatters: Formatters) {
         // `isRealTime` gates on the feed's own `predicted` flag rather than on the
         // two dates differing: a payload can carry a prediction while declaring
         // itself unpredicted, and `DepartureStatus` refuses to trust that too.
@@ -52,7 +51,7 @@ struct DepartureTimeDisplay: Equatable {
         self.scheduledTimeText = scheduled == expected ? nil : scheduled
     }
 
-    init(arrivalDeparture: ArrivalDeparture, formatters: Formatters) {
+    public init(arrivalDeparture: ArrivalDeparture, formatters: Formatters) {
         self.init(
             scheduledDate: arrivalDeparture.scheduledDate,
             expectedDate: arrivalDeparture.arrivalDepartureDate,
@@ -66,10 +65,10 @@ struct DepartureTimeDisplay: Equatable {
     /// Computed rather than stored: the render path never reads it, and building
     /// it eagerly would charge every row a bundle lookup for a string most
     /// people never hear.
-    var accessibilityTimeDescription: String {
+    public var accessibilityTimeDescription: String {
         guard let scheduledTimeText else {
             let fmt = OBALoc(
-                "stop_page.time.a11y_at_fmt",
+                "departure_time.a11y_at_fmt",
                 value: "at %@",
                 comment: "VoiceOver clause naming the clock time of a departure. %@ is the time."
             )
@@ -77,7 +76,7 @@ struct DepartureTimeDisplay: Equatable {
         }
 
         let fmt = OBALoc(
-            "stop_page.time.a11y_rescheduled_fmt",
+            "departure_time.a11y_rescheduled_fmt",
             value: "scheduled %1$@, now expected %2$@",
             comment: "VoiceOver clause for a departure whose real-time prediction differs from its scheduled time. %1$@ is the scheduled time, %2$@ the predicted time."
         )
@@ -92,12 +91,15 @@ struct DepartureTimeDisplay: Equatable {
 /// tint on the scheduled time — font and foreground style are inherited, so the
 /// call sites keep the type scale they already had. Concatenated `Text` rather
 /// than a stack so the pair wraps as ordinary text at large Dynamic Type sizes.
-struct DepartureTimeText: View {
-    let display: DepartureTimeDisplay
+public struct DepartureTimeText: View {
+    public let display: DepartureTimeDisplay
 
-    var body: some View {
-        time
-            .monospacedDigit()
+    public init(display: DepartureTimeDisplay) {
+        self.display = display
+    }
+
+    public var body: some View {
+        Self.text(for: display)
             // Every consumer speaks `accessibilityTimeDescription` in its own
             // combined label (those parents use `children: .ignore`, which drops
             // child labels outright), and a strikethrough is inaudible, so
@@ -105,13 +107,21 @@ struct DepartureTimeText: View {
             .accessibilityHidden(true)
     }
 
-    private var time: Text {
-        guard let scheduledTimeText = display.scheduledTimeText else {
-            return Text(display.expectedTimeText)
+    /// The concatenated `Text` this view renders, for call sites that must
+    /// splice the time into a *larger* run of wrapping text — the widget's
+    /// fixed-width column concatenates this with its deviation label so the
+    /// whole line wraps as ordinary text; composing views in an `HStack` there
+    /// would truncate instead. Callers are responsible for speaking
+    /// `accessibilityTimeDescription`, exactly as with the view form.
+    public static func text(for display: DepartureTimeDisplay) -> Text {
+        let time: Text
+        if let scheduledTimeText = display.scheduledTimeText {
+            time = Text(scheduledTimeText).strikethrough().foregroundStyle(.secondary)
+                + Text(" ")
+                + Text(display.expectedTimeText)
+        } else {
+            time = Text(display.expectedTimeText)
         }
-
-        return Text(scheduledTimeText).strikethrough().foregroundStyle(.secondary)
-            + Text(" ")
-            + Text(display.expectedTimeText)
+        return time.monospacedDigit()
     }
 }

--- a/OBAKitCore/UI/TripActivityPresenter.swift
+++ b/OBAKitCore/UI/TripActivityPresenter.swift
@@ -64,6 +64,38 @@ public struct TripActivityPresenter {
         )
     }
 
+    /// The corrected clock time(s) for an arrival: the scheduled time (struck
+    /// through by `DepartureTimeText`) ahead of the predicted one when the two
+    /// render differently.
+    ///
+    /// `ContentState` doesn't carry the scheduled instant, so it's derived by
+    /// walking `scheduleDeviation` back off the departure time. App-built
+    /// content states round the deviation to whole minutes
+    /// (`deviationFromScheduleInMinutes * 60`), so for locally-started
+    /// activities the derived time can sit up to half a minute off the true
+    /// timetable — occasionally shifting the struck-through minute by one.
+    /// Server pushes carry raw seconds, where the derivation is exact.
+    /// Carrying the exact scheduled time instead would be a change to the
+    /// OBACloud content-state wire contract, which isn't worth it for a
+    /// glanceable correction affordance.
+    public func timeDisplay(for arrival: TripAttributes.ContentState.ArrivalInfo) -> DepartureTimeDisplay {
+        // `.unknown` means the feed offered no prediction, so `departureDate`
+        // *is* the timetable time. A deviation riding along anyway is data the
+        // feed told us not to trust — walking it back here would shift the
+        // displayed schedule by exactly that untrusted amount.
+        let isRealTime = arrival.scheduleStatus != .unknown
+        let scheduledDate = isRealTime
+            ? arrival.departureDate.addingTimeInterval(-TimeInterval(arrival.scheduleDeviation))
+            : arrival.departureDate
+
+        return DepartureTimeDisplay(
+            scheduledDate: scheduledDate,
+            expectedDate: arrival.departureDate,
+            isRealTime: isRealTime,
+            formatters: formatters
+        )
+    }
+
     /// Color for the first upcoming arrival; gray when all have departed or empty.
     public func primaryColor(for state: TripAttributes.ContentState, now: Date = Date()) -> UIColor {
         guard let first = state.upcomingArrivals(now: now).first else {

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -10,7 +10,8 @@
 import SwiftUI
 
 /// Lock-screen Live Activity card that matches the grouped route card header from StopPageView:
-/// route badge + headsign + scheduled time/adherence status + countdown + departure chips.
+/// route badge + headsign + corrected departure time (the scheduled time struck through when a
+/// prediction has moved it) with adherence status + countdown + departure chips.
 /// No alarm pill or expand chevron.
 public struct TripLiveActivityCardView: View {
     public let staticData: TripAttributes.StaticData
@@ -65,18 +66,27 @@ public struct TripLiveActivityCardView: View {
 
     @ViewBuilder
     private func timeStatusLine(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+        // Shared corrected-time component (#1225): when the prediction has
+        // moved off the timetable, the scheduled time renders struck through
+        // ahead of the corrected one.
+        let display = presenter.timeDisplay(for: arrival)
+        let deviation = presenter.deviationLabel(for: arrival, now: now)
+
         HStack(spacing: 6) {
-            Text(arrival.departureDate, style: .time)
+            DepartureTimeText(display: display)
                 .font(.footnote)
-                .monospacedDigit()
                 .foregroundStyle(.secondary)
             Text("·")
                 .font(.footnote)
                 .foregroundStyle(.tertiary)
-            Text(presenter.deviationLabel(for: arrival, now: now))
+            Text(deviation)
                 .font(.footnote.weight(.semibold))
                 .foregroundStyle(Color(uiColor: presenter.color(for: arrival)))
         }
+        // `DepartureTimeText` hides itself from VoiceOver (a strikethrough is
+        // inaudible), so the line speaks the combined clause instead.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(display.accessibilityTimeDescription), \(deviation)")
     }
 
     @ViewBuilder

--- a/OBAKitTests/Models/DepartureTimeDisplayTests.swift
+++ b/OBAKitTests/Models/DepartureTimeDisplayTests.swift
@@ -7,7 +7,6 @@
 import Foundation
 import Testing
 import OBAKitCore
-@testable import OBAKit
 
 @MainActor
 @Suite(.serialized)

--- a/OBAKitTests/Models/TripActivityPresenterTests.swift
+++ b/OBAKitTests/Models/TripActivityPresenterTests.swift
@@ -14,9 +14,9 @@ import Testing
 @MainActor
 @Suite(.serialized)
 final class TripActivityPresenterTests {
-    private let presenter = TripActivityPresenter(
-        formatters: Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
-    )
+    private static let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+    private let formatters = TripActivityPresenterTests.formatters
+    private let presenter = TripActivityPresenter(formatters: TripActivityPresenterTests.formatters)
 
     private func arrival(offsetSeconds: Int, status: TripAttributes.ContentState.ScheduleStatusValue = .onTime, deviation: Int = 0, now: Date) -> TripAttributes.ContentState.ArrivalInfo {
         TripAttributes.ContentState.ArrivalInfo(
@@ -38,7 +38,6 @@ final class TripActivityPresenterTests {
     }
 
     @Test func `Color matches formatters schedule status color`() {
-        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
         #expect(presenter.color(for: arrival(offsetSeconds: 300, status: .delayed, now: now)) == formatters.colorForScheduleStatus(.delayed))
     }
 
@@ -57,8 +56,52 @@ final class TripActivityPresenterTests {
     }
 
     @Test func `Primary color for empty arrivals is unknown status color`() {
-        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
         let state = TripAttributes.ContentState(arrivals: [])
         #expect(presenter.primaryColor(for: state) == formatters.colorForScheduleStatus(.unknown))
+    }
+
+    // MARK: - timeDisplay
+
+    /// `ContentState` doesn't carry the scheduled instant, so `timeDisplay`
+    /// derives it by walking the deviation back off the departure time: five
+    /// minutes late means the timetable said five minutes earlier.
+    @Test func `Time display derives scheduled time from deviation`() {
+        let display = presenter.timeDisplay(for: arrival(offsetSeconds: 600, status: .delayed, deviation: 300, now: now))
+
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(600)))
+        #expect(display.scheduledTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(300)))
+    }
+
+    /// The inverse direction: an early arrival's timetable time sits *after*
+    /// the prediction (negative deviation walks forward).
+    @Test func `Time display early derives scheduled time after predicted`() {
+        let display = presenter.timeDisplay(for: arrival(offsetSeconds: 300, status: .early, deviation: -240, now: now))
+
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(300)))
+        #expect(display.scheduledTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(540)))
+    }
+
+    /// `.unknown` means the feed offered no prediction; a struck-through time
+    /// would imply a correction that never happened — even when a stale
+    /// deviation value rides along.
+    @Test func `Time display unknown status shows no strikethrough`() {
+        let display = presenter.timeDisplay(for: arrival(offsetSeconds: 600, status: .unknown, deviation: 300, now: now))
+
+        #expect(display.scheduledTimeText == nil)
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(600)))
+    }
+
+    /// A deviation that lands in the same clock minute must not strike
+    /// anything: "10:42 10:42" with one struck through reads as a bug.
+    ///
+    /// `now` sits at :20 past the minute (1_700_000_000 % 60 == 20), so a 20s
+    /// deviation walks the schedule back to exactly :00 of the *same* minute —
+    /// the largest deviation that stays same-minute from this epoch. Changing
+    /// either constant moves the test off this boundary.
+    @Test func `Time display same minute deviation shows one time`() {
+        let display = presenter.timeDisplay(for: arrival(offsetSeconds: 600, status: .onTime, deviation: 20, now: now))
+
+        #expect(display.scheduledTimeText == nil)
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: now.addingTimeInterval(600)))
     }
 }

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -321,6 +321,78 @@ final class BookmarksViewModelTests: OBATestCase {
         #expect(row.routesSubtitle != nil)
     }
 
+    // MARK: - Accessibility value
+
+    /// The bookmark card renders the corrected time with the schedule struck
+    /// through (`DepartureTimeText`); VoiceOver can't perceive a strikethrough,
+    /// so the correction must arrive in words — appended as its own sentence,
+    /// because the base value ends with terminal punctuation. The fixture's
+    /// arrival is predicted 156 s off its timetable, which lands in a
+    /// different clock minute and therefore renders (and must speak) the
+    /// correction.
+    @Test @MainActor
+    func `Accessibility value speaks corrected time clause when prediction moves off schedule`() throws {
+        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
+        let bookmark = Bookmark(name: "Route 49", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: arrivalDep)
+        let row = BookmarkRowViewModel(bookmark: bookmark, arrivalDepartures: [arrivalDep], highlightedTripIDs: [])
+
+        let value = try #require(formatters.accessibilityValue(for: row))
+
+        let scheduled = formatters.timeFormatter.string(from: arrivalDep.scheduledDate)
+        let expected = formatters.timeFormatter.string(from: arrivalDep.arrivalDepartureDate)
+        #expect(value == formatters.accessibilityValue(for: arrivalDep) + " scheduled \(scheduled), now expected \(expected).")
+    }
+
+    /// Without a rendered correction there's nothing the strikethrough shows
+    /// that the base value doesn't already say — the clause must be absent,
+    /// not repeating the expected time. The RVTD fixture's arrival declares
+    /// `predicted: false`, so no correction ever renders.
+    @Test @MainActor
+    func `Accessibility value omits time clause without a correction`() throws {
+        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1739-rvtd.json"
+        )
+        let unpredicted = try #require(stopArrivals.arrivalsAndDepartures.first)
+        let bookmark = Bookmark(name: "RVTD", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: unpredicted)
+        let row = BookmarkRowViewModel(bookmark: bookmark, arrivalDepartures: [unpredicted], highlightedTripIDs: [])
+
+        let value = try #require(formatters.accessibilityValue(for: row))
+
+        #expect(value == formatters.accessibilityValue(for: unpredicted))
+    }
+
+    /// With follow-up departures present, the corrected-time clause slots
+    /// between the first arrival's base value and the "Following …" sentence.
+    /// That relative order is user-facing VoiceOver output — a refactor must
+    /// not silently reorder it.
+    @Test @MainActor
+    func `Accessibility value speaks clause before followup departures`() throws {
+        let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914-duplicates.json"
+        )
+        let arrivals = Array(stopArrivals.arrivalsAndDepartures.prefix(2))
+        let first = try #require(arrivals.first)
+        let bookmark = Bookmark(name: "Route 49", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: first)
+        let row = BookmarkRowViewModel(bookmark: bookmark, arrivalDepartures: arrivals, highlightedTripIDs: [])
+
+        let value = try #require(formatters.accessibilityValue(for: row))
+
+        let scheduled = formatters.timeFormatter.string(from: first.scheduledDate)
+        let expected = formatters.timeFormatter.string(from: first.arrivalDepartureDate)
+        let prefix = formatters.accessibilityValue(for: first) + " scheduled \(scheduled), now expected \(expected)."
+        #expect(value.hasPrefix(prefix), "clause must directly follow the base value: \(value)")
+        #expect(value.dropFirst(prefix.count).contains("Following"), "follow-up sentence must come after the clause: \(value)")
+    }
+
     // MARK: - lastRefreshHadError
 
     /// A failed batch sets `lastRefreshHadError` to `true`; a subsequent clean batch resets it.

--- a/OBAWidget/Views/WidgetRowView.swift
+++ b/OBAWidget/Views/WidgetRowView.swift
@@ -27,12 +27,14 @@ struct WidgetRowView: View {
         bookmark?.name ?? " "
     }
 
-    private var nextDepartureLabel: String {
-        if departures != nil {
-            return updateNextDepartureLabel()
-        } else {
-            return LocalizationKeys.tapForMoreInformation
-        }
+    /// Fallback copy for the second line when there is no departure to
+    /// describe: no data yet → "tap for more information"; fetched-but-empty →
+    /// "no departures in the next hour". Only reached when `departures?.first`
+    /// is nil, so the two cases below are exhaustive.
+    private var fallbackLabel: String {
+        guard departures != nil else { return LocalizationKeys.tapForMoreInformation }
+
+        return String(format: LocalizationKeys.noDeparturesInNextNMinutes, String(Constants.minutes))
     }
 
     var body: some View {
@@ -43,11 +45,7 @@ struct WidgetRowView: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                Text(nextDepartureLabel)
-                    .font(.system(size: Constants.fontSize))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
+                departureLabel
             }
             // if the badge is hidden take up the full width otherwise use constant
             .frame(maxWidth: departures?.isEmpty == false ? Constants.rowWidth : .infinity, alignment: .leading)
@@ -57,6 +55,42 @@ struct WidgetRowView: View {
             if departures?.isEmpty == false {
                 departureTimeBadges
             }
+        }
+    }
+
+    /// The second line: the corrected clock time and the schedule deviation
+    /// (the "time · status" idiom the stop page and bookmark cards use), or
+    /// `fallbackLabel` when there is no departure to describe. When a
+    /// prediction moves the trip off its timetable, the scheduled time renders
+    /// struck through ahead of the corrected one (#1225).
+    ///
+    /// Built as one concatenated `Text`, not an `HStack`: the struck-through
+    /// case can outgrow the fixed text column, and a single text run wraps to
+    /// the second line the way this label always has, where an `HStack` would
+    /// truncate the deviation — precisely the correction the line exists to
+    /// show.
+    @ViewBuilder
+    private var departureLabel: some View {
+        if let first = departures?.first {
+            let display = DepartureTimeDisplay(arrivalDeparture: first, formatters: formatters)
+            let deviation = formatters.formattedScheduleDeviation(for: first)
+
+            (DepartureTimeText.text(for: display)
+                + Text(" · ").foregroundStyle(.tertiary)
+                + Text(deviation))
+                .font(.system(size: Constants.fontSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                // The strikethrough is inaudible, so speak the correction in
+                // words instead of letting VoiceOver read two bare times.
+                .accessibilityLabel("\(display.accessibilityTimeDescription), \(deviation)")
+        } else {
+            Text(fallbackLabel)
+                .font(.system(size: Constants.fontSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -70,20 +104,6 @@ struct WidgetRowView: View {
                     formatters: formatters
                 )
             }
-        }
-    }
-
-    // MARK: - Helper Functions
-
-    private func updateNextDepartureLabel() -> String {
-        guard let departures = departures else {
-            return LocalizationKeys.tapForMoreInformation
-        }
-
-        if let firstDeparture = departures.first {
-            return formatters.formattedScheduleDeviation(for: firstDeparture)
-        } else {
-            return String(format: LocalizationKeys.noDeparturesInNextNMinutes, String(Constants.minutes))
         }
     }
 }


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes #1225.</p>
<p><code>DepartureTimeDisplay</code> and <code>DepartureTimeText</code> (from #1224) lived in OBAKit, so only the Stop page could render the corrected departure time. This moves both types into OBAKitCore — defined once, <code>public</code> — and adopts them on the three surfaces that couldn't reach them: bookmark cards, the widget, and the Live Activity card.</p>
<p>Each of those surfaces previously showed a single plain time. All three now show the scheduled time struck through ahead of the corrected one whenever a prediction moves a trip off its timetable, with the correction spoken to VoiceOver on every surface. A strikethrough is inaudible, so each consumer carries the clause in its combined accessibility label.</p>
<h2>What changed</h2>
<ul>
<li><strong><code>OBAKitCore/UI/DepartureTimeDisplay.swift</code> (moved, public)</strong> — localization keys renamed off the <code>stop_page.</code> prefix to <code>departure_time.*</code>. Also gained <code>DepartureTimeText.text(for:)</code>, a <code>Text</code> builder for call sites that splice the time into a larger wrapping line.</li>
<li><strong>Strings</strong> — both VoiceOver keys moved from OBAKit to OBAKitCore across all 13 locales, translations carried over verbatim. <code>LocalizationTests</code> passes for both bundles.</li>
<li><strong><code>BookmarkCardView</code></strong> — <code>timeText(for:)</code> renders the shared component; <code>Formatters.accessibilityValue(for:)</code> appends the corrected-time clause only when a correction actually renders, since the base value already names the expected time.</li>
<li><strong><code>WidgetRowView</code></strong> — the second line is now "time · deviation", built as one concatenated <code>Text</code> so it wraps at the fixed column width instead of truncating the correction. Replaced <code>nextDepartureLabel</code> / <code>updateNextDepartureLabel</code> with a single <code>fallbackLabel</code> (dead code removed).</li>
<li><strong><code>TripLiveActivityCardView</code></strong> — uses the shared component via a new <code>TripActivityPresenter.timeDisplay(for:)</code>. <code>ContentState</code> doesn't carry the scheduled instant, so it is derived by walking <code>scheduleDeviation</code> back off the departure time — except when <code>scheduleStatus == .unknown</code>, where the deviation is untrusted and <code>departureDate</code> <em>is</em> the timetable time. Also fixed the stale "scheduled time" doc comment called out in the issue.</li>
</ul>

### Screenshots

All three captured in the simulator against live Puget Sound data:

| Bookmark cards | Widget | Live Activity |
|---|---|---|
| <img width="1206" height="2622" alt="Bookmark cards" src="https://github.com/user-attachments/assets/d67bb10d-2e7d-4048-acc0-c036d614f3e6" /> | <img width="1206" height="2622" alt="Widget" src="https://github.com/user-attachments/assets/34539a98-a71e-474f-9fdb-bdd0c9dfd6d2" /> | <img width="1206" height="2622" alt="Live Activity" src="https://github.com/user-attachments/assets/e543f1f3-5be4-4b80-8622-82a1163d23ba" /> |

On the Live Activity, the derived schedule checks out against real data: 12:50 AM expected − 3 min late = the struck-through 12:47 AM.


<h2>Notes</h2>
<ul>
<li>The spoken clause's sentence punctuation is handled in code rather than as a second localized key. The string is spoken-only, and a sentence-form key would force all 13 locales to re-adjudicate punctuation for translations that carried over verbatim. Happy to switch to a distinct key if you'd prefer.</li>
<li>The widget's second line now gains the clock time (previously deviation-only). That read as the natural meaning of "WidgetRowView uses it" — easy to adjust if you had a different arrangement in mind.</li>
</ul></body></html>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-ios/pr/1237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787858985&installation_model_id=429412&pr_number=1237&repository=OneBusAway%2Fonebusaway-ios&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-ios%2Fpull%2F1237&signature=0b862e6400dbc9cceb5592c1ab84cab7e5e1bf994474adcc924f326974cecd92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved departure-time rendering across bookmarks, live activity cards, and widgets, showing corrected predicted times alongside scheduled times (scheduled time is struck through when updated).
  * VoiceOver now speaks clearer scheduled vs expected (“corrected”) departure timing with consistent phrasing across supported languages.

* **Bug Fixes**
  * Updated stop-page accessibility strings to ensure departure-time voiceover reflects the corrected schedule logic.

* **Tests**
  * Added/expanded tests validating corrected-time display behavior and VoiceOver accessibility output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->