### PR TITLE
Migrate OBAKitTests to Swift Testing, and finish the Swift 6 migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,9 +178,11 @@ jobs:
     # anyone ever adds it to actions/cache, this ratchet stops being meaningful:
     # pass COMPILATION_CACHE_CAS_PATH to a scratch dir here, as
     # scripts/measure_concurrency does locally.
-    # All remaining warnings are in OBAKitTests (pinned to Swift 5, see its
-    # project.yml); every Swift 6 target is at zero and additionally locked by
-    # SWIFT_WARNINGS_AS_ERRORS_GROUPS in Apps/Shared/app_shared.yml.
+    # The baseline is 0: every target, OBAKitTests included, is at zero and
+    # additionally locked by SWIFT_WARNINGS_AS_ERRORS_GROUPS in
+    # Apps/Shared/app_shared.yml, which escalates the five concurrency
+    # diagnostic groups to errors so the compiler — not this grep — is the
+    # real gate.
     - name: Concurrency warning ratchet
       run: scripts/concurrency_ratchet xcodebuild-build.log
 
@@ -203,17 +205,29 @@ jobs:
 
     # Surface the slowest tests in the job summary so a regression in *test*
     # time (vs. infra time) is easy to spot without re-running the investigation.
-    # Parses the classic XCTest "passed (N seconds)" log format; if the suite ever
-    # moves to swift-testing/xcbeautify output the list just comes up empty.
+    #
+    # Parses both formats, because the suite spans both: swift-testing's
+    # "✔ Test <name> passed after N seconds" covers everything except
+    # PolylinePerformanceTests, which stays on XCTest (`measure` has no
+    # swift-testing equivalent) and still prints the classic
+    # "'-[OBAKitTests.Foo testBar]' passed (N seconds)".
+    #
+    # The `grep -v` drops swift-testing's run summary, "✔ Test run with N tests
+    # in M suites passed after …", which otherwise matches the same pattern and
+    # sorts to the top as the slowest "test".
     - name: Report slowest tests
       if: success() || failure()
       run: |
         {
           echo "### Slowest 20 tests"
           echo '```'
-          grep -oE "'-\[OBAKitTests\.[^]]+\]' passed \([0-9.]+ seconds\)" xcodebuild-test.log \
-            | sed -E "s/'-\[OBAKitTests\.(.+)\]' passed \(([0-9.]+) seconds\)/\2  \1/" \
-            | sort -rn | head -20
+          {
+            grep -oE "✔ Test .+ passed after [0-9.]+ seconds" xcodebuild-test.log \
+              | grep -v '✔ Test run with ' \
+              | sed -E "s/✔ Test (.+) passed after ([0-9.]+) seconds/\2  \1/"
+            grep -oE "'-\[OBAKitTests\.[^]]+\]' passed \([0-9.]+ seconds\)" xcodebuild-test.log \
+              | sed -E "s/'-\[OBAKitTests\.(.+)\]' passed \(([0-9.]+) seconds\)/\2  \1/"
+          } | sort -rn | head -20
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY" || true
 

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -8,8 +8,9 @@ settings:
   base:
     MARKETING_VERSION: 26.3.0
     # Swift 6 migration, now complete (docs/swift6-migration-plan.md): every
-    # target in the project — frameworks, apps, widget and OBAKitTests —
-    # builds in the Swift 6 language mode with main-actor default isolation.
+    # target in the project — frameworks, apps, widget, OBAKitTests and
+    # OBAKitUITests — builds in the Swift 6 language mode with main-actor
+    # default isolation.
     # Exactly one target overrides this base: OBAKitCore pins
     # SWIFT_DEFAULT_ACTOR_ISOLATION back to nonisolated, because it owns the
     # actors and the background decode. OBAKitTests used to override it too;

--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -7,14 +7,15 @@ name: OBAKit
 settings:
   base:
     MARKETING_VERSION: 26.3.0
-    # Swift 6 migration Phases 3–4 (docs/swift6-migration-plan.md): every
-    # framework and app target builds in the Swift 6 language mode with
-    # main-actor default isolation. Two targets override this base:
-    # OBAKitCore pins SWIFT_DEFAULT_ACTOR_ISOLATION back to nonisolated (it
-    # owns actors and background decode), and OBAKitTests is temporarily
-    # pinned to Swift 5 (see OBAKitTests/project.yml). Approachable
-    # concurrency stays on permanently for Swift 6 targets (two of its five
-    # features are not part of the Swift 6 language mode).
+    # Swift 6 migration, now complete (docs/swift6-migration-plan.md): every
+    # target in the project — frameworks, apps, widget and OBAKitTests —
+    # builds in the Swift 6 language mode with main-actor default isolation.
+    # Exactly one target overrides this base: OBAKitCore pins
+    # SWIFT_DEFAULT_ACTOR_ISOLATION back to nonisolated, because it owns the
+    # actors and the background decode. OBAKitTests used to override it too;
+    # that pin went away when the suite moved to Swift Testing (see Phase 4).
+    # Approachable concurrency stays on permanently for Swift 6 targets (two
+    # of its five features are not part of the Swift 6 language mode).
     SWIFT_STRICT_CONCURRENCY: complete
     SWIFT_APPROACHABLE_CONCURRENCY: YES
     SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,13 +88,22 @@ scripts/extract_strings               # Extract strings for localization
 - `Apps/Shared/`: Common configuration and analytics
 
 ### Testing
-- `OBAKitTests/`: Unit tests for all frameworks
+- `OBAKitTests/`: Unit tests for all frameworks. Written with **Swift Testing**
+  (`@Suite` / `@Test` / `#expect`), not XCTest. The single exception is
+  `PolylinePerformanceTests`, which stays on XCTest because `measure` has no
+  Swift Testing equivalent — and is marked `nonisolated`, without which the
+  target cannot build in the Swift 6 language mode.
+- Suites are marked `.serialized` to preserve the one-test-at-a-time execution
+  XCTest gave them.
+- `OBATestCase` is a plain `@MainActor` base class, not an `XCTestCase`. Suites
+  that need its fixtures inherit it and override `init() async throws` (where
+  `setUp` used to go); teardown goes in `deinit`.
 
 ## Third-Party Dependencies
 
 **UI Libraries**: BulletinBoard, Eureka, FloatingPanel, MarqueeLabel
 **Networking**: CocoaLumberjack, Hyperconnectivity, SwiftProtobuf
-**Testing**: Nimble
+**Testing**: Swift Testing (first-party; Nimble was removed)
 
 ## Configuration & Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,6 @@ scripts/extract_strings               # Extract strings for localization
 
 ### Applications
 - `Apps/OneBusAway/`: Main OneBusAway branded app
-- `Apps/MTA/`: MTA-specific variant
 - `Apps/KiedyBus/`: Polish transit app variant
 - `Apps/Shared/`: Common configuration and analytics
 
@@ -93,8 +92,14 @@ scripts/extract_strings               # Extract strings for localization
   `PolylinePerformanceTests`, which stays on XCTest because `measure` has no
   Swift Testing equivalent — and is marked `nonisolated`, without which the
   target cannot build in the Swift 6 language mode.
-- Suites are marked `.serialized` to preserve the one-test-at-a-time execution
-  XCTest gave them.
+- Suites are marked `.serialized`, which serializes the tests *within* each
+  suite — that is the ordering XCTest gave them, and what the suites were
+  written against. It does **not** stop separate suites running concurrently,
+  so anything process-global (`NSTimeZone.default`, `UserDefaults.standard`,
+  singletons) still needs handling on its own terms; see the GMT pin in
+  `OBAKitTests/Helpers/OBATestCase.swift` for the pattern. Whole-target
+  serialization, where it holds, comes from `parallelizable: false` on the test
+  target in `Apps/Shared/app_shared.yml`.
 - `OBATestCase` is a plain `@MainActor` base class, not an `XCTestCase`. Suites
   that need its fixtures inherit it and override `init() async throws` (where
   `setUp` used to go); teardown goes in `deinit`.
@@ -108,7 +113,7 @@ scripts/extract_strings               # Extract strings for localization
 ## Configuration & Deployment
 
 - **Target iOS Version**: 18.0+
-- **Swift Version**: Swift 5/6 language modes, current Xcode toolchain (modern syntax like shorthand optional binding and `URL.host()` is fine — the iOS 18 deployment target exceeds their requirements)
+- **Swift Version**: every target builds in the **Swift 6 language mode** with main-actor default isolation (`Apps/Shared/app_shared.yml`); OBAKitCore is the one target that pins `SWIFT_DEFAULT_ACTOR_ISOLATION` back to `nonisolated`. The five concurrency diagnostic groups are escalated to errors, so a data-race warning fails the build. Modern syntax (shorthand optional binding, `URL.host()`) is fine — the iOS 18 deployment target exceeds their requirements.
 - **Package Manager**: Swift Package Manager
 - **Project Generation**: XcodeGen from YAML configurations
 - **Localization**: in-repo .strings files (OBAKit/Strings, OBAKitCore/Strings)

--- a/OBAKitTests/Analytics/UmamiAnalyticsTests.swift
+++ b/OBAKitTests/Analytics/UmamiAnalyticsTests.swift
@@ -55,16 +55,18 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     @Test func `Report stop viewed builds contract request`() async throws {
         let loader = MockDataLoader(testName: name)
-        var captured: URLRequest?
+        // Boxed: the matcher is @Sendable and runs off the main actor, so it
+        // cannot write to a main-actor-isolated local.
+        let captured = SendableBox<URLRequest?>(nil)
         loader.mock(data: successBody) { request in
-            captured = request
+            captured.value = request
             return true
         }
 
         let reporter = makeReporter(loader: loader)
         await reporter.reportStopViewed(name: "Pine St", id: "1_75403", stopDistance: "near")
 
-        let request = try #require(captured)
+        let request = try #require(captured.value)
         #expect(request.url?.absoluteString == "https://analytics.example.com/api/send")
         #expect(request.httpMethod == "POST")
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
@@ -89,16 +91,18 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     @Test func `Report event includes name`() async throws {
         let loader = MockDataLoader(testName: name)
-        var captured: URLRequest?
+        // Boxed: the matcher is @Sendable and runs off the main actor, so it
+        // cannot write to a main-actor-isolated local.
+        let captured = SendableBox<URLRequest?>(nil)
         loader.mock(data: successBody) { request in
-            captured = request
+            captured.value = request
             return true
         }
 
         let reporter = makeReporter(loader: loader)
         await reporter.reportEvent(pageURL: "app://localhost/map", label: "Clicked MapStopIcon", value: nil)
 
-        let request = try #require(captured)
+        let request = try #require(captured.value)
         let body = try JSONSerialization.jsonObject(with: try #require(request.httpBody)) as! [String: Any]
         let payload = body["payload"] as! [String: Any]
         #expect((payload["name"] as? String) == "Clicked MapStopIcon")

--- a/OBAKitTests/Analytics/UmamiAnalyticsTests.swift
+++ b/OBAKitTests/Analytics/UmamiAnalyticsTests.swift
@@ -7,11 +7,12 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import App
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class UmamiAnalyticsTests: OBATestCase {
 
     private let successBody = #"{"cache":"x","sessionId":"s","visitId":"v"}"#.data(using: .utf8)!
@@ -26,7 +27,7 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     // MARK: - path(from:)
 
-    func testPathReduction() {
+    @Test func `Path reduction`() {
         #expect(UmamiAnalytics.path(from: "app://localhost/map") == "/map")
         #expect(UmamiAnalytics.path(from: "app://localhost") == "/")
         #expect(UmamiAnalytics.path(from: "app://localhost/search?q=x") == "/search")
@@ -34,7 +35,7 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     // MARK: - isSuccessfulIngest
 
-    func testSuccessDetection() {
+    @Test func `Success detection`() {
         #expect(UmamiAnalytics.isSuccessfulIngest(self.successBody))
         #expect(!UmamiAnalytics.isSuccessfulIngest(self.beepBoopBody))
         #expect(!UmamiAnalytics.isSuccessfulIngest("not json".data(using: .utf8)!))
@@ -42,7 +43,7 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     // MARK: - UmamiJSONValue coercion
 
-    func testJSONValueCoercion() {
+    @Test func `JSON value coercion`() {
         #expect(UmamiJSONValue("hi") != nil)
         #expect(UmamiJSONValue(42) != nil)
         // Non-JSON / non-finite values are dropped (nil), never crash.
@@ -52,7 +53,7 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     // MARK: - Request construction
 
-    func testReportStopViewedBuildsContractRequest() async throws {
+    @Test func `Report stop viewed builds contract request`() async throws {
         let loader = MockDataLoader(testName: name)
         var captured: URLRequest?
         loader.mock(data: successBody) { request in
@@ -63,18 +64,18 @@ final class UmamiAnalyticsTests: OBATestCase {
         let reporter = makeReporter(loader: loader)
         await reporter.reportStopViewed(name: "Pine St", id: "1_75403", stopDistance: "near")
 
-        let request = try XCTUnwrap(captured)
+        let request = try #require(captured)
         #expect(request.url?.absoluteString == "https://analytics.example.com/api/send")
         #expect(request.httpMethod == "POST")
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
 
         // Explicit, non-bot User-Agent — full format: "OneBusAway/<version> (iOS <ver>; <model>)".
-        let ua = try XCTUnwrap(request.value(forHTTPHeaderField: "User-Agent"))
+        let ua = try #require(request.value(forHTTPHeaderField: "User-Agent"))
         #expect(ua.contains("OneBusAway/"))
         #expect(NSPredicate(format: "SELF MATCHES %@", "^OneBusAway/.+ \\(iOS .+; .+\\)$").evaluate(with: ua))
 
         // Body matches the Umami contract.
-        let body = try JSONSerialization.jsonObject(with: try XCTUnwrap(request.httpBody)) as! [String: Any]
+        let body = try JSONSerialization.jsonObject(with: try #require(request.httpBody)) as! [String: Any]
         #expect((body["type"] as? String) == "event")
         let payload = body["payload"] as! [String: Any]
         #expect((payload["website"] as? String) == "site-uuid")
@@ -86,7 +87,7 @@ final class UmamiAnalyticsTests: OBATestCase {
         #expect((data["distance"] as? String) == "near")
     }
 
-    func testReportEventIncludesName() async throws {
+    @Test func `Report event includes name`() async throws {
         let loader = MockDataLoader(testName: name)
         var captured: URLRequest?
         loader.mock(data: successBody) { request in
@@ -97,8 +98,8 @@ final class UmamiAnalyticsTests: OBATestCase {
         let reporter = makeReporter(loader: loader)
         await reporter.reportEvent(pageURL: "app://localhost/map", label: "Clicked MapStopIcon", value: nil)
 
-        let request = try XCTUnwrap(captured)
-        let body = try JSONSerialization.jsonObject(with: try XCTUnwrap(request.httpBody)) as! [String: Any]
+        let request = try #require(captured)
+        let body = try JSONSerialization.jsonObject(with: try #require(request.httpBody)) as! [String: Any]
         let payload = body["payload"] as! [String: Any]
         #expect((payload["name"] as? String) == "Clicked MapStopIcon")
         #expect((payload["url"] as? String) == "/map")
@@ -106,7 +107,7 @@ final class UmamiAnalyticsTests: OBATestCase {
 
     // MARK: - Fail-safe
 
-    func testNonJSONValueDoesNotCrashOrThrow() async throws {
+    @Test func `Non JSON value does not crash or throw`() async throws {
         let loader = MockDataLoader(testName: name)
         loader.mock(data: successBody) { _ in true }
         let reporter = makeReporter(loader: loader)
@@ -116,7 +117,7 @@ final class UmamiAnalyticsTests: OBATestCase {
         #expect(loader.recordedRequestURLs.count == 1)
     }
 
-    func testBeepBoopResponseIsSwallowed() async throws {
+    @Test func `Beep boop response is swallowed`() async throws {
         let loader = MockDataLoader(testName: name)
         loader.mock(data: beepBoopBody) { _ in true }
         let reporter = makeReporter(loader: loader)

--- a/OBAKitTests/Application/AppConfigTests.swift
+++ b/OBAKitTests/Application/AppConfigTests.swift
@@ -10,16 +10,16 @@
 import UIKit
 
 import Foundation
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
 import Testing
 
-class AppConfigTests: OBATestCase {
+@Suite(.serialized)
+final class AppConfigTests: OBATestCase {
     let regionsBaseURL = URL(string: "http://www.example.com")!
 
-    func testAppConfig_creation_propertiesWork() {
+    @Test func `App config creation properties work`() {
         let queue = OperationQueue()
 
         let locationManager = MockAuthorizedLocationManager(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -9,7 +9,6 @@
 
 import Foundation
 import UIKit
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
@@ -50,18 +49,18 @@ class TestRegionsServiceDelegate: NSObject, RegionsServiceDelegate {
     }
 }
 
-class ApplicationTests: OBATestCase {
+@Suite(.serialized)
+final class ApplicationTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
 
         queue.cancelAllOperations()
     }
@@ -76,7 +75,7 @@ class ApplicationTests: OBATestCase {
         return (locManager, locationService, config)
     }
 
-    @MainActor func test_appCreation_locationAlreadyAuthorized_updatesLocation() async {
+    @Test @MainActor func `App creation location already authorized updates location`() async {
         let (locManager, _, config) = configureAuthorizedObjects()
 
         let dataLoader = (config.dataLoader as! MockDataLoader)
@@ -110,7 +109,7 @@ class ApplicationTests: OBATestCase {
         }
     }
 
-    func test_appCreation_locationAlreadyAuthorized_regionAvailable_createsRESTAPIService() {
+    @Test func `App creation location already authorized region available creates RESTAPI service`() {
         let (_, locService, config) = configureAuthorizedObjects()
 
         let dataLoader = (config.dataLoader as! MockDataLoader)
@@ -133,7 +132,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - When location not been authorized
 
-    func test_app_locationNotDetermined_init() {
+    @Test func `App location not determined init`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -157,7 +156,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.apiService == nil)
     }
 
-    func test_app_locationNewlyAuthorized() async {
+    @Test func `App location newly authorized`() async {
         let dataLoader = MockDataLoader(testName: name)
 
         stubRegions(dataLoader: dataLoader)
@@ -189,7 +188,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Minimal Proof of Concept Tests
 
-    func test_application_initializes_with_config() {
+    @Test func `Application initializes with config`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -201,7 +200,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.applicationBundle == Bundle.main)
     }
 
-    func test_application_delegate_communication() {
+    @Test func `Application delegate communication`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -219,7 +218,7 @@ class ApplicationTests: OBATestCase {
         #expect(delegate.called_applicationReloadRootInterface)
     }
 
-    func test_application_idle_timer_disabled_proxies_delegate() {
+    @Test func `Application idle timer disabled proxies delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -240,7 +239,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Property and Feature Tests
 
-    func test_application_can_open_url_proxies_delegate() {
+    @Test func `Application can open url proxies delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -257,7 +256,7 @@ class ApplicationTests: OBATestCase {
         #expect(!result)  // TestAppDelegate returns false
     }
 
-    func test_application_is_registered_for_remote_notifications_proxies_delegate() {
+    @Test func `Application is registered for remote notifications proxies delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -272,7 +271,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.isRegisteredForRemoteNotifications)
     }
 
-    func test_application_credits_proxies_delegate() {
+    @Test func `Application credits proxies delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -284,7 +283,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.credits.isEmpty)
     }
 
-    func test_application_should_show_crash_button_returns_false_without_delegate() {
+    @Test func `Application should show crash button returns false without delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -297,7 +296,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Feature Availability Tests
 
-    func test_features_obaco_status_off_when_no_region() {
+    @Test func `Features obaco status off when no region`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -308,7 +307,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.features.obaco == Application.FeatureStatus.off)
     }
 
-    func test_features_push_status_off_when_no_provider() {
+    @Test func `Features push status off when no provider`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -319,7 +318,7 @@ class ApplicationTests: OBATestCase {
         #expect(app.features.push == Application.FeatureStatus.off)
     }
 
-    func test_features_deep_linking_status_when_router_created() {
+    @Test func `Features deep linking status when router created`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -334,7 +333,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Application Lifecycle Tests
 
-    func test_application_did_finish_launching() {
+    @Test func `Application did finish launching`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -356,7 +355,7 @@ class ApplicationTests: OBATestCase {
         #expect(delegate.called_applicationReloadRootInterface)
     }
 
-    @MainActor func test_application_will_resign_active() {
+    @Test @MainActor func `Application will resign active`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -377,7 +376,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Data Migration Tests
 
-    func test_should_perform_migration_returns_data_migrator_value() {
+    @Test func `Should perform migration returns data migrator value`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -390,7 +389,7 @@ class ApplicationTests: OBATestCase {
         #expect([true, false].contains(shouldPerform))
     }
 
-    func test_has_data_to_migrate_returns_data_migrator_value() {
+    @Test func `Has data to migrate returns data migrator value`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -405,7 +404,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - URL Scheme and Deep Link Tests
 
-    func test_application_url_scheme_add_region_returns_true() async {
+    @Test func `Application url scheme add region returns true`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -428,7 +427,7 @@ class ApplicationTests: OBATestCase {
     }
 
 
-    func test_application_url_scheme_view_stop_with_no_root_yet_is_stashed_and_accepted() async {
+    @Test func `Application url scheme view stop with no root yet is stashed and accepted`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -464,7 +463,7 @@ class ApplicationTests: OBATestCase {
     /// empty seen-store) gets backfilled and — with no push provider configured, as in
     /// this test harness — matches no steps, so `evaluate` hands back nil and the app
     /// goes straight to its root UI.
-    func test_onboarding_evaluate_existingUser_returnsNil() async {
+    @Test func `Onboarding evaluate existing user returns nil`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
 
@@ -500,7 +499,7 @@ class ApplicationTests: OBATestCase {
     }
 
     /// A new user (no region) gets a flow — evaluate returns a controller.
-    func test_onboarding_evaluate_newUser_returnsController() async {
+    @Test func `Onboarding evaluate new user returns controller`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -517,7 +516,7 @@ class ApplicationTests: OBATestCase {
         #expect(controller != nil)
     }
 
-    func test_application_url_scheme_invalid_url_returns_false() async {
+    @Test func `Application url scheme invalid url returns false`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -535,7 +534,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - User Activity Tests
 
-    func test_application_continue_user_activity_without_app_links_router() {
+    @Test func `Application continue user activity without app links router`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -552,7 +551,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Analytics Tests
 
-    func test_application_has_analytics_property() {
+    @Test func `Application has analytics property`() {
         let mockAnalytics = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
@@ -567,7 +566,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Regions Service Delegate Tests
 
-    func test_regions_service_changed_automatic_region_selection() {
+    @Test func `Regions service changed automatic region selection`() {
         let mockAnalytics = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
@@ -584,7 +583,7 @@ class ApplicationTests: OBATestCase {
         #expect(mockAnalytics.reportedEvents.count >= 2)
     }
 
-    func test_regions_service_updated_region() {
+    @Test func `Regions service updated region`() {
         let mockAnalytics = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
@@ -603,7 +602,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Push Service Tests
 
-    func test_push_service_received_donation_prompt_with_no_top_view_controller() {
+    @Test func `Push service received donation prompt with no top view controller`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -624,7 +623,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Error Display Tests
 
-    func test_display_error_without_delegate() async {
+    @Test func `Display error without delegate`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -640,7 +639,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Agency Alerts Tests
 
-    func test_agency_alerts_store_display_error() {
+    @Test func `Agency alerts store display error`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -654,8 +653,8 @@ class ApplicationTests: OBATestCase {
         app.agencyAlertsStore(app.alertsStore, displayError: testError)
     }
 
-    @MainActor
-    func test_agency_alerts_updated_without_alerts() {
+    @Test @MainActor
+    func `Agency alerts updated without alerts`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -669,7 +668,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - API Services Tests
 
-    func test_api_services_refreshed() {
+    @Test func `Api services refreshed`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -683,7 +682,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Crash Button Tests
 
-    func test_perform_test_crash_without_delegate() {
+    @Test func `Perform test crash without delegate`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
@@ -697,7 +696,7 @@ class ApplicationTests: OBATestCase {
 
     // MARK: - Property Access Tests
 
-    func test_lazy_properties_initialization() {
+    @Test func `Lazy properties initialization`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -25,7 +25,7 @@ final class FormattersTests: OBATestCase {
     let usLocale = Locale(identifier: "en_US")
     let calendar = Calendar(identifier: .gregorian)
 
-    @Test func `Example`() {
+    @Test func example() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
         let stopArrivals = try! Fixtures.loadRESTAPIPayload(type: StopArrivals.self, fileName: "arrivals-and-departures-for-stop-1_75414.json")
         let arrDep = stopArrivals.arrivalsAndDepartures.first!

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -21,11 +20,12 @@ enum ModelDecodingError: Error {
     case invalidModelList
 }
 
-class FormattersTests: OBATestCase {
+@Suite(.serialized)
+final class FormattersTests: OBATestCase {
     let usLocale = Locale(identifier: "en_US")
     let calendar = Calendar(identifier: .gregorian)
 
-    func testExample() {
+    @Test func `Example`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
         let stopArrivals = try! Fixtures.loadRESTAPIPayload(type: StopArrivals.self, fileName: "arrivals-and-departures-for-stop-1_75414.json")
         let arrDep = stopArrivals.arrivalsAndDepartures.first!
@@ -41,25 +41,25 @@ class FormattersTests: OBATestCase {
 
     // MARK: - Transfer-Relative Time
 
-    func test_shortFormattedTransferTime_positiveMinutes() {
+    @Test func `Short formatted transfer time positive minutes`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
         let result = formatters.shortFormattedTransferTime(minutes: 4)
-        XCTAssertEqual(result, "4m")
+        #expect(result == "4m")
     }
 
-    func test_shortFormattedTransferTime_negativeMinutes() {
+    @Test func `Short formatted transfer time negative minutes`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
         let result = formatters.shortFormattedTransferTime(minutes: -3)
-        XCTAssertEqual(result, "-3m")
+        #expect(result == "-3m")
     }
 
-    func test_shortFormattedTransferTime_zero() {
+    @Test func `Short formatted transfer time zero`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
         let result = formatters.shortFormattedTransferTime(minutes: 0)
-        XCTAssertEqual(result, "NOW")
+        #expect(result == "NOW")
     }
 
-    func test_transferArrivalBannerText() {
+    @Test func `Transfer arrival banner text`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
 
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
@@ -69,7 +69,7 @@ class FormattersTests: OBATestCase {
 
         let result = formatters.transferArrivalBannerText(arrivalTime: arrivalTime, routeDisplay: "10 - Capitol Hill")
 
-        XCTAssertTrue(result.contains("10 - Capitol Hill"), "Banner should contain route display: \(result)")
-        XCTAssertTrue(result.contains(expectedTime), "Banner should contain formatted time '\(expectedTime)': \(result)")
+        #expect(result.contains("10 - Capitol Hill"), "Banner should contain route display: \(result)")
+        #expect(result.contains(expectedTime), "Banner should contain formatted time '\(expectedTime)': \(result)")
     }
 }

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -104,7 +104,16 @@ final class LiveActivityRegistryTests: OBATestCase {
     }
 
     /// Thread-safe collector for the DELETEs a registry issued.
-    private final class DeleteRecorder {
+    ///
+    /// `nonisolated` is load-bearing. The matcher closure that calls `record(_:)`
+    /// is invoked by `MockDataLoader` on whichever task issued the request, and
+    /// `reconcile()` deliberately sends its DELETEs from a detached task so they
+    /// outlive the caller's cancellation. Left on the target's main-actor default
+    /// isolation, that call trips the runtime's isolation assertion and kills the
+    /// test process — which is exactly what happened when this target moved to
+    /// the Swift 6 language mode. The lock, not the actor, is what makes this
+    /// safe, so `@unchecked Sendable` states the promise the lock already keeps.
+    private nonisolated final class DeleteRecorder: @unchecked Sendable {
         private let lock = NSLock()
         private var _urls = [URL]()
 
@@ -424,7 +433,12 @@ final class LiveActivityRegistryTests: OBATestCase {
 
     /// Holds the task that a mocked response needs to cancel. `@unchecked Sendable` because the
     /// matcher runs on whatever thread the request is issued from; the lock is the real guarantee.
-    private final class UnsafeTaskBox: @unchecked Sendable {
+    ///
+    /// `nonisolated` for the same reason, and it has to be said explicitly: the
+    /// target defaults to main-actor isolation, so without it these methods are
+    /// main-actor and calling them from a matcher is the same runtime isolation
+    /// trap that `DeleteRecorder` hit.
+    private nonisolated final class UnsafeTaskBox: @unchecked Sendable {
         private let lock = NSLock()
         private var task: Task<Void, Never>?
 

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -109,10 +109,12 @@ final class LiveActivityRegistryTests: OBATestCase {
     /// is invoked by `MockDataLoader` on whichever task issued the request, and
     /// `reconcile()` deliberately sends its DELETEs from a detached task so they
     /// outlive the caller's cancellation. Left on the target's main-actor default
-    /// isolation, that call trips the runtime's isolation assertion and kills the
-    /// test process — which is exactly what happened when this target moved to
-    /// the Swift 6 language mode. The lock, not the actor, is what makes this
-    /// safe, so `@unchecked Sendable` states the promise the lock already keeps.
+    /// isolation, that call tripped the runtime's isolation assertion and killed
+    /// the test process — which is exactly what happened when this target moved
+    /// to the Swift 6 language mode. `MockDataLoaderMatcher` is `@Sendable` now,
+    /// so the same mistake would be caught at build time rather than at runtime.
+    /// The lock, not the actor, is what makes this safe, so `@unchecked Sendable`
+    /// states the promise the lock already keeps.
     private nonisolated final class DeleteRecorder: @unchecked Sendable {
         private let lock = NSLock()
         private var _urls = [URL]()

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import ActivityKit
 @testable import OBAKit
 @testable import OBAKitCore
@@ -27,7 +28,8 @@ import ActivityKit
 /// 2. **A delete URL may only be forgotten once the server confirms it.** It's the only handle
 ///    the app has on the server-side subscription, so dropping it after a failed DELETE leaks
 ///    the subscription permanently.
-class LiveActivityRegistryTests: OBATestCase {
+@Suite(.serialized)
+final class LiveActivityRegistryTests: OBATestCase {
 
     private let deadActivityID = "dead-activity"
     private let liveActivityID = "live-activity"
@@ -119,18 +121,18 @@ class LiveActivityRegistryTests: OBATestCase {
 
     /// The predicate the whole sweep turns on. `.dismissed`/`.ended` are the two states the view
     /// controllers' `activityStateUpdates` observers treat as death; everything else is alive.
-    func testOnlyDismissedAndEndedActivitiesAreConsideredDead() {
-        XCTAssertFalse(LiveActivityRegistry.isLive(.dismissed), "A dismissed activity is dead, even though ActivityKit still lists it.")
-        XCTAssertFalse(LiveActivityRegistry.isLive(.ended), "An ended activity is dead, even though ActivityKit still lists it.")
+    @Test func `Only dismissed and ended activities are considered dead`() {
+        #expect(!LiveActivityRegistry.isLive(.dismissed), "A dismissed activity is dead, even though ActivityKit still lists it.")
+        #expect(!LiveActivityRegistry.isLive(.ended), "An ended activity is dead, even though ActivityKit still lists it.")
 
-        XCTAssertTrue(LiveActivityRegistry.isLive(.active))
-        XCTAssertTrue(LiveActivityRegistry.isLive(.stale))
+        #expect(LiveActivityRegistry.isLive(.active))
+        #expect(LiveActivityRegistry.isLive(.stale))
 
         // `.pending` postdates our deployment target, hence the gate. It's also the reason
         // `isLive(_:)` is written as "not dead" rather than as an allow-list of live states: a
         // state case the app was never compiled against must not be mistaken for death.
         if #available(iOS 26.0, *) {
-            XCTAssertTrue(LiveActivityRegistry.isLive(.pending))
+            #expect(LiveActivityRegistry.isLive(.pending))
         }
     }
 
@@ -140,66 +142,66 @@ class LiveActivityRegistryTests: OBATestCase {
     /// lists it* in `Activity.activities` — with a state of `.dismissed`. The original sweep
     /// checked only for presence in that array, concluded the activity was alive, skipped it, and
     /// the server went on pushing to a dead activity forever. Presence is not life.
-    func testReconcileSweepsActivityStillListedByActivityKitButDismissed() async {
+    @Test func `Reconcile sweeps activity still listed by activity kit but dismissed`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(activityKitReports: [(deadActivityID, .dismissed)]).reconcile()
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for a dismissed activity that ActivityKit still lists.")
-        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
+        #expect(recorder.urls == [deadDeleteURL], "Expected reconcile() to DELETE the subscription for a dismissed activity that ActivityKit still lists.")
+        #expect(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
     }
 
     /// Same regression, other dead state: an `.ended` activity also lingers in `activities`.
-    func testReconcileSweepsActivityStillListedByActivityKitButEnded() async {
+    @Test func `Reconcile sweeps activity still listed by activity kit but ended`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(activityKitReports: [(deadActivityID, .ended)]).reconcile()
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an ended activity that ActivityKit still lists.")
-        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+        #expect(recorder.urls == [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an ended activity that ActivityKit still lists.")
+        #expect(persistedDeleteURLs.isEmpty)
     }
 
     /// The user cleared a Live Activity while the app wasn't running and the system has since
     /// purged it: nothing ever observed the dismissal, so its delete URL was left behind.
-    func testReconcileDeletesSubscriptionForActivityThatNoLongerExists() async {
+    @Test func `Reconcile deletes subscription for activity that no longer exists`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(activityKitReports: []).reconcile()
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an activity that no longer exists.")
-        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
+        #expect(recorder.urls == [deadDeleteURL], "Expected reconcile() to DELETE the subscription for an activity that no longer exists.")
+        #expect(persistedDeleteURLs.isEmpty, "Expected a confirmed DELETE to drop the persisted delete URL.")
     }
 
     /// An active activity still has (or will get) a lifecycle observer that unregisters it when
     /// it ends. Reconciliation must not touch it — sweeping it would kill the updates for a Live
     /// Activity the user is looking at right now.
-    func testReconcileLeavesActiveActivityAlone() async {
+    @Test func `Reconcile leaves active activity alone`() async {
         persistDeleteURLs([liveActivityID: liveDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(activityKitReports: [(liveActivityID, .active)]).reconcile()
 
-        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for an active activity.")
-        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString], "Expected an active activity's delete URL to be retained.")
+        #expect(recorder.urls.isEmpty, "Expected reconcile() to make no requests for an active activity.")
+        #expect(persistedDeleteURLs == [liveActivityID: liveDeleteURL.absoluteString], "Expected an active activity's delete URL to be retained.")
     }
 
     /// `.stale` means "on screen, showing old data" — the exact situation a push update is meant
     /// to fix. Sweeping it would guarantee it stays stale.
-    func testReconcileLeavesStaleActivityAlone() async {
+    @Test func `Reconcile leaves stale activity alone`() async {
         persistDeleteURLs([liveActivityID: liveDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(activityKitReports: [(liveActivityID, .stale)]).reconcile()
 
-        XCTAssertTrue(recorder.urls.isEmpty, "Expected reconcile() to make no requests for a stale (but still live) activity.")
-        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString])
+        #expect(recorder.urls.isEmpty, "Expected reconcile() to make no requests for a stale (but still live) activity.")
+        #expect(persistedDeleteURLs == [liveActivityID: liveDeleteURL.absoluteString])
     }
 
     /// Both activities are listed by ActivityKit; only their states tell them apart.
-    func testReconcileOnlySweepsTheDismissedActivityWhenBothAreListed() async {
+    @Test func `Reconcile only sweeps the dismissed activity when both are listed`() async {
         persistDeleteURLs([
             deadActivityID: deadDeleteURL.absoluteString,
             liveActivityID: liveDeleteURL.absoluteString
@@ -211,110 +213,98 @@ class LiveActivityRegistryTests: OBATestCase {
             (liveActivityID, .active)
         ]).reconcile()
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL])
-        XCTAssertEqual(persistedDeleteURLs, [liveActivityID: liveDeleteURL.absoluteString])
+        #expect(recorder.urls == [deadDeleteURL])
+        #expect(persistedDeleteURLs == [liveActivityID: liveDeleteURL.absoluteString])
     }
 
     /// The critical failure mode: if a flaky network let us forget the delete URL, the server-side
     /// subscription could never be deleted again. A transient failure must leave the entry in
     /// place so a later launch retries it.
-    func testReconcileRetainsDeleteURLWhenTheDeviceIsOffline() async {
+    @Test func `Reconcile retains delete URL when the device is offline`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteFailure(URLError(.notConnectedToInternet))
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL])
-        XCTAssertEqual(
-            persistedDeleteURLs,
-            [deadActivityID: deadDeleteURL.absoluteString],
-            "Expected a transient DELETE failure to retain the persisted delete URL for a later retry."
-        )
+        #expect(recorder.urls == [deadDeleteURL])
+        #expect(persistedDeleteURLs == [deadActivityID: deadDeleteURL.absoluteString], "Expected a transient DELETE failure to retain the persisted delete URL for a later retry.")
     }
 
-    func testReconcileRetainsDeleteURLOnServerError() async {
+    @Test func `Reconcile retains delete URL on server error`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 500)
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertEqual(
-            persistedDeleteURLs,
-            [deadActivityID: deadDeleteURL.absoluteString],
-            "Expected a 500 to be treated as transient and retain the persisted delete URL."
-        )
+        #expect(persistedDeleteURLs == [deadActivityID: deadDeleteURL.absoluteString], "Expected a 500 to be treated as transient and retain the persisted delete URL.")
     }
 
     /// A retry that finds the row already deleted has nothing left to do, so the entry can go.
-    func testReconcileForgetsDeleteURLWhenServerReports404() async {
+    @Test func `Reconcile forgets delete URL when server reports404`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 404)
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 404 (the subscription is already gone) to drop the persisted delete URL.")
+        #expect(persistedDeleteURLs.isEmpty, "Expected a 404 (the subscription is already gone) to drop the persisted delete URL.")
     }
 
-    func testReconcileForgetsDeleteURLWhenServerReports410() async {
+    @Test func `Reconcile forgets delete URL when server reports410`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 410)
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected a 410 Gone to drop the persisted delete URL.")
+        #expect(persistedDeleteURLs.isEmpty, "Expected a 410 Gone to drop the persisted delete URL.")
     }
 
     /// A malformed entry can never produce a request, so retaining it would just fail this check
     /// forever.
-    func testReconcileDiscardsUnparseableDeleteURL() async {
+    @Test func `Reconcile discards unparseable delete URL`() async {
         persistDeleteURLs([deadActivityID: ""])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertTrue(recorder.urls.isEmpty)
-        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+        #expect(recorder.urls.isEmpty)
+        #expect(persistedDeleteURLs.isEmpty)
     }
 
-    func testReconcileMakesNoRequestsWhenNothingIsPersisted() async {
+    @Test func `Reconcile makes no requests when nothing is persisted`() async {
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(liveActivityIDs: []).reconcile()
 
-        XCTAssertTrue(recorder.urls.isEmpty)
+        #expect(recorder.urls.isEmpty)
     }
 
     // MARK: - unregister()
 
-    func testUnregisterDeletesSubscriptionAndForgetsItsURL() async {
+    @Test func `Unregister deletes subscription and forgets its URL`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(liveActivityIDs: []).unregister(activityID: deadActivityID)
 
-        XCTAssertEqual(recorder.urls, [deadDeleteURL])
-        XCTAssertTrue(persistedDeleteURLs.isEmpty)
+        #expect(recorder.urls == [deadDeleteURL])
+        #expect(persistedDeleteURLs.isEmpty)
     }
 
-    func testUnregisterRetainsDeleteURLWhenTheDeviceIsOffline() async {
+    @Test func `Unregister retains delete URL when the device is offline`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteFailure(URLError(.timedOut))
 
         await buildRegistry(liveActivityIDs: []).unregister(activityID: deadActivityID)
 
-        XCTAssertEqual(
-            persistedDeleteURLs,
-            [deadActivityID: deadDeleteURL.absoluteString],
-            "Expected a transient DELETE failure to retain the persisted delete URL so reconcile() can retry it."
-        )
+        #expect(persistedDeleteURLs == [deadActivityID: deadDeleteURL.absoluteString], "Expected a transient DELETE failure to retain the persisted delete URL so reconcile() can retry it.")
     }
 
-    func testUnregisterIsANoOpForAnUnknownActivity() async {
+    @Test func `Unregister is a no op for an unknown activity`() async {
         let recorder = mockDeleteResponse(statusCode: 204)
 
         await buildRegistry(liveActivityIDs: []).unregister(activityID: "never-registered")
 
-        XCTAssertTrue(recorder.urls.isEmpty)
+        #expect(recorder.urls.isEmpty)
     }
 
     // MARK: - Cancellation
@@ -328,7 +318,7 @@ class LiveActivityRegistryTests: OBATestCase {
     /// So the property under test is not "unregister sends a DELETE" (the tests above already
     /// pass with the bug present) but "unregister sends a DELETE *even from a cancelled task*".
     /// `MockDataLoader` models `URLSession`'s cancellation check, so this fails without the fix.
-    func testUnregisterIssuesItsDeleteEvenWhenTheCallingTaskIsCancelled() async {
+    @Test func `Unregister issues its delete even when the calling task is cancelled`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         let recorder = mockDeleteResponse(statusCode: 204)
 
@@ -348,12 +338,8 @@ class LiveActivityRegistryTests: OBATestCase {
         observer.cancel()
         await observer.value
 
-        XCTAssertEqual(
-            recorder.urls,
-            [expectedURL],
-            "The unregister DELETE must reach the network even though the task that triggered it was cancelled — cancelling teardown work only ever leaks the subscription."
-        )
-        XCTAssertTrue(persistedDeleteURLs.isEmpty, "Expected the confirmed DELETE to drop the persisted delete URL.")
+        #expect(recorder.urls == [expectedURL], "The unregister DELETE must reach the network even though the task that triggered it was cancelled — cancelling teardown work only ever leaks the subscription.")
+        #expect(persistedDeleteURLs.isEmpty, "Expected the confirmed DELETE to drop the persisted delete URL.")
     }
 
     /// The same defect, one layer over: the registration POST wins its race with a dismissal, so
@@ -362,7 +348,7 @@ class LiveActivityRegistryTests: OBATestCase {
     /// is *why* `confirm()` returned false. Cancellation-honoring cleanup here orphans a row that
     /// nothing else will ever delete: the app never persisted its delete URL, so `reconcile()`
     /// can't find it either.
-    func testRegisterCleansUpTheOrphanedRowEvenWhenItsTokenTaskWasCancelledMidRegistration() async {
+    @Test func `Register cleans up the orphaned row even when its token task was cancelled mid registration`() async {
         let registry = buildRegistry(liveActivityIDs: [])
         let deleteRecorder = mockDeleteResponse(statusCode: 204)
         let activityID = deadActivityID
@@ -405,22 +391,15 @@ class LiveActivityRegistryTests: OBATestCase {
         gate.continuation.finish()
         await task.value
 
-        XCTAssertEqual(
-            deleteRecorder.urls,
-            [expectedURL],
-            "The orphan-cleanup DELETE must reach the network even though the token task issuing it was cancelled."
-        )
-        XCTAssertTrue(
-            persistedDeleteURLs.isEmpty,
-            "An unconfirmed registration must not leave a persisted delete URL behind."
-        )
+        #expect(deleteRecorder.urls == [expectedURL], "The orphan-cleanup DELETE must reach the network even though the token task issuing it was cancelled.")
+        #expect(persistedDeleteURLs.isEmpty, "An unconfirmed registration must not leave a persisted delete URL behind.")
     }
 
     /// Guards the seam the two tests above lean on. They can only fail against the buggy ordering
     /// if `MockDataLoader` refuses to serve a request from a cancelled task, the way `URLSession`
     /// does. If someone "simplifies" that check away, those tests would go on passing while the
     /// device kept failing — so assert the mock's fidelity directly.
-    func testMockDataLoaderRefusesToServeRequestsFromACancelledTaskLikeURLSession() async {
+    @Test func `Mock data loader refuses to serve requests from a cancelled task like URL session`() async {
         let recorder = mockDeleteResponse(statusCode: 204)
         let service: ObacoAPIService = obacoService
         let url = deadDeleteURL
@@ -439,12 +418,8 @@ class LiveActivityRegistryTests: OBATestCase {
         task.cancel()
         let error = await task.value
 
-        XCTAssertEqual(
-            (error as? URLError)?.code,
-            .cancelled,
-            "Expected the mock to fail a request from a cancelled task with URLError.cancelled (-999), exactly as URLSession does."
-        )
-        XCTAssertTrue(recorder.urls.isEmpty, "A cancelled request is one the server never saw; the mock must not record it.")
+        #expect((error as? URLError)?.code == .cancelled, "Expected the mock to fail a request from a cancelled task with URLError.cancelled (-999), exactly as URLSession does.")
+        #expect(recorder.urls.isEmpty, "A cancelled request is one the server never saw; the mock must not record it.")
     }
 
     /// Holds the task that a mocked response needs to cancel. `@unchecked Sendable` because the
@@ -466,12 +441,12 @@ class LiveActivityRegistryTests: OBATestCase {
 
     /// The key and value shape are a field-persisted contract: delete URLs written by shipped
     /// builds must still be found (and cleaned up) by this code.
-    func testRegistryReadsTheLegacyUserDefaultsKeyAndShape() {
-        XCTAssertEqual(LiveActivityRegistry.deleteURLsDefaultsKey, "liveActivityDeleteURLs")
+    @Test func `Registry reads the legacy user defaults key and shape`() {
+        #expect(LiveActivityRegistry.deleteURLsDefaultsKey == "liveActivityDeleteURLs")
 
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
 
         let registry = buildRegistry(liveActivityIDs: [])
-        XCTAssertEqual(registry.deleteURL(forActivityID: deadActivityID), deadDeleteURL)
+        #expect(registry.deleteURL(forActivityID: deadActivityID) == deadDeleteURL)
     }
 }

--- a/OBAKitTests/Application/LiveActivityRegistryTests.swift
+++ b/OBAKitTests/Application/LiveActivityRegistryTests.swift
@@ -249,7 +249,7 @@ final class LiveActivityRegistryTests: OBATestCase {
     }
 
     /// A retry that finds the row already deleted has nothing left to do, so the entry can go.
-    @Test func `Reconcile forgets delete URL when server reports404`() async {
+    @Test func `Reconcile forgets delete URL when server reports 404`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 404)
 
@@ -258,7 +258,7 @@ final class LiveActivityRegistryTests: OBATestCase {
         #expect(persistedDeleteURLs.isEmpty, "Expected a 404 (the subscription is already gone) to drop the persisted delete URL.")
     }
 
-    @Test func `Reconcile forgets delete URL when server reports410`() async {
+    @Test func `Reconcile forgets delete URL when server reports 410`() async {
         persistDeleteURLs([deadActivityID: deadDeleteURL.absoluteString])
         mockDeleteResponse(statusCode: 410)
 
@@ -364,7 +364,7 @@ final class LiveActivityRegistryTests: OBATestCase {
         let expectedURL = deadDeleteURL
 
         // Lets the mocked POST cancel the very task that issued it.
-        let tokenTask = UnsafeTaskBox()
+        let tokenTask = SendableBox<Task<Void, Never>?>(nil)
 
         let registrationBody = Data(#"{"url":"\#(deadDeleteURL.absoluteString)"}"#.utf8)
         dataLoader.mock(data: registrationBody, statusCode: 200) { request in
@@ -372,7 +372,7 @@ final class LiveActivityRegistryTests: OBATestCase {
             // The production race, made deterministic: the user dismisses the Live Activity while
             // its push token registration is still in flight, so the token task is cancelled after
             // the server has already created the row.
-            tokenTask.cancel()
+            tokenTask.value?.cancel()
             return true
         }
 
@@ -395,7 +395,7 @@ final class LiveActivityRegistryTests: OBATestCase {
                 confirm: { !Task.isCancelled }
             )
         }
-        tokenTask.set(task)
+        tokenTask.value = task
         gate.continuation.yield(())
         gate.continuation.finish()
         await task.value
@@ -429,26 +429,6 @@ final class LiveActivityRegistryTests: OBATestCase {
 
         #expect((error as? URLError)?.code == .cancelled, "Expected the mock to fail a request from a cancelled task with URLError.cancelled (-999), exactly as URLSession does.")
         #expect(recorder.urls.isEmpty, "A cancelled request is one the server never saw; the mock must not record it.")
-    }
-
-    /// Holds the task that a mocked response needs to cancel. `@unchecked Sendable` because the
-    /// matcher runs on whatever thread the request is issued from; the lock is the real guarantee.
-    ///
-    /// `nonisolated` for the same reason, and it has to be said explicitly: the
-    /// target defaults to main-actor isolation, so without it these methods are
-    /// main-actor and calling them from a matcher is the same runtime isolation
-    /// trap that `DeleteRecorder` hit.
-    private nonisolated final class UnsafeTaskBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var task: Task<Void, Never>?
-
-        func set(_ task: Task<Void, Never>) {
-            lock.withLock { self.task = task }
-        }
-
-        func cancel() {
-            lock.withLock { task }?.cancel()
-        }
     }
 
     // MARK: - Persistence contract

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -8,14 +8,14 @@
 //
 
 import Foundation
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 import Testing
 
 // swiftlintXdisable force_try
 
-class MapRegionManagerTests: OBATestCase {
+@Suite(.serialized)
+final class MapRegionManagerTests: OBATestCase {
     private var regionsFilePath: String { Bundle.main.path(forResource: "regions", ofType: "json")! }
 
     private func makeConfig(locationService: LocationService, bundledRegionsPath: String, dataLoader: MockDataLoader) -> AppConfig {
@@ -33,7 +33,7 @@ class MapRegionManagerTests: OBATestCase {
         )
     }
 
-    func test_init() {
+    @Test func `Init`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -66,7 +66,7 @@ class MapRegionManagerTests: OBATestCase {
     }
 
     /// When `currentRegion` is nil, `visibleMapRect` also returns `nil`.
-    func test_visibleMapRect_nilRegion() {
+    @Test func `Visible map rect nil region`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -91,7 +91,7 @@ class MapRegionManagerTests: OBATestCase {
     /// The shared zoom-in-warning predicate (used by both the UIKit map's
     /// `zoomInStatus` and the SwiftUI `MapPanelRootView`) shows the warning only
     /// when the visible map rect is taller than the stop-loading threshold.
-    func test_shouldShowZoomInWarning_thresholdBehavior() {
+    @Test func `Should show zoom in warning threshold behavior`() {
         // Comfortably above the 40,000-point threshold → warn.
         #expect(MapRegionManager.shouldShowZoomInWarning(forVisibleMapRectHeight: 100_000) == true)
         // Comfortably below → no warning.

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -33,7 +33,7 @@ final class MapRegionManagerTests: OBATestCase {
         )
     }
 
-    @Test func `Init`() {
+    @Test func initialization() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)

--- a/OBAKitTests/Controllers/AddBookmarkViewControllerTests.swift
+++ b/OBAKitTests/Controllers/AddBookmarkViewControllerTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -15,17 +15,18 @@ import Testing
 /// Locks down the `preloadedArrivals` short-circuit on `AddBookmarkViewController.loadData()`:
 /// when the parent screen already has arrivals in hand, the controller must reuse them and
 /// skip the `arrivals-and-departures-for-stop` REST call.
-class AddBookmarkViewControllerTests: OBATestCase {
+@Suite(.serialized)
+final class AddBookmarkViewControllerTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -68,7 +69,7 @@ class AddBookmarkViewControllerTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        return try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
     }
 
     /// Returns the count of recorded requests whose path identifies the
@@ -81,8 +82,8 @@ class AddBookmarkViewControllerTests: OBATestCase {
 
     // MARK: - Preloaded short-circuit
 
-    @MainActor
-    func test_loadData_withPreloadedArrivals_returnsThemWithoutNetworkFetch() async throws {
+    @Test @MainActor
+    func `Load data with preloaded arrivals returns them without network fetch`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let stop = try makeStop()
@@ -102,8 +103,8 @@ class AddBookmarkViewControllerTests: OBATestCase {
 
     // MARK: - Fallback to API
 
-    @MainActor
-    func test_loadData_withoutPreloadedArrivals_fetchesFromAPI() async throws {
+    @Test @MainActor
+    func `Load data without preloaded arrivals fetches from API`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let stop = try makeStop()

--- a/OBAKitTests/Controls/AlertPresenterTests.swift
+++ b/OBAKitTests/Controls/AlertPresenterTests.swift
@@ -8,24 +8,23 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class AlertPresenterTests: XCTestCase {
+@Suite(.serialized)
+final class AlertPresenterTests {
     
     var viewController: MockPresentingViewController!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         viewController = MockPresentingViewController()
     }
     
-    @MainActor
-    func test_showError_withError() async {
+    @Test @MainActor
+    func `Show error with error`() async {
         let error = TestError.testError
         
         await AlertPresenter.show(error: error, presentingController: viewController)
@@ -44,8 +43,8 @@ class AlertPresenterTests: XCTestCase {
         #expect(alertController.actions.first?.title == Strings.dismiss)
     }
     
-    @MainActor
-    func test_showError_withErrorMessage() async {
+    @Test @MainActor
+    func `Show error with error message`() async {
         let errorMessage = "Test error message"
         
         await AlertPresenter.show(errorMessage: errorMessage, presentingController: viewController)
@@ -64,8 +63,8 @@ class AlertPresenterTests: XCTestCase {
         #expect(alertController.actions.first?.title == Strings.dismiss)
     }
     
-    @MainActor
-    func test_showDismissableAlert() async {
+    @Test @MainActor
+    func `Show dismissable alert`() async {
         let title = "Test Title"
         let message = "Test Message"
         
@@ -86,8 +85,8 @@ class AlertPresenterTests: XCTestCase {
         #expect(alertController.preferredStyle == UIAlertController.Style.alert)
     }
     
-    @MainActor
-    func test_showDismissableAlert_withNilTitleAndMessage() async {
+    @Test @MainActor
+    func `Show dismissable alert with nil title and message`() async {
         await AlertPresenter.showDismissableAlert(title: nil, message: nil, presentingController: viewController)
         
         #expect(self.viewController.presentCallCount == 1)

--- a/OBAKitTests/Controls/BarButtonActivityIndicatorTests.swift
+++ b/OBAKitTests/Controls/BarButtonActivityIndicatorTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class BarButtonActivityIndicatorTests: XCTestCase {
+@Suite(.serialized)
+final class BarButtonActivityIndicatorTests {
     
-    func test_UIActivityIndicatorView_asNavigationItem() {
+    @Test func `UI activity indicator view as navigation item`() {
         let barButtonItem = UIActivityIndicatorView.asNavigationItem()
         
         #expect(type(of: barButtonItem) == UIBarButtonItem.self)

--- a/OBAKitTests/Controls/DataLoadFeedbackGeneratorTests.swift
+++ b/OBAKitTests/Controls/DataLoadFeedbackGeneratorTests.swift
@@ -8,27 +8,28 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
-class DataLoadFeedbackGeneratorTests: OBATestCase {
+@Suite(.serialized)
+final class DataLoadFeedbackGeneratorTests: OBATestCase {
     
     var feedbackGenerator: DataLoadFeedbackGenerator!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         feedbackGenerator = DataLoadFeedbackGenerator(userDefaults: userDefaults)
     }
     
-    func test_init_registersDefaults() {
+    @Test func `Init registers defaults`() {
         _ = DataLoadFeedbackGenerator(userDefaults: userDefaults)
         
         #expect(self.userDefaults.bool(forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey) == true)
     }
     
-    func test_init_withApplication() {
+    @Test func `Init with application`() {
         // Inject a MockDataLoader instead of the `AppConfig(appBundle:userDefaults:analytics:)`
         // convenience init, which defaults to `URLSession.shared`. `Application.init` calls
         // `regionsService.updateRegionsList()`, so that init would hit the live regions server.
@@ -52,7 +53,7 @@ class DataLoadFeedbackGeneratorTests: OBATestCase {
         _ = DataLoadFeedbackGenerator(application: application)
     }
     
-    func test_dataLoad_success() {
+    @Test func `Data load success`() {
         // Enable feedback
         userDefaults.set(true, forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey)
         
@@ -62,7 +63,7 @@ class DataLoadFeedbackGeneratorTests: OBATestCase {
         #expect(true)  // Test that it doesn't crash
     }
     
-    func test_dataLoad_failed() {
+    @Test func `Data load failed`() {
         // Enable feedback
         userDefaults.set(true, forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey)
         
@@ -72,7 +73,7 @@ class DataLoadFeedbackGeneratorTests: OBATestCase {
         #expect(true)  // Test that it doesn't crash
     }
     
-    func test_dataLoad_disabled() {
+    @Test func `Data load disabled`() {
         // Disable feedback
         userDefaults.set(false, forKey: DataLoadFeedbackGenerator.EnabledUserDefaultsKey)
         
@@ -83,7 +84,7 @@ class DataLoadFeedbackGeneratorTests: OBATestCase {
         #expect(true)  // Test that it doesn't crash
     }
     
-    func test_feedbackType_cases() {
+    @Test func `Feedback type cases`() {
         // Test that the enum cases exist
         let successType = DataLoadFeedbackGenerator.FeedbackType.success
         let failedType = DataLoadFeedbackGenerator.FeedbackType.failed

--- a/OBAKitTests/Controls/HighlightChangeLabelTests.swift
+++ b/OBAKitTests/Controls/HighlightChangeLabelTests.swift
@@ -8,41 +8,42 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
-class HighlightChangeLabelTests: OBATestCase {
+@Suite(.serialized)
+final class HighlightChangeLabelTests: OBATestCase {
     
     var label: HighlightChangeLabel!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         label = HighlightChangeLabel(frame: .zero)
     }
     
-    func test_init_setsContentPriorities() {
+    @Test func `Init sets content priorities`() {
         #expect(self.label.contentCompressionResistancePriority(for: .vertical) == .required)
         #expect(self.label.contentCompressionResistancePriority(for: .horizontal) == .required)
         #expect(self.label.contentHuggingPriority(for: .horizontal) == .required - 1)
         #expect(self.label.contentHuggingPriority(for: .vertical) == .required)
     }
     
-    func test_highlightedBackgroundColor_defaultValue() {
+    @Test func `Highlighted background color default value`() {
         #expect(self.label.highlightedBackgroundColor == ThemeColors.shared.propertyChanged)
     }
     
-    func test_highlightedBackgroundColor_canBeSet() {
+    @Test func `Highlighted background color can be set`() {
         let newColor = UIColor.red
         label.highlightedBackgroundColor = newColor
         
         #expect(self.label.highlightedBackgroundColor == newColor)
     }
     
-    func test_highlightBackground_triggersAnimation() {
+    @Test func `Highlight background triggers animation`() {
         // Set an initial background color
         let initialColor = UIColor.blue.cgColor
         label.layer.backgroundColor = initialColor
@@ -64,7 +65,7 @@ class HighlightChangeLabelTests: OBATestCase {
         }
     }
     
-    func test_configure_withArrivalDeparture() {
+    @Test func `Configure with arrival departure`() {
         // This test verifies that the configure method doesn't crash
         // We'll use minimal setup since model creation is complex
         _ = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar.current, themeColors: ThemeColors.shared)

--- a/OBAKitTests/Controls/ModalDelegateTests.swift
+++ b/OBAKitTests/Controls/ModalDelegateTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class ModalDelegateTests: XCTestCase {
+@Suite(.serialized)
+final class ModalDelegateTests {
     
-    func test_ModalDelegate_protocol() {
+    @Test func `Modal delegate protocol`() {
         // Test that a class can conform to ModalDelegate
         class TestModalDelegate: NSObject, ModalDelegate {
             var dismissedController: UIViewController?

--- a/OBAKitTests/Controls/PreviewableTests.swift
+++ b/OBAKitTests/Controls/PreviewableTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class PreviewableTests: XCTestCase {
+@Suite(.serialized)
+final class PreviewableTests {
     
-    func test_Previewable_protocol() {
+    @Test func `Previewable protocol`() {
         // Test that a class can conform to Previewable
         class TestPreviewableController: UIViewController, Previewable {
             var enteredPreviewMode = false
@@ -40,7 +40,7 @@ class PreviewableTests: XCTestCase {
         #expect(controller.exitedPreviewMode == true)
     }
     
-    func test_ControllerPreviewProvider_typealias() {
+    @Test func `Controller preview provider typealias`() {
         // Test that the typealias works correctly
         let provider: ControllerPreviewProvider = {
             return UIViewController()

--- a/OBAKitTests/Controls/StackedButtonTests.swift
+++ b/OBAKitTests/Controls/StackedButtonTests.swift
@@ -8,29 +8,28 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class StackedButtonTests: XCTestCase {
+@Suite(.serialized)
+final class StackedButtonTests {
     
     var stackedButton: StackedButton!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         stackedButton = StackedButton(frame: .zero)
     }
     
-    func test_init_setsDefaultProperties() {
+    @Test func `Init sets default properties`() {
         #expect(self.stackedButton.translatesAutoresizingMaskIntoConstraints == false)
         #expect(self.stackedButton.isUserInteractionEnabled == true)
         #expect(self.stackedButton.backgroundColor == .clear)
     }
     
-    func test_title_getterAndSetter() {
+    @Test func `Title getter and setter`() {
         let testTitle = "Test Button"
         stackedButton.title = testTitle
         
@@ -39,7 +38,7 @@ class StackedButtonTests: XCTestCase {
         #expect(self.stackedButton.accessibilityLabel == testTitle)
     }
     
-    func test_title_nilValue() {
+    @Test func `Title nil value`() {
         stackedButton.title = nil
         
         #expect(self.stackedButton.title == nil)
@@ -47,7 +46,7 @@ class StackedButtonTests: XCTestCase {
         #expect(self.stackedButton.accessibilityLabel == nil)
     }
     
-    func test_textLabel_properties() {
+    @Test func `Text label properties`() {
         let textLabel = stackedButton.textLabel
         
         #expect(textLabel.numberOfLines == 1)
@@ -60,7 +59,7 @@ class StackedButtonTests: XCTestCase {
         #expect(textLabel.font == UIFont.preferredFont(forTextStyle: .footnote).bold)
     }
     
-    func test_imageView_properties() {
+    @Test func `Image view properties`() {
         let imageView = stackedButton.imageView
         
         #expect(imageView.contentMode == .scaleAspectFit)
@@ -71,14 +70,14 @@ class StackedButtonTests: XCTestCase {
         #expect(imageView.tintColor == ThemeColors.shared.brand)
     }
     
-    func test_imageView_canSetImage() {
+    @Test func `Image view can set image`() {
         let testImage = UIImage(systemName: "star")
         stackedButton.imageView.image = testImage
         
         #expect(self.stackedButton.imageView.image == testImage)
     }
     
-    func test_stackView_configuration() {
+    @Test func `Stack view configuration`() {
         // Check that the button has the expected subview structure
         #expect(self.stackedButton.subviews.count == 1)
         

--- a/OBAKitTests/Controls/StackedMarqueeTitleViewTests.swift
+++ b/OBAKitTests/Controls/StackedMarqueeTitleViewTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 import MarqueeLabel
@@ -16,29 +15,29 @@ import MarqueeLabel
 @testable import OBAKitCore
 
 @MainActor
-class StackedMarqueeTitleViewTests: XCTestCase {
+@Suite(.serialized)
+final class StackedMarqueeTitleViewTests {
     
     var titleView: StackedMarqueeTitleView!
     let testWidth: CGFloat = 200.0
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         titleView = StackedMarqueeTitleView(width: testWidth)
     }
     
-    func test_init_createsLabels() {
+    @Test func `Init creates labels`() {
         #expect(self.titleView != nil)
         #expect(type(of: self.titleView.topLabel) == MarqueeLabel.self)
         #expect(type(of: self.titleView.bottomLabel) == MarqueeLabel.self)
     }
     
-    func test_init_addsLabelsAsSubviews() {
+    @Test func `Init adds labels as subviews`() {
         #expect(self.titleView.subviews.count == 2)
         #expect(self.titleView.subviews.contains(self.titleView.topLabel))
         #expect(self.titleView.subviews.contains(self.titleView.bottomLabel))
     }
     
-    func test_topLabel_configuration() {
+    @Test func `Top label configuration`() {
         let topLabel = titleView.topLabel
         
         #expect(topLabel.frame.width == testWidth)
@@ -50,7 +49,7 @@ class StackedMarqueeTitleViewTests: XCTestCase {
         #expect(topLabel.fadeLength == ThemeMetrics.padding)
     }
     
-    func test_bottomLabel_configuration() {
+    @Test func `Bottom label configuration`() {
         let bottomLabel = titleView.bottomLabel
         
         #expect(bottomLabel.frame.width == testWidth)
@@ -62,13 +61,13 @@ class StackedMarqueeTitleViewTests: XCTestCase {
         #expect(bottomLabel.fadeLength == ThemeMetrics.padding)
     }
     
-    func test_labels_positioning() {
+    @Test func `Labels positioning`() {
         // Bottom label should be positioned below top label
         #expect(self.titleView.bottomLabel.frame.origin.y == self.titleView.topLabel.frame.maxY)
         #expect(self.titleView.topLabel.frame.origin.y == 0)
     }
     
-    func test_frame_sizing() {
+    @Test func `Frame sizing`() {
         let expectedHeight = titleView.topLabel.frame.height + titleView.bottomLabel.frame.height
         #expect(self.titleView.frame.width == testWidth)
         #expect(self.titleView.frame.height == expectedHeight)

--- a/OBAKitTests/Controls/StackedTitleViewTests.swift
+++ b/OBAKitTests/Controls/StackedTitleViewTests.swift
@@ -8,27 +8,26 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class StackedTitleViewTests: XCTestCase {
+@Suite(.serialized)
+final class StackedTitleViewTests {
     
     var stackedTitleView: StackedTitleView!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         stackedTitleView = StackedTitleView(frame: .zero)
     }
     
-    func test_init_createsLabels() {
+    @Test func `Init creates labels`() {
         #expect(type(of: self.stackedTitleView.titleLabel) == UILabel.self)
         #expect(type(of: self.stackedTitleView.subtitleLabel) == UILabel.self)
     }
     
-    func test_titleLabel_properties() {
+    @Test func `Title label properties`() {
         let titleLabel = stackedTitleView.titleLabel
         
         #expect(titleLabel.textAlignment == .center)
@@ -38,7 +37,7 @@ class StackedTitleViewTests: XCTestCase {
         #expect(titleLabel.contentHuggingPriority(for: .horizontal) == .defaultLow)
     }
     
-    func test_subtitleLabel_properties() {
+    @Test func `Subtitle label properties`() {
         let subtitleLabel = stackedTitleView.subtitleLabel
         
         #expect(subtitleLabel.textAlignment == .center)
@@ -48,7 +47,7 @@ class StackedTitleViewTests: XCTestCase {
         #expect(subtitleLabel.contentHuggingPriority(for: .horizontal) == .defaultLow)
     }
     
-    func test_stackView_configuration() {
+    @Test func `Stack view configuration`() {
         // Access the stack view indirectly by checking the subviews
         #expect(self.stackedTitleView.subviews.count == 1)
         let stackView = self.stackedTitleView.subviews.first as? UIStackView
@@ -58,7 +57,7 @@ class StackedTitleViewTests: XCTestCase {
         #expect(stackView?.arrangedSubviews.last === self.stackedTitleView.subtitleLabel)
     }
     
-    func test_titleAndSubtitle_canBeSet() {
+    @Test func `Title and subtitle can be set`() {
         stackedTitleView.titleLabel.text = "Test Title"
         stackedTitleView.subtitleLabel.text = "Test Subtitle"
         

--- a/OBAKitTests/Controls/TaskButtonTests.swift
+++ b/OBAKitTests/Controls/TaskButtonTests.swift
@@ -8,16 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import SwiftUI
 @testable import OBAKit
 
-@available(iOS 14.0, *)
 @MainActor
-class TaskButtonTests: XCTestCase {
+@Suite(.serialized)
+final class TaskButtonTests {
     
-    func test_ActionOption_allCases() {
+    @Test func `Action option all cases`() {
         let allCases = TaskButton<Text>.ActionOption.allCases
         
         #expect(allCases.count == 2)
@@ -25,12 +24,12 @@ class TaskButtonTests: XCTestCase {
         #expect(allCases.contains(.showProgressView))
     }
     
-    func test_TaskButton_withText_init() {
+    @Test func `Task button with text init`() {
         let testAction: () async -> Void = { }
         _ = TaskButton("Test Button", action: testAction)
     }
     
-    func test_TaskButton_withText_customActionOptions() {
+    @Test func `Task button with text custom action options`() {
         let testAction: () async -> Void = { }
         let customOptions: Set<TaskButton<Text>.ActionOption> = [.disableButton]
         let button = TaskButton("Test Button", actionOptions: customOptions, action: testAction)
@@ -38,12 +37,12 @@ class TaskButtonTests: XCTestCase {
         #expect(button.actionOptions == customOptions)
     }
 
-    func test_TaskButton_withImage_init() {
+    @Test func `Task button with image init`() {
         let testAction: () async -> Void = { }
         _ = TaskButton(systemImageName: "star", action: testAction)
     }
     
-    func test_TaskButton_withImage_customActionOptions() {
+    @Test func `Task button with image custom action options`() {
         let testAction: () async -> Void = { }
         let customOptions: Set<TaskButton<Image>.ActionOption> = [.showProgressView]
         let button = TaskButton(systemImageName: "star", actionOptions: customOptions, action: testAction)
@@ -51,7 +50,7 @@ class TaskButtonTests: XCTestCase {
         #expect(button.actionOptions == customOptions)
     }
     
-    func test_TaskButton_genericInit() {
+    @Test func `Task button generic init`() {
         let testAction: () async -> Void = { }
         let button = TaskButton(action: testAction) {
             Text("Custom Label")

--- a/OBAKitTests/Controls/UIImageShadowTests.swift
+++ b/OBAKitTests/Controls/UIImageShadowTests.swift
@@ -8,16 +8,16 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 import CoreGraphics
 @testable import OBAKit
 
 @MainActor
-class UIImageShadowTests: XCTestCase {
+@Suite(.serialized)
+final class UIImageShadowTests {
     
-    func test_Shadow_struct() {
+    @Test func `Shadow struct`() {
         let offset = CGSize(width: 1, height: 2)
         let blur: CGFloat = 5.0
         let color = UIColor.black
@@ -29,7 +29,7 @@ class UIImageShadowTests: XCTestCase {
         #expect(shadow.color == color)
     }
     
-    func test_UIImage_resizableShadowImage_basic() {
+    @Test func `UI image resizable shadow image basic`() {
         let sideLength: CGFloat = 50.0
         let cornerRadius: CGFloat = 10.0
         let shadow = Shadow(offset: .zero, blur: 5.0, color: .black)
@@ -52,7 +52,7 @@ class UIImageShadowTests: XCTestCase {
         #expect(shadowImage.resizingMode == .tile)
     }
     
-    func test_UIImage_resizableShadowImage_withCapInsets() {
+    @Test func `UI image resizable shadow image with cap insets`() {
         let sideLength: CGFloat = 40.0
         let cornerRadius: CGFloat = 8.0
         let shadow = Shadow(offset: CGSize(width: 2, height: 2), blur: 3.0, color: .gray)
@@ -74,7 +74,7 @@ class UIImageShadowTests: XCTestCase {
         #expect(shadowImage.capInsets.right > 0)
     }
     
-    func test_UIImage_resizableShadowImage_differentParameters() {
+    @Test func `UI image resizable shadow image different parameters`() {
         // Test with different parameters to ensure robustness
         let shadows = [
             Shadow(offset: .zero, blur: 0.0, color: .clear),
@@ -95,7 +95,7 @@ class UIImageShadowTests: XCTestCase {
         }
     }
     
-    func test_UIImage_resizableShadowImage_zeroCornerRadius() {
+    @Test func `UI image resizable shadow image zero corner radius`() {
         let sideLength: CGFloat = 60.0
         let cornerRadius: CGFloat = 0.0 // No rounded corners
         let shadow = Shadow(offset: CGSize(width: 1, height: 1), blur: 4.0, color: .black)
@@ -117,7 +117,7 @@ class UIImageShadowTests: XCTestCase {
         #expect(shadowImage.capInsets.right == shadow.blur)
     }
     
-    func test_UIImage_resizableShadowImage_imageSizeCalculation() {
+    @Test func `UI image resizable shadow image image size calculation`() {
         let sideLength: CGFloat = 100.0
         let cornerRadius: CGFloat = 15.0
         let blur: CGFloat = 8.0

--- a/OBAKitTests/Controls/VisualEffectContainerViewTests.swift
+++ b/OBAKitTests/Controls/VisualEffectContainerViewTests.swift
@@ -8,29 +8,28 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class VisualEffectContainerViewTests: XCTestCase {
+@Suite(.serialized)
+final class VisualEffectContainerViewTests {
     
     var containerView: VisualEffectContainerView!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         let blurEffect = UIBlurEffect(style: .regular)
         containerView = VisualEffectContainerView(blurEffect: blurEffect)
     }
     
-    func test_init_createsEffectView() {
+    @Test func `Init creates effect view`() {
         #expect(self.containerView != nil)
         #expect(self.containerView.subviews.count == 1)
         #expect(self.containerView.subviews.first.map { type(of: $0) == UIVisualEffectView.self } == true)
     }
     
-    func test_contentView_isEffectViewContentView() {
+    @Test func `Content view is effect view content view`() {
         let contentView = containerView.contentView
         
         // Verify it's the content view from the visual effect view
@@ -38,7 +37,7 @@ class VisualEffectContainerViewTests: XCTestCase {
         #expect(contentView === effectView?.contentView)
     }
     
-    func test_addingSubviewsToContentView() {
+    @Test func `Adding subviews to content view`() {
         let testLabel = UILabel()
         testLabel.text = "Test Label"
         
@@ -48,7 +47,7 @@ class VisualEffectContainerViewTests: XCTestCase {
         #expect(self.containerView.contentView.subviews.first === testLabel)
     }
     
-    func test_visualEffectViewConstraints() {
+    @Test func `Visual effect view constraints`() {
         // Verify the effect view is properly constrained
         let effectView = containerView.subviews.first as? UIVisualEffectView
         #expect(effectView?.translatesAutoresizingMaskIntoConstraints == false)

--- a/OBAKitTests/Controls/VisualEffectViewControllerTests.swift
+++ b/OBAKitTests/Controls/VisualEffectViewControllerTests.swift
@@ -8,45 +8,44 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class VisualEffectViewControllerTests: XCTestCase {
+@Suite(.serialized)
+final class VisualEffectViewControllerTests {
     
     var viewController: VisualEffectViewController!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         viewController = VisualEffectViewController()
     }
     
-    func test_init_setsUpView() {
+    @Test func `Init sets up view`() {
         #expect(self.viewController != nil)
         #expect(self.viewController.view != nil)
     }
     
-    func test_viewDidLoad_setsUpVisualEffectView() {
+    @Test func `View did load sets up visual effect view`() {
         viewController.viewDidLoad()
         
         #expect(self.viewController.view.subviews.contains(self.viewController.visualEffectView))
         #expect(self.viewController.view.backgroundColor == UIColor.clear)
     }
     
-    func test_visualEffectView_isAccessible() {
+    @Test func `Visual effect view is accessible`() {
         let visualEffectView = viewController.visualEffectView
         #expect(type(of: visualEffectView) == UIVisualEffectView.self)
     }
     
-    func test_contentView_throughVisualEffectView() {
+    @Test func `Content view through visual effect view`() {
         // Test that visualEffectView has a content view  
         let visualEffectView = viewController.visualEffectView
         #expect(type(of: visualEffectView) == UIVisualEffectView.self)
     }
     
-    func test_addingSubviewsToContentView() {
+    @Test func `Adding subviews to content view`() {
         // Trigger viewDidLoad to ensure view is set up
         _ = viewController.view
         

--- a/OBAKitTests/Donations/DonationsManagerTests.swift
+++ b/OBAKitTests/Donations/DonationsManagerTests.swift
@@ -18,7 +18,9 @@ import Testing
 /// instances by path and would otherwise return a previously-created fake.
 // `Bundle` is already `@unchecked Sendable`; a subclass has to restate it or the
 // compiler warns. Mutated only from the test that owns the instance.
-private class DonationsConfigBundle: Bundle, @unchecked Sendable {
+// `nonisolated`: overrides nonisolated Bundle members, which the
+// target's main-actor default isolation would conflict with.
+private nonisolated class DonationsConfigBundle: Bundle, @unchecked Sendable {
     var donationsEnabledValue = true
 
     override func object(forInfoDictionaryKey key: String) -> Any? {

--- a/OBAKitTests/Donations/DonationsManagerTests.swift
+++ b/OBAKitTests/Donations/DonationsManagerTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -31,13 +31,14 @@ private class DonationsConfigBundle: Bundle, @unchecked Sendable {
     static func create(donationsEnabled: Bool) throws -> DonationsConfigBundle {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let bundle = try XCTUnwrap(DonationsConfigBundle(path: dir.path))
+        let bundle = try #require(DonationsConfigBundle(path: dir.path))
         bundle.donationsEnabledValue = donationsEnabled
         return bundle
     }
 }
 
-class DonationsManagerTests: OBATestCase {
+@Suite(.serialized)
+final class DonationsManagerTests: OBATestCase {
 
     private func buildManager(appLaunchCount: Int, donationsEnabled: Bool = true) throws -> DonationsManager {
         DonationsManager(
@@ -51,47 +52,47 @@ class DonationsManagerTests: OBATestCase {
 
     // MARK: - Launch Count Gating
 
-    func test_shouldRequestDonations_firstLaunch_isFalse() throws {
+    @Test func `Should request donations first launch is false`() throws {
         let manager = try buildManager(appLaunchCount: 1)
         #expect(manager.shouldRequestDonations == false)
     }
 
-    func test_shouldRequestDonations_secondLaunch_isFalse() throws {
+    @Test func `Should request donations second launch is false`() throws {
         let manager = try buildManager(appLaunchCount: 2)
         #expect(manager.shouldRequestDonations == false)
     }
 
-    func test_shouldRequestDonations_thirdLaunch_isTrue() throws {
+    @Test func `Should request donations third launch is true`() throws {
         let manager = try buildManager(appLaunchCount: 3)
         #expect(manager.shouldRequestDonations == true)
     }
 
-    func test_shouldRequestDonations_laterLaunches_isTrue() throws {
+    @Test func `Should request donations later launches is true`() throws {
         let manager = try buildManager(appLaunchCount: 100)
         #expect(manager.shouldRequestDonations == true)
     }
 
     // MARK: - Composition with Other Gates
 
-    func test_shouldRequestDonations_thirdLaunch_dismissed_isFalse() throws {
+    @Test func `Should request donations third launch dismissed is false`() throws {
         let manager = try buildManager(appLaunchCount: 3)
         manager.dismissDonationsRequests()
         #expect(manager.shouldRequestDonations == false)
     }
 
-    func test_shouldRequestDonations_thirdLaunch_futureReminder_isFalse() throws {
+    @Test func `Should request donations third launch future reminder is false`() throws {
         let manager = try buildManager(appLaunchCount: 3)
         manager.remindUserLater()
         #expect(manager.shouldRequestDonations == false)
     }
 
-    func test_shouldRequestDonations_thirdLaunch_pastReminder_isTrue() throws {
+    @Test func `Should request donations third launch past reminder is true`() throws {
         let manager = try buildManager(appLaunchCount: 3)
         manager.donationRequestReminderDate = Date(timeIntervalSinceNow: -3600)
         #expect(manager.shouldRequestDonations == true)
     }
 
-    func test_shouldRequestDonations_donationsDisabled_isFalse() throws {
+    @Test func `Should request donations donations disabled is false`() throws {
         let manager = try buildManager(appLaunchCount: 3, donationsEnabled: false)
         #expect(manager.shouldRequestDonations == false)
     }

--- a/OBAKitTests/Extensions/AutoLayoutExtensionsTests.swift
+++ b/OBAKitTests/Extensions/AutoLayoutExtensionsTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKitCore
 
 @MainActor
-class AutoLayoutExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class AutoLayoutExtensionsTests {
     
-    func test_UIView_layoutDirectionIsRTL() {
+    @Test func `UI view layout direction is RTL`() {
         let view = UIView()
         
         // For most locales, this should be false
@@ -28,7 +28,7 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(view.layoutDirectionIsRTL == true)
     }
     
-    func test_UIView_layoutDirectionIsLTR() {
+    @Test func `UI view layout direction is LTR`() {
         let view = UIView()
         
         // For most locales, this should be true
@@ -44,14 +44,14 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(view.layoutDirectionIsLTR == true)
     }
     
-    func test_UIView_autolayoutNew() {
+    @Test func `UI view autolayout new`() {
         let view = UIView.autolayoutNew()
         
         #expect(view.translatesAutoresizingMaskIntoConstraints == false)
         #expect(view.frame == .zero)
     }
     
-    func test_UILabel_autolayoutNew() {
+    @Test func `UI label autolayout new`() {
         let label = UILabel.autolayoutNew()
         
         #expect(label.translatesAutoresizingMaskIntoConstraints == false)
@@ -59,7 +59,7 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(type(of: label) == UILabel.self)
     }
     
-    func test_UIView_spacerView() {
+    @Test func `UI view spacer view`() {
         let height: CGFloat = 20.0
         let spacer = UIView.spacerView(height: height)
         
@@ -72,7 +72,7 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(heightConstraints.count == 1)
     }
     
-    func test_UIView_embedInWrapperView_withConstraints() {
+    @Test func `UI view embed in wrapper view with constraints`() {
         let childView = UIView()
         let wrapper = childView.embedInWrapperView(setConstraints: true)
         
@@ -82,7 +82,7 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(childView.superview === wrapper)
     }
     
-    func test_UIView_embedInWrapperView_withoutConstraints() {
+    @Test func `UI view embed in wrapper view without constraints`() {
         let childView = UIView()
         let wrapper = childView.embedInWrapperView(setConstraints: false)
         
@@ -92,14 +92,14 @@ class AutoLayoutExtensionsTests: XCTestCase {
         #expect(childView.superview === wrapper)
     }
     
-    func test_AutoLayoutPinTarget_cases() {
+    @Test func `Auto layout pin target cases`() {
         #expect(UIView.AutoLayoutPinTarget.edges.rawValue == 0)
         #expect(UIView.AutoLayoutPinTarget.layoutMargins.rawValue == 1)
         #expect(UIView.AutoLayoutPinTarget.readableContent.rawValue == 2)
         #expect(UIView.AutoLayoutPinTarget.safeArea.rawValue == 3)
     }
     
-    func test_LayoutConstraints_struct() {
+    @Test func `Layout constraints struct`() {
         let view = UIView()
         let superview = UIView()
         superview.addSubview(view)

--- a/OBAKitTests/Extensions/CodableExtensionsTests.swift
+++ b/OBAKitTests/Extensions/CodableExtensionsTests.swift
@@ -8,12 +8,12 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKitCore
 
 @MainActor
-class CodableExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class CodableExtensionsTests {
     
     struct TestStruct: Codable {
         let validURL: URL?
@@ -35,7 +35,7 @@ class CodableExtensionsTests: XCTestCase {
         }
     }
     
-    func test_decodeGarbageURL_validURL() throws {
+    @Test func `Decode garbage URL valid URL`() throws {
         let json = """
         {
             "validURL": "https://example.com",
@@ -55,7 +55,7 @@ class CodableExtensionsTests: XCTestCase {
         #expect(result.nilURL == nil)  // Null value becomes nil
     }
     
-    func test_decodeGarbageURL_missingKey() throws {
+    @Test func `Decode garbage URL missing key`() throws {
         let json = """
         {
             "validURL": "https://example.com"
@@ -72,7 +72,7 @@ class CodableExtensionsTests: XCTestCase {
         #expect(result.nilURL == nil)
     }
     
-    func test_decodeGarbageURL_whitespaceURL() throws {
+    @Test func `Decode garbage URL whitespace URL`() throws {
         let json = """
         {
             "blankURL": "   ",
@@ -88,7 +88,7 @@ class CodableExtensionsTests: XCTestCase {
         #expect(result.blankURL == nil)  // Whitespace-only string should become nil
     }
     
-    func test_decodeGarbageURL_malformedURL() throws {
+    @Test func `Decode garbage URL malformed URL`() throws {
         let json = """
         {
             "invalidURL": "http://[malformed",
@@ -104,7 +104,7 @@ class CodableExtensionsTests: XCTestCase {
         #expect(result.invalidURL == nil)  // Malformed URL becomes nil
     }
     
-    func test_decodeGarbageURL_pathURL() throws {
+    @Test func `Decode garbage URL path URL`() throws {
         let json = """
         {
             "validURL": "/path/to/resource"

--- a/OBAKitTests/Extensions/CollectionsTests.swift
+++ b/OBAKitTests/Extensions/CollectionsTests.swift
@@ -25,7 +25,7 @@ final class CollectionsTests {
         #expect(array.contains("three"))
     }
 
-    @Test func `Filter`() {
+    @Test func filter() {
         let list: [Any] = [1, "two", 3, "four", 5]
         let filtered = list.filter(type: Int.self)
         #expect(filtered == [1, 3, 5])

--- a/OBAKitTests/Extensions/CollectionsTests.swift
+++ b/OBAKitTests/Extensions/CollectionsTests.swift
@@ -9,14 +9,14 @@
 
 import Foundation
 import Testing
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class CollectionsTests: XCTestCase {
+@Suite(.serialized)
+final class CollectionsTests {
 
-    func test_set_allObjects() {
+    @Test func `Set all objects`() {
         let mySet: Set = ["one", "two", "three"]
         let array = mySet.allObjects
 
@@ -25,7 +25,7 @@ class CollectionsTests: XCTestCase {
         #expect(array.contains("three"))
     }
 
-    func testFilter() {
+    @Test func `Filter`() {
         let list: [Any] = [1, "two", 3, "four", 5]
         let filtered = list.filter(type: Int.self)
         #expect(filtered == [1, 3, 5])

--- a/OBAKitTests/Extensions/CoreGraphicsExtensionsTests.swift
+++ b/OBAKitTests/Extensions/CoreGraphicsExtensionsTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import CoreGraphics
 import UIKit
@@ -16,9 +15,10 @@ import UIKit
 @testable import OBAKitCore
 
 @MainActor
-class CoreGraphicsExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class CoreGraphicsExtensionsTests {
     
-    func test_CGContext_pushPop() {
+    @Test func `CG context push pop`() {
         // Create a simple graphics context for testing
         let size = CGSize(width: 100, height: 100)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
@@ -46,7 +46,7 @@ class CoreGraphicsExtensionsTests: XCTestCase {
         #expect(restoredTransform.ty == initialTransform.ty)
     }
     
-    func test_CGContext_pushPop_nested() {
+    @Test func `CG context push pop nested`() {
         let size = CGSize(width: 100, height: 100)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let context = CGContext(data: nil, width: Int(size.width), height: Int(size.height), bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
@@ -78,7 +78,7 @@ class CoreGraphicsExtensionsTests: XCTestCase {
         #expect(finalTransform.ty == initialTransform.ty)
     }
     
-    func test_CGContext_pushPop_doesNotCrash() {
+    @Test func `CG context push pop does not crash`() {
         let size = CGSize(width: 100, height: 100)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let context = CGContext(data: nil, width: Int(size.width), height: Int(size.height), bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)

--- a/OBAKitTests/Extensions/CoreLocationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/CoreLocationExtensionsTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import CoreLocation
 import MapKit
 import CoreGraphics
@@ -16,9 +15,10 @@ import Testing
 @testable import OBAKitCore
 
 @MainActor
-class CoreLocationExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class CoreLocationExtensionsTests {
     
-    func test_CLAuthorizationStatus_description() {
+    @Test func `CL authorization status description`() {
         #expect(CLAuthorizationStatus.authorizedAlways.description == "authorizedAlways")
         #expect(CLAuthorizationStatus.authorizedWhenInUse.description == "authorizedWhenInUse")
         #expect(CLAuthorizationStatus.denied.description == "denied")
@@ -26,14 +26,14 @@ class CoreLocationExtensionsTests: XCTestCase {
         #expect(CLAuthorizationStatus.restricted.description == "restricted")
     }
     
-    func test_CLAuthorizationStatus_initFromString() {
+    @Test func `CL authorization status init from string`() {
         // LosslessStringConvertible init always returns nil as implemented
         #expect(CLAuthorizationStatus("authorizedAlways") == nil)
         #expect(CLAuthorizationStatus("denied") == nil)
         #expect(CLAuthorizationStatus("invalid") == nil)
     }
     
-    func test_CLLocationDirection_radians() {
+    @Test func `CL location direction radians`() {
         let direction: CLLocationDirection = 180.0 // 180 degrees
         let expectedRadians = Double.pi // π radians
         
@@ -46,7 +46,7 @@ class CoreLocationExtensionsTests: XCTestCase {
         expectClose(direction0.radians, 0.0, within: 0.0001)
     }
     
-    func test_CLLocationDirection_affineTransform() {
+    @Test func `CL location direction affine transform`() {
         let direction: CLLocationDirection = 90.0 // 90 degrees
         let additionalRotation: CGFloat = CGFloat.pi / 4 // 45 degrees
         
@@ -60,7 +60,7 @@ class CoreLocationExtensionsTests: XCTestCase {
         #expect(type(of: transform0) == CGAffineTransform.self)
     }
     
-    func test_CLLocationCoordinate2D_distance() {
+    @Test func `CL location coordinate2 d distance`() {
         let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         let bellevue = CLLocationCoordinate2D(latitude: 47.6101, longitude: -122.2015)
         
@@ -74,7 +74,7 @@ class CoreLocationExtensionsTests: XCTestCase {
         expectClose(samePointDistance, 0, within: 0.1)
     }
     
-    func test_CLLocationCoordinate2D_isNullIsland() {
+    @Test func `CL location coordinate2 d is null island`() {
         let nullIsland = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
         #expect(nullIsland.isNullIsland == true)
         
@@ -88,7 +88,7 @@ class CoreLocationExtensionsTests: XCTestCase {
         #expect(otherZero.isNullIsland == false)
     }
     
-    func test_CLCircularRegion_initWithMapRect() {
+    @Test func `CL circular region init with map rect`() {
         let mapRect = MKMapRect(
             x: 43013871.99811534,
             y: 93728205.2278356,

--- a/OBAKitTests/Extensions/CoreLocationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/CoreLocationExtensionsTests.swift
@@ -60,7 +60,7 @@ final class CoreLocationExtensionsTests {
         #expect(type(of: transform0) == CGAffineTransform.self)
     }
     
-    @Test func `CL location coordinate2 d distance`() {
+    @Test func `CL location coordinate 2 d distance`() {
         let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         let bellevue = CLLocationCoordinate2D(latitude: 47.6101, longitude: -122.2015)
         
@@ -74,7 +74,7 @@ final class CoreLocationExtensionsTests {
         expectClose(samePointDistance, 0, within: 0.1)
     }
     
-    @Test func `CL location coordinate2 d is null island`() {
+    @Test func `CL location coordinate 2 d is null island`() {
         let nullIsland = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
         #expect(nullIsland.isNullIsland == true)
         

--- a/OBAKitTests/Extensions/CoreLocationTests.swift
+++ b/OBAKitTests/Extensions/CoreLocationTests.swift
@@ -8,18 +8,18 @@
 //
 
 import Foundation
-import XCTest
 import CoreLocation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class CoreLocationTests: XCTestCase {
+@Suite(.serialized)
+final class CoreLocationTests {
 
     // MARK: - CLCircularRegion
 
-    func test_creation_fromMapRect() {
+    @Test func `Creation from map rect`() {
         let region = CLCircularRegion(mapRect: TestData.seattleMapRect)
 
         expectClose(region.center.latitude, TestData.seattleMapRectCenter.latitude)
@@ -29,7 +29,7 @@ class CoreLocationTests: XCTestCase {
 
     // MARK: - Distance
 
-    func test_distanceCalculation() {
+    @Test func `Distance calculation`() {
         let pt1 = CLLocationCoordinate2D(latitude: 47.62365100, longitude: -122.31257200)
         let pt2 = CLLocationCoordinate2D(latitude: 47.632352, longitude: -122.312526)
 

--- a/OBAKitTests/Extensions/DispatchExtensionsTests.swift
+++ b/OBAKitTests/Extensions/DispatchExtensionsTests.swift
@@ -8,34 +8,36 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKit
 
 @MainActor
-class DispatchExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class DispatchExtensionsTests {
     
-    func test_debounce_executesAction() {
-        let expectation = self.expectation(description: "Debounce executes action")
-        
-        DispatchQueue.main.debounce(interval: 0.1) {
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1.0)
-    }
-    
-    func test_throttle_executesAction() {
-        let expectation = self.expectation(description: "Throttle executes action")
+    // These three genuinely wait on a dispatch callback, so — unlike the
+    // handler tests elsewhere — they cannot collapse into a bare
+    // `confirmation`. `poll` is the repo's replacement for "wait until this
+    // becomes true", and it returns as soon as the condition holds rather than
+    // burning the full timeout the way `waitForExpectations` did.
 
-        DispatchQueue.main.throttle(deadline: .now() + 0.1) {
-            expectation.fulfill()
-        }
+    @Test func `Debounce executes action`() async {
+        var ran = false
 
-        waitForExpectations(timeout: 1.0)
+        DispatchQueue.main.debounce(interval: 0.1) { ran = true }
+
+        await poll(until: { ran }, "debounced action should have run")
     }
 
-    func test_debounce_suppressesSecondCallWithinInterval() {
-        let expectation = self.expectation(description: "Debounced action runs exactly once")
+    @Test func `Throttle executes action`() async {
+        var ran = false
+
+        DispatchQueue.main.throttle(deadline: .now() + 0.1) { ran = true }
+
+        await poll(until: { ran }, "throttled action should have run")
+    }
+
+    @Test func `Debounce suppresses second call within interval`() async throws {
         var count = 0
 
         // Unique context: the debounce bookkeeping is global and would otherwise
@@ -44,11 +46,11 @@ class DispatchExtensionsTests: XCTestCase {
         DispatchQueue.main.debounce(interval: 0.5, context: context) { count += 1 }
         DispatchQueue.main.debounce(interval: 0.5, context: context) { count += 1 }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            XCTAssertEqual(count, 1)
-            expectation.fulfill()
-        }
+        // Deliberately a fixed wait rather than a poll: the assertion is that a
+        // second call never lands, and polling for "count == 1" would pass the
+        // instant the first one did — before the suppressed one could show up.
+        try await Task.sleep(for: .milliseconds(200))
 
-        waitForExpectations(timeout: 1.0)
+        #expect(count == 1)
     }
 }

--- a/OBAKitTests/Extensions/DispatchExtensionsTests.swift
+++ b/OBAKitTests/Extensions/DispatchExtensionsTests.swift
@@ -17,9 +17,10 @@ final class DispatchExtensionsTests {
     
     // These three genuinely wait on a dispatch callback, so — unlike the
     // handler tests elsewhere — they cannot collapse into a bare
-    // `confirmation`. `poll` is the repo's replacement for "wait until this
-    // becomes true", and it returns as soon as the condition holds rather than
-    // burning the full timeout the way `waitForExpectations` did.
+    // `confirmation`. The first two use `poll`, the repo's replacement for
+    // "wait until this becomes true", which returns as soon as the condition
+    // holds rather than burning the full timeout the way `waitForExpectations`
+    // did. The third deliberately keeps a fixed wait; see its own comment.
 
     @Test func `Debounce executes action`() async {
         var ran = false

--- a/OBAKitTests/Extensions/FoundationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/FoundationExtensionsTests.swift
@@ -174,7 +174,9 @@ final class FoundationExtensionsTests {
 /// so these tests don't depend on the host app's Info.plist.
 // `Bundle` is already `@unchecked Sendable`; a subclass has to restate it or the
 // compiler warns. Mutated only from the test that owns the instance.
-private class FeedbackConfigBundle: Bundle, @unchecked Sendable {
+// `nonisolated`: overrides nonisolated Bundle members, which the
+// target's main-actor default isolation would conflict with.
+private nonisolated class FeedbackConfigBundle: Bundle, @unchecked Sendable {
     var config: [AnyHashable: Any] = [:]
 
     override func object(forInfoDictionaryKey key: String) -> Any? {

--- a/OBAKitTests/Extensions/FoundationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/FoundationExtensionsTests.swift
@@ -8,12 +8,12 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKitCore
 
 @MainActor
-class FoundationExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class FoundationExtensionsTests {
 
     // MARK: - Error.isCancellation
 
@@ -21,7 +21,7 @@ class FoundationExtensionsTests: XCTestCase {
     /// surfaced (e.g. `TripViewModel`), so misclassification in either
     /// direction is user-visible: swallow a real error, or alert on every
     /// dismissed context-menu preview.
-    func test_error_isCancellation() {
+    @Test func `Error is cancellation`() {
         #expect(CancellationError().isCancellation)
         #expect(URLError(.cancelled).isCancellation)
         #expect(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled).isCancellation)
@@ -31,7 +31,7 @@ class FoundationExtensionsTests: XCTestCase {
         #expect(!NSError(domain: NSCocoaErrorDomain, code: NSURLErrorCancelled).isCancellation)
     }
     
-    func test_Bundle_appName() {
+    @Test func `Bundle app name`() {
         let bundle = Bundle.main
         let appName = bundle.appName
         
@@ -39,7 +39,7 @@ class FoundationExtensionsTests: XCTestCase {
         #expect(!appName.isEmpty)
     }
     
-    func test_Bundle_bundleIdentifier_extension() {
+    @Test func `Bundle bundle identifier extension`() {
         let bundle = Bundle.main
         // Test that our bundleIdentifier extension works by getting the CFBundleIdentifier value
         let bundleIdentifier = bundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String
@@ -51,21 +51,21 @@ class FoundationExtensionsTests: XCTestCase {
         #expect(bundleIdentifier?.contains(".") == true)
     }
     
-    func test_Bundle_appVersion() {
+    @Test func `Bundle app version`() {
         let bundle = Bundle.main
         let appVersion = bundle.appVersion
         
         #expect(!appVersion.isEmpty)
     }
     
-    func test_Bundle_copyright() {
+    @Test func `Bundle copyright`() {
         let bundle = Bundle.main
 
         // This may be empty in test bundles, but should not crash
         _ = bundle.copyright
     }
     
-    func test_Bundle_userActivityTypes() {
+    @Test func `Bundle user activity types`() {
         let bundle = Bundle.main
         let userActivityTypes = bundle.userActivityTypes
         
@@ -75,7 +75,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_donationsEnabled() {
+    @Test func `Bundle donations enabled`() {
         let bundle = Bundle.main
         let donationsEnabled = bundle.donationsEnabled
         
@@ -83,7 +83,7 @@ class FoundationExtensionsTests: XCTestCase {
         #expect(type(of: donationsEnabled) == Bool.self)
     }
     
-    func test_Bundle_donationManagementPortal() {
+    @Test func `Bundle donation management portal`() {
         let bundle = Bundle.main
         let portal = bundle.donationManagementPortal
         
@@ -93,7 +93,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_extensionURLScheme() {
+    @Test func `Bundle extension URL scheme`() {
         let bundle = Bundle.main
         let scheme = bundle.extensionURLScheme
         
@@ -104,7 +104,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_bundledRegionsFileName() {
+    @Test func `Bundle bundled regions file name`() {
         let bundle = Bundle.main
         let fileName = bundle.bundledRegionsFileName
         
@@ -115,7 +115,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_bundledRegionsFilePath() {
+    @Test func `Bundle bundled regions file path`() {
         let bundle = Bundle.main
         let filePath = bundle.bundledRegionsFilePath
         
@@ -126,7 +126,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_regionsServerBaseAddress() {
+    @Test func `Bundle regions server base address`() {
         let bundle = Bundle.main
         let baseAddress = bundle.regionsServerBaseAddress
         
@@ -136,7 +136,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_regionsServerAPIPath() {
+    @Test func `Bundle regions server API path`() {
         let bundle = Bundle.main
         let apiPath = bundle.regionsServerAPIPath
         
@@ -147,7 +147,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_restServerAPIKey() {
+    @Test func `Bundle rest server API key`() {
         let bundle = Bundle.main
         let apiKey = bundle.restServerAPIKey
         
@@ -158,7 +158,7 @@ class FoundationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_Bundle_appGroup() {
+    @Test func `Bundle app group`() {
         let bundle = Bundle.main
         let appGroup = bundle.appGroup
 
@@ -185,31 +185,32 @@ private class FeedbackConfigBundle: Bundle, @unchecked Sendable {
     static func create(config: [AnyHashable: Any]) throws -> FeedbackConfigBundle {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let bundle = try XCTUnwrap(FeedbackConfigBundle(path: dir.path))
+        let bundle = try #require(FeedbackConfigBundle(path: dir.path))
         bundle.config = config
         return bundle
     }
 }
 
-final class BundleFeedbackConfigTests: XCTestCase {
+@Suite(.serialized)
+final class BundleFeedbackConfigTests {
 
-    func test_appStoreID_readsFromOBAKitConfig() throws {
+    @Test func `App store ID reads from OBA kit config`() throws {
         let bundle = try FeedbackConfigBundle.create(config: ["AppStoreID": "329380089"])
-        XCTAssertEqual(bundle.appStoreID, "329380089")
+        #expect(bundle.appStoreID == "329380089")
     }
 
-    func test_appStoreID_isNilWhenAbsent() throws {
+    @Test func `App store ID is nil when absent`() throws {
         let bundle = try FeedbackConfigBundle.create(config: [:])
-        XCTAssertNil(bundle.appStoreID)
+        #expect(bundle.appStoreID == nil)
     }
 
-    func test_feedbackPromptEnabled_defaultsToTrueWhenAbsent() throws {
+    @Test func `Feedback prompt enabled defaults to true when absent`() throws {
         let bundle = try FeedbackConfigBundle.create(config: [:])
-        XCTAssertTrue(bundle.feedbackPromptEnabled)
+        #expect(bundle.feedbackPromptEnabled)
     }
 
-    func test_feedbackPromptEnabled_honorsExplicitFalse() throws {
+    @Test func `Feedback prompt enabled honors explicit false`() throws {
         let bundle = try FeedbackConfigBundle.create(config: ["FeedbackPromptEnabled": false])
-        XCTAssertFalse(bundle.feedbackPromptEnabled)
+        #expect(!bundle.feedbackPromptEnabled)
     }
 }

--- a/OBAKitTests/Extensions/MapKitExtensionTest.swift
+++ b/OBAKitTests/Extensions/MapKitExtensionTest.swift
@@ -10,14 +10,14 @@
 import Foundation
 import MapKit
 import Testing
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class MapKitExtensionTest: OBATestCase {
-    func testMapRectCodable_roundTripping() {
+@Suite(.serialized)
+final class MapKitExtensionTest: OBATestCase {
+    @Test func `Map rect codable round tripping`() {
         let decoded = try! Fixtures.roundtripCodable(type: MKMapRect.self, model: TestData.seattleMapRect)
         #expect(decoded.origin.x == TestData.seattleMapRect.origin.x)
         #expect(decoded.origin.y == TestData.seattleMapRect.origin.y)

--- a/OBAKitTests/Extensions/MapKitExtensionsTests.swift
+++ b/OBAKitTests/Extensions/MapKitExtensionsTests.swift
@@ -8,16 +8,16 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import MapKit
 import CoreLocation
 @testable import OBAKit
 
 @MainActor
-class MapKitExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class MapKitExtensionsTests {
     
-    func test_MKDirections_walkingDirections() {
+    @Test func `MK directions walking directions`() {
         let coordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         let directions = MKDirections.walkingDirections(to: coordinate)
         
@@ -25,7 +25,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(type(of: directions) == MKDirections.self)
     }
     
-    func test_MKMapRect_mapPoints() {
+    @Test func `MK map rect map points`() {
         let mapRect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
         let points = mapRect.mapPoints
         
@@ -40,7 +40,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(points[3].y == 200)
     }
     
-    func test_MKMapRect_polygon() {
+    @Test func `MK map rect polygon`() {
         let mapRect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
         let polygon = mapRect.polygon
         
@@ -48,7 +48,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(type(of: polygon) == MKPolygon.self)
     }
     
-    func test_MKMapRect_initFromCoordinateRegion() {
+    @Test func `MK map rect init from coordinate region`() {
         let center = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         let span = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
         let region = MKCoordinateRegion(center: center, span: span)
@@ -59,7 +59,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(mapRect.size.height > 0)
     }
     
-    func test_MKMapRect_codable() throws {
+    @Test func `MK map rect codable`() throws {
         let originalRect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
         
         let encoder = JSONEncoder()
@@ -74,7 +74,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(decodedRect.size.height == originalRect.size.height)
     }
     
-    func test_MKMapPoint_codable() throws {
+    @Test func `MK map point codable`() throws {
         let originalPoint = MKMapPoint(x: 123.45, y: 678.90)
         
         let encoder = JSONEncoder()
@@ -87,7 +87,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(decodedPoint.y == originalPoint.y)
     }
     
-    func test_MKMapSize_codable() throws {
+    @Test func `MK map size codable`() throws {
         let originalSize = MKMapSize(width: 100.5, height: 200.75)
         
         let encoder = JSONEncoder()
@@ -100,14 +100,14 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(decodedSize.height == originalSize.height)
     }
     
-    func test_MKMapView_reuseIdentifier() {
+    @Test func `MK map view reuse identifier`() {
         class TestAnnotationView: MKAnnotationView {}
         
         let identifier = MKMapView.reuseIdentifier(for: TestAnnotationView.self)
         #expect(identifier == "TestAnnotationView")
     }
     
-    func test_MKPolygon_initFromCoordinateRegion() {
+    @Test func `MK polygon init from coordinate region`() {
         let center = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         let span = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
         let region = MKCoordinateRegion(center: center, span: span)
@@ -118,7 +118,7 @@ class MapKitExtensionsTests: XCTestCase {
         #expect(type(of: polygon) == MKPolygon.self)
     }
     
-    func test_MKUserLocation_isValid() {
+    @Test func `MK user location is valid`() {
         let userLocation = MKUserLocation()
         
         // Test with nil location

--- a/OBAKitTests/Extensions/ModelExtensionsTests.swift
+++ b/OBAKitTests/Extensions/ModelExtensionsTests.swift
@@ -8,16 +8,16 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import MapKit
 import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
-class ModelExtensionsTests: OBATestCase {
+@Suite(.serialized)
+final class ModelExtensionsTests: OBATestCase {
     
-    func test_MKAnnotation_conformance() {
+    @Test func `MK annotation conformance`() {
         // Test that our model extensions properly conform to MKAnnotation
         // These models use Decodable initializers only, so we'll test the protocol conformance
         
@@ -32,7 +32,7 @@ class ModelExtensionsTests: OBATestCase {
         #expect(zeroCoordinate.longitude == 0)
     }
     
-    func test_CLLocationCoordinate2D_validation() {
+    @Test func `CL location coordinate2 d validation`() {
         // Test coordinate validation methods
         let validCoordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         #expect(CLLocationCoordinate2DIsValid(validCoordinate) == true)

--- a/OBAKitTests/Extensions/ModelExtensionsTests.swift
+++ b/OBAKitTests/Extensions/ModelExtensionsTests.swift
@@ -32,7 +32,7 @@ final class ModelExtensionsTests: OBATestCase {
         #expect(zeroCoordinate.longitude == 0)
     }
     
-    @Test func `CL location coordinate2 d validation`() {
+    @Test func `CL location coordinate 2 d validation`() {
         // Test coordinate validation methods
         let validCoordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
         #expect(CLLocationCoordinate2DIsValid(validCoordinate) == true)

--- a/OBAKitTests/Extensions/ProgressHUDExtensionsTests.swift
+++ b/OBAKitTests/Extensions/ProgressHUDExtensionsTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class ProgressHUDExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class ProgressHUDExtensionsTests {
     
-    func test_showSuccessAndDismiss_withMessage() {
+    @Test func `Show success and dismiss with message`() {
         // This test is limited since ProgressHUD is a third-party library
         // and we can't easily mock its behavior in unit tests
         // But we can verify the method exists and doesn't crash when called
@@ -27,7 +27,7 @@ class ProgressHUDExtensionsTests: XCTestCase {
         #expect(true)
     }
     
-    func test_showSuccessAndDismiss_withoutMessage() {
+    @Test func `Show success and dismiss without message`() {
         ProgressHUD.showSuccessAndDismiss(dismissAfter: 0.1)
         
         // Verify the method completes without throwing

--- a/OBAKitTests/Extensions/SwiftUIExtensionsTests.swift
+++ b/OBAKitTests/Extensions/SwiftUIExtensionsTests.swift
@@ -8,16 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import SwiftUI
 @testable import OBAKit
 
-@available(iOS 14.0, *)
 @MainActor
-class SwiftUIExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class SwiftUIExtensionsTests {
     
-    func test_onFirstAppear_callsActionOnlyOnce() {
+    @Test func `On first appear calls action only once`() {
         var callCount = 0
         _ = Text("Test")
             .onFirstAppear {

--- a/OBAKitTests/Extensions/UIApplicationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/UIApplicationExtensionsTests.swift
@@ -8,15 +8,15 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 
 @MainActor
-class UIApplicationExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class UIApplicationExtensionsTests {
     
-    func test_keyWindowFromScene_returnsKeyWindow() {
+    @Test func `Key window from scene returns key window`() {
         // This test is limited in unit test environment since we can't easily create real scenes
         // We'll test that the property exists and returns a window when available
         let app = UIApplication.shared
@@ -32,7 +32,7 @@ class UIApplicationExtensionsTests: XCTestCase {
         }
     }
     
-    func test_activeWindows_returnsWindowArray() {
+    @Test func `Active windows returns window array`() {
         let app = UIApplication.shared
         
         // The property should exist and return an array

--- a/OBAKitTests/Extensions/UIKitExtensionsTests.swift
+++ b/OBAKitTests/Extensions/UIKitExtensionsTests.swift
@@ -8,28 +8,28 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class UIKitExtensionsTests: XCTestCase {
+@Suite(.serialized)
+final class UIKitExtensionsTests {
     
-    func test_UIButton_chevronButton() {
+    @Test func `UI button chevron button`() {
         let button = UIButton.chevronButton
         #expect(button.buttonType == .detailDisclosure)
         #expect(button.image(for: .normal) != nil)
     }
     
-    func test_UIButton_buildCloseButton() {
+    @Test func `UI button build close button`() {
         let button = UIButton.buildCloseButton()
         #expect(button.translatesAutoresizingMaskIntoConstraints == false)
         #expect(button.accessibilityLabel == Strings.close)
     }
     
-    func test_UITraitEnvironment_isAccessibility() {
+    @Test func `UI trait environment is accessibility`() {
         _ = UITraitCollection(preferredContentSizeCategory: .extraLarge)
         let view = UIView()
         view.overrideUserInterfaceStyle = .unspecified

--- a/OBAKitTests/Feedback/PromptCoordinatorTests.swift
+++ b/OBAKitTests/Feedback/PromptCoordinatorTests.swift
@@ -90,7 +90,7 @@ final class PromptCoordinatorTests: OBATestCase {
 
     // MARK: - 14-day engagement cooldown
 
-    @Test func `Review refused within14 days of donation modal`() {
+    @Test func `Review refused within 14 days of donation modal`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal)
 
@@ -103,7 +103,7 @@ final class PromptCoordinatorTests: OBATestCase {
         #expect(later.canShowReviewPrompt())
     }
 
-    @Test func `Review refused within14 days of survey engagement`() {
+    @Test func `Review refused within 14 days of survey engagement`() {
         let coordinator = makeCoordinator()
         coordinator.noteSurveyEngaged()
 

--- a/OBAKitTests/Feedback/PromptCoordinatorTests.swift
+++ b/OBAKitTests/Feedback/PromptCoordinatorTests.swift
@@ -7,16 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import UIKit
 @testable import OBAKit
 
+@Suite(.serialized)
 final class PromptCoordinatorTests: OBATestCase {
 
     private var clock: Date!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         clock = Date(timeIntervalSince1970: 1_700_000_000)
     }
 
@@ -33,126 +36,126 @@ final class PromptCoordinatorTests: OBATestCase {
 
     // MARK: - One interruption per session
 
-    func test_reviewAllowedInFreshSession() {
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+    @Test func `Review allowed in fresh session`() {
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
-    func test_reviewRefusedAfterSurveyPromptSameSession() {
+    @Test func `Review refused after survey prompt same session`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.surveyPrompt)
-        XCTAssertFalse(coordinator.canShowReviewPrompt())
+        #expect(!coordinator.canShowReviewPrompt())
     }
 
     /// The headline case: the session budget has to hold against the review prompt
     /// itself, not just against the other two kinds.
-    func test_reviewRefusedAfterReviewPromptSameSession() {
+    @Test func `Review refused after review prompt same session`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.review)
-        XCTAssertFalse(coordinator.canShowReviewPrompt())
+        #expect(!coordinator.canShowReviewPrompt())
     }
 
-    func test_reviewRefusedAfterDonationModalSameSession() {
+    @Test func `Review refused after donation modal same session`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal)
-        XCTAssertFalse(coordinator.canShowReviewPrompt())
+        #expect(!coordinator.canShowReviewPrompt())
     }
 
-    func test_newSessionClearsSessionState() {
+    @Test func `New session clears session state`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.review)
         coordinator.sawErrorThisSession = true
-        XCTAssertFalse(coordinator.canShowInlineCards())
+        #expect(!coordinator.canShowInlineCards())
 
         coordinator.beginNewSession()
-        XCTAssertTrue(coordinator.canShowInlineCards())
-        XCTAssertFalse(coordinator.sawErrorThisSession)
+        #expect(coordinator.canShowInlineCards())
+        #expect(!coordinator.sawErrorThisSession)
     }
 
-    func test_noteNotShownReleasesTheSessionSlot() {
+    @Test func `Note not shown releases the session slot`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.surveyPrompt)
-        XCTAssertFalse(coordinator.canShowReviewPrompt())
+        #expect(!coordinator.canShowReviewPrompt())
 
         coordinator.noteNotShown(.surveyPrompt)
-        XCTAssertTrue(coordinator.canShowReviewPrompt())
+        #expect(coordinator.canShowReviewPrompt())
     }
 
     // MARK: - Error suppression
 
-    func test_reviewRefusedAfterStopLoadError() {
+    @Test func `Review refused after stop load error`() {
         let coordinator = makeCoordinator()
         coordinator.sawErrorThisSession = true
-        XCTAssertFalse(coordinator.canShowReviewPrompt())
+        #expect(!coordinator.canShowReviewPrompt())
     }
 
     // MARK: - 14-day engagement cooldown
 
-    func test_reviewRefusedWithin14DaysOfDonationModal() {
+    @Test func `Review refused within14 days of donation modal`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal)
 
         advance(days: 13)
         let next = makeCoordinator()
-        XCTAssertFalse(next.canShowReviewPrompt())
+        #expect(!next.canShowReviewPrompt())
 
         advance(days: 2)
         let later = makeCoordinator()
-        XCTAssertTrue(later.canShowReviewPrompt())
+        #expect(later.canShowReviewPrompt())
     }
 
-    func test_reviewRefusedWithin14DaysOfSurveyEngagement() {
+    @Test func `Review refused within14 days of survey engagement`() {
         let coordinator = makeCoordinator()
         coordinator.noteSurveyEngaged()
 
         advance(days: 13)
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 2)
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     /// A review prompt is not itself a donation/survey engagement, so it must
     /// not start the 14-day clock that gates *itself*.
-    func test_reviewPromptDoesNotStartEngagementCooldown() {
+    @Test func `Review prompt does not start engagement cooldown`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.review)
 
         let nextSession = makeCoordinator()
-        XCTAssertTrue(nextSession.canShowReviewPrompt())
+        #expect(nextSession.canShowReviewPrompt())
     }
 
     // MARK: - Inline cards
 
-    func test_inlineCardsAllowedByDefault() {
-        XCTAssertTrue(makeCoordinator().canShowInlineCards())
+    @Test func `Inline cards allowed by default`() {
+        #expect(makeCoordinator().canShowInlineCards())
     }
 
-    func test_inlineCardsSuppressedForRestOfSessionAfterReview() {
+    @Test func `Inline cards suppressed for rest of session after review`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.review)
-        XCTAssertFalse(coordinator.canShowInlineCards())
+        #expect(!coordinator.canShowInlineCards())
     }
 
     /// Regression test for the starvation bug: rendering an inline donation
     /// card is not an interruption and must never consume the review budget,
     /// no matter how many times it happens.
-    func test_inlineCardRendersNeverAffectReviewEligibility() {
+    @Test func `Inline card renders never affect review eligibility`() {
         let coordinator = makeCoordinator()
         for _ in 0..<100 {
             _ = coordinator.canShowInlineCards()
         }
-        XCTAssertTrue(coordinator.canShowReviewPrompt())
+        #expect(coordinator.canShowReviewPrompt())
     }
 
     // MARK: - Reset
 
-    func test_resetClearsEngagementCooldown() {
+    @Test func `Reset clears engagement cooldown`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal)
         coordinator.reset()
 
         let next = makeCoordinator()
-        XCTAssertTrue(next.canShowReviewPrompt())
+        #expect(next.canShowReviewPrompt())
     }
 
     // MARK: - noteNotShown undo safety (review-round Finding 1 / 3a)
@@ -161,7 +164,7 @@ final class PromptCoordinatorTests: OBATestCase {
     /// gate and its matching `noteNotShown(_:)` must survive: the undo must
     /// only ever roll back its own write, never a later engagement that
     /// happens to share the same persisted key.
-    func test_noteNotShownDoesNotClobberLaterSurveyEngagement() {
+    @Test func `Note not shown does not clobber later survey engagement`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.surveyPrompt)
 
@@ -171,10 +174,10 @@ final class PromptCoordinatorTests: OBATestCase {
         coordinator.noteNotShown(.surveyPrompt)
 
         advance(days: 13)
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 2)
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     /// Shows `.donationModal` then, 5 days later, `.surveyPrompt`; only the
@@ -185,7 +188,7 @@ final class PromptCoordinatorTests: OBATestCase {
     /// surveyPrompt date" and "wrongly reverted to the donationModal date"
     /// disagree: at day 15 only the wrong-revert behavior would have let the
     /// cooldown lapse.
-    func test_noteNotShownForEarlierKindDoesNotRestoreAfterNewerKindShown() {
+    @Test func `Note not shown for earlier kind does not restore after newer kind shown`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal) // T0
 
@@ -194,16 +197,16 @@ final class PromptCoordinatorTests: OBATestCase {
         coordinator.noteNotShown(.donationModal) // mismatched kind — must be a no-op
 
         advance(days: 10) // now = T0 + 15d: within 14d of surveyPrompt's date, past donationModal's
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 5) // now = T0 + 20d: past both 14-day windows
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     /// Same as above with the two kinds reversed, to pin that the "decline to
     /// restore" behavior isn't an artifact of which kind happens to be shown
     /// second.
-    func test_noteNotShownForEarlierKindDoesNotRestoreAfterNewerKindShownReversed() {
+    @Test func `Note not shown for earlier kind does not restore after newer kind shown reversed`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.surveyPrompt) // T0
 
@@ -212,10 +215,10 @@ final class PromptCoordinatorTests: OBATestCase {
         coordinator.noteNotShown(.surveyPrompt) // mismatched kind — must be a no-op
 
         advance(days: 10) // now = T0 + 15d
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 5) // now = T0 + 20d
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     /// Two kinds gated at once, both rolled back: neither was ever presented, so no
@@ -225,7 +228,7 @@ final class PromptCoordinatorTests: OBATestCase {
     /// and the first's `noteNotShown` then found nothing to restore — leaving the
     /// engagement date set, and the review prompt blocked for 14 days, on behalf of two
     /// prompts the rider never saw.
-    func test_bothKindsRolledBackLeaveNoCooldown() {
+    @Test func `Both kinds rolled back leave no cooldown`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.surveyPrompt) // T0
 
@@ -236,28 +239,28 @@ final class PromptCoordinatorTests: OBATestCase {
         coordinator.noteNotShown(.donationModal) // restores the survey's date
         coordinator.noteNotShown(.surveyPrompt) // must clear it entirely
 
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt(), "no engagement ever happened")
+        #expect(makeCoordinator().canShowReviewPrompt(), "no engagement ever happened")
     }
 
     /// `noteNotShown(_:)` with no preceding `noteShown(_:)` for that kind must
     /// be a safe no-op rather than disturbing an unrelated, already-persisted
     /// engagement (e.g. one written directly by `noteSurveyEngaged()`).
-    func test_noteNotShownWithoutMatchingNoteShownIsANoOp() {
+    @Test func `Note not shown without matching note shown is a no op`() {
         let coordinator = makeCoordinator()
         coordinator.noteSurveyEngaged()
         coordinator.noteNotShown(.surveyPrompt)
 
         advance(days: 13)
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 2)
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     /// A `noteNotShown(_:)` call that arrives after `beginNewSession()` has
     /// already rolled the session over must not resurrect the discarded undo
     /// record and erase the engagement the earlier `noteShown(_:)` recorded.
-    func test_noteNotShownAfterNewSessionDoesNotRestoreStaleEngagement() {
+    @Test func `Note not shown after new session does not restore stale engagement`() {
         let coordinator = makeCoordinator()
         coordinator.noteShown(.donationModal)
         coordinator.beginNewSession()
@@ -265,10 +268,10 @@ final class PromptCoordinatorTests: OBATestCase {
         coordinator.noteNotShown(.donationModal)
 
         advance(days: 13)
-        XCTAssertFalse(makeCoordinator().canShowReviewPrompt())
+        #expect(!makeCoordinator().canShowReviewPrompt())
 
         advance(days: 2)
-        XCTAssertTrue(makeCoordinator().canShowReviewPrompt())
+        #expect(makeCoordinator().canShowReviewPrompt())
     }
 
     // MARK: - Foreground notification wiring (review-round Finding 2 / 3b)
@@ -277,23 +280,23 @@ final class PromptCoordinatorTests: OBATestCase {
     /// posting `willEnterForegroundNotification` on an injected center must
     /// clear session state, proving `init` and `deinit` operate on the same
     /// (injected, not `.default`) center.
-    func test_foregroundNotificationBeginsNewSession() {
+    @Test func `Foreground notification begins new session`() async {
         let center = NotificationCenter()
         let coordinator = makeCoordinator(notificationCenter: center)
         coordinator.noteShown(.review)
         coordinator.sawErrorThisSession = true
-        XCTAssertFalse(coordinator.canShowInlineCards())
+        #expect(!coordinator.canShowInlineCards())
 
         center.post(name: UIApplication.willEnterForegroundNotification, object: nil)
 
         // The observer block was registered on the main OperationQueue, which
         // dispatches asynchronously; round-trip through the main queue once
         // more so it has run before we assert.
-        let drained = expectation(description: "main queue drained")
-        DispatchQueue.main.async { drained.fulfill() }
-        wait(for: [drained], timeout: 1.0)
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
 
-        XCTAssertTrue(coordinator.canShowInlineCards())
-        XCTAssertFalse(coordinator.sawErrorThisSession)
+        #expect(coordinator.canShowInlineCards())
+        #expect(!coordinator.sawErrorThisSession)
     }
 }

--- a/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
+++ b/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
@@ -164,7 +164,7 @@ final class ReviewPromptPolicyTests: OBATestCase {
         #expect(!policy.isPromptPending)
     }
 
-    @Test func `Negative backs off180 days`() {
+    @Test func `Negative backs off 180 days`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -179,7 +179,7 @@ final class ReviewPromptPolicyTests: OBATestCase {
         #expect(policy.isPromptPending)
     }
 
-    @Test func `Deferred backs off60 days`() {
+    @Test func `Deferred backs off 60 days`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()

--- a/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
+++ b/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
@@ -16,7 +16,9 @@ import Testing
 /// switch and version gate are testable without the host app's Info.plist.
 // `Bundle` is already `@unchecked Sendable`; a subclass has to restate it or the
 // compiler warns. Mutated only from the test that owns the instance.
-private class PolicyBundle: Bundle, @unchecked Sendable {
+// `nonisolated`: `object(forInfoDictionaryKey:)` overrides a nonisolated
+// Bundle method, which main-actor isolation would conflict with.
+private nonisolated class PolicyBundle: Bundle, @unchecked Sendable {
     var config: [AnyHashable: Any] = [:]
     var version = "1.0"
 

--- a/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
+++ b/OBAKitTests/Feedback/ReviewPromptPolicyTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -28,7 +29,7 @@ private class PolicyBundle: Bundle, @unchecked Sendable {
     static func create(enabled: Bool = true, version: String = "1.0", appStoreID: String? = "329380089") throws -> PolicyBundle {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let bundle = try XCTUnwrap(PolicyBundle(path: dir.path))
+        let bundle = try #require(PolicyBundle(path: dir.path))
         var config: [String: Any] = ["FeedbackPromptEnabled": enabled]
         if let appStoreID { config["AppStoreID"] = appStoreID }
         bundle.config = config
@@ -37,13 +38,15 @@ private class PolicyBundle: Bundle, @unchecked Sendable {
     }
 }
 
+@Suite(.serialized)
 final class ReviewPromptPolicyTests: OBATestCase {
 
     private var clock: Date!
     private var bundle: PolicyBundle!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         clock = Date(timeIntervalSince1970: 1_700_000_000)
         bundle = try PolicyBundle.create()
     }
@@ -51,9 +54,8 @@ final class ReviewPromptPolicyTests: OBATestCase {
     /// `reset()` deliberately spares this key, so nothing else clears it between tests —
     /// and since it short-circuits `isPromptPending` to `true`, a leak turns later
     /// assertions into false passes.
-    override func tearDown() async throws {
+    isolated deinit {
         userDefaults.removeObject(forKey: "ReviewPrompt.alwaysShow")
-        try await super.tearDown()
     }
 
     private func makePolicy() -> ReviewPromptPolicy {
@@ -70,16 +72,16 @@ final class ReviewPromptPolicyTests: OBATestCase {
 
     // MARK: - Threshold
 
-    func test_fourSuccesses_isNotPending() {
+    @Test func `Four successes is not pending`() {
         let policy = makePolicy()
         recordSuccesses(4, on: policy)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
     }
 
-    func test_fiveSuccesses_isPending() {
+    @Test func `Five successes is pending`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
-        XCTAssertTrue(policy.isPromptPending)
+        #expect(policy.isPromptPending)
     }
 
     /// A fresh policy instance built from the same defaults (as after app
@@ -93,26 +95,26 @@ final class ReviewPromptPolicyTests: OBATestCase {
     /// from `false` to `true` purely by advancing the clock with no
     /// intervening `recordSuccess()` call — no one-way edge-triggered flag
     /// could do that.
-    func test_pendingSurvivesFreshPolicyInstance() {
+    @Test func `Pending survives fresh policy instance`() {
         let first = makePolicy()
         recordSuccesses(7, on: first)
-        XCTAssertTrue(first.isPromptPending)
+        #expect(first.isPromptPending)
 
         let second = makePolicy()
-        XCTAssertTrue(second.isPromptPending)
+        #expect(second.isPromptPending)
     }
 
     // MARK: - Presentation bookkeeping
 
-    func test_presentingResetsCounterAndSetsDeferredOutcome() {
+    @Test func `Presenting resets counter and sets deferred outcome`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
 
-        XCTAssertEqual(policy.outcome, .deferred, "outcome must be written up front, before the rider answers")
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(policy.outcome == .deferred, "outcome must be written up front, before the rider answers")
+        #expect(!policy.isPromptPending)
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending, "backoff should still block")
+        #expect(!policy.isPromptPending, "backoff should still block")
     }
 
     /// Calling `recordOutcome` without a preceding `recordPromptPresented()` is an
@@ -120,18 +122,18 @@ final class ReviewPromptPolicyTests: OBATestCase {
     /// `if let` in `isPromptPending` would be skipped entirely, and `successCount`
     /// was never zeroed — so the rider would stay pending and get re-prompted on
     /// every subsequent stop view, unboundedly, without ever burning an ask.
-    func test_outcomeWithoutPresentationStillConsumesTheAsk() {
+    @Test func `Outcome without presentation still consumes the ask`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         // No recordPromptPresented() call.
         policy.recordOutcome(.negative)
 
-        XCTAssertFalse(policy.isPromptPending, "recording an outcome must always consume the ask")
+        #expect(!policy.isPromptPending, "recording an outcome must always consume the ask")
     }
 
     /// An alert the rider abandons (app killed mid-prompt) never gets an
     /// outcome written, so it must already be a well-defined deferral.
-    func test_abandonedAskBehavesAsDeferral() {
+    @Test func `Abandoned ask behaves as deferral`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -140,15 +142,15 @@ final class ReviewPromptPolicyTests: OBATestCase {
         bundle.version = "1.1"
         advance(days: 59)
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending, "59 days is inside the 60-day deferral")
+        #expect(!policy.isPromptPending, "59 days is inside the 60-day deferral")
 
         advance(days: 2)
-        XCTAssertTrue(policy.isPromptPending)
+        #expect(policy.isPromptPending)
     }
 
     // MARK: - Outcomes
 
-    func test_positiveSilencesPermanently() {
+    @Test func `Positive silences permanently`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -157,10 +159,10 @@ final class ReviewPromptPolicyTests: OBATestCase {
         bundle.version = "2.0"
         advance(days: 3650)
         recordSuccesses(50, on: policy)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
     }
 
-    func test_negativeBacksOff180Days() {
+    @Test func `Negative backs off180 days`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -169,13 +171,13 @@ final class ReviewPromptPolicyTests: OBATestCase {
         bundle.version = "1.1"
         advance(days: 179)
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
 
         advance(days: 2)
-        XCTAssertTrue(policy.isPromptPending)
+        #expect(policy.isPromptPending)
     }
 
-    func test_deferredBacksOff60Days() {
+    @Test func `Deferred backs off60 days`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -189,38 +191,38 @@ final class ReviewPromptPolicyTests: OBATestCase {
         // success count rather than on elapsed time.
         advance(days: 59)
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending, "the 60-day deferral must still be closed on day 59")
+        #expect(!policy.isPromptPending, "the 60-day deferral must still be closed on day 59")
 
         advance(days: 2)
-        XCTAssertTrue(policy.isPromptPending, "and open once it elapses")
+        #expect(policy.isPromptPending, "and open once it elapses")
     }
 
     /// A white-label target with no `AppStoreID` can't send anyone to the App Store, so
     /// it must never be asked. Shipping without this gate meant KiedyBus riders got the
     /// prompt, tapped "Yes!", went nowhere, and were recorded `.positive` — permanently
     /// silencing both branches for someone who was never really asked.
-    func test_missingAppStoreIDSuppressesThePromptEntirely() throws {
+    @Test func `Missing app store ID suppresses the prompt entirely`() throws {
         bundle = try PolicyBundle.create(appStoreID: nil)
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
 
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
 
         // Not even the debug override may open it — there is still nowhere to go.
         policy.alwaysShowPrompt = true
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
     }
 
     /// The Settings footer promises the toggle survives a reset.
-    func test_resetPreservesTheDebugOverride() {
+    @Test func `Reset preserves the debug override`() {
         let policy = makePolicy()
         policy.alwaysShowPrompt = true
         recordSuccesses(5, on: policy)
 
         policy.reset()
 
-        XCTAssertTrue(policy.alwaysShowPrompt)
-        XCTAssertEqual(policy.successCount, 0)
+        #expect(policy.alwaysShowPrompt)
+        #expect(policy.successCount == 0)
     }
 
     /// A QA tap on "Yes!" must not write `.positive`. `recordPromptPresented()` already
@@ -231,7 +233,7 @@ final class ReviewPromptPolicyTests: OBATestCase {
     /// The install is still left in the ordinary `.deferred` state the presentation
     /// writes up front, so the organic prompt comes back on its own after the 60-day
     /// backoff rather than never.
-    func test_debugOverrideDoesNotRecordOutcomes() {
+    @Test func `Debug override does not record outcomes`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.alwaysShowPrompt = true
@@ -239,17 +241,17 @@ final class ReviewPromptPolicyTests: OBATestCase {
         policy.recordPromptPresented()
         policy.recordOutcome(.positive)
 
-        XCTAssertEqual(policy.outcome, .deferred, "the QA answer must not be persisted")
+        #expect(policy.outcome == .deferred, "the QA answer must not be persisted")
 
         policy.alwaysShowPrompt = false
         advance(days: 61)
         recordSuccesses(5, on: policy)
-        XCTAssertTrue(policy.isPromptPending, "a QA pass defers the organic prompt, it doesn't kill it")
+        #expect(policy.isPromptPending, "a QA pass defers the organic prompt, it doesn't kill it")
     }
 
     // MARK: - Version gate
 
-    func test_sameVersionBlocksSecondPrompt() {
+    @Test func `Same version blocks second prompt`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
@@ -257,21 +259,21 @@ final class ReviewPromptPolicyTests: OBATestCase {
 
         advance(days: 61)
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending, "same app version must not re-prompt")
+        #expect(!policy.isPromptPending, "same app version must not re-prompt")
 
         bundle.version = "1.1"
-        XCTAssertTrue(policy.isPromptPending)
+        #expect(policy.isPromptPending)
     }
 
     // MARK: - Lifetime cap
 
-    func test_thirdAskSilencesPermanently() {
+    @Test func `Third ask silences permanently`() {
         let policy = makePolicy()
         let versions = ["1.1", "1.2", "1.3"]
 
         for (index, version) in versions.enumerated() {
             recordSuccesses(5, on: policy)
-            XCTAssertTrue(policy.isPromptPending, "ask \(index + 1) should be pending")
+            #expect(policy.isPromptPending, "ask \(index + 1) should be pending")
             policy.recordPromptPresented()
             policy.recordOutcome(.deferred)
             bundle.version = version
@@ -279,11 +281,11 @@ final class ReviewPromptPolicyTests: OBATestCase {
         }
 
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending, "askCount reached 3")
+        #expect(!policy.isPromptPending, "askCount reached 3")
     }
 
     /// The cap counts asks, not deferrals, so a mixed sequence still caps.
-    func test_capCountsAsksRegardlessOfOutcome() {
+    @Test func `Cap counts asks regardless of outcome`() {
         let policy = makePolicy()
 
         recordSuccesses(5, on: policy)
@@ -299,40 +301,40 @@ final class ReviewPromptPolicyTests: OBATestCase {
         advance(days: 181)
 
         recordSuccesses(5, on: policy)
-        XCTAssertTrue(policy.isPromptPending, "third ask still allowed")
+        #expect(policy.isPromptPending, "third ask still allowed")
         policy.recordPromptPresented()
         policy.recordOutcome(.deferred)
         bundle.version = "1.3"
         advance(days: 61)
 
         recordSuccesses(5, on: policy)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
     }
 
     // MARK: - Kill switch and debug
 
-    func test_disabledBundleIsNeverPending() throws {
+    @Test func `Disabled bundle is never pending`() throws {
         bundle = try PolicyBundle.create(enabled: false)
         let policy = makePolicy()
         recordSuccesses(20, on: policy)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
     }
 
-    func test_alwaysShowBypassesGatesButNotKillSwitch() throws {
+    @Test func `Always show bypasses gates but not kill switch`() throws {
         let policy = makePolicy()
         policy.alwaysShowPrompt = true
-        XCTAssertTrue(policy.isPromptPending, "no successes recorded, but debug override is on")
+        #expect(policy.isPromptPending, "no successes recorded, but debug override is on")
 
         bundle = try PolicyBundle.create(enabled: false)
         let disabled = makePolicy()
         disabled.alwaysShowPrompt = true
-        XCTAssertFalse(disabled.isPromptPending)
+        #expect(!disabled.isPromptPending)
     }
 
     /// `alwaysShowPrompt` short-circuits `isPromptPending` ahead of the ask cap and the
     /// version gate, so presentations made under it must not spend either. Three QA taps
     /// used to silence the organic prompt on that install for good.
-    func test_alwaysShowDoesNotSpendTheLifetimeAskBudget() {
+    @Test func `Always show does not spend the lifetime ask budget`() {
         let policy = makePolicy()
         policy.alwaysShowPrompt = true
 
@@ -344,43 +346,44 @@ final class ReviewPromptPolicyTests: OBATestCase {
         policy.alwaysShowPrompt = false
         advance(days: 61)
         recordSuccesses(5, on: policy)
-        XCTAssertTrue(policy.isPromptPending, "the real prompt is still available after five debug asks")
+        #expect(policy.isPromptPending, "the real prompt is still available after five debug asks")
     }
 
     /// Everything else about `recordPromptPresented()` still runs under the toggle, so an
     /// abandoned debug alert lands in the same defined state a real one would.
-    func test_alwaysShowStillWritesTheDeferredOutcomeUpFront() {
+    @Test func `Always show still writes the deferred outcome up front`() {
         let policy = makePolicy()
         policy.alwaysShowPrompt = true
         recordSuccesses(5, on: policy)
 
         policy.recordPromptPresented()
 
-        XCTAssertEqual(policy.outcome, .deferred)
-        XCTAssertEqual(policy.successCount, 0)
+        #expect(policy.outcome == .deferred)
+        #expect(policy.successCount == 0)
     }
 
-    func test_resetClearsAllState() {
+    @Test func `Reset clears all state`() {
         let policy = makePolicy()
         recordSuccesses(5, on: policy)
         policy.recordPromptPresented()
         policy.recordOutcome(.positive)
-        XCTAssertFalse(policy.isPromptPending)
+        #expect(!policy.isPromptPending)
 
         policy.reset()
         recordSuccesses(5, on: policy)
-        XCTAssertTrue(policy.isPromptPending)
+        #expect(policy.isPromptPending)
     }
 }
 
 /// The write-review URL is the entire point of the positive branch, and it fails
 /// silently when wrong — drop `?action=write-review` and the App Store opens the
 /// ordinary product page, so the rider lands somewhere plausible and never reviews.
-final class WriteReviewURLTests: XCTestCase {
+@Suite(.serialized)
+final class WriteReviewURLTests {
 
-    @MainActor
-    func test_writeReviewURL_carriesTheWriteReviewAction() throws {
-        let url = try XCTUnwrap(FeedbackPromptPresenter.writeReviewURL(appStoreID: "329380089"))
-        XCTAssertEqual(url.absoluteString, "https://apps.apple.com/app/id329380089?action=write-review")
+    @Test @MainActor
+    func `Write review URL carries the write review action`() throws {
+        let url = try #require(FeedbackPromptPresenter.writeReviewURL(appStoreID: "329380089"))
+        #expect(url.absoluteString == "https://apps.apple.com/app/id329380089?action=write-review")
     }
 }

--- a/OBAKitTests/Helpers/DelegateTestingHelper.swift
+++ b/OBAKitTests/Helpers/DelegateTestingHelper.swift
@@ -5,14 +5,14 @@
 //  Created by Alan Chu on 1/12/23.
 //
 
-import XCTest
+import Testing
 
 /// Helpers for testing delegates.
 enum DelegateTestingHelper {
 
     /// An enum for indicating whether a delegate method was called, and with what method parameters.
     ///
-    /// The example below describes how to use this in an ``XCTestCase`` to compare the expected value of a delegate call:
+    /// The example below describes how to use this in a test suite to compare the expected value of a delegate call:
     /// ```
     /// private class LocationServiceTestDelegate: LocationServiceDelegate {
     ///     // You will need to manually implement each delegate method to test.
@@ -23,7 +23,7 @@ enum DelegateTestingHelper {
     ///     }
     /// }
     ///
-    /// func testLocationDelegateCallsDidUpdateLocation() async {
+    /// @Test func `Location delegate calls didUpdateLocation`() async {
     ///     let myCurrentLocation: CLLocation /* ... */
     ///     let delegate = LocationServiceTestDelegate()
     ///     let locationService = LocationService(delegate: delegate)
@@ -31,9 +31,9 @@ enum DelegateTestingHelper {
     ///     // We are testing that updateLocation() informs the delegate of an updated location.
     ///     await locationService.updateLocation()
     ///
-    ///     // Use XCTAssertDidCallDelegateMethodWithValue to check the delegate was called
+    ///     // Use expectDidCallDelegateMethod to check the delegate was called
     ///     // with the expected value.
-    ///     XCTAssertDidCallDelegateMethodWithValue(
+    ///     expectDidCallDelegateMethod(
     ///         delegate.locationServiceDidUpdateLocation,
     ///         myCurrentLocation,
     ///         "Expected LocationService to inform delegate with the updated location."
@@ -42,11 +42,11 @@ enum DelegateTestingHelper {
     /// ```
     ///
     /// - To test a delegate method with no parameters, use `DidCallDelegateMethod<Void>`. A delegate method that includes its caller as a parameter should not considered a parameter (in the above example, `locationService(locationService:didUpdateLocation:)` only used `didUpdateLocation`).
-    /// - To test a delegate method with multiple parameters, use a tuple. All types of the tuple must conform to ``Equatable`` to use `XCTAssertDidCallDelegateMethodWithValue`.
+    /// - To test a delegate method with multiple parameters, use a tuple. All types of the tuple must conform to ``Equatable`` to use `expectDidCallDelegateMethod`.
     ///
     /// - To test whether a delegate method was called, regardless of the parameter values:
     /// ```
-    /// XCTAssertTrue(delegate.locationServiceDidUpdateLocation.didCall, "Expected the LocationService to inform delegate of an updated location.")
+    /// #expect(delegate.locationServiceDidUpdateLocation.didCall, "Expected the LocationService to inform delegate of an updated location.")
     /// ```
     enum DidCallDelegateMethod<T> {
         case didNotCall
@@ -76,10 +76,11 @@ extension DelegateTestingHelper.DidCallDelegateMethod: Equatable where T: Equata
     }
 }
 
-func XCTAssertDidCallDelegateMethodWithValue<Value: Equatable>(
+func expectDidCallDelegateMethod<Value: Equatable>(
     _ didCall: DelegateTestingHelper.DidCallDelegateMethod<Value>,
     _ expectedValue: Value,
-    _ message: String = ""
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation
 ) {
-    XCTAssertEqual(didCall, .called(expectedValue), message)
+    #expect(didCall == .called(expectedValue), comment, sourceLocation: sourceLocation)
 }

--- a/OBAKitTests/Helpers/Extensions/FoundationExtensions.swift
+++ b/OBAKitTests/Helpers/Extensions/FoundationExtensions.swift
@@ -11,7 +11,8 @@ import Foundation
 
 // MARK: - Date
 
-public extension Date {
+// `nonisolated`: pure value helpers, called from @Sendable matchers.
+public nonisolated extension Date {
     static func fromComponents(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Date {
         let timeZone = TimeZone(secondsFromGMT: 0)
         let components = DateComponents(calendar: Calendar(identifier: .gregorian), timeZone: timeZone, era: nil, year: year, month: month, day: day, hour: hour, minute: minute, second: second, nanosecond: nil, weekday: nil, weekdayOrdinal: nil, quarter: nil, weekOfMonth: nil, weekOfYear: nil, yearForWeekOfYear: nil)
@@ -21,7 +22,8 @@ public extension Date {
 
 // MARK: - URL
 
-public extension URL {
+// `nonisolated`: pure value helpers, called from @Sendable matchers.
+public nonisolated extension URL {
     func containsQueryParams(_ params: [String: String?]) -> Bool {
         guard
             let comps = URLComponents(url: self, resolvingAgainstBaseURL: true),

--- a/OBAKitTests/Helpers/Matchers/Approximately.swift
+++ b/OBAKitTests/Helpers/Matchers/Approximately.swift
@@ -17,10 +17,17 @@ let defaultDelta: Double = 0.0001
 /// Asserts that `actual` is within `delta` of `expected`.
 ///
 /// Replacement for Nimble's `beCloseTo`. The semantics are deliberately
-/// identical to Nimble's so the conversion couldn't change any test's verdict:
-/// the default tolerance is 0.0001 and the comparison is **strict** (`<`, not
-/// `<=`), matching `abs(actual - expected) < delta` in Nimble's
+/// identical to Nimble's, so *that* conversion couldn't change any test's
+/// verdict: the default tolerance is 0.0001 and the comparison is **strict**
+/// (`<`, not `<=`), matching `abs(actual - expected) < delta` in Nimble's
 /// `Matchers/BeCloseTo.swift`.
+///
+/// That strictness is worth knowing at the call sites converted from
+/// `XCTAssertEqual(_:_:accuracy:)`, which failed on `difference > accuracy` —
+/// i.e. a difference exactly equal to the tolerance passed there and fails
+/// here. No current call site sits on that boundary, and tightening was the
+/// safe direction to differ in, but a test written to sit exactly on its
+/// tolerance would need `within:` nudged.
 ///
 /// `actual` is optional so that call sites reading through an optional chain
 /// (`vehicle.location?.coordinate.latitude`) work unchanged; `nil` fails, as it

--- a/OBAKitTests/Helpers/Matchers/Approximately.swift
+++ b/OBAKitTests/Helpers/Matchers/Approximately.swift
@@ -25,26 +25,28 @@ let defaultDelta: Double = 0.0001
 /// `actual` is optional so that call sites reading through an optional chain
 /// (`vehicle.location?.coordinate.latitude`) work unchanged; `nil` fails, as it
 /// did under Nimble.
+/// - Parameter comment: Optional context, carried over from the message
+///   argument that `XCTAssertEqual(_:_:accuracy:_:)` accepted.
 func expectClose(
     _ actual: Double?,
     _ expected: Double,
     within delta: Double = defaultDelta,
+    _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
 ) {
+    func record(_ description: String) {
+        let detail = comment.map { "\($0.rawValue) — " } ?? ""
+        Issue.record("\(detail)\(description)", sourceLocation: sourceLocation)
+    }
+
     guard let actual else {
-        Issue.record(
-            "expected a value close to \(expected), got nil",
-            sourceLocation: sourceLocation
-        )
+        record("expected a value close to \(expected), got nil")
         return
     }
 
     let difference = abs(actual - expected)
     guard difference < delta else {
-        Issue.record(
-            "expected \(actual) to be within \(delta) of \(expected), but it is off by \(difference)",
-            sourceLocation: sourceLocation
-        )
+        record("expected \(actual) to be within \(delta) of \(expected), but it is off by \(difference)")
         return
     }
 }
@@ -55,12 +57,14 @@ func expectClose(
     _ actual: Date?,
     _ expected: Date,
     within delta: TimeInterval = defaultDelta,
+    _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
 ) {
     expectClose(
         actual?.timeIntervalSinceReferenceDate,
         expected.timeIntervalSinceReferenceDate,
         within: delta,
+        comment,
         sourceLocation: sourceLocation
     )
 }

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -10,16 +10,27 @@
 import Foundation
 import OBAKitCore
 
-typealias MockDataLoaderMatcher = (URLRequest) -> Bool
+/// `@Sendable` on purpose. Matchers run wherever the request is issued — which,
+/// for the Live Activity cleanup paths, is a detached task — so a matcher that
+/// closes over main-actor state is a data race. Without `@Sendable` the compiler
+/// cannot see that capture, and the mistake surfaces only as a runtime isolation
+/// trap that kills the test process (it did: see DeleteRecorder in
+/// LiveActivityRegistryTests). With it, the same mistake is a build error.
+typealias MockDataLoaderMatcher = @Sendable (URLRequest) -> Bool
 
-struct MockDataResponse {
+// `nonisolated`: built and matched from `URLDataLoader`'s nonisolated methods,
+// which run on whatever task the app's background work happens to be on. The
+// test target defaults to main-actor isolation, which would be wrong here.
+nonisolated struct MockDataResponse {
     let data: Data?
     let urlResponse: URLResponse?
     let error: Error?
     let matcher: MockDataLoaderMatcher
 }
 
-class MockTask: URLSessionDataTask, @unchecked Sendable {
+// `nonisolated`: every member here overrides a nonisolated URLSessionDataTask
+// declaration, so main-actor isolation would be an isolation mismatch.
+nonisolated class MockTask: URLSessionDataTask, @unchecked Sendable {
     override var progress: Progress {
         return Progress()
     }
@@ -44,7 +55,9 @@ class MockTask: URLSessionDataTask, @unchecked Sendable {
 }
 
 // @unchecked Sendable: all mutable state is guarded by the locks below.
-class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
+// `nonisolated` for the same reason the locks exist — this is read concurrently
+// by background tasks, so it must not pick up the target's main-actor default.
+nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     /// Guarded by `mockResponsesLock`: tests mutate the response table from the main
     /// thread while `Application` background tasks (regions refresh, agency alerts)
     /// concurrently match requests against it.

--- a/OBAKitTests/Helpers/Mocks/OBAMockHeading.swift
+++ b/OBAKitTests/Helpers/Mocks/OBAMockHeading.swift
@@ -14,7 +14,9 @@ import CoreLocation
 /// honest: every stored property is a `let`, and the class is `final` so no
 /// subclass can add mutable state and silently inherit the promise. Needed
 /// because `TestData.mockHeading` is a shared static.
-public final class OBAMockHeading: CLHeading, @unchecked Sendable {
+// `nonisolated`: overrides nonisolated CLHeading members, which the target's
+// main-actor default isolation would conflict with.
+public final nonisolated class OBAMockHeading: CLHeading, @unchecked Sendable {
 
     let _magneticHeading: CLLocationDirection
     public override var magneticHeading: CLLocationDirection {

--- a/OBAKitTests/Helpers/OBATestCase.swift
+++ b/OBAKitTests/Helpers/OBATestCase.swift
@@ -7,22 +7,40 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import OBAKit
 @testable import OBAKitCore
 
-// Main-actor-isolated (inherited by every test class): the frameworks under test
-// are largely @MainActor. XCTest runs sync test methods on the main thread; it is
-// this @MainActor annotation that makes async setUp/tearDown and async test
-// methods hop to main as well.
+/// Pins the process to GMT once, for the lifetime of the test bundle.
+///
+/// This used to be set in `setUp` and undone in `tearDown`. `NSTimeZone.default`
+/// is process-global, so under Swift Testing — which may run suites
+/// concurrently — one suite's teardown could reset the zone out from under
+/// another suite's running test. Setting it once and never resetting it removes
+/// the race entirely, and is behaviourally identical for these tests: every
+/// suite that inherited `OBATestCase` wanted GMT, and no test reads the
+/// system zone (the Weather tests set their own calendar's zone explicitly).
+private let pinnedToGMT: Void = {
+    NSTimeZone.default = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
+}()
+
+// Main-actor-isolated (inherited by every test suite that uses it): the
+// frameworks under test are largely @MainActor, and this annotation makes the
+// async initializer and any async test methods hop to main.
+//
+// This is a plain base class, not a suite in its own right — it declares no
+// `@Test` methods. Swift Testing instantiates the *subclass* fresh for each of
+// its test functions, so `init` runs per test exactly as `setUp` used to.
 @MainActor
-open class OBATestCase: XCTestCase {
+class OBATestCase {
 
     var userDefaults: UserDefaults!
 
-    open override func setUp() async throws {
-        try await super.setUp()
-        NSTimeZone.default = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
+    /// Replaces `setUp`. Swift Testing calls this once per test function.
+    init() async throws {
+        _ = pinnedToGMT
+
         userDefaults = buildUserDefaults()
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
 
@@ -33,10 +51,19 @@ open class OBATestCase: XCTestCase {
         restService = buildRESTService()
     }
 
-    open override func tearDown() async throws {
-        try await super.tearDown()
-        NSTimeZone.resetSystemTimeZone()
-        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+    /// Replaces `tearDown`. Deliberately `nonisolated` and reading only
+    /// `nonisolated` stored state, so it needs no `isolated deinit`.
+    deinit {
+        UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    // MARK: - Test identity
+
+    /// The running test's name. Stands in for `XCTestCase.name`, which the many
+    /// `MockDataLoader(testName: name)` call sites used to get a label for
+    /// unmocked-URL failure messages.
+    nonisolated var name: String {
+        Test.current?.name ?? "OBAKitTests"
     }
 
     // MARK: - User Defaults
@@ -45,9 +72,16 @@ open class OBATestCase: XCTestCase {
         UserDefaults(suiteName: suiteName ?? userDefaultsSuiteName)!
     }
 
-    var userDefaultsSuiteName: String {
-        return String(describing: self)
-    }
+    /// A defaults domain unique to this instance — and therefore, since Swift
+    /// Testing builds a fresh instance per test, unique to each test.
+    ///
+    /// It was previously `String(describing: self)`, i.e. one domain shared by
+    /// every test in a class. That was safe only because XCTest ran them one at
+    /// a time; a per-instance domain holds regardless of how tests are
+    /// scheduled. Suites that derive their own domains from this one (the
+    /// Survey tests append `.state`, `.prioritization`, …) keep working, since
+    /// this is a stored constant rather than a freshly computed value.
+    nonisolated let userDefaultsSuiteName = "OBAKitTests.\(UUID().uuidString)"
 
     // MARK: - API Service Data
 

--- a/OBAKitTests/Helpers/OBATestCase.swift
+++ b/OBAKitTests/Helpers/OBATestCase.swift
@@ -205,8 +205,10 @@ class OBATestCase {
     /// (e.g. anything that constructs a view controller which reads
     /// `application.regionsService` / stores at init time).
     ///
-    /// Test classes still own their own `queue` because a per-test queue
-    /// keeps `cancelAllOperations()` scoped to each `tearDown`.
+    /// Test suites still own their own `queue` because a per-suite queue keeps
+    /// `cancelAllOperations()` scoped to one test — Swift Testing builds a fresh
+    /// suite instance per test function and releases it afterwards, so the
+    /// cancellation lands in that instance's `deinit`.
     func buildApplication(queue: OperationQueue, dataLoader: MockDataLoader) -> Application {
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)

--- a/OBAKitTests/Helpers/Polling.swift
+++ b/OBAKitTests/Helpers/Polling.swift
@@ -60,3 +60,21 @@ func poll(
         sourceLocation: sourceLocation
     )
 }
+
+/// Lets queued main-actor work and in-flight animations run for `seconds`.
+///
+/// This replaced `RunLoop.current.run(until:)`, which used to work and no longer
+/// does. Under XCTest a test method ran directly on the main thread's run loop,
+/// so blocking there still drained the main queue. A Swift Testing `@MainActor`
+/// test body is itself a main-queue item, and blocking inside it cannot
+/// re-entrantly drain further main-queue blocks — UIView animation completion
+/// handlers simply never fire. Suspending releases the main actor, which is what
+/// actually lets that work run.
+///
+/// Prefer ``poll(until:timeout:interval:_:sourceLocation:)`` when there is a
+/// condition to wait on: it returns as soon as the condition holds, where this
+/// always burns the full duration. Use this only to let an animation of known
+/// length play out.
+func spin(_ seconds: TimeInterval) async {
+    try? await Task.sleep(for: .seconds(seconds))
+}

--- a/OBAKitTests/Helpers/SendableBox.swift
+++ b/OBAKitTests/Helpers/SendableBox.swift
@@ -1,0 +1,36 @@
+//
+//  SendableBox.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// A lock-guarded box for a value a test needs to capture out of concurrently
+/// executing code — a `MockDataLoader` matcher, a `@Sendable` completion
+/// handler, anything the runtime may call off the main actor.
+///
+/// The test target defaults to main-actor isolation, so the obvious `var
+/// captured: T?` in a test body is main-actor state; mutating it from a matcher
+/// is a data race, and one the compiler now rejects because
+/// `MockDataLoaderMatcher` is `@Sendable`.
+///
+/// `@unchecked Sendable` is honest here because the lock, not isolation, is what
+/// serialises access — and `nonisolated` keeps the box out of the target's
+/// main-actor default so it can be touched from wherever the callback lands.
+nonisolated final class SendableBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: T
+
+    var value: T {
+        get { lock.withLock { storage } }
+        set { lock.withLock { storage = newValue } }
+    }
+
+    init(_ value: T) {
+        storage = value
+    }
+}

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
@@ -16,15 +15,17 @@ import Testing
 
 // swiftlint:disable force_try
 
-class LocationServiceRegionMonitoringTests: OBATestCase {
+@Suite(.serialized)
+final class LocationServiceRegionMonitoringTests: OBATestCase {
 
     var locationManagerMock: AuthorizableLocationManagerMock!
     var service: LocationService!
     var delegate: LocDelegate!
     var stop: Stop!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         let location = CLLocation(latitude: 47.0, longitude: -122.0)
         locationManagerMock = AuthorizableLocationManagerMock(updateLocation: location, updateHeading: OBAMockHeading(heading: 0.0))
         locationManagerMock._authorizationStatus = .authorizedWhenInUse
@@ -36,7 +37,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Start Monitoring
 
-    func test_startMonitoringProximity_createsRegionWithCorrectProperties() {
+    @Test func `Start monitoring proximity creates region with correct properties`() {
         let alert = ProximityAlert(stop: stop, radiusMeters: 300.0)
 
         service.startMonitoringProximity(for: alert)
@@ -53,7 +54,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(region?.notifyOnExit == false)
     }
 
-    func test_startMonitoringProximity_unauthorized_doesNotMonitor() {
+    @Test func `Start monitoring proximity unauthorized does not monitor`() {
         let unauthorizedMock = LocationManagerMock()
         let unauthorizedService = LocationService(userDefaults: userDefaults, locationManager: unauthorizedMock)
         let alert = ProximityAlert(stop: stop)
@@ -63,7 +64,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(unauthorizedMock.monitoredRegions.isEmpty)
     }
 
-    func test_startMonitoringProximity_defaultRadius() {
+    @Test func `Start monitoring proximity default radius`() {
         let alert = ProximityAlert(stop: stop)
 
         service.startMonitoringProximity(for: alert)
@@ -72,7 +73,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(region?.radius == 200.0)
     }
 
-    func test_startMonitoringProximity_duplicateAlert_replacesRegion() {
+    @Test func `Start monitoring proximity duplicate alert replaces region`() {
         let alert = ProximityAlert(stop: stop)
 
         service.startMonitoringProximity(for: alert)
@@ -83,7 +84,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.first?.identifier == "oba.proximity.\(alert.id.uuidString)")
     }
 
-    func test_startMonitoringProximity_multipleAlerts() {
+    @Test func `Start monitoring proximity multiple alerts`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -96,7 +97,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Stop Monitoring
 
-    func test_stopMonitoringProximity_removesCorrectRegion() {
+    @Test func `Stop monitoring proximity removes correct region`() {
         let alert = ProximityAlert(stop: stop)
 
         service.startMonitoringProximity(for: alert)
@@ -106,7 +107,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.isEmpty)
     }
 
-    func test_stopMonitoringProximity_nonexistentAlert_isNoOp() {
+    @Test func `Stop monitoring proximity nonexistent alert is no op`() {
         let alert1 = ProximityAlert(stop: stop)
         let alert2 = ProximityAlert(stop: stop)
 
@@ -117,7 +118,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.count == 1)
     }
 
-    func test_stopMonitoringProximity_onlyRemovesTargetRegion() {
+    @Test func `Stop monitoring proximity only removes target region`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -134,7 +135,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Stop All Monitoring
 
-    func test_stopMonitoringAllProximityAlerts_removesAllPrefixedRegions() {
+    @Test func `Stop monitoring all proximity alerts removes all prefixed regions`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -147,7 +148,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.isEmpty)
     }
 
-    func test_stopMonitoringAllProximityAlerts_preservesNonPrefixedRegions() {
+    @Test func `Stop monitoring all proximity alerts preserves non prefixed regions`() {
         let alert = ProximityAlert(stop: stop)
         service.startMonitoringProximity(for: alert)
 
@@ -166,7 +167,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.first?.identifier == "some-other-region")
     }
 
-    func test_stopMonitoringAllProximityAlerts_emptyRegions_isNoOp() {
+    @Test func `Stop monitoring all proximity alerts empty regions is no op`() {
         #expect(self.locationManagerMock.monitoredRegions.isEmpty)
 
         service.stopMonitoringAllProximityAlerts()
@@ -176,7 +177,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Delegate: didEnterRegion
 
-    func test_didEnterRegion_notifiesDelegate() {
+    @Test func `Did enter region notifies delegate`() {
         let alert = ProximityAlert(stop: stop)
         let region = CLCircularRegion(
             center: alert.coordinate,
@@ -189,7 +190,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.delegate.enteredRegionIdentifier == "oba.proximity.\(alert.id.uuidString)")
     }
 
-    func test_didEnterRegion_nonPrefixedCircularRegion_doesNotNotify() {
+    @Test func `Did enter region non prefixed circular region does not notify`() {
         let region = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
             radius: 200,
@@ -201,7 +202,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.delegate.enteredRegionIdentifier == nil)
     }
 
-    func test_didEnterRegion_nonCircularRegion_doesNotNotify() {
+    @Test func `Did enter region non circular region does not notify`() {
         let beaconRegion = CLBeaconRegion(
             uuid: UUID(),
             identifier: "oba.proximity.beacon-test"
@@ -214,7 +215,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Delegate: monitoringDidFail
 
-    func test_monitoringDidFail_notifiesDelegate() {
+    @Test func `Monitoring did fail notifies delegate`() {
         let region = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
             radius: 200,
@@ -228,7 +229,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect((self.delegate.monitoringFailedError as? NSError)?.code == 5)
     }
 
-    func test_monitoringDidFail_nilRegion_notifiesDelegate() {
+    @Test func `Monitoring did fail nil region notifies delegate`() {
         let error = NSError(domain: "CLError", code: 5, userInfo: nil)
 
         service.locationManager(CLLocationManager(), monitoringDidFailFor: nil, withError: error)
@@ -239,7 +240,7 @@ class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Multiple Delegates
 
-    func test_didEnterRegion_notifiesMultipleDelegates() {
+    @Test func `Did enter region notifies multiple delegates`() {
         let delegate2 = LocDelegate()
         service.addDelegate(delegate2)
 

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -8,17 +8,17 @@
 //
 
 import Foundation
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
 import Testing
 
 @MainActor
-class LocationServiceTests: XCTestCase {
+@Suite(.serialized)
+final class LocationServiceTests {
     // MARK: - Authorization
 
-    func test_authorization_defaultValueIsNotDetermined() {
+    @Test func `Authorization default value is not determined`() {
         let service = LocationService(userDefaults: UserDefaults(), locationManager: LocationManagerMock())
 
         #expect(service.authorizationStatus == .notDetermined)
@@ -26,7 +26,7 @@ class LocationServiceTests: XCTestCase {
         #expect(service.canRequestAuthorization)
     }
 
-    func test_authorization_granted() async {
+    @Test func `Authorization granted`() async {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
         let delegate = LocDelegate()
@@ -44,7 +44,7 @@ class LocationServiceTests: XCTestCase {
         #expect(delegate.error == nil)
     }
 
-    func test_updateLocation_successiveUpdates_succeed() {
+    @Test func `Update location successive updates succeed`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         locationManagerMock.requestWhenInUseAuthorization()
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
@@ -60,7 +60,7 @@ class LocationServiceTests: XCTestCase {
         #expect(service.currentLocation == TestData.mockTampaLocation)
     }
 
-    func test_updateLocation_withNoLocation_doesNotTriggerUpdates() {
+    @Test func `Update location with no location does not trigger updates`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
 
@@ -73,7 +73,7 @@ class LocationServiceTests: XCTestCase {
         #expect(del.location == TestData.mockSeattleLocation)
     }
 
-    func test_updateLocation_withLowAccuracy_doesNotTriggerUpdates() {
+    @Test func `Update location with low accuracy does not trigger updates`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
         service.successiveLocationComparisonWindow = 60.0
@@ -91,7 +91,7 @@ class LocationServiceTests: XCTestCase {
         #expect(service.currentLocation == seattle)
     }
 
-    func test_stopUpdates_disablesUpdates() {
+    @Test func `Stop updates disables updates`() {
         let locationManagerMock = AuthorizableLocationManagerMock(updateLocation: TestData.mockSeattleLocation, updateHeading: TestData.mockHeading)
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
 
@@ -100,7 +100,7 @@ class LocationServiceTests: XCTestCase {
         #expect(!locationManagerMock.headingUpdatesStarted)
     }
 
-    func test_startUpdates_withoutAuthorization_doesNothing() {
+    @Test func `Start updates without authorization does nothing`() {
         let locationManagerMock = LocationManagerMock()
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
 
@@ -115,7 +115,7 @@ class LocationServiceTests: XCTestCase {
         #expect(!locationManagerMock.headingUpdatesStarted)
     }
 
-    func test_receiveErrors() {
+    @Test func `Receive errors`() {
         let locationManagerMock = LocationManagerMock()
         let service = LocationService(userDefaults: UserDefaults(), locationManager: locationManagerMock)
         let del = LocDelegate()

--- a/OBAKitTests/Location/RegionsFileStorageTests.swift
+++ b/OBAKitTests/Location/RegionsFileStorageTests.swift
@@ -137,7 +137,9 @@ final class RegionsFileStorageTests {
 
 /// A `FileManager` subclass that redirects Application Support and Documents
 /// directory lookups to a temporary directory so tests never touch the real file system.
-private class TemporaryDirectoryFileManager: FileManager {
+// `nonisolated`: overrides nonisolated FileManager members, which the target's
+// main-actor default isolation would conflict with.
+private nonisolated class TemporaryDirectoryFileManager: FileManager {
 
     private let baseURL: URL
 

--- a/OBAKitTests/Location/RegionsFileStorageTests.swift
+++ b/OBAKitTests/Location/RegionsFileStorageTests.swift
@@ -8,18 +8,18 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKitCore
 
 @MainActor
-class RegionsFileStorageTests: XCTestCase {
+@Suite(.serialized)
+final class RegionsFileStorageTests {
 
     private var temporaryDirectory: URL!
     private var fileManager: FileManager!
     private var storage: RegionsFileStorage!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
 
         fileManager = .default
         temporaryDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -29,90 +29,89 @@ class RegionsFileStorageTests: XCTestCase {
         storage = RegionsFileStorage(fileManager: TemporaryDirectoryFileManager(temporaryDirectory: temporaryDirectory))
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         try? fileManager.removeItem(at: temporaryDirectory)
-        try await super.tearDown()
     }
 
     // MARK: - Default Regions
 
-    func test_loadDefaultRegions_returnsNilWhenNoFileExists() throws {
+    @Test func `Load default regions returns nil when no file exists`() throws {
         let result = try storage.loadDefaultRegions()
-        XCTAssertNil(result, "Expected nil when no default regions file has been written")
+        #expect(result == nil, "Expected nil when no default regions file has been written")
     }
 
-    func test_saveAndLoadDefaultRegions_roundTrip() throws {
+    @Test func `Save and load default regions round trip`() throws {
         let regions = [Fixtures.customMinneapolisRegion]
         try storage.saveDefaultRegions(regions)
 
-        let loaded = try XCTUnwrap(storage.loadDefaultRegions())
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded.first?.name, regions.first?.name)
-        XCTAssertEqual(loaded.first?.regionIdentifier, regions.first?.regionIdentifier)
+        let loaded = try #require(try storage.loadDefaultRegions())
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.name == regions.first?.name)
+        #expect(loaded.first?.regionIdentifier == regions.first?.regionIdentifier)
     }
 
-    func test_saveDefaultRegions_overwritesPreviousFile() throws {
+    @Test func `Save default regions overwrites previous file`() throws {
         let first = [Fixtures.customMinneapolisRegion]
         try storage.saveDefaultRegions(first)
 
-        let second = try XCTUnwrap(Fixtures.loadSomeRegions()).prefix(1).map { $0 }
+        let second = try Fixtures.loadSomeRegions().prefix(1).map { $0 }
         try storage.saveDefaultRegions(second)
 
-        let loaded = try XCTUnwrap(storage.loadDefaultRegions())
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded.first?.name, second.first?.name)
+        let loaded = try #require(try storage.loadDefaultRegions())
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.name == second.first?.name)
     }
 
-    func test_saveDefaultRegions_createsIntermediateDirectories() throws {
+    @Test func `Save default regions creates intermediate directories`() throws {
         // The storage should auto-create any missing parent directories.
         let regions = [Fixtures.customMinneapolisRegion]
-        XCTAssertNoThrow(try storage.saveDefaultRegions(regions))
+        #expect(throws: Never.self) { try storage.saveDefaultRegions(regions) }
         let loaded = try storage.loadDefaultRegions()
-        XCTAssertNotNil(loaded)
+        #expect(loaded != nil)
     }
 
     // MARK: - Custom Regions
 
-    func test_loadCustomRegions_returnsEmptyWhenNoFilesExist() throws {
+    @Test func `Load custom regions returns empty when no files exist`() throws {
         let result = try storage.loadCustomRegions()
-        XCTAssertTrue(result.isEmpty, "Expected empty array when no custom region files exist")
+        #expect(result.isEmpty, "Expected empty array when no custom region files exist")
     }
 
-    func test_saveAndLoadCustomRegion_roundTrip() throws {
+    @Test func `Save and load custom region round trip`() throws {
         let region = Fixtures.customMinneapolisRegion
         try storage.saveCustomRegion(region)
 
         let loaded = try storage.loadCustomRegions()
-        XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded.first?.name, region.name)
-        XCTAssertEqual(loaded.first?.regionIdentifier, region.regionIdentifier)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.name == region.name)
+        #expect(loaded.first?.regionIdentifier == region.regionIdentifier)
     }
 
-    func test_saveCustomRegion_replacesExistingRegionWithSameIdentifier() throws {
+    @Test func `Save custom region replaces existing region with same identifier`() throws {
         let region = Fixtures.customMinneapolisRegion
         try storage.saveCustomRegion(region)
-        XCTAssertEqual(try storage.loadCustomRegions().count, 1)
+        #expect(try storage.loadCustomRegions().count == 1)
 
         // Saving the same region again should overwrite the existing file, not create a second one.
         try storage.saveCustomRegion(region)
 
-        XCTAssertEqual(try storage.loadCustomRegions().count, 1, "Expected saving the same region twice to result in a single file")
+        #expect(try storage.loadCustomRegions().count == 1, "Expected saving the same region twice to result in a single file")
     }
 
-    func test_deleteCustomRegion_removesFile() throws {
+    @Test func `Delete custom region removes file`() throws {
         let region = Fixtures.customMinneapolisRegion
         try storage.saveCustomRegion(region)
-        XCTAssertEqual(try storage.loadCustomRegions().count, 1)
+        #expect(try storage.loadCustomRegions().count == 1)
 
         try storage.deleteCustomRegion(identifier: region.regionIdentifier)
-        XCTAssertTrue(try storage.loadCustomRegions().isEmpty, "Expected custom regions to be empty after deletion")
+        #expect(try storage.loadCustomRegions().isEmpty, "Expected custom regions to be empty after deletion")
     }
 
-    func test_deleteCustomRegion_doesNotThrowWhenFileDoesNotExist() {
-        XCTAssertNoThrow(try storage.deleteCustomRegion(identifier: 9999))
+    @Test func `Delete custom region does not throw when file does not exist`() {
+        #expect(throws: Never.self) { try storage.deleteCustomRegion(identifier: 9999) }
     }
 
-    func test_loadCustomRegions_skipsCorruptedFiles() throws {
+    @Test func `Load custom regions skips corrupted files`() throws {
         // Write a valid region and a corrupted JSON file side by side.
         let validRegion = Fixtures.customMinneapolisRegion
         try storage.saveCustomRegion(validRegion)
@@ -123,8 +122,8 @@ class RegionsFileStorageTests: XCTestCase {
 
         // loadCustomRegions must not throw when individual files are corrupted — it skips them and returns the rest.
         let loaded = try storage.loadCustomRegions()
-        XCTAssertEqual(loaded.count, 1, "Expected corrupted file to be skipped; only valid region should be returned")
-        XCTAssertEqual(loaded.first?.name, validRegion.name)
+        #expect(loaded.count == 1, "Expected corrupted file to be skipped; only valid region should be returned")
+        #expect(loaded.first?.name == validRegion.name)
     }
 
     // MARK: - Helpers

--- a/OBAKitTests/Location/RegionsFileStorageTests.swift
+++ b/OBAKitTests/Location/RegionsFileStorageTests.swift
@@ -20,7 +20,6 @@ final class RegionsFileStorageTests {
     private var storage: RegionsFileStorage!
 
     init() {
-
         fileManager = .default
         temporaryDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try! fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)

--- a/OBAKitTests/Location/RegionsServiceAutoSelectTests.swift
+++ b/OBAKitTests/Location/RegionsServiceAutoSelectTests.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
@@ -16,14 +16,15 @@ import CoreLocation
 // MARK: - Auto Region Selection Tests
 // See: https://github.com/OneBusAway/onebusaway-ios/issues/608
 
-class RegionsServiceAutoSelectTests: OBATestCase {
+@Suite(.serialized)
+final class RegionsServiceAutoSelectTests: OBATestCase {
     var locationManagerMock: LocationManagerMock!
     var locationService: LocationService!
     var dataLoader: MockDataLoader!
     var mockFileStorage: MockRegionsFileStorage!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         locationManagerMock = LocationManagerMock()
         locationService = LocationService(userDefaults: userDefaults, locationManager: locationManagerMock)
@@ -33,7 +34,7 @@ class RegionsServiceAutoSelectTests: OBATestCase {
 
     // MARK: - Fixed Region by Name
 
-    func test_fixedRegionName_matchesBundledRegion() throws {
+    @Test func `Fixed region name matches bundled region`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let service = RegionsService(
@@ -46,11 +47,11 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionName: "Puget Sound"
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Puget Sound")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Puget Sound")
     }
 
-    func test_fixedRegionName_noMatch_fallsToURL() throws {
+    @Test func `Fixed region name no match falls to URL`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let service = RegionsService(
@@ -64,11 +65,11 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionOBABaseURL: URL(string: "https://api.tampa.onebusawaycloud.com/")
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Tampa Bay")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Tampa Bay")
     }
 
-    func test_fixedRegionName_noMatch_noURL_regionRemainsNil() {
+    @Test func `Fixed region name no match no URL region remains nil`() {
         stubRegions(dataLoader: dataLoader)
 
         let service = RegionsService(
@@ -81,10 +82,10 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionName: "Nonexistent Region"
         )
 
-        XCTAssertNil(service.currentRegion)
+        #expect(service.currentRegion == nil)
     }
 
-    func test_fixedRegion_disablesAutoSelect() throws {
+    @Test func `Fixed region disables auto select`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let service = RegionsService(
@@ -97,14 +98,14 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionName: "Puget Sound"
         )
 
-        XCTAssertNotNil(service.currentRegion)
-        XCTAssertFalse(service.automaticallySelectRegion, "Auto-select should be disabled when a fixed region is matched")
+        #expect(service.currentRegion != nil)
+        #expect(!service.automaticallySelectRegion, "Auto-select should be disabled when a fixed region is matched")
     }
 
-    func test_fixedRegion_onlyAppliesWhenCurrentRegionNil() throws {
+    @Test func `Fixed region only applies when current region nil`() throws {
         stubRegions(dataLoader: dataLoader)
 
-        let tampaBay = try XCTUnwrap(Fixtures.loadSomeRegions().first(where: { $0.name == "Tampa Bay" }))
+        let tampaBay = try #require(Fixtures.loadSomeRegions().first(where: { $0.name == "Tampa Bay" }))
         userDefaults.set(tampaBay.regionIdentifier, forKey: RegionsService.currentRegionIdentifierUserDefaultsKey)
         userDefaults.set(false, forKey: RegionsService.automaticallySelectRegionUserDefaultsKey)
 
@@ -118,17 +119,17 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionName: "Puget Sound"
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Tampa Bay", "Fixed region should not override a previously selected region")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Tampa Bay", "Fixed region should not override a previously selected region")
     }
 
     // MARK: - Single Active Region Auto-Select
 
-    func test_singleActiveRegion_autoSelected() throws {
+    @Test func `Single active region auto selected`() throws {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
 
         // Seed file storage with just one region so it's the only active region available.
-        let pugetSound = try XCTUnwrap(Fixtures.loadSomeRegions().first(where: { $0.name == "Puget Sound" }))
+        let pugetSound = try #require(Fixtures.loadSomeRegions().first(where: { $0.name == "Puget Sound" }))
         mockFileStorage.storedDefaultRegions = [pugetSound]
 
         let service = RegionsService(
@@ -140,11 +141,11 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fileStorage: mockFileStorage
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Puget Sound", "The only active region should be auto-selected")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Puget Sound", "The only active region should be auto-selected")
     }
 
-    func test_multipleActiveRegions_noAutoSelect() {
+    @Test func `Multiple active regions no auto select`() {
         stubRegions(dataLoader: dataLoader)
 
         // The bundled regions-v3.json has multiple active regions.
@@ -157,12 +158,12 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fileStorage: mockFileStorage
         )
 
-        XCTAssertNil(service.currentRegion, "Region should not be auto-selected when multiple active regions exist")
+        #expect(service.currentRegion == nil, "Region should not be auto-selected when multiple active regions exist")
     }
 
     // MARK: - Location-Based Selection Priority
 
-    func test_locationBasedSelection_takesPriority() throws {
+    @Test func `Location based selection takes priority`() throws {
         stubRegions(dataLoader: dataLoader)
 
         // Set location inside Puget Sound region.
@@ -178,13 +179,13 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionName: "Tampa Bay"
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Puget Sound", "Location-based selection should take priority over fixed region config")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Puget Sound", "Location-based selection should take priority over fixed region config")
     }
 
     // MARK: - Fixed Region with URL Match
 
-    func test_fixedRegionURL_matchesBundledRegion() throws {
+    @Test func `Fixed region URL matches bundled region`() throws {
         stubRegions(dataLoader: dataLoader)
 
         // Use a name that won't match, but provide the correct Tampa Bay URL.
@@ -199,13 +200,13 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fixedRegionOBABaseURL: URL(string: "https://api.tampa.onebusawaycloud.com/")
         )
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Tampa Bay")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Tampa Bay")
     }
 
     // MARK: - No Config, No Location, Multiple Regions
 
-    func test_noFixedRegion_noLocation_multipleRegions_remainsNil() {
+    @Test func `No fixed region no location multiple regions remains nil`() {
         stubRegions(dataLoader: dataLoader)
 
         let service = RegionsService(
@@ -217,6 +218,6 @@ class RegionsServiceAutoSelectTests: OBATestCase {
             fileStorage: mockFileStorage
         )
 
-        XCTAssertNil(service.currentRegion, "Without config, location, or single region, currentRegion should remain nil")
+        #expect(service.currentRegion == nil, "Without config, location, or single region, currentRegion should remain nil")
     }
 }

--- a/OBAKitTests/Location/RegionsServiceMigrationTests.swift
+++ b/OBAKitTests/Location/RegionsServiceMigrationTests.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKitCore
 
 /// Tests for the one-time migration of region data from UserDefaults to disk storage.
@@ -16,12 +16,14 @@ import XCTest
 /// Every user upgrading from a pre-disk-storage release runs this migration exactly once
 /// at launch, so these tests guard against losing the user's selected region, the
 /// downloaded region list, or their custom regions during an app update.
-class RegionsServiceMigrationTests: OBATestCase {
+@Suite(.serialized)
+final class RegionsServiceMigrationTests: OBATestCase {
 
     private var fileStorage: MockRegionsFileStorage!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         fileStorage = MockRegionsFileStorage()
     }
 
@@ -41,127 +43,122 @@ class RegionsServiceMigrationTests: OBATestCase {
 
     // MARK: - No Legacy Data
 
-    func test_noLegacyData_isANoOp() {
+    @Test func `No legacy data is a no op`() {
         migrate()
 
-        XCTAssertNil(fileStorage.storedDefaultRegions)
-        XCTAssertTrue(fileStorage.storedCustomRegions.isEmpty)
-        XCTAssertNil(userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey))
+        #expect(fileStorage.storedDefaultRegions == nil)
+        #expect(fileStorage.storedCustomRegions.isEmpty)
+        #expect(userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) == nil)
     }
 
     // MARK: - Default Regions
 
-    func test_defaultRegions_migratedToDiskAndLegacyKeyRemoved() {
+    @Test func `Default regions migrated to disk and legacy key removed`() {
         let regions = [Fixtures.pugetSoundRegion, Fixtures.tampaRegion]
         userDefaults.set(encode(regions), forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
 
         migrate()
 
-        XCTAssertEqual(fileStorage.storedDefaultRegions?.map(\.regionIdentifier), regions.map(\.regionIdentifier))
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey))
+        #expect(fileStorage.storedDefaultRegions?.map(\.regionIdentifier) == regions.map(\.regionIdentifier))
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil)
     }
 
-    func test_defaultRegions_corruptedData_isDiscardedAndKeyRemoved() {
+    @Test func `Default regions corrupted data is discarded and key removed`() {
         userDefaults.set(Data([0x00, 0x01, 0x02]), forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
 
         migrate()
 
-        XCTAssertNil(fileStorage.storedDefaultRegions)
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey))
+        #expect(fileStorage.storedDefaultRegions == nil)
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil)
     }
 
-    func test_defaultRegions_emptyList_clearsKeyWithoutWriting() {
+    @Test func `Default regions empty list clears key without writing`() {
         userDefaults.set(encode([Region]()), forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
 
         migrate()
 
-        XCTAssertNil(fileStorage.storedDefaultRegions)
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey))
+        #expect(fileStorage.storedDefaultRegions == nil)
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil)
     }
 
-    func test_defaultRegions_diskWriteFails_keyIsKeptForRetry() {
+    @Test func `Default regions disk write fails key is kept for retry`() {
         let regions = [Fixtures.pugetSoundRegion]
         userDefaults.set(encode(regions), forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
         fileStorage.saveDefaultRegionsError = TestError.diskWriteFailed
 
         migrate()
 
-        XCTAssertNotNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey),
-                        "A failed disk write must leave the legacy key intact so migration retries on next launch")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) != nil, "A failed disk write must leave the legacy key intact so migration retries on next launch")
 
         // Next launch: the disk write succeeds and the key is cleared.
         fileStorage.saveDefaultRegionsError = nil
         migrate()
 
-        XCTAssertEqual(fileStorage.storedDefaultRegions?.count, 1)
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey))
+        #expect(fileStorage.storedDefaultRegions?.count == 1)
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil)
     }
 
     // MARK: - Custom Regions
 
-    func test_customRegions_migratedToDiskAndLegacyKeyRemoved() {
+    @Test func `Custom regions migrated to disk and legacy key removed`() {
         let regions = [Fixtures.customMinneapolisRegion]
         userDefaults.set(encode(regions), forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey)
 
         migrate()
 
-        XCTAssertEqual(fileStorage.storedCustomRegions.map(\.regionIdentifier), regions.map(\.regionIdentifier))
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey))
+        #expect(fileStorage.storedCustomRegions.map(\.regionIdentifier) == regions.map(\.regionIdentifier))
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) == nil)
     }
 
-    func test_customRegions_corruptedData_isDiscardedAndKeyRemoved() {
+    @Test func `Custom regions corrupted data is discarded and key removed`() {
         userDefaults.set(Data([0xFF]), forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey)
 
         migrate()
 
-        XCTAssertTrue(fileStorage.storedCustomRegions.isEmpty)
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey))
+        #expect(fileStorage.storedCustomRegions.isEmpty)
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) == nil)
     }
 
-    func test_customRegions_saveFails_keyIsKeptForRetry() {
+    @Test func `Custom regions save fails key is kept for retry`() {
         let regions = [Fixtures.customMinneapolisRegion]
         userDefaults.set(encode(regions), forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey)
         fileStorage.saveCustomRegionError = TestError.diskWriteFailed
 
         migrate()
 
-        XCTAssertNotNil(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey),
-                        "A failed save must leave the legacy key intact so migration retries on next launch")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) != nil, "A failed save must leave the legacy key intact so migration retries on next launch")
 
         fileStorage.saveCustomRegionError = nil
         migrate()
 
-        XCTAssertEqual(fileStorage.storedCustomRegions.count, 1)
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey))
+        #expect(fileStorage.storedCustomRegions.count == 1)
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) == nil)
     }
 
     // MARK: - Current Region
 
-    func test_currentRegion_convertedToIdentifierAndLegacyKeyRemoved() {
+    @Test func `Current region converted to identifier and legacy key removed`() {
         let region = Fixtures.pugetSoundRegion
         userDefaults.set(encode(region), forKey: RegionsService.legacyCurrentRegionUserDefaultsKey)
 
         migrate()
 
-        XCTAssertEqual(
-            userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) as? Int,
-            region.regionIdentifier
-        )
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey))
+        #expect((userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) as? Int) == region.regionIdentifier)
+        #expect(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey) == nil)
     }
 
-    func test_currentRegion_corruptedData_isDiscardedAndKeyRemoved() {
+    @Test func `Current region corrupted data is discarded and key removed`() {
         userDefaults.set(Data([0x42]), forKey: RegionsService.legacyCurrentRegionUserDefaultsKey)
 
         migrate()
 
-        XCTAssertNil(userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey))
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey))
+        #expect(userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) == nil)
+        #expect(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey) == nil)
     }
 
     // MARK: - Idempotency
 
-    func test_fullMigration_isIdempotent() {
+    @Test func `Full migration is idempotent`() {
         userDefaults.set(encode([Fixtures.pugetSoundRegion]), forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
         userDefaults.set(encode([Fixtures.customMinneapolisRegion]), forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey)
         userDefaults.set(encode(Fixtures.pugetSoundRegion), forKey: RegionsService.legacyCurrentRegionUserDefaultsKey)
@@ -172,11 +169,8 @@ class RegionsServiceMigrationTests: OBATestCase {
 
         migrate()
 
-        XCTAssertEqual(fileStorage.storedDefaultRegions?.map(\.regionIdentifier), defaultsAfterFirstRun?.map(\.regionIdentifier))
-        XCTAssertEqual(fileStorage.storedCustomRegions.map(\.regionIdentifier), customAfterFirstRun.map(\.regionIdentifier))
-        XCTAssertEqual(
-            userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) as? Int,
-            Fixtures.pugetSoundRegion.regionIdentifier
-        )
+        #expect(fileStorage.storedDefaultRegions?.map(\.regionIdentifier) == defaultsAfterFirstRun?.map(\.regionIdentifier))
+        #expect(fileStorage.storedCustomRegions.map(\.regionIdentifier) == customAfterFirstRun.map(\.regionIdentifier))
+        #expect((userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) as? Int) == Fixtures.pugetSoundRegion.regionIdentifier)
     }
 }

--- a/OBAKitTests/Location/RegionsServiceTests.swift
+++ b/OBAKitTests/Location/RegionsServiceTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -41,15 +40,16 @@ private class RegionsServiceTestDelegate: NSObject, RegionsServiceDelegate {
 
 // MARK: - Test Case
 
-class RegionsServiceTests: OBATestCase {
+@Suite(.serialized)
+final class RegionsServiceTests: OBATestCase {
     private var testDelegate: RegionsServiceTestDelegate!
     var locationManagerMock: LocationManagerMock!
     var locationService: LocationService!
     var dataLoader: MockDataLoader!
     var mockFileStorage: MockRegionsFileStorage!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         testDelegate = RegionsServiceTestDelegate()
         locationManagerMock = LocationManagerMock()
@@ -75,15 +75,15 @@ class RegionsServiceTests: OBATestCase {
     // MARK: - Upon creating the Regions Service
 
     // It loads bundled regions from its framework when no other data exists
-    func test_init_loadsBundledRegions() {
+    @Test func `Init loads bundled regions`() {
         stubRegions(dataLoader: dataLoader)
 
         let service = makeRegionsService()
-        XCTAssertEqual(service.regions.count, 7)
+        #expect(service.regions.count == 7)
     }
 
     // It loads regions saved to disk when they exist
-    func test_init_loadsSavedRegions() throws {
+    @Test func `Init loads saved regions`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -91,13 +91,13 @@ class RegionsServiceTests: OBATestCase {
 
         let service = makeRegionsService()
 
-        let firstRegion = try XCTUnwrap(service.regions.first)
-        XCTAssertEqual(firstRegion.name, "Custom Region", "Expected the first region to be the custom region")
-        XCTAssertEqual(service.regions.count, 1)
+        let firstRegion = try #require(service.regions.first)
+        #expect(firstRegion.name == "Custom Region", "Expected the first region to be the custom region")
+        #expect(service.regions.count == 1)
     }
 
     // It loads the current region identifier from user defaults when it exists (auto-select disabled)
-    func test_init_loadsCurrentRegion_autoSelectDisabled() throws {
+    @Test func `Init loads current region auto select disabled`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -107,10 +107,10 @@ class RegionsServiceTests: OBATestCase {
 
         let service = makeRegionsService()
 
-        XCTAssertEqual(service.currentRegion, customRegion)
+        #expect(service.currentRegion == customRegion)
     }
 
-    func test_init_loadsCurrentRegion_autoSelectEnabled() throws {
+    @Test func `Init loads current region auto select enabled`() throws {
         stubRegions(dataLoader: dataLoader)
 
         // Store the Minneapolis region identifier, but location points to Puget Sound —
@@ -121,12 +121,12 @@ class RegionsServiceTests: OBATestCase {
 
         let service = makeRegionsService()
 
-        let currentRegion = try XCTUnwrap(service.currentRegion)
-        XCTAssertEqual(currentRegion.name, "Puget Sound")
+        let currentRegion = try #require(service.currentRegion)
+        #expect(currentRegion.name == "Puget Sound")
     }
 
     /// It downloads an up-to-date list of regions if that list hasn't been updated in at least a week.
-    func test_init_updateRegionsList() async {
+    @Test func `Init update regions list`() async {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
 
         let regionsService = RegionsService(
@@ -141,11 +141,11 @@ class RegionsServiceTests: OBATestCase {
 
         await regionsService.updateRegionsList()
 
-        XCTAssertTrue(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
+        #expect(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
     }
 
     /// It *does not* download a list of regions if the list was last updated less than a week ago.
-    func test_init_skipUpdateRegionsList() async {
+    @Test func `Init skip update regions list`() async {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
 
@@ -161,12 +161,12 @@ class RegionsServiceTests: OBATestCase {
 
         await regionsService.updateRegionsList()
 
-        XCTAssertTrue(testDelegate.regionUpdateCancelled.didCall, "Expected RegionsService to inform delegates that the region update was cancelled")
-        XCTAssertEqual(regionsService.regions.count, 7)
+        #expect(testDelegate.regionUpdateCancelled.didCall, "Expected RegionsService to inform delegates that the region update was cancelled")
+        #expect(regionsService.regions.count == 7)
     }
 
     /// It *does* download a list of regions—even if the list was last updated less than a week ago—if the update is forced.
-    func test_init_forceUpdateRegionsList() async {
+    @Test func `Init force update regions list`() async {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
 
@@ -181,13 +181,13 @@ class RegionsServiceTests: OBATestCase {
         )
 
         await regionsService.updateRegionsList(forceUpdate: true)
-        XCTAssertFalse(testDelegate.regionUpdateCancelled.didCall, "Expected RegionsService to not inform delegates that a region update was cancelled")
-        XCTAssertTrue(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
-        XCTAssertEqual(regionsService.regions.count, 1)
+        #expect(!testDelegate.regionUpdateCancelled.didCall, "Expected RegionsService to not inform delegates that a region update was cancelled")
+        #expect(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
+        #expect(regionsService.regions.count == 1)
     }
 
     /// It *does* download a list of regions—even if the list was last updated less than a week ago—if alwaysRefreshRegionsOnLaunchUserDefaultsKey is true.
-    func test_init_alwaysRefreshRegionsOnLaunch() async {
+    @Test func `Init always refresh regions on launch`() async {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
         userDefaults.set(true, forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
@@ -203,14 +203,14 @@ class RegionsServiceTests: OBATestCase {
         )
 
         await regionsService.updateRegionsList()
-        XCTAssertTrue(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
-        XCTAssertEqual(regionsService.regions.count, 1)
+        #expect(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
+        #expect(regionsService.regions.count == 1)
     }
 
     // MARK: - Persistence
 
     // It stores downloaded region data in file storage when the regions property is set.
-    func test_persistence() async throws {
+    @Test func `Persistence`() async throws {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
 
@@ -225,31 +225,28 @@ class RegionsServiceTests: OBATestCase {
         )
 
         await regionsService.updateRegionsList(forceUpdate: true)
-        XCTAssertTrue(testDelegate.updatedRegionsList.didCall)
+        #expect(testDelegate.updatedRegionsList.didCall)
 
         // Verify regions were saved to file storage (not UserDefaults).
-        let regions = try XCTUnwrap(
-            mockFileStorage.storedDefaultRegions,
-            "Expected regions to be saved to file storage"
-        )
+        let regions = try #require(mockFileStorage.storedDefaultRegions, "Expected regions to be saved to file storage")
 
-        XCTAssertEqual(regions.count, 1)
-        XCTAssertEqual(regions.first?.name, "Puget Sound")
+        #expect(regions.count == 1)
+        #expect(regions.first?.name == "Puget Sound")
     }
 
     /// It loads the bundled regions when file storage returns an error (e.g. corrupted data).
-    func test_corruptedStorage() {
+    @Test func `Corrupted storage`() {
         stubRegions(dataLoader: dataLoader)
 
         mockFileStorage.loadDefaultRegionsError = CocoaError(.fileReadCorruptFile)
 
         let regionsService = makeRegionsService()
 
-        XCTAssertEqual(regionsService.regions.count, 7)
+        #expect(regionsService.regions.count == 7)
     }
 
     /// It calls delegates to tell them that the current region is updated when that property is written.
-    func test_regionUpdated_notifications() {
+    @Test func `Region updated notifications`() {
         stubRegions(dataLoader: dataLoader)
 
         let regionsService = RegionsService(
@@ -269,13 +266,13 @@ class RegionsServiceTests: OBATestCase {
         regionsService.currentRegion = newRegion
 
         expectDidCallDelegateMethod(testDelegate.newRegionSelected, newRegion, "Expected RegionsService to inform delegates of the new region selection")
-        XCTAssertEqual(regionsService.currentRegion, newRegion, "Expected RegionsService to update its currentRegion property to the new region")
+        #expect(regionsService.currentRegion == newRegion, "Expected RegionsService to update its currentRegion property to the new region")
     }
 
     // MARK: - Network Data
 
     // It updates the 'last updated at' date in user defaults when the regions list is downloaded.
-    func test_regionListUpdated_updatedAtDateIsWritten() async throws {
+    @Test func `Region list updated updated at date is written`() async throws {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date.distantPast, forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
 
@@ -290,22 +287,19 @@ class RegionsServiceTests: OBATestCase {
         )
 
         await regionsService.updateRegionsList()
-        XCTAssertTrue(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
+        #expect(testDelegate.updatedRegionsList.didCall, "Expected RegionsService to inform delegates that the regionsList was updated")
 
-        let newDate = try XCTUnwrap(
-            userDefaults.value(forKey: RegionsService.regionsUpdatedAtUserDefaultsKey) as? Date,
-            "Expected \(RegionsService.regionsUpdatedAtUserDefaultsKey) to be of type Date"
-        )
+        let newDate = try #require(userDefaults.value(forKey: RegionsService.regionsUpdatedAtUserDefaultsKey) as? Date, "Expected \(RegionsService.regionsUpdatedAtUserDefaultsKey) to be of type Date")
 
         let interval = newDate.timeIntervalSince(.now)
-        XCTAssertEqual(interval, 0.0, accuracy: 2.0, "Expected the regionsUpdatedAt time to be near the current time")
-        XCTAssertEqual(regionsService.regions.first?.name, "Puget Sound", "Expected a region to exist in the regionsService")
+        expectClose(interval, 0.0, within: 2.0, "Expected the regionsUpdatedAt time to be near the current time")
+        #expect(regionsService.regions.first?.name == "Puget Sound", "Expected a region to exist in the regionsService")
     }
 
     // MARK: - Migration
 
     /// It migrates downloaded regions from UserDefaults to disk storage on first launch.
-    func test_migration_defaultRegions() throws {
+    @Test func `Migration default regions`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -315,16 +309,16 @@ class RegionsServiceTests: OBATestCase {
         _ = makeRegionsService()
 
         // After init, the region should have been migrated to file storage.
-        let migratedRegions = try XCTUnwrap(mockFileStorage.storedDefaultRegions, "Expected regions to be migrated to file storage")
-        XCTAssertEqual(migratedRegions.count, 1)
-        XCTAssertEqual(migratedRegions.first?.name, "Custom Region")
+        let migratedRegions = try #require(mockFileStorage.storedDefaultRegions, "Expected regions to be migrated to file storage")
+        #expect(migratedRegions.count == 1)
+        #expect(migratedRegions.first?.name == "Custom Region")
 
         // Legacy UserDefaults key should be cleared.
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey), "Expected legacy UserDefaults key to be cleared after migration")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil, "Expected legacy UserDefaults key to be cleared after migration")
     }
 
     /// It migrates custom regions from UserDefaults to individual disk files on first launch.
-    func test_migration_customRegions() throws {
+    @Test func `Migration custom regions`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -333,14 +327,14 @@ class RegionsServiceTests: OBATestCase {
 
         _ = makeRegionsService()
 
-        XCTAssertEqual(mockFileStorage.storedCustomRegions.count, 1)
-        XCTAssertEqual(mockFileStorage.storedCustomRegions.first?.name, "Custom Region")
+        #expect(mockFileStorage.storedCustomRegions.count == 1)
+        #expect(mockFileStorage.storedCustomRegions.first?.name == "Custom Region")
 
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey), "Expected legacy custom regions key to be cleared after migration")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) == nil, "Expected legacy custom regions key to be cleared after migration")
     }
 
     /// It migrates the current region from a full Region object to just the identifier.
-    func test_migration_currentRegion() throws {
+    @Test func `Migration current region`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -350,13 +344,13 @@ class RegionsServiceTests: OBATestCase {
         _ = makeRegionsService()
 
         let migratedIdentifier = userDefaults.integer(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey)
-        XCTAssertEqual(migratedIdentifier, customRegion.regionIdentifier, "Expected current region identifier to be migrated")
+        #expect(migratedIdentifier == customRegion.regionIdentifier, "Expected current region identifier to be migrated")
 
-        XCTAssertNil(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey), "Expected legacy current region key to be cleared after migration")
+        #expect(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey) == nil, "Expected legacy current region key to be cleared after migration")
     }
 
     /// Corrupt plist in the legacy default-regions key must be discarded (key cleared) without saving anything to disk.
-    func test_migration_defaultRegions_corruptData_discardsKey() {
+    @Test func `Migration default regions corrupt data discards key`() {
         stubRegions(dataLoader: dataLoader)
 
         let data = "corrupted data".data(using: .utf8)
@@ -364,15 +358,12 @@ class RegionsServiceTests: OBATestCase {
 
         _ = makeRegionsService()
 
-        XCTAssertNil(
-            userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey),
-            "Corrupt legacy data should be discarded — the key must be cleared so migration does not retry on bad data"
-        )
-        XCTAssertNil(mockFileStorage.storedDefaultRegions, "Nothing should be written to file storage when the legacy data is undecodable")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil, "Corrupt legacy data should be discarded — the key must be cleared so migration does not retry on bad data")
+        #expect(mockFileStorage.storedDefaultRegions == nil, "Nothing should be written to file storage when the legacy data is undecodable")
     }
 
     /// An empty region list in the legacy key must clear the key without touching file storage.
-    func test_migration_defaultRegions_emptyArray_clearsKeyWithoutSaving() throws {
+    @Test func `Migration default regions empty array clears key without saving`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let plistData = try PropertyListEncoder().encode([Region]())
@@ -380,15 +371,12 @@ class RegionsServiceTests: OBATestCase {
 
         _ = makeRegionsService()
 
-        XCTAssertNil(
-            userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey),
-            "An empty legacy region array should clear the key"
-        )
-        XCTAssertNil(mockFileStorage.storedDefaultRegions, "Nothing should be written to file storage for an empty region list")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey) == nil, "An empty legacy region array should clear the key")
+        #expect(mockFileStorage.storedDefaultRegions == nil, "Nothing should be written to file storage for an empty region list")
     }
 
     /// Corrupt plist in the legacy custom-regions key must be discarded (key cleared).
-    func test_migration_customRegions_corruptData_discardsKey() {
+    @Test func `Migration custom regions corrupt data discards key`() {
         stubRegions(dataLoader: dataLoader)
 
         let data = "corrupted data".data(using: .utf8)
@@ -396,15 +384,12 @@ class RegionsServiceTests: OBATestCase {
 
         _ = makeRegionsService()
 
-        XCTAssertNil(
-            userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey),
-            "Corrupt legacy custom-region data should be discarded — key must be cleared"
-        )
-        XCTAssertTrue(mockFileStorage.storedCustomRegions.isEmpty, "Nothing should be written to file storage when the legacy data is undecodable")
+        #expect(userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey) == nil, "Corrupt legacy custom-region data should be discarded — key must be cleared")
+        #expect(mockFileStorage.storedCustomRegions.isEmpty, "Nothing should be written to file storage when the legacy data is undecodable")
     }
 
     /// When any `saveCustomRegion` throws during migration the legacy key must be preserved for retry.
-    func test_migration_customRegions_saveFailure_preservesLegacyKey() throws {
+    @Test func `Migration custom regions save failure preserves legacy key`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -416,17 +401,14 @@ class RegionsServiceTests: OBATestCase {
         _ = makeRegionsService()
 
         let preservedData = userDefaults.data(forKey: RegionsService.legacyStoredCustomRegionsUserDefaultsKey)
-        XCTAssertNotNil(
-            preservedData,
-            "Legacy custom-regions key must NOT be deleted when saveCustomRegion throws — data would be lost permanently"
-        )
-        XCTAssertEqual(preservedData, plistData, "Preserved legacy data must be byte-for-byte identical to the original")
-        XCTAssertTrue(mockFileStorage.storedCustomRegions.isEmpty, "No custom regions should be stored when the save threw an error")
+        #expect(preservedData != nil, "Legacy custom-regions key must NOT be deleted when saveCustomRegion throws — data would be lost permanently")
+        #expect(preservedData == plistData, "Preserved legacy data must be byte-for-byte identical to the original")
+        #expect(mockFileStorage.storedCustomRegions.isEmpty, "No custom regions should be stored when the save threw an error")
     }
 
     /// Corrupt plist in the legacy current-region key must be discarded via defer and must not
     /// write any identifier — unlike the default/custom cases this path does not retry on next launch.
-    func test_migration_currentRegion_corruptData_clearsKeyWithoutWritingIdentifier() {
+    @Test func `Migration current region corrupt data clears key without writing identifier`() {
         stubRegions(dataLoader: dataLoader)
         
         let data = "corrupted data".data(using: .utf8)
@@ -434,19 +416,13 @@ class RegionsServiceTests: OBATestCase {
 
         _ = makeRegionsService()
 
-        XCTAssertNil(
-            userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey),
-            "Corrupt legacy current-region data should be cleared — there is nothing to retry"
-        )
-        XCTAssertNil(
-            userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey),
-            "No region identifier should be written when the legacy current-region data is undecodable"
-        )
+        #expect(userDefaults.data(forKey: RegionsService.legacyCurrentRegionUserDefaultsKey) == nil, "Corrupt legacy current-region data should be cleared — there is nothing to retry")
+        #expect(userDefaults.object(forKey: RegionsService.currentRegionIdentifierUserDefaultsKey) == nil, "No region identifier should be written when the legacy current-region data is undecodable")
     }
 
     /// When `saveDefaultRegions` throws during migration the legacy UserDefaults key must not be deleted
     /// — preserving the data so the migration can retry on the next launch.
-    func test_migration_defaultRegions_saveFailure_preservesLegacyKey() throws {
+    @Test func `Migration default regions save failure preserves legacy key`() throws {
         stubRegions(dataLoader: dataLoader)
 
         let customRegion = Fixtures.customMinneapolisRegion
@@ -460,17 +436,11 @@ class RegionsServiceTests: OBATestCase {
 
         // The legacy key must still be present with its original data intact so the migration retries on next launch.
         let preservedData = userDefaults.data(forKey: RegionsService.legacyStoredRegionsUserDefaultsKey)
-        XCTAssertNotNil(
-            preservedData,
-            "Legacy UserDefaults key must NOT be deleted when saveDefaultRegions throws — data would be lost permanently"
-        )
-        XCTAssertEqual(preservedData, plistData, "Preserved legacy data must be byte-for-byte identical to the original")
+        #expect(preservedData != nil, "Legacy UserDefaults key must NOT be deleted when saveDefaultRegions throws — data would be lost permanently")
+        #expect(preservedData == plistData, "Preserved legacy data must be byte-for-byte identical to the original")
 
         // Nothing should have been written to file storage.
-        XCTAssertNil(
-            mockFileStorage.storedDefaultRegions,
-            "No regions should be stored in file storage when the save threw an error"
-        )
+        #expect(mockFileStorage.storedDefaultRegions == nil, "No regions should be stored in file storage when the save threw an error")
     }
 
     // MARK: - Location Services

--- a/OBAKitTests/Location/RegionsServiceTests.swift
+++ b/OBAKitTests/Location/RegionsServiceTests.swift
@@ -210,7 +210,7 @@ final class RegionsServiceTests: OBATestCase {
     // MARK: - Persistence
 
     // It stores downloaded region data in file storage when the regions property is set.
-    @Test func `Persistence`() async throws {
+    @Test func persistence() async throws {
         stubRegionsJustPugetSound(dataLoader: dataLoader)
         userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
 

--- a/OBAKitTests/Location/RegionsServiceTests.swift
+++ b/OBAKitTests/Location/RegionsServiceTests.swift
@@ -9,6 +9,7 @@
 
 import Foundation
 import XCTest
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 import CoreLocation
@@ -267,7 +268,7 @@ class RegionsServiceTests: OBATestCase {
 
         regionsService.currentRegion = newRegion
 
-        XCTAssertDidCallDelegateMethodWithValue(testDelegate.newRegionSelected, newRegion, "Expected RegionsService to inform delegates of the new region selection")
+        expectDidCallDelegateMethod(testDelegate.newRegionSelected, newRegion, "Expected RegionsService to inform delegates of the new region selection")
         XCTAssertEqual(regionsService.currentRegion, newRegion, "Expected RegionsService to update its currentRegion property to the new region")
     }
 

--- a/OBAKitTests/Mapping/StopAnnotationCalloutTests.swift
+++ b/OBAKitTests/Mapping/StopAnnotationCalloutTests.swift
@@ -7,16 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import MapKit
 @testable import OBAKit
 @testable import OBAKitCore
+import Foundation
 import Testing
 
 /// Covers the gate that decides whether tapping a stop annotation shows a callout or opens the
 /// stop outright. The legacy Stop page depends on the callout — it is the only way to reach the
 /// chevron that pushes the stop — so a regression here silently breaks that screen's entry point.
-class StopAnnotationCalloutTests: OBATestCase {
+@Suite(.serialized)
+final class StopAnnotationCalloutTests: OBATestCase {
 
     /// `@MainActor` because `StopIconFactory` is: OBAKit builds with
     /// `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` while OBAKitTests is `nonisolated`
@@ -42,25 +43,25 @@ class StopAnnotationCalloutTests: OBATestCase {
 
     // MARK: - StopAnnotationView
 
-    func test_annotationView_withoutDelegate_showsCallout() {
+    @Test func `Annotation view without delegate shows callout`() {
         // The delegate is assigned after init, so the pre-delegate default has to be the
         // conservative one: showing a callout is recoverable, hiding one strands the legacy page.
         #expect(self.makeAnnotationView().canShowCallout)
     }
 
-    func test_annotationView_delegateAllowsCallouts_showsCallout() {
+    @Test func `Annotation view delegate allows callouts shows callout`() {
         let view = makeAnnotationView()
         view.delegate = StopAnnotationDelegateStub(showsStopAnnotationCallouts: true)
         #expect(view.canShowCallout)
     }
 
-    func test_annotationView_delegateSuppressesCallouts_hidesCallout() {
+    @Test func `Annotation view delegate suppresses callouts hides callout`() {
         let view = makeAnnotationView()
         view.delegate = StopAnnotationDelegateStub(showsStopAnnotationCallouts: false)
         #expect(!view.canShowCallout)
     }
 
-    func test_annotationView_delegateReassigned_recomputesCallout() {
+    @Test func `Annotation view delegate reassigned recomputes callout`() {
         // Annotation views are recycled and `viewFor` reassigns the delegate on each reuse.
         let view = makeAnnotationView()
         view.delegate = StopAnnotationDelegateStub(showsStopAnnotationCallouts: false)
@@ -76,17 +77,17 @@ class StopAnnotationCalloutTests: OBATestCase {
         return MapRegionManager(application: application)
     }
 
-    func test_regionManager_newStopPageEnabled_suppressesCallouts() {
+    @Test func `Region manager new stop page enabled suppresses callouts`() {
         userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
         #expect(!self.makeRegionManager().showsStopAnnotationCallouts)
     }
 
-    func test_regionManager_newStopPageDisabled_keepsCallouts() {
+    @Test func `Region manager new stop page disabled keeps callouts`() {
         userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
         #expect(self.makeRegionManager().showsStopAnnotationCallouts)
     }
 
-    func test_regionManager_flagUnset_suppressesCallouts() {
+    @Test func `Region manager flag unset suppresses callouts`() {
         // `isNewStopPageEnabled` defaults to true, so an untouched install gets the sheet.
         userDefaults.removeObject(forKey: FeatureFlags.useNewStopPageKey)
         #expect(!self.makeRegionManager().showsStopAnnotationCallouts)
@@ -97,22 +98,22 @@ class StopAnnotationCalloutTests: OBATestCase {
     /// The delegate stubs above prove the rule; this proves the wiring. `viewFor` is the only
     /// place the real delegate gets attached, so a stop annotation that comes out of it has to
     /// carry the flag's answer.
-    @MainActor
-    func test_viewFor_flagDisabled_stopAnnotationShowsCallout() throws {
+    @Test @MainActor
+    func `View for flag disabled stop annotation shows callout`() throws {
         userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
         let manager = makeRegionManager()
-        let stop = try XCTUnwrap(Fixtures.loadSomeStops().first)
+        let stop = try #require(Fixtures.loadSomeStops().first)
 
         let view = manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView
 
         #expect(view?.canShowCallout == true)
     }
 
-    @MainActor
-    func test_viewFor_flagEnabled_stopAnnotationSuppressesCallout() throws {
+    @Test @MainActor
+    func `View for flag enabled stop annotation suppresses callout`() throws {
         userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
         let manager = makeRegionManager()
-        let stop = try XCTUnwrap(Fixtures.loadSomeStops().first)
+        let stop = try #require(Fixtures.loadSomeStops().first)
 
         let view = manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView
 
@@ -125,12 +126,12 @@ class StopAnnotationCalloutTests: OBATestCase {
     /// starts returning the legacy Stop page again — but an annotation view already on the map
     /// answered the callout question at creation time. Left stale, the legacy page opens on the
     /// first tap with no callout, which is the new page's behavior on the old page's screen.
-    @MainActor
-    func test_annotationOnMap_flagTurnedOff_refreshRestoresCallout() throws {
+    @Test @MainActor
+    func `Annotation on map flag turned off refresh restores callout`() throws {
         userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
         let manager = makeRegionManager()
-        let stop = try XCTUnwrap(Fixtures.loadSomeStops().first)
-        let view = try XCTUnwrap(manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView)
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let view = try #require(manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView)
         #expect(!view.canShowCallout)
 
         userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
@@ -142,12 +143,12 @@ class StopAnnotationCalloutTests: OBATestCase {
 
     /// MapKit's own re-display hook has to pick the change up too, for annotations that scroll
     /// back into view rather than sitting on screen across the flag change.
-    @MainActor
-    func test_annotationOnMap_flagTurnedOn_prepareForDisplaySuppressesCallout() throws {
+    @Test @MainActor
+    func `Annotation on map flag turned on prepare for display suppresses callout`() throws {
         userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
         let manager = makeRegionManager()
-        let stop = try XCTUnwrap(Fixtures.loadSomeStops().first)
-        let view = try XCTUnwrap(manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView)
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let view = try #require(manager.mapView(manager.mapView, viewFor: stop) as? StopAnnotationView)
         #expect(view.canShowCallout)
 
         userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
@@ -156,10 +157,10 @@ class StopAnnotationCalloutTests: OBATestCase {
         #expect(!view.canShowCallout)
     }
 
-    @MainActor
-    func test_refreshStopAnnotationCallouts_withNoDisplayedAnnotations_isSafe() throws {
+    @Test @MainActor
+    func `Refresh stop annotation callouts with no displayed annotations is safe`() throws {
         let manager = makeRegionManager()
-        manager.mapView.addAnnotation(try XCTUnwrap(Fixtures.loadSomeStops().first))
+        manager.mapView.addAnnotation(try #require(Fixtures.loadSomeStops().first))
 
         manager.refreshStopAnnotationCallouts()
     }

--- a/OBAKitTests/Mapping/StopSheetPresenterTests.swift
+++ b/OBAKitTests/Mapping/StopSheetPresenterTests.swift
@@ -26,7 +26,6 @@ final class StopSheetPresenterTests {
     private var presenter: StopSheetPresenter!
 
     init() {
-
         parent = UIViewController()
         window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = parent
@@ -51,18 +50,6 @@ final class StopSheetPresenterTests {
 
     /// Lets an in-flight presentation or dismissal animation finish. Measuring a panel that is
     /// still being animated into place reports whatever position that frame happened to catch.
-    /// Lets queued main-actor work and in-flight animations run.
-    ///
-    /// This used to be `RunLoop.current.run(until:)`. Under XCTest that drained
-    /// the main queue, because the test method ran directly on the main thread's
-    /// run loop. A Swift Testing `@MainActor` test body is itself a main-queue
-    /// item, so blocking inside it cannot re-entrantly drain further main-queue
-    /// blocks — dismissal completion handlers would never fire. Suspending
-    /// instead releases the main actor, which is what actually lets the work run.
-    private func spin(_ seconds: TimeInterval) async {
-        try? await Task.sleep(for: .seconds(seconds))
-    }
-
     // MARK: - Presentation
 
     @Test func `Present adds one panel opened at the half detent`() {

--- a/OBAKitTests/Mapping/StopSheetPresenterTests.swift
+++ b/OBAKitTests/Mapping/StopSheetPresenterTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import UIKit
 import FloatingPanel
 @testable import OBAKit
@@ -17,14 +18,14 @@ import FloatingPanel
 /// verified by hand; what's tested here is the bookkeeping this app owns — that only one sheet
 /// is ever onscreen, and that each presentation's cleanup runs exactly once.
 @MainActor
-final class StopSheetPresenterTests: XCTestCase {
+@Suite(.serialized)
+final class StopSheetPresenterTests {
 
     private var window: UIWindow!
     private var parent: UIViewController!
     private var presenter: StopSheetPresenter!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
 
         parent = UIViewController()
         window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
@@ -35,14 +36,13 @@ final class StopSheetPresenterTests: XCTestCase {
         presenter = StopSheetPresenter()
     }
 
-    override func tearDown() async throws {
+    // `isolated deinit` because the cleanup below touches main-actor UI state.
+    // The `= nil` assignments the old `tearDown` performed are dropped: they
+    // only mattered because XCTest holds test-case instances for the whole run,
+    // and assigning nil inside `deinit` releases nothing extra regardless.
+    isolated deinit {
         presenter.dismiss(animated: false)
-        presenter = nil
         window.isHidden = true
-        window = nil
-        parent = nil
-
-        try await super.tearDown()
     }
 
     private var panels: [FloatingPanelController] {
@@ -51,98 +51,106 @@ final class StopSheetPresenterTests: XCTestCase {
 
     /// Lets an in-flight presentation or dismissal animation finish. Measuring a panel that is
     /// still being animated into place reports whatever position that frame happened to catch.
-    private func spin(_ seconds: TimeInterval) {
-        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    /// Lets queued main-actor work and in-flight animations run.
+    ///
+    /// This used to be `RunLoop.current.run(until:)`. Under XCTest that drained
+    /// the main queue, because the test method ran directly on the main thread's
+    /// run loop. A Swift Testing `@MainActor` test body is itself a main-queue
+    /// item, so blocking inside it cannot re-entrantly drain further main-queue
+    /// blocks — dismissal completion handlers would never fire. Suspending
+    /// instead releases the main actor, which is what actually lets the work run.
+    private func spin(_ seconds: TimeInterval) async {
+        try? await Task.sleep(for: .seconds(seconds))
     }
 
     // MARK: - Presentation
 
-    func test_present_addsOnePanelOpenedAtTheHalfDetent() {
+    @Test func `Present adds one panel opened at the half detent`() {
         presenter.present(UIViewController(), from: parent) {}
 
-        XCTAssertTrue(presenter.isPresenting)
-        XCTAssertEqual(panels.count, 1)
-        XCTAssertEqual(panels.first?.state, .half)
+        #expect(presenter.isPresenting)
+        #expect(panels.count == 1)
+        #expect(panels.first?.state == .half)
     }
 
     /// The stop page publishes its Filter / More / Schedules chrome through `navigationItem`
     /// and pushes Trip screens through `ViewRouter`, both of which need a navigation
     /// controller. Losing this wrapper would silently drop the chrome and trip the router's
     /// `navigationController != nil` assertion.
-    func test_present_wrapsContentInANavigationController() {
+    @Test func `Present wraps content in a navigation controller`() {
         let content = UIViewController()
         presenter.present(content, from: parent) {}
 
         let navigation = panels.first?.contentViewController as? UINavigationController
-        XCTAssertNotNil(navigation)
-        XCTAssertIdentical(navigation?.viewControllers.first, content)
+        #expect(navigation != nil)
+        #expect(navigation?.viewControllers.first === content)
     }
 
     /// Swipe-to-dismiss is off: the sheet header carries an explicit close button, and with
     /// removal enabled a downward flick past `.tip` tears the sheet down instead of settling
     /// there, which costs the rider the peek-at-the-map detent.
-    func test_present_disablesSwipeToDismiss() {
+    @Test func `Present disables swipe to dismiss`() {
         presenter.present(UIViewController(), from: parent) {}
 
-        XCTAssertEqual(panels.first?.isRemovalInteractionEnabled, false)
+        #expect(panels.first?.isRemovalInteractionEnabled == false)
     }
 
     /// The tracked scroll view keeps its own content insets. FloatingPanel's default
     /// (`.always`) assigns `contentInset` outright on every layout pass, which wipes the top
     /// inset the stop page's `safeAreaInset(edge: .top)` header installs and strands the mode
     /// toggle and first departure underneath it.
-    func test_present_leavesTheTrackedScrollViewsContentInsetsAlone() {
+    @Test func `Present leaves the tracked scroll views content insets alone`() {
         presenter.present(UIViewController(), from: parent) {}
 
-        XCTAssertEqual(panels.first?.contentInsetAdjustmentBehavior, .never)
+        #expect(panels.first?.contentInsetAdjustmentBehavior == .never)
     }
 
     // MARK: - Replacement
 
     /// The HIG is explicit that one sheet shows at a time, and the map has several things
     /// competing for this space.
-    func test_presentingASecondStop_leavesExactlyOnePanel() {
+    @Test func `Presenting a second stop leaves exactly one panel`() {
         presenter.present(UIViewController(), from: parent) {}
         presenter.present(UIViewController(), from: parent) {}
 
-        XCTAssertEqual(panels.count, 1)
-        XCTAssertTrue(presenter.isPresenting)
+        #expect(panels.count == 1)
+        #expect(presenter.isPresenting)
     }
 
     /// Replacement must run the *outgoing* presentation's cleanup — the map uses it to
     /// deselect that stop's annotation, and running the incoming one instead would deselect
     /// the pin the rider just tapped.
-    func test_presentingASecondStop_runsOnlyTheOutgoingDismissHandler() {
+    @Test func `Presenting a second stop runs only the outgoing dismiss handler`() {
         var firstDismissed = 0
         var secondDismissed = 0
 
         presenter.present(UIViewController(), from: parent) { firstDismissed += 1 }
         presenter.present(UIViewController(), from: parent) { secondDismissed += 1 }
 
-        XCTAssertEqual(firstDismissed, 1)
-        XCTAssertEqual(secondDismissed, 0)
+        #expect(firstDismissed == 1)
+        #expect(secondDismissed == 0)
     }
 
     // MARK: - Dismissal
 
-    func test_dismiss_clearsStateAndRunsTheHandler() {
+    @Test func `Dismiss clears state and runs the handler`() {
         var dismissed = 0
         presenter.present(UIViewController(), from: parent) { dismissed += 1 }
 
         presenter.dismiss(animated: false)
 
-        XCTAssertFalse(presenter.isPresenting)
-        XCTAssertEqual(dismissed, 1)
+        #expect(!presenter.isPresenting)
+        #expect(dismissed == 1)
     }
 
-    func test_dismiss_isIdempotent() {
+    @Test func `Dismiss is idempotent`() {
         var dismissed = 0
         presenter.present(UIViewController(), from: parent) { dismissed += 1 }
 
         presenter.dismiss(animated: false)
         presenter.dismiss(animated: false)
 
-        XCTAssertEqual(dismissed, 1)
+        #expect(dismissed == 1)
     }
 
     /// A dismissal should look like one thing leaving: the sheet travels straight down, at the
@@ -158,81 +166,69 @@ final class StopSheetPresenterTests: XCTestCase {
     ///
     /// Measured against the panel's own view: the surface ends flush with the bottom edge, and
     /// neither it nor the page inside it changed size on the way there.
-    func test_dismiss_slidesTheSheetStraightDownAtTheSizeItHad() throws {
+    @Test func `Dismiss slides the sheet straight down at the size it had`() async throws {
         let (_, hosted) = makeTabBarHostedParent()
 
         for detent in [FloatingPanelState.full, .half, .tip] {
             let presenter = StopSheetPresenter()
             presenter.present(UIViewController(), from: hosted) {}
 
-            spin(0.5)
+            await spin(0.5)
 
-            let panel = try XCTUnwrap(panels(in: hosted).first)
+            let panel = try #require(panels(in: hosted).first)
             panel.move(to: detent, animated: false)
             hosted.view.layoutIfNeeded()
 
             let surface = panel.surfaceView
-            let contentView = try XCTUnwrap(surface.contentView)
+            let contentView = try #require(surface.contentView)
             let frameBefore = surface.frame
             let contentHeightBefore = contentView.bounds.height
 
             presenter.dismiss(animated: true)
             hosted.view.layoutIfNeeded()
 
-            XCTAssertEqual(
-                surface.frame.minY, panel.view.bounds.maxY, accuracy: 0.5,
-                "Dismissing from \(detent) left the sheet's top edge short of the bottom of the screen."
-            )
-            XCTAssertEqual(
-                surface.frame.minX, frameBefore.minX, accuracy: 0.5,
-                "Dismissing from \(detent) moved the sheet sideways."
-            )
-            XCTAssertEqual(
-                surface.frame.height, frameBefore.height, accuracy: 0.5,
-                "Dismissing from \(detent) resized the sheet instead of sliding it away."
-            )
-            XCTAssertEqual(
-                contentView.bounds.height, contentHeightBefore, accuracy: 0.5,
-                "Dismissing from \(detent) re-laid the stop page out mid-slide."
-            )
+            expectClose(surface.frame.minY, panel.view.bounds.maxY, within: 0.5, "Dismissing from \(detent) left the sheet's top edge short of the bottom of the screen.")
+            expectClose(surface.frame.minX, frameBefore.minX, within: 0.5, "Dismissing from \(detent) moved the sheet sideways.")
+            expectClose(surface.frame.height, frameBefore.height, within: 0.5, "Dismissing from \(detent) resized the sheet instead of sliding it away.")
+            expectClose(contentView.bounds.height, contentHeightBefore, within: 0.5, "Dismissing from \(detent) re-laid the stop page out mid-slide.")
 
             // Let the slide finish, so the next detent measures its own sheet rather than one
             // still on its way out.
-            spin(0.5)
-            XCTAssertEqual(panels(in: hosted).count, 0, "The \(detent) sheet never detached itself.")
+            await spin(0.5)
+            #expect(panels(in: hosted).count == 0, "The \(detent) sheet never detached itself.")
         }
     }
 
     /// The tab bar's return is what changes the safe area the `.half` anchor is measured
     /// against, so it has to wait for the sheet to be gone — but it does still have to happen.
-    func test_dismiss_animated_restoresTheHostTabBarOnceTheSheetHasGone() {
+    @Test func `Dismiss animated restores the host tab bar once the sheet has gone`() async {
         let (tabBarController, hosted) = makeTabBarHostedParent()
         presenter.present(UIViewController(), from: hosted) {}
-        spin(0.5)
+        await spin(0.5)
 
         presenter.dismiss(animated: true)
-        XCTAssertTrue(tabBarController.isTabBarHidden, "The tab bar came back while the sheet was still onscreen.")
+        #expect(tabBarController.isTabBarHidden, "The tab bar came back while the sheet was still onscreen.")
 
-        spin(0.8)
-        XCTAssertFalse(tabBarController.isTabBarHidden, "The tab bar never came back after the sheet left.")
+        await spin(0.8)
+        #expect(!tabBarController.isTabBarHidden, "The tab bar never came back after the sheet left.")
     }
 
-    func test_dismiss_withNothingPresented_isANoOp() {
+    @Test func `Dismiss with nothing presented is a no op`() {
         presenter.dismiss(animated: false)
-        XCTAssertFalse(presenter.isPresenting)
-        XCTAssertEqual(panels.count, 0)
+        #expect(!presenter.isPresenting)
+        #expect(panels.count == 0)
     }
 
     /// A swipe-away routes through `floatingPanelDidRemove` rather than `dismiss`, so it needs
     /// its own path to the same cleanup.
-    func test_swipeAwayRemoval_runsTheHandlerAndClearsState() throws {
+    @Test func `Swipe away removal runs the handler and clears state`() throws {
         var dismissed = 0
         presenter.present(UIViewController(), from: parent) { dismissed += 1 }
 
-        presenter.floatingPanelDidRemove(try XCTUnwrap(panels.first))
+        presenter.floatingPanelDidRemove(try #require(panels.first))
 
-        XCTAssertFalse(presenter.isPresenting)
-        XCTAssertEqual(dismissed, 1)
+        #expect(!presenter.isPresenting)
+        #expect(dismissed == 1)
     }
 
     // MARK: - Tab Bar
@@ -251,53 +247,53 @@ final class StopSheetPresenterTests: XCTestCase {
 
     /// The tab bar can't be beaten on z-order from inside the map, so the sheet hides it to
     /// claim the bottom edge of the screen for its own chrome.
-    func test_present_hidesTheHostTabBar() {
+    @Test func `Present hides the host tab bar`() {
         let (tabBarController, hosted) = makeTabBarHostedParent()
-        XCTAssertFalse(tabBarController.isTabBarHidden)
+        #expect(!tabBarController.isTabBarHidden)
 
         presenter.present(UIViewController(), from: hosted) {}
 
-        XCTAssertTrue(tabBarController.isTabBarHidden)
+        #expect(tabBarController.isTabBarHidden)
     }
 
-    func test_dismiss_restoresTheHostTabBar() {
+    @Test func `Dismiss restores the host tab bar`() {
         let (tabBarController, hosted) = makeTabBarHostedParent()
         presenter.present(UIViewController(), from: hosted) {}
 
         presenter.dismiss(animated: false)
 
-        XCTAssertFalse(tabBarController.isTabBarHidden)
+        #expect(!tabBarController.isTabBarHidden)
     }
 
     /// Swiping the sheet away skips `dismiss`, so the tab bar has to come back on this path too
     /// or the rider is left with no way to change tabs.
-    func test_swipeAwayRemoval_restoresTheHostTabBar() throws {
+    @Test func `Swipe away removal restores the host tab bar`() throws {
         let (tabBarController, hosted) = makeTabBarHostedParent()
         presenter.present(UIViewController(), from: hosted) {}
 
-        presenter.floatingPanelDidRemove(try XCTUnwrap(panels(in: hosted).first))
+        presenter.floatingPanelDidRemove(try #require(panels(in: hosted).first))
 
-        XCTAssertFalse(tabBarController.isTabBarHidden)
+        #expect(!tabBarController.isTabBarHidden)
     }
 
     /// Tapping a second stop tears the first sheet down, but the bar must stay hidden the whole
     /// way through — restoring it mid-swap flashes it back behind the incoming sheet.
-    func test_presentingASecondStop_keepsTheHostTabBarHidden() {
+    @Test func `Presenting a second stop keeps the host tab bar hidden`() {
         let (tabBarController, hosted) = makeTabBarHostedParent()
 
         presenter.present(UIViewController(), from: hosted) {}
         presenter.present(UIViewController(), from: hosted) {}
 
-        XCTAssertTrue(tabBarController.isTabBarHidden)
+        #expect(tabBarController.isTabBarHidden)
     }
 
     /// The map-panel experience presents the stop page outside a tab bar controller, so a nil
     /// host has to be a no-op rather than a crash.
-    func test_present_withoutAHostTabBar_stillPresents() {
+    @Test func `Present without a host tab bar still presents`() {
         presenter.present(UIViewController(), from: parent) {}
 
-        XCTAssertTrue(presenter.isPresenting)
-        XCTAssertEqual(panels.count, 1)
+        #expect(presenter.isPresenting)
+        #expect(panels.count == 1)
     }
 
     private func panels(in parent: UIViewController) -> [FloatingPanelController] {

--- a/OBAKitTests/Mapping/StopSheetPresenterTests.swift
+++ b/OBAKitTests/Mapping/StopSheetPresenterTests.swift
@@ -48,8 +48,6 @@ final class StopSheetPresenterTests {
         parent.children.compactMap { $0 as? FloatingPanelController }
     }
 
-    /// Lets an in-flight presentation or dismissal animation finish. Measuring a panel that is
-    /// still being animated into place reports whatever position that frame happened to catch.
     // MARK: - Presentation
 
     @Test func `Present adds one panel opened at the half detent`() {

--- a/OBAKitTests/Modeling/AgencyAlertsTestDeviceGatingTests.swift
+++ b/OBAKitTests/Modeling/AgencyAlertsTestDeviceGatingTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -15,7 +14,8 @@ import Testing
 /// Test alerts are a preview channel for OBACloud admins: displaying them requires
 /// both the "Display test alerts" switch *and* a Test Device Name, mirroring how
 /// push registration only sends `test_device=true` once the device is named.
-class AgencyAlertsTestDeviceGatingTests: OBATestCase {
+@Suite(.serialized)
+final class AgencyAlertsTestDeviceGatingTests: OBATestCase {
 
     private func setTestDeviceName(_ name: String?) {
         userDefaults.set(name, forKey: AgencyAlertsStore.UserDefaultKeys.testDeviceDescription)
@@ -25,40 +25,40 @@ class AgencyAlertsTestDeviceGatingTests: OBATestCase {
         userDefaults.set(enabled, forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
     }
 
-    func test_switchOff_noName_doesNotDisplay() {
+    @Test func `Switch off no name does not display`() {
         setDisplayTestAlerts(false)
 
         #expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults) == false)
     }
 
-    func test_switchOn_noName_doesNotDisplay() {
+    @Test func `Switch on no name does not display`() {
         setDisplayTestAlerts(true)
 
         #expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults) == false)
     }
 
-    func test_switchOn_whitespaceOnlyName_doesNotDisplay() {
+    @Test func `Switch on whitespace only name does not display`() {
         setDisplayTestAlerts(true)
         setTestDeviceName("   \n")
 
         #expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults) == false)
     }
 
-    func test_switchOff_withName_doesNotDisplay() {
+    @Test func `Switch off with name does not display`() {
         setDisplayTestAlerts(false)
         setTestDeviceName("Aaron's iPhone")
 
         #expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults) == false)
     }
 
-    func test_switchOn_withName_displays() {
+    @Test func `Switch on with name displays`() {
         setDisplayTestAlerts(true)
         setTestDeviceName("Aaron's iPhone")
 
         #expect(AgencyAlertsStore.shouldDisplayTestAlerts(userDefaults: self.userDefaults) == true)
     }
 
-    func test_keyMatchesPushRegistrationManagersKey() {
+    @Test func `Key matches push registration managers key`() {
         // The gate reads the same defaults entry that the Settings form writes and
         // PushRegistrationManager reads — if these diverge, the gate silently breaks.
         #expect(AgencyAlertsStore.UserDefaultKeys.testDeviceDescription == PushRegistrationManager.testDeviceDescriptionDefaultsKey)

--- a/OBAKitTests/Modeling/DeepLinks/AppLinksRouterDeepLinkFormatTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/AppLinksRouterDeepLinkFormatTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKitCore
 
@@ -16,11 +15,12 @@ import Testing
 /// These tests verify URL construction and parsing without requiring a full `Application` object.
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/449
 @MainActor
-class AppLinksRouterDeepLinkFormatTests: XCTestCase {
+@Suite(.serialized)
+final class AppLinksRouterDeepLinkFormatTests {
 
     // MARK: - URL Construction with destination_stop_id
 
-    func test_urlWithDestinationStopID_containsQueryParam() {
+    @Test func `Url with destination stop ID contains query param`() {
         var components = URLComponents(string: "https://onebusaway.co")!
         components.path = "/regions/1/stops/1_75403/trips"
 
@@ -41,7 +41,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
         #expect(parsed.queryItem(named: "stop_sequence")?.value == "12")
     }
 
-    func test_urlWithoutDestinationStopID_doesNotContainQueryParam() {
+    @Test func `Url without destination stop ID does not contain query param`() {
         var components = URLComponents(string: "https://onebusaway.co")!
         components.path = "/regions/1/stops/1_75403/trips"
         components.queryItems = [
@@ -57,7 +57,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
         #expect(parsed.queryItems?.count == 3)
     }
 
-    func test_destinationStopIDWithSpecialCharacters_encodedCorrectly() {
+    @Test func `Destination stop ID with special characters encoded correctly`() {
         var components = URLComponents(string: "https://onebusaway.co")!
         components.path = "/regions/1/stops/1_75403/trips"
         components.queryItems = [
@@ -75,7 +75,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
 
     // MARK: - Deep Link Model from URL with destination_stop_id
 
-    func test_deepLinkInit_withDestinationStopID_setsProperty() {
+    @Test func `Deep link init with destination stop ID sets property`() {
         let link = ArrivalDepartureDeepLink(
             title: "545 - Seattle",
             regionID: 1,
@@ -92,7 +92,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
         #expect(link.regionID == 1)
     }
 
-    func test_deepLinkInit_withoutDestinationStopID_isNil() {
+    @Test func `Deep link init without destination stop ID is nil`() {
         let link = ArrivalDepartureDeepLink(
             title: "545 - Seattle",
             regionID: 1,
@@ -108,7 +108,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
 
     // MARK: - Backward Compatibility
 
-    func test_backwardCompatibility_existingURLFormat_parsesWithoutDestination() {
+    @Test func `Backward compatibility existing URL format parses without destination`() {
         // Simulates a URL from an older client that doesn't include destination_stop_id
         let urlString = "https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_545_trip&service_date=1710273600.0&stop_sequence=12"
         let url = URL(string: urlString)!
@@ -119,7 +119,7 @@ class AppLinksRouterDeepLinkFormatTests: XCTestCase {
         #expect(components.queryItem(named: "stop_sequence")?.value == "12")
     }
 
-    func test_backwardCompatibility_newURLFormat_parsesWithDestination() {
+    @Test func `Backward compatibility new URL format parses with destination`() {
         // Simulates a URL from a new client that includes destination_stop_id
         let urlString = "https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_545_trip&service_date=1710273600.0&stop_sequence=12&destination_stop_id=1_431"
         let url = URL(string: urlString)!

--- a/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
@@ -8,23 +8,22 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKitCore
 
 @MainActor
-class URLSchemeRouterTests: XCTestCase {
+@Suite(.serialized)
+final class URLSchemeRouterTests {
     
     var router: URLSchemeRouter!
     
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         router = URLSchemeRouter(scheme: "onebusaway")
     }
     
     // MARK: - Initialization Tests
     
-    func test_initialization_setsScheme() {
+    @Test func `Initialization sets scheme`() {
         let customRouter = URLSchemeRouter(scheme: "customscheme")
         // Test by trying to encode a URL and checking the scheme
         let url = customRouter.encodeViewStop(stopID: "123", regionID: 1)
@@ -33,7 +32,7 @@ class URLSchemeRouterTests: XCTestCase {
     
     // MARK: - View Stop URL Tests
     
-    func test_encodeViewStop_createsValidURL() {
+    @Test func `Encode view stop creates valid URL`() {
         let stopID = "12345"
         let regionID = 1
         
@@ -48,7 +47,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(components?.queryItems?.contains { $0.name == "regionID" && $0.value == String(regionID) } == true)
     }
     
-    func test_decodeURLType_viewStop_decodesValidURL() {
+    @Test func `Decode URL type view stop decodes valid URL`() {
         // First encode a URL
         let stopID = "67890"
         let regionID = 2
@@ -66,7 +65,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_viewStop_returnsNilForMissingStopID() {
+    @Test func `Decode URL type view stop returns nil for missing stop ID`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "view-stop"
@@ -81,7 +80,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(result == nil)
     }
     
-    func test_decodeURLType_viewStop_returnsNilForMissingRegionID() {
+    @Test func `Decode URL type view stop returns nil for missing region ID`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "view-stop"
@@ -96,7 +95,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(result == nil)
     }
     
-    func test_decodeURLType_viewStop_returnsNilForInvalidRegionID() {
+    @Test func `Decode URL type view stop returns nil for invalid region ID`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "view-stop"
@@ -116,7 +115,7 @@ class URLSchemeRouterTests: XCTestCase {
     
     // MARK: - Add Region URL Tests
 
-    func test_decodeURLType_addRegion_decodesRegionID() {
+    @Test func `Decode URL type add region decodes region ID`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -140,7 +139,7 @@ class URLSchemeRouterTests: XCTestCase {
     }
 
     // Links generated before region-id was emitted must still add the region.
-    func test_decodeURLType_addRegion_regionIDIsNilWhenAbsent() {
+    @Test func `Decode URL type add region region IDIs nil when absent`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -165,7 +164,7 @@ class URLSchemeRouterTests: XCTestCase {
 
     // A junk region-id costs sidecar features, but the region is still worth
     // adding — so it degrades to nil rather than rejecting the whole link.
-    func test_decodeURLType_addRegion_malformedRegionIDDegradesToNil() {
+    @Test func `Decode URL type add region malformed region ID degrades to nil`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -190,7 +189,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
 
-    func test_decodeURLType_addRegion_decodesValidURLWithOTPURL() {
+    @Test func `Decode URL type add region decodes valid URL with OTPURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -218,7 +217,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_decodesValidURLWithoutOTPURL() {
+    @Test func `Decode URL type add region decodes valid URL without OTPURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -245,7 +244,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_returnsNilDataForMissingName() {
+    @Test func `Decode URL type add region returns nil data for missing name`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -268,7 +267,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_returnsNilDataForMissingOBAURL() {
+    @Test func `Decode URL type add region returns nil data for missing OBAURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -291,7 +290,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_returnsNilDataForEmptyOBAURL() {
+    @Test func `Decode URL type add region returns nil data for empty OBAURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -315,7 +314,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_handlesEmptyOTPURL() {
+    @Test func `Decode URL type add region handles empty OTPURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -345,7 +344,7 @@ class URLSchemeRouterTests: XCTestCase {
     
     // MARK: - General URL Decoding Tests
     
-    func test_decodeURLType_returnsNilForUnknownHost() {
+    @Test func `Decode URL type returns nil for unknown host`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "unknown-host"
@@ -360,13 +359,13 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(result == nil)
     }
     
-    func test_decodeURLType_returnsNilForInvalidURL() {
+    @Test func `Decode URL type returns nil for invalid URL`() {
         let url = URL(string: "not://a/valid/url")!
         let result = router.decodeURLType(from: url)
         #expect(result == nil)
     }
     
-    func test_decodeURLType_returnsNilForURLWithoutHost() {
+    @Test func `Decode URL type returns nil for URL without host`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.path = "/some/path"
@@ -382,7 +381,7 @@ class URLSchemeRouterTests: XCTestCase {
     
     // MARK: - Edge Cases
     
-    func test_encodeViewStop_handlesSpecialCharactersInStopID() {
+    @Test func `Encode view stop handles special characters in stop ID`() {
         let stopID = "stop+with/special&chars=123"
         let regionID = 1
         
@@ -400,7 +399,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_handlesEncodedURLValues() {
+    @Test func `Decode URL type add region handles encoded URL values`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -426,7 +425,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_handlesEmptyQueryValues() {
+    @Test func `Decode URL type handles empty query values`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "view-stop"
@@ -453,7 +452,7 @@ class URLSchemeRouterTests: XCTestCase {
     
     // MARK: - URL Validation Tests
     
-    func test_decodeURLType_addRegion_rejectsInvalidOBAURL() {
+    @Test func `Decode URL type add region rejects invalid OBAURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -477,7 +476,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_rejectsWhitespaceOnlyOBAURL() {
+    @Test func `Decode URL type add region rejects whitespace only OBAURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -501,7 +500,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_rejectsInvalidOTPURL() {
+    @Test func `Decode URL type add region rejects invalid OTPURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -529,7 +528,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_acceptsValidPathOBAURL() {
+    @Test func `Decode URL type add region accepts valid path OBAURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -556,7 +555,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_acceptsValidPathOTPURL() {
+    @Test func `Decode URL type add region accepts valid path OTPURL`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -584,7 +583,7 @@ class URLSchemeRouterTests: XCTestCase {
         }
     }
     
-    func test_decodeURLType_addRegion_acceptsComplexValidURLs() {
+    @Test func `Decode URL type add region accepts complex valid URLs`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"
@@ -626,7 +625,7 @@ class URLSchemeRouterTests: XCTestCase {
         return data
     }
 
-    func test_decodeURLType_addRegion_decodesAllNewParameters() {
+    @Test func `Decode URL type add region decodes all new parameters`() {
         let data = decodeAddRegion([
             URLQueryItem(name: "name", value: "Test Region"),
             URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
@@ -642,7 +641,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(data?.umamiAnalytics?.id == "site-uuid-123")
     }
 
-    func test_decodeURLType_addRegion_newParametersDefaultToNil() {
+    @Test func `Decode URL type add region new parameters default to nil`() {
         let data = decodeAddRegion([
             URLQueryItem(name: "name", value: "Test Region"),
             URLQueryItem(name: "oba-url", value: "https://oba.example.com")
@@ -654,7 +653,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(data?.umamiAnalytics == nil)
     }
 
-    func test_decodeURLType_addRegion_partialUmamiPairCollapsesToNilConfig() {
+    @Test func `Decode URL type add region partial umami pair collapses to nil config`() {
         // URL without ID.
         let urlOnly = decodeAddRegion([
             URLQueryItem(name: "name", value: "Test Region"),
@@ -684,7 +683,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(invalidURL?.umamiAnalytics == nil)
     }
 
-    func test_decodeURLType_addRegion_blankUmamiIDBecomesNil() {
+    @Test func `Decode URL type add region blank umami ID becomes nil`() {
         let data = decodeAddRegion([
             URLQueryItem(name: "name", value: "Test Region"),
             URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
@@ -695,7 +694,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(data?.umamiAnalytics == nil)
     }
 
-    func test_decodeURLType_addRegion_invalidSidecarURLDegradesToNil() {
+    @Test func `Decode URL type add region invalid sidecar URL degrades to nil`() {
         let data = decodeAddRegion([
             URLQueryItem(name: "name", value: "Test Region"),
             URLQueryItem(name: "oba-url", value: "https://oba.example.com"),
@@ -711,7 +710,7 @@ class URLSchemeRouterTests: XCTestCase {
     // can never exercise encoding bugs. These two lock in the documented contract:
     // nested URLs MUST be percent-encoded; an unencoded `&` truncates.
 
-    func test_decodeURLType_addRegion_rawString_percentEncodedNestedURL() {
+    @Test func `Decode URL type add region raw string percent encoded nested URL`() {
         let url = URL(string: "onebusaway://add-region?name=Raw%20Region&oba-url=https%3A%2F%2Foba.example.com&sidecar-url=https%3A%2F%2Fobaco.example.com%2Fapi%3Fa%3D1%26b%3D2&umami-url=https%3A%2F%2Fanalytics.example.com&umami-id=site-uuid-123")!
 
         guard case .addRegion(let data)? = router.decodeURLType(from: url) else {
@@ -725,7 +724,7 @@ class URLSchemeRouterTests: XCTestCase {
         #expect(data?.umamiAnalytics?.id == "site-uuid-123")
     }
 
-    func test_decodeURLType_addRegion_rawString_unencodedAmpersandTruncates() {
+    @Test func `Decode URL type add region raw string unencoded ampersand truncates`() {
         let url = URL(string: "onebusaway://add-region?name=Raw&oba-url=https://oba.example.com&sidecar-url=https://obaco.example.com/api?a=1&b=2")!
 
         guard case .addRegion(let data)? = router.decodeURLType(from: url) else {

--- a/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/URLSchemeRouterTests.swift
@@ -139,7 +139,7 @@ final class URLSchemeRouterTests {
     }
 
     // Links generated before region-id was emitted must still add the region.
-    @Test func `Decode URL type add region region IDIs nil when absent`() {
+    @Test func `Decode URL type add region region ID is nil when absent`() {
         var components = URLComponents()
         components.scheme = "onebusaway"
         components.host = "add-region"

--- a/OBAKitTests/Modeling/Migration/DataMigratorTests.swift
+++ b/OBAKitTests/Modeling/Migration/DataMigratorTests.swift
@@ -5,12 +5,13 @@
 //  Created by Alan Chu on 1/1/23.
 //
 
-import XCTest
+import Testing
 import Foundation
 @testable import OBAKit
 @testable import OBAKitCore
 
-class DataMigrator_Tests: OBATestCase {
+@Suite(.serialized)
+final class DataMigrator_Tests: OBATestCase {
 
     var dataLoader: MockDataLoader!
     var migrator: DataMigrator!
@@ -18,8 +19,8 @@ class DataMigrator_Tests: OBATestCase {
     private var dataStore: DataStore!
     private var migrationParameters: DataMigrator.MigrationParameters!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         // Load user defaults from the plist fixture.
         let userDefaults = buildUserDefaults()
@@ -66,27 +67,29 @@ class DataMigrator_Tests: OBATestCase {
         dataLoader.mock(URLString: "https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_99610.json", with: Fixtures.loadData(file: "arrivals-and-departures_1_99610.json"))
     }
 
-    func testMigration_basicProperties() async throws {
+    @Test func `Migration basic properties`() async throws {
         let report = try await self.migrator.performMigration(migrationParameters, apiService: self.restService)
 
         // Check results metadata
-        XCTAssertNotNil(report.dateFinished)
-        XCTAssertTrue(report.isFinished)
+        #expect(report.dateFinished != nil)
+        #expect(report.isFinished)
 
         // Check User ID
-        let userIDMigrationResult = try XCTUnwrap(report.userIDMigrationResult)
-        XCTAssertNoThrow(try userIDMigrationResult.get(), "Expected User ID migration to be successful")
+        let userIDMigrationResult = try #require(report.userIDMigrationResult)
+        #expect(throws: Never.self, "Expected User ID migration to be successful") {
+            try userIDMigrationResult.get()
+        }
 
-        let storedUserID = try XCTUnwrap(dataStore.userID, "Expected the userID to be stored.")
-        XCTAssertEqual(storedUserID, "B72C5F1A-B8E5-4FB3-A857-CAC6EAC86DE0")
+        let storedUserID = try #require(dataStore.userID, "Expected the userID to be stored.")
+        #expect(storedUserID == "B72C5F1A-B8E5-4FB3-A857-CAC6EAC86DE0")
 
         // Check region
-        let storedRegion = try XCTUnwrap(dataStore.region, "Expected the region to be stored.")
-        XCTAssertEqual(storedRegion.name, "Puget Sound")
-        XCTAssertEqual(storedRegion.identifier, pugetSoundRegionIdentifier, "Expected the region identifier to be stored as \(pugetSoundRegionIdentifier)")
+        let storedRegion = try #require(dataStore.region, "Expected the region to be stored.")
+        #expect(storedRegion.name == "Puget Sound")
+        #expect(storedRegion.identifier == pugetSoundRegionIdentifier, "Expected the region identifier to be stored as \(pugetSoundRegionIdentifier)")
     }
 
-    func testMigration_recentStops() async throws {
+    @Test func `Migration recent stops`() async throws {
         let results = try await self.migrator.performMigration(migrationParameters, apiService: self.restService)
 
         let recentStopErrors = results.recentStopsMigrationResult.filter { key, value in
@@ -97,65 +100,62 @@ class DataMigrator_Tests: OBATestCase {
             }
         }
 
-        XCTAssertTrue(recentStopErrors.isEmpty, "Recent stops migration should have no errors")
+        #expect(recentStopErrors.isEmpty, "Recent stops migration should have no errors")
 
         // Check stops
         let stops = dataStore.recentStops.sorted(by: { $0.id > $1.id })
-        XCTAssertEqual(stops.count, 6)
+        #expect(stops.count == 6)
 
-        let firstStop = try XCTUnwrap(stops.first)
-        XCTAssertEqual(firstStop.name, "Capitol Hill Link Station")
-        XCTAssertEqual(firstStop.id, "1_99610")
-        XCTAssertEqual(firstStop.coordinate.latitude, 47.6196, accuracy: 0.0001)
-        XCTAssertEqual(firstStop.coordinate.longitude, -122.3204, accuracy: 0.0001)
-        XCTAssertEqual(firstStop.routeIDs, ["40_100479"])
-        XCTAssertEqual(firstStop.routes.count, 1)
+        let firstStop = try #require(stops.first)
+        #expect(firstStop.name == "Capitol Hill Link Station")
+        #expect(firstStop.id == "1_99610")
+        expectClose(firstStop.coordinate.latitude, 47.6196, within: 0.0001)
+        expectClose(firstStop.coordinate.longitude, -122.3204, within: 0.0001)
+        #expect(firstStop.routeIDs == ["40_100479"])
+        #expect(firstStop.routes.count == 1)
 
-        XCTAssertEqual(stops[1].name, "24th Ave E & E Galer St")
-        XCTAssertEqual(stops[2].name, "E John St & Broadway  E")
-        XCTAssertEqual(stops[3].name, "15th Ave E & E Galer St")
-        XCTAssertEqual(stops[4].name, "10th Ave E & E Galer St")
-        XCTAssertEqual(stops[5].name, "Westlake Station - Bay A")
+        #expect(stops[1].name == "24th Ave E & E Galer St")
+        #expect(stops[2].name == "E John St & Broadway  E")
+        #expect(stops[3].name == "15th Ave E & E Galer St")
+        #expect(stops[4].name == "10th Ave E & E Galer St")
+        #expect(stops[5].name == "Westlake Station - Bay A")
     }
 
-    func testMigration_bookmarkGroups() async throws {
+    @Test func `Migration bookmark groups`() async throws {
         _ = try await self.migrator.performMigration(migrationParameters, apiService: self.restService)
 
         let groups = dataStore.bookmarkGroups.sorted(by: { $1.sortOrder > $0.sortOrder })
-        XCTAssertEqual(groups.count, 3)
+        #expect(groups.count == 3)
 
-        XCTAssertEqual(groups[0].name, "Work")
-        XCTAssertEqual(groups[0].id.uuidString, "E87AFBD5-6B61-4916-947F-458476ACBF98")
-        XCTAssertEqual(groups[0].sortOrder, 1)
+        #expect(groups[0].name == "Work")
+        #expect(groups[0].id.uuidString == "E87AFBD5-6B61-4916-947F-458476ACBF98")
+        #expect(groups[0].sortOrder == 1)
 
-        XCTAssertEqual(groups[1].name, "Home")
-        XCTAssertEqual(groups[1].id.uuidString, "C8AD00F0-8C30-48B1-B194-E5167E45C80E")
-        XCTAssertEqual(groups[1].sortOrder, 2)
+        #expect(groups[1].name == "Home")
+        #expect(groups[1].id.uuidString == "C8AD00F0-8C30-48B1-B194-E5167E45C80E")
+        #expect(groups[1].sortOrder == 2)
 
-        XCTAssertEqual(groups[2].name, "Mika")
-        XCTAssertEqual(groups[2].id.uuidString, "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
-        XCTAssertEqual(groups[2].sortOrder, 3)
+        #expect(groups[2].name == "Mika")
+        #expect(groups[2].id.uuidString == "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
+        #expect(groups[2].sortOrder == 3)
     }
 
-    func testMigration_bookmarks() async throws {
+    @Test func `Migration bookmarks`() async throws {
         let report = try await self.migrator.performMigration(migrationParameters, apiService: self.restService)
 
         // MARK: Testing the graceful handling of migration failures
         // Get the failing `BookmarkMigration` object, so we can test the dictionary key.
-        let failingBookmark = try XCTUnwrap(report.bookmarksMigrationResult.keys.first { bookmark in
+        let failingBookmark = try #require(report.bookmarksMigrationResult.keys.first { bookmark in
             return bookmark.stopID == "1_99610"
         }, "Expected to find a bookmark with a Stop ID of 1_99610")
 
         // Testing the dictionary key retrieval
-        let failingBookmarkResult = try XCTUnwrap(report.bookmarksMigrationResult[failingBookmark], "Expected the migration report to contain Bookmark Migration Results for bookmark with Stop ID 1_99610")
+        let failingBookmarkResult = try #require(report.bookmarksMigrationResult[failingBookmark], "Expected the migration report to contain Bookmark Migration Results for bookmark with Stop ID 1_99610")
 
-        // Testing that the specific migration error is surfaced in the report
-        XCTAssertThrowsError(try failingBookmarkResult.get(),"The failing bookmark should have a result type of .failure") { error in
-            guard let migrationError = error as? DataMigrationBookmarkError else {
-                return XCTFail("Expected the migration error type to be a MigrationBookmarkError")
-            }
-
-            XCTAssertEqual(migrationError, .noActiveTrips, "Expected the migration to fail because there are no active trips associated with the bookmark's stop")
+        // Testing that the specific migration error is surfaced in the report.
+        // Expected to fail because the bookmark's stop has no active trips.
+        #expect(throws: DataMigrationBookmarkError.noActiveTrips) {
+            try failingBookmarkResult.get()
         }
 
         // MARK: Testing the successful bookmark migrations
@@ -168,66 +168,66 @@ class DataMigrator_Tests: OBATestCase {
             }
         }
 
-        XCTAssertEqual(bookmarks.count, 5)
-        XCTAssertNotNil(bookmarks[0].id)
-        XCTAssertEqual(bookmarks[0].groupID?.uuidString, "C8AD00F0-8C30-48B1-B194-E5167E45C80E")
-        XCTAssertEqual(bookmarks[0].name, "10 to Home")
-        XCTAssertEqual(bookmarks[0].regionIdentifier, pugetSoundRegionIdentifier)
-        XCTAssertEqual(bookmarks[0].stopID, "1_29270")
-        XCTAssertNotNil(bookmarks[0].stop)
-        XCTAssertFalse(bookmarks[0].isFavorite)
-        XCTAssertEqual(bookmarks[0].routeShortName, "10")
-        XCTAssertEqual(bookmarks[0].routeID, "1_100002")
-        XCTAssertEqual(bookmarks[0].sortOrder, Int.max)
-        XCTAssertEqual(bookmarks[0].tripHeadsign, "Capitol Hill Via 15th Ave E")
+        #expect(bookmarks.count == 5)
+        #expect(bookmarks[0].id != nil)
+        #expect(bookmarks[0].groupID?.uuidString == "C8AD00F0-8C30-48B1-B194-E5167E45C80E")
+        #expect(bookmarks[0].name == "10 to Home")
+        #expect(bookmarks[0].regionIdentifier == pugetSoundRegionIdentifier)
+        #expect(bookmarks[0].stopID == "1_29270")
+        #expect(bookmarks[0].stop != nil)
+        #expect(!bookmarks[0].isFavorite)
+        #expect(bookmarks[0].routeShortName == "10")
+        #expect(bookmarks[0].routeID == "1_100002")
+        #expect(bookmarks[0].sortOrder == Int.max)
+        #expect(bookmarks[0].tripHeadsign == "Capitol Hill Via 15th Ave E")
 
-        XCTAssertNotNil(bookmarks[1].id)
-        XCTAssertEqual(bookmarks[1].groupID?.uuidString, "E87AFBD5-6B61-4916-947F-458476ACBF98")
-        XCTAssertEqual(bookmarks[1].name, "10 to Work")
-        XCTAssertEqual(bookmarks[1].regionIdentifier, pugetSoundRegionIdentifier)
-        XCTAssertEqual(bookmarks[1].stopID, "1_11370")
-        XCTAssertNotNil(bookmarks[1].stop)
-        XCTAssertFalse(bookmarks[1].isFavorite)
-        XCTAssertEqual(bookmarks[1].routeShortName, "10")
-        XCTAssertEqual(bookmarks[1].routeID, "1_100002")
-        XCTAssertEqual(bookmarks[1].sortOrder, Int.max)
-        XCTAssertEqual(bookmarks[1].tripHeadsign, "Downtown Seattle")
+        #expect(bookmarks[1].id != nil)
+        #expect(bookmarks[1].groupID?.uuidString == "E87AFBD5-6B61-4916-947F-458476ACBF98")
+        #expect(bookmarks[1].name == "10 to Work")
+        #expect(bookmarks[1].regionIdentifier == pugetSoundRegionIdentifier)
+        #expect(bookmarks[1].stopID == "1_11370")
+        #expect(bookmarks[1].stop != nil)
+        #expect(!bookmarks[1].isFavorite)
+        #expect(bookmarks[1].routeShortName == "10")
+        #expect(bookmarks[1].routeID == "1_100002")
+        #expect(bookmarks[1].sortOrder == Int.max)
+        #expect(bookmarks[1].tripHeadsign == "Downtown Seattle")
 
-        XCTAssertNotNil(bookmarks[2].id)
-        XCTAssertEqual(bookmarks[2].groupID?.uuidString, "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
-        XCTAssertEqual(bookmarks[2].name, "48 to UW")
-        XCTAssertEqual(bookmarks[2].regionIdentifier, pugetSoundRegionIdentifier)
-        XCTAssertEqual(bookmarks[2].stopID, "1_29320")
-        XCTAssertNotNil(bookmarks[2].stop)
-        XCTAssertFalse(bookmarks[2].isFavorite)
-        XCTAssertEqual(bookmarks[2].routeShortName, "48")
-        XCTAssertEqual(bookmarks[2].routeID, "1_100228")
-        XCTAssertEqual(bookmarks[2].sortOrder, Int.max)
-        XCTAssertEqual(bookmarks[2].tripHeadsign, "University District")
+        #expect(bookmarks[2].id != nil)
+        #expect(bookmarks[2].groupID?.uuidString == "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
+        #expect(bookmarks[2].name == "48 to UW")
+        #expect(bookmarks[2].regionIdentifier == pugetSoundRegionIdentifier)
+        #expect(bookmarks[2].stopID == "1_29320")
+        #expect(bookmarks[2].stop != nil)
+        #expect(!bookmarks[2].isFavorite)
+        #expect(bookmarks[2].routeShortName == "48")
+        #expect(bookmarks[2].routeID == "1_100228")
+        #expect(bookmarks[2].sortOrder == Int.max)
+        #expect(bookmarks[2].tripHeadsign == "University District")
 
-        XCTAssertNotNil(bookmarks[3].id)
-        XCTAssertEqual(bookmarks[3].groupID?.uuidString, "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
-        XCTAssertEqual(bookmarks[3].name, "49 to UW")
-        XCTAssertEqual(bookmarks[3].regionIdentifier, pugetSoundRegionIdentifier)
-        XCTAssertEqual(bookmarks[3].stopID, "1_11250")
-        XCTAssertNotNil(bookmarks[3].stop)
-        XCTAssertFalse(bookmarks[3].isFavorite)
-        XCTAssertEqual(bookmarks[3].routeShortName, "49")
-        XCTAssertEqual(bookmarks[3].routeID, "1_100447")
-        XCTAssertEqual(bookmarks[3].sortOrder, Int.max)
-        XCTAssertEqual(bookmarks[3].tripHeadsign, "University District")
+        #expect(bookmarks[3].id != nil)
+        #expect(bookmarks[3].groupID?.uuidString == "7CFB03E7-8C74-4CF6-A415-B1EEE7259812")
+        #expect(bookmarks[3].name == "49 to UW")
+        #expect(bookmarks[3].regionIdentifier == pugetSoundRegionIdentifier)
+        #expect(bookmarks[3].stopID == "1_11250")
+        #expect(bookmarks[3].stop != nil)
+        #expect(!bookmarks[3].isFavorite)
+        #expect(bookmarks[3].routeShortName == "49")
+        #expect(bookmarks[3].routeID == "1_100447")
+        #expect(bookmarks[3].sortOrder == Int.max)
+        #expect(bookmarks[3].tripHeadsign == "University District")
 
-        XCTAssertNotNil(bookmarks[4].id)
-        XCTAssertNil(bookmarks[4].groupID)
-        XCTAssertEqual(bookmarks[4].name, "Link to CHS")
-        XCTAssertEqual(bookmarks[4].regionIdentifier, pugetSoundRegionIdentifier)
-        XCTAssertEqual(bookmarks[4].stopID, "1_1121")
-        XCTAssertNotNil(bookmarks[4].stop)
-        XCTAssertFalse(bookmarks[4].isFavorite)
-        XCTAssertEqual(bookmarks[4].routeShortName, "Link")
-        XCTAssertEqual(bookmarks[4].routeID, "40_100479")
-        XCTAssertEqual(bookmarks[4].sortOrder, Int.max)
-        XCTAssertEqual(bookmarks[4].tripHeadsign, "University Of Washington Station")
+        #expect(bookmarks[4].id != nil)
+        #expect(bookmarks[4].groupID == nil)
+        #expect(bookmarks[4].name == "Link to CHS")
+        #expect(bookmarks[4].regionIdentifier == pugetSoundRegionIdentifier)
+        #expect(bookmarks[4].stopID == "1_1121")
+        #expect(bookmarks[4].stop != nil)
+        #expect(!bookmarks[4].isFavorite)
+        #expect(bookmarks[4].routeShortName == "Link")
+        #expect(bookmarks[4].routeID == "40_100479")
+        #expect(bookmarks[4].sortOrder == Int.max)
+        #expect(bookmarks[4].tripHeadsign == "University Of Washington Station")
     }
 
     // MARK: - TestDelegate

--- a/OBAKitTests/Modeling/Migration/MigrationDataExtractorTests.swift
+++ b/OBAKitTests/Modeling/Migration/MigrationDataExtractorTests.swift
@@ -14,12 +14,13 @@ import Testing
 
 // swiftlint:disable force_try syntactic_sugar
 
-class MigrationDataExtractorTests: OBATestCase {
+@Suite(.serialized)
+final class MigrationDataExtractorTests: OBATestCase {
 
     var extractor: MigrationDataExtractor!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         let testValues = try! Dictionary<String, Any>(plistPath: Fixtures.path(to: "migration_test_preferences.plist"))!
         for (k, v) in testValues {
@@ -29,15 +30,15 @@ class MigrationDataExtractorTests: OBATestCase {
         extractor = MigrationDataExtractor(defaults: userDefaults)
     }
 
-    func test_hasData() {
+    @Test func `Has data`() {
         #expect(self.extractor.hasDataToMigrate == true)
     }
 
-    func test_userID() {
+    @Test func `User ID`() {
         #expect(self.extractor.oldUserID == "B72C5F1A-B8E5-4FB3-A857-CAC6EAC86DE0")
     }
 
-    func test_bookmarkGroups() {
+    @Test func `Bookmark groups`() {
         let groups = extractor.extractBookmarkGroups()!
 
         #expect(groups.count == 4)
@@ -70,7 +71,7 @@ class MigrationDataExtractorTests: OBATestCase {
         #expect(mikaGroup.bookmarks.count == 2)
     }
 
-    func test_bookmarks() {
+    @Test func `Bookmarks`() {
         let bookmarks = extractor.extractBookmarks()!
 
         #expect(bookmarks.count == 2)
@@ -83,13 +84,13 @@ class MigrationDataExtractorTests: OBATestCase {
         #expect(bm1.routeID == "40_100479")
     }
 
-    func test_recentStops() {
+    @Test func `Recent stops`() {
         let recentStops = extractor.extractRecentStops()!
 
         #expect(recentStops.count == 6)
     }
 
-    func test_currentRegion() {
+    @Test func `Current region`() {
         let region = extractor.extractRegion()!
 
         #expect(region.name == "Puget Sound")

--- a/OBAKitTests/Modeling/Migration/MigrationDataExtractorTests.swift
+++ b/OBAKitTests/Modeling/Migration/MigrationDataExtractorTests.swift
@@ -71,7 +71,7 @@ final class MigrationDataExtractorTests: OBATestCase {
         #expect(mikaGroup.bookmarks.count == 2)
     }
 
-    @Test func `Bookmarks`() {
+    @Test func bookmarks() {
         let bookmarks = extractor.extractBookmarks()!
 
         #expect(bookmarks.count == 2)

--- a/OBAKitTests/Modeling/Model Unit Tests/AgencyModelTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/AgencyModelTests.swift
@@ -7,16 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class AgencyModelTests: OBATestCase {
+@Suite(.serialized)
+final class AgencyModelTests: OBATestCase {
 
-    func test_BasicAgencyDecoding() {
+    @Test func `Basic agency decoding`() {
         let agencyData: [String: Any] = [
             "id": "1",
             "name": "King County Metro",

--- a/OBAKitTests/Modeling/Model Unit Tests/AgencyTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/AgencyTests.swift
@@ -7,16 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class AgencyTests: OBATestCase {
+@Suite(.serialized)
+final class AgencyTests: OBATestCase {
     
-    func test_decodeValidAgency() {
+    @Test func `Decode valid agency`() {
         let agencyData: [String: Any] = [
             "id": "1",
             "name": "King County Metro",
@@ -44,7 +44,7 @@ class AgencyTests: OBATestCase {
         #expect(agency.isPrivateService == false)
     }
     
-    func test_decodeMinimalAgency() {
+    @Test func `Decode minimal agency`() {
         let minimalData: [String: Any] = [
             "id": "minimal_agency",
             "name": "Minimal Agency",
@@ -69,7 +69,7 @@ class AgencyTests: OBATestCase {
         #expect(agency.disclaimer == nil)
     }
     
-    func test_decodeWithBlankValues() {
+    @Test func `Decode with blank values`() {
         let dataWithBlanks: [String: Any] = [
             "id": "blank_agency",
             "name": "Agency With Blanks",
@@ -91,7 +91,7 @@ class AgencyTests: OBATestCase {
         #expect(agency.fareURL == nil)
     }
     
-    func test_encodeDecodeRoundTrip() {
+    @Test func `Encode decode round trip`() {
         let agencyData: [String: Any] = [
             "id": "roundtrip_test",
             "name": "Test Agency",
@@ -118,7 +118,7 @@ class AgencyTests: OBATestCase {
         #expect(roundTrippedAgency.isPrivateService == originalAgency.isPrivateService)
     }
     
-    func test_decodeFailureWhenMissingRequiredFields() {
+    @Test func `Decode failure when missing required fields`() {
         var incompleteData: [String: Any] = [
             "name": "Missing ID Agency",
             "url": "https://example.com",

--- a/OBAKitTests/Modeling/Model Unit Tests/AlarmTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/AlarmTests.swift
@@ -8,21 +8,21 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class AlarmTests: OBATestCase {
+@Suite(.serialized)
+final class AlarmTests: OBATestCase {
 
-    func test_init_baseCase_success() {
+    @Test func `Init base case success`() {
         let alarm = try! Fixtures.loadAlarm()
         #expect(alarm.url.absoluteString == "https://alerts.example.com/regions/1/alarms/1234567890")
     }
 
-    func test_appendingData() {
+    @Test func `Appending data`() {
         let alarm = try! Fixtures.loadAlarm()
         let interval: TimeInterval = 1580428800
         let serviceDate = Date(timeIntervalSince1970: interval) // January 31, 2020, 12:00 AM GMT

--- a/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureItemTransferTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureItemTransferTests.swift
@@ -7,18 +7,20 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ArrivalDepartureItemTransferTests: OBATestCase {
+@Suite(.serialized)
+final class ArrivalDepartureItemTransferTests: OBATestCase {
 
     /// Loads a real ArrivalDeparture from fixture data and verifies that
     /// creating an ArrivalDepartureItem with a TransferContext produces
     /// different minutes and temporal state than without one.
-    func test_arrivalDepartureItem_withTransferContext_overridesMinutesAndTemporalState() {
+    @Test func `Arrival departure item with transfer context overrides minutes and temporal state`() {
         let stopArrivals = try! Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_75414.json"
@@ -47,19 +49,15 @@ class ArrivalDepartureItemTransferTests: OBATestCase {
         )
 
         // The transfer-relative minutes should be -5 (departed 5 min before rider arrives).
-        XCTAssertEqual(itemWithTransfer.arrivalDepartureMinutes, -5)
-        XCTAssertEqual(itemWithTransfer.temporalState, .past)
+        #expect(itemWithTransfer.arrivalDepartureMinutes == -5)
+        #expect(itemWithTransfer.temporalState == .past)
 
         // Without transfer context, minutes are relative to Date.now — they should differ.
-        XCTAssertNotEqual(
-            itemWithoutTransfer.arrivalDepartureMinutes,
-            itemWithTransfer.arrivalDepartureMinutes,
-            "Transfer context should produce different minutes than real-time minutes"
-        )
+        #expect(itemWithoutTransfer.arrivalDepartureMinutes != itemWithTransfer.arrivalDepartureMinutes, "Transfer context should produce different minutes than real-time minutes")
     }
 
     /// Verifies that a departure exactly at the transfer arrival time shows as .present / 0 min.
-    func test_arrivalDepartureItem_withTransferContext_atArrivalTime() {
+    @Test func `Arrival departure item with transfer context at arrival time`() {
         let stopArrivals = try! Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_75414.json"
@@ -79,12 +77,12 @@ class ArrivalDepartureItemTransferTests: OBATestCase {
             transferContext: context
         )
 
-        XCTAssertEqual(item.arrivalDepartureMinutes, 0)
-        XCTAssertEqual(item.temporalState, .present)
+        #expect(item.arrivalDepartureMinutes == 0)
+        #expect(item.temporalState == .present)
     }
 
     /// Verifies that a departure 10 minutes after transfer arrival shows as .future / 10 min.
-    func test_arrivalDepartureItem_withTransferContext_futureAfterArrival() {
+    @Test func `Arrival departure item with transfer context future after arrival`() {
         let stopArrivals = try! Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_75414.json"
@@ -105,7 +103,7 @@ class ArrivalDepartureItemTransferTests: OBATestCase {
             transferContext: context
         )
 
-        XCTAssertEqual(item.arrivalDepartureMinutes, 10)
-        XCTAssertEqual(item.temporalState, .future)
+        #expect(item.arrivalDepartureMinutes == 10)
+        #expect(item.temporalState == .future)
     }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
@@ -7,16 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ArrivalDepartureTests: OBATestCase {
+@Suite(.serialized)
+final class ArrivalDepartureTests: OBATestCase {
     
-    func test_decodeValidArrivalDeparture() {
+    @Test func `Decode valid arrival departure`() {
         let arrivalData: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 2,
@@ -69,7 +69,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.tripStatus == nil)
     }
     
-    func test_decodeMinimalArrivalDeparture() {
+    @Test func `Decode minimal arrival departure`() {
         let minimalData: [String: Any] = [
             "arrivalEnabled": false,
             "blockTripSequence": 1,
@@ -110,7 +110,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.vehicleID == nil)
     }
     
-    func test_decodeArrivalDepartureWithBlankValues() {
+    @Test func `Decode arrival departure with blank values`() {
         let dataWithBlanks: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 1,
@@ -141,7 +141,7 @@ class ArrivalDepartureTests: OBATestCase {
         // Private properties are not directly testable, but their effects should be seen in computed properties
     }
     
-    func test_decodeArrivalDepartureWithInvalidPredictedTimes() {
+    @Test func `Decode arrival departure with invalid predicted times`() {
         // Test with very early predicted times that should be nullified
         let dataWithInvalidTimes: [String: Any] = [
             "arrivalEnabled": true,
@@ -172,7 +172,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.predictedDeparture == nil)
     }
     
-    func test_hasReferencesLoadReferences() {
+    @Test func `Has references load references`() {
         let arrivalData: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 1,
@@ -269,7 +269,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.serviceAlerts.map { $0.id }.sorted() == ["alert_ref_1", "alert_ref_2"])
     }
     
-    func test_occupancyStatusDecoding() {
+    @Test func `Occupancy status decoding`() {
         let occupancyData: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 1,
@@ -298,7 +298,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.historicalOccupancyStatus?.rawValue == "MANY_SEATS_AVAILABLE")
     }
     
-    func test_arrivalDepartureEquality() {
+    @Test func `Arrival departure equality`() {
         let arrivalData: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 1,
@@ -332,7 +332,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival1.hash != arrival3.hash)
     }
     
-    func test_decodeFailureWhenMissingRequiredFields() {
+    @Test func `Decode failure when missing required fields`() {
         var incompleteData: [String: Any] = [
             "blockTripSequence": 1,
             "departureEnabled": true,
@@ -397,7 +397,7 @@ class ArrivalDepartureTests: OBATestCase {
         )
     }
 
-    func test_deviation_forArrivingTrip_measuresAgainstScheduledArrival() throws {
+    @Test func `Deviation for arriving trip measures against scheduled arrival`() throws {
         // A non-zero stopSequence means `.arriving`, so the comparable baseline
         // is scheduledArrival — not scheduledDeparture on the far side of the
         // layover, which would report this late trip as 7 minutes early.
@@ -408,7 +408,7 @@ class ArrivalDepartureTests: OBATestCase {
         #expect(arrival.scheduleStatus == .delayed)
     }
 
-    func test_deviation_forDepartingTrip_measuresAgainstScheduledDeparture() throws {
+    @Test func `Deviation for departing trip measures against scheduled departure`() throws {
         let departure = try layoverArrivalDeparture(stopSequence: 0)
 
         #expect(departure.arrivalDepartureStatus == .departing)

--- a/OBAKitTests/Modeling/Model Unit Tests/BinarySearchTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/BinarySearchTests.swift
@@ -5,18 +5,18 @@
 //  Created by Alan Chu on 8/23/20.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
-class BinarySearchTests: OBATestCase {
+@Suite(.serialized)
+final class BinarySearchTests: OBATestCase {
     struct Person {
         var id: String
         var name: String
     }
 
-    func testBinarySearch() {
+    @Test func `Binary search`() {
         let people: [Person] = [
             .init(id: "43", name: "Bob"),
             .init(id: "33", name: "Rob"),

--- a/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
@@ -7,28 +7,30 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ReferencesTests: OBATestCase {
+@Suite(.serialized)
+final class ReferencesTests: OBATestCase {
     var references: References!
 
     let tampaRegionIdentifier = 0
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         let data = Fixtures.loadData(file: "references.json")
         references = try! JSONDecoder.RESTDecoder(regionIdentifier: tampaRegionIdentifier).decode(References.self, from: data)
     }
 
     // MARK: - Agencies
 
-    func test_agencies_success() {
+    @Test func `Agencies success`() {
         let agencies = references.agencies
 
         #expect(agencies.count == 1)
@@ -46,7 +48,7 @@ class ReferencesTests: OBATestCase {
 
     // MARK: - Routes
 
-    func test_routes_success() {
+    @Test func `Routes success`() {
         // Make sure routes are being sorted by their IDs for binary searching.
         let expectedRoutes = ["Hillsborough Area Regional Transit_1", "Hillsborough Area Regional Transit_12", "Hillsborough Area Regional Transit_14", "Hillsborough Area Regional Transit_16", "Hillsborough Area Regional Transit_18", "Hillsborough Area Regional Transit_2", "Hillsborough Area Regional Transit_21", "Hillsborough Area Regional Transit_33", "Hillsborough Area Regional Transit_39", "Hillsborough Area Regional Transit_400", "Hillsborough Area Regional Transit_41", "Hillsborough Area Regional Transit_45", "Hillsborough Area Regional Transit_5", "Hillsborough Area Regional Transit_57", "Hillsborough Area Regional Transit_6", "Hillsborough Area Regional Transit_9"]
 
@@ -68,7 +70,7 @@ class ReferencesTests: OBATestCase {
 
     // MARK: - Service Alerts
 
-    func test_serviceAlerts_success() {
+    @Test func `Service alerts success`() {
         let data = Fixtures.loadData(file: "arrival-and-departure-for-stop-MTS_11589.json")
         let response = try! JSONDecoder.RESTDecoder().decode(RESTAPIResponse<ArrivalDeparture>.self, from: data)
         let situations = response.references!.serviceAlerts
@@ -106,7 +108,7 @@ class ReferencesTests: OBATestCase {
 
     // MARK: - Stops
 
-    func test_stops_success() {
+    @Test func `Stops success`() {
         // Make sure stops are being sorted by their IDs for binary searching.
         let expectedOrder = ["Hillsborough Area Regional Transit_1513", "Hillsborough Area Regional Transit_2601", "Hillsborough Area Regional Transit_2625", "Hillsborough Area Regional Transit_3113", "Hillsborough Area Regional Transit_3114", "Hillsborough Area Regional Transit_3432", "Hillsborough Area Regional Transit_4301", "Hillsborough Area Regional Transit_4493", "Hillsborough Area Regional Transit_454", "Hillsborough Area Regional Transit_4547", "Hillsborough Area Regional Transit_455", "Hillsborough Area Regional Transit_4604", "Hillsborough Area Regional Transit_4677", "Hillsborough Area Regional Transit_6497", "Hillsborough Area Regional Transit_6499", "Hillsborough Area Regional Transit_6528", "Hillsborough Area Regional Transit_6592", "Hillsborough Area Regional Transit_683", "Hillsborough Area Regional Transit_6902", "Hillsborough Area Regional Transit_698", "Hillsborough Area Regional Transit_6990", "Hillsborough Area Regional Transit_7434", "Hillsborough Area Regional Transit_7581", "Hillsborough Area Regional Transit_7703", "Hillsborough Area Regional Transit_7924", "Hillsborough Area Regional Transit_928"]
 
@@ -130,7 +132,7 @@ class ReferencesTests: OBATestCase {
         #expect(stop.wheelchairBoarding == .unknown)
     }
 
-    func test_stopsWithIDs_preservesInputOrder() {
+    @Test func `Stops with IDs preserves input order`() {
         // Get some stop IDs from the references in a specific order that differs from the internal sorted order
         let stopIDs = references.stops.map { $0.id }
 
@@ -145,12 +147,12 @@ class ReferencesTests: OBATestCase {
                 "stopsWithIDs should preserve the order of the input IDs array")
     }
 
-    func test_stopsWithIDs_returnsEmptyArrayForEmptyInput() {
+    @Test func `Stops with IDs returns empty array for empty input`() {
         let result = references.stopsWithIDs([])
         #expect(result.isEmpty)
     }
 
-    func test_stopsWithIDs_filtersOutInvalidIDs() {
+    @Test func `Stops with IDs filters out invalid IDs`() {
         let validID = references.stops.first!.id
         let invalidID = "invalid_stop_id_that_does_not_exist"
 
@@ -163,7 +165,7 @@ class ReferencesTests: OBATestCase {
 
     // MARK: - Trips
 
-    func test_trips_success() {
+    @Test func `Trips success`() {
         // Make sure stops are being sorted by their IDs for binary searching.
         let expectedTrips = ["Hillsborough Area Regional Transit_101412", "Hillsborough Area Regional Transit_101445", "Hillsborough Area Regional Transit_102332", "Hillsborough Area Regional Transit_102333", "Hillsborough Area Regional Transit_102381", "Hillsborough Area Regional Transit_102382", "Hillsborough Area Regional Transit_102675", "Hillsborough Area Regional Transit_102676", "Hillsborough Area Regional Transit_102677", "Hillsborough Area Regional Transit_98479", "Hillsborough Area Regional Transit_98522", "Hillsborough Area Regional Transit_98523", "Hillsborough Area Regional Transit_98683", "Hillsborough Area Regional Transit_98684", "Hillsborough Area Regional Transit_98715", "Hillsborough Area Regional Transit_98716", "Hillsborough Area Regional Transit_98870", "Hillsborough Area Regional Transit_98902", "Hillsborough Area Regional Transit_99282", "Hillsborough Area Regional Transit_99283", "Hillsborough Area Regional Transit_99312", "Hillsborough Area Regional Transit_99313", "Hillsborough Area Regional Transit_99494", "Hillsborough Area Regional Transit_99495", "Hillsborough Area Regional Transit_99538", "Hillsborough Area Regional Transit_99539", "Hillsborough Area Regional Transit_99872", "Hillsborough Area Regional Transit_99873", "Hillsborough Area Regional Transit_99904", "Hillsborough Area Regional Transit_99905"]
 

--- a/OBAKitTests/Modeling/Model Unit Tests/RegionSupportsScheduleForRouteTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RegionSupportsScheduleForRouteTests.swift
@@ -7,12 +7,12 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
-class RegionSupportsScheduleForRouteTests: OBATestCase {
+@Suite(.serialized)
+final class RegionSupportsScheduleForRouteTests: OBATestCase {
 
     /// Helper to create a Region with a specific `obaVersionInfo` value.
     private func regionWithVersionInfo(_ versionInfo: String) throws -> Region {
@@ -40,14 +40,14 @@ class RegionSupportsScheduleForRouteTests: OBATestCase {
 
     // MARK: - OBA 2.0.x should not support schedule-for-route
 
-    func test_supportsScheduleForRoute_OBA2_0_SNAPSHOT_returnsFalse() throws {
+    @Test func `Supports schedule for route OBA 2 0 SNAPSHOT returns false`() throws {
         let region = try regionWithVersionInfo("2.0.0-SNAPSHOT|2|0|0|SNAPSHOT|abc")
         #expect(!region.supportsScheduleForRoute)
     }
 
     // MARK: - OBA 2.1+ should support schedule-for-route
 
-    func test_supportsScheduleForRoute_Tampa_returnsTrue() throws {
+    @Test func `Supports schedule for route tampa returns true`() throws {
         // Real Tampa fixture data
         let region = try regionWithVersionInfo("2.4.15-cs|2|4|15|cs|d41e1a8978da14e98a2e19d109a23018957db7cf")
         #expect(region.supportsScheduleForRoute)
@@ -55,21 +55,21 @@ class RegionSupportsScheduleForRouteTests: OBATestCase {
 
     // MARK: - Empty/unparseable version info should default to true
 
-    func test_supportsScheduleForRoute_emptyString_returnsTrue() throws {
+    @Test func `Supports schedule for route empty string returns true`() throws {
         let region = try regionWithVersionInfo("")
         #expect(region.supportsScheduleForRoute)
     }
 
     // MARK: - Custom region (hardcoded "x.y.z.custom" in init) should default to true
 
-    func test_supportsScheduleForRoute_customRegion_returnsTrue() {
+    @Test func `Supports schedule for route custom region returns true`() {
         let region = Fixtures.customMinneapolisRegion
         #expect(region.supportsScheduleForRoute)
     }
 
     // MARK: - No-pipe format (e.g. Mayaguez "2.1.0") should default to true
 
-    func test_supportsScheduleForRoute_noPipeFormat_returnsTrue() throws {
+    @Test func `Supports schedule for route no pipe format returns true`() throws {
         let region = try regionWithVersionInfo("2.1.0")
         #expect(region.supportsScheduleForRoute)
     }

--- a/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RegionsEncodingTests.swift
@@ -7,18 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable function_body_length force_try
 
-class RegionsEncodingTests: OBATestCase {
+@Suite(.serialized)
+final class RegionsEncodingTests: OBATestCase {
 
-    func testRoundtrippingRegion() {
+    @Test func `Roundtripping region`() {
         let regionsObjects = try! Fixtures.loadRESTAPIPayload(type: [Region].self, fileName: "regions-v3.json")
 
         #expect(regionsObjects.count == 17)
@@ -81,7 +82,7 @@ class RegionsEncodingTests: OBATestCase {
         expectClose(bounds[1].lonSpan, 0.3967700000000036)
     }
 
-    func testUmamiAnalyticsDecoding() {
+    @Test func `Umami analytics decoding`() {
         let regions = try! Fixtures.loadRESTAPIPayload(type: [Region].self, fileName: "regions-v3.json")
 
         // Present: region 0 decodes url + id.
@@ -103,7 +104,7 @@ class RegionsEncodingTests: OBATestCase {
         #expect(roundTripped[1].umamiAnalytics == nil)
     }
 
-    func testCustomRegions_creation() {
+    @Test func `Custom regions creation`() {
         let customRegion = Fixtures.customMinneapolisRegion
 
         #expect(customRegion.name == "Custom Region")
@@ -116,7 +117,7 @@ class RegionsEncodingTests: OBATestCase {
         expectClose(customRegion.serviceRect.width, 9453.3477, within: 0.1)
     }
 
-    func testCustomRegions_roundtripping() {
+    @Test func `Custom regions roundtripping`() {
         let customRegion = Fixtures.customMinneapolisRegion
         let plistData = try! PropertyListEncoder().encode([customRegion])
         let roundTripped = try! PropertyListDecoder().decode([Region].self, from: plistData)
@@ -134,23 +135,23 @@ class RegionsEncodingTests: OBATestCase {
 
     // MARK: - UmamiAnalyticsConfig inits
 
-    func testUmamiConfig_memberwiseInit() {
+    @Test func `Umami config memberwise init`() {
         let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com")!, id: "site-123")
         #expect(config.url.absoluteString == "https://analytics.example.com")
         #expect(config.id == "site-123")
     }
 
-    func testUmamiConfig_failableInit_bothPresent() {
+    @Test func `Umami config failable init both present`() {
         let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "site-123")
         #expect(config?.id == "site-123")
     }
 
-    func testUmamiConfig_failableInit_trimsID() {
+    @Test func `Umami config failable init trims ID`() {
         let config = UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "  site-123 \n")
         #expect(config?.id == "site-123")
     }
 
-    func testUmamiConfig_failableInit_partialPairsCollapseToNil() {
+    @Test func `Umami config failable init partial pairs collapse to nil`() {
         #expect(UmamiAnalyticsConfig(url: nil, id: "site-123") == nil)
         #expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: nil) == nil)
         #expect(UmamiAnalyticsConfig(url: URL(string: "https://analytics.example.com"), id: "") == nil)
@@ -158,14 +159,14 @@ class RegionsEncodingTests: OBATestCase {
         #expect(UmamiAnalyticsConfig(url: nil, id: nil) == nil)
     }
 
-    func testCustomRegions_creation_withSidecarAndUmami() {
+    @Test func `Custom regions creation with sidecar and umami`() {
         let region = Fixtures.customRegionWithSidecarAndUmami
         #expect(region.sidecarBaseURL?.absoluteString == "https://obaco.example.com")
         #expect(region.umamiAnalytics?.url.absoluteString == "https://analytics.example.com")
         #expect(region.umamiAnalytics?.id == "site-uuid-123")
     }
 
-    func testCustomRegions_roundtripping_withSidecarAndUmami() {
+    @Test func `Custom regions roundtripping with sidecar and umami`() {
         let plistData = try! PropertyListEncoder().encode([Fixtures.customRegionWithSidecarAndUmami])
         let rt = try! PropertyListDecoder().decode([Region].self, from: plistData)[0]
 

--- a/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/RouteTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import UIKit
 @testable import OBAKit
@@ -15,9 +14,10 @@ import UIKit
 
 // swiftlint:disable force_try
 
-class RouteTests: OBATestCase {
+@Suite(.serialized)
+final class RouteTests: OBATestCase {
     
-    func test_decodeValidRoute() {
+    @Test func `Decode valid route`() {
         let routeData: [String: Any] = [
             "id": "1_100002",
             "agencyId": "1",
@@ -45,7 +45,7 @@ class RouteTests: OBATestCase {
         #expect(route.regionIdentifier == nil)
     }
     
-    func test_decodeMinimalRoute() {
+    @Test func `Decode minimal route`() {
         let minimalData: [String: Any] = [
             "id": "minimal_route",
             "agencyId": "2",
@@ -66,7 +66,7 @@ class RouteTests: OBATestCase {
         #expect(route.routeURL == nil)
     }
     
-    func test_decodeWithBlankValues() {
+    @Test func `Decode with blank values`() {
         let dataWithBlanks: [String: Any] = [
             "id": "blank_route",
             "agencyId": "3",
@@ -87,7 +87,7 @@ class RouteTests: OBATestCase {
         #expect(route.textColor == nil)
     }
     
-    func test_routeTypeDecoding() {
+    @Test func `Route type decoding`() {
         let testCases: [(Int, Route.RouteType)] = [
             (0, .lightRail),
             (1, .subway),
@@ -114,7 +114,7 @@ class RouteTests: OBATestCase {
         }
     }
     
-    func test_hasReferencesLoadReferences() {
+    @Test func `Has references load references`() {
         let routeData: [String: Any] = [
             "id": "1_100002",
             "agencyId": "1",
@@ -146,7 +146,7 @@ class RouteTests: OBATestCase {
         #expect(route.regionIdentifier == 123)
     }
     
-    func test_equalityAndHash() {
+    @Test func `Equality and hash`() {
         let routeData: [String: Any] = [
             "id": "equality_test",
             "agencyId": "1",
@@ -174,7 +174,7 @@ class RouteTests: OBATestCase {
         #expect(route1.hash != route3.hash)
     }
     
-    func test_encodeDecodeRoundTrip() {
+    @Test func `Encode decode round trip`() {
         let routeData: [String: Any] = [
             "id": "roundtrip_test",
             "agencyId": "1",
@@ -197,7 +197,7 @@ class RouteTests: OBATestCase {
         #expect(roundTrippedRoute.routeURL == originalRoute.routeURL)
     }
     
-    func test_arrayExtensionSort() {
+    @Test func `Array extension sort`() {
         let route1Data: [String: Any] = ["id": "route1", "agencyId": "1", "shortName": "z Route", "type": 3]
         let route2Data: [String: Any] = ["id": "route2", "agencyId": "1", "shortName": "A Route", "type": 3]
         let route3Data: [String: Any] = ["id": "route3", "agencyId": "1", "shortName": "m Route", "type": 3]
@@ -215,7 +215,7 @@ class RouteTests: OBATestCase {
         #expect(sortedRoutes[2].shortName == "z Route")
     }
 
-    func test_arrayExtensionSort_numeric() {
+    @Test func `Array extension sort numeric`() {
         let routeNames = ["10", "3", "11", "49", "Bellevue", "12"]
         let routes = try! routeNames.enumerated().map { (index, name) -> Route in
             let dict: [String: Any] = ["id": "route_\(index)", "agencyId": "1", "shortName": name, "type": 3]
@@ -231,9 +231,10 @@ class RouteTests: OBATestCase {
 
 // MARK: - Frequency Tests
 
-class FrequencyTests: OBATestCase {
+@Suite(.serialized)
+final class FrequencyTests: OBATestCase {
     
-    func test_decodeValidFrequency() {
+    @Test func `Decode valid frequency`() {
         let frequencyData: [String: Any] = [
             "startTime": 1609459200000, // Milliseconds since epoch
             "endTime": 1609545600000,   
@@ -247,7 +248,7 @@ class FrequencyTests: OBATestCase {
         #expect(frequency.headway == 600.0)
     }
     
-    func test_frequencyEquality() {
+    @Test func `Frequency equality`() {
         let frequencyData: [String: Any] = [
             "startTime": 1609459200000,
             "endTime": 1609545600000,
@@ -267,7 +268,7 @@ class FrequencyTests: OBATestCase {
         #expect(frequency1.hash != frequency3.hash)
     }
     
-    func test_decodeFailureWhenMissingRequiredFields() {
+    @Test func `Decode failure when missing required fields`() {
         let incompleteData: [String: Any] = [
             "endTime": 1609545600000,
             "headway": 600.0

--- a/OBAKitTests/Modeling/Model Unit Tests/ServiceAlertTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ServiceAlertTests.swift
@@ -7,16 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ServiceAlertTests: OBATestCase {
+@Suite(.serialized)
+final class ServiceAlertTests: OBATestCase {
     
-    func test_decodeValidServiceAlert() {
+    @Test func `Decode valid service alert`() {
         let alertData: [String: Any] = [
             "id": "test_alert_123",
             "creationTime": 1234567890,
@@ -79,7 +80,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(alert.regionIdentifier == nil)
     }
     
-    func test_decodeMinimalServiceAlert() {
+    @Test func `Decode minimal service alert`() {
         let minimalData: [String: Any] = [
             "id": "minimal_alert",
             "creationTime": 1000000000,
@@ -106,7 +107,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(alert.consequences.count == 0)
     }
     
-    func test_timeWindowDecoding() {
+    @Test func `Time window decoding`() {
         let timeWindowData: [String: Any] = [
             "from": 1234567890,
             "to": 1234567999
@@ -120,7 +121,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(timeWindow.interval.end == timeWindow.to)
     }
 
-    func test_timeWindowDecodingWithMilliseconds() {
+    @Test func `Time window decoding with milliseconds`() {
         let millisecondsData: [String: Any] = [
             "from": 1539781200000,
             "to": 1539826200000
@@ -132,7 +133,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(timeWindow.to.timeIntervalSince1970 == 1539826200)
     }
 
-    func test_timeWindowThresholdBoundary() {
+    @Test func `Time window threshold boundary`() {
         // Just at threshold (10_000_000_000) -> Treated as seconds
         let atThresholdData: [String: Any] = ["from": 10_000_000_000, "to": 10_000_003_600]
         let atThresholdWindow = try! Fixtures.dictionaryToModel(type: ServiceAlert.TimeWindow.self, dictionary: atThresholdData)
@@ -147,7 +148,7 @@ class ServiceAlertTests: OBATestCase {
         expectClose(aboveThresholdWindow.from.timeIntervalSince1970, 10_000_000.001, within: 0.0001)
     }
     
-    func test_timeWindowWithMissingTo() {
+    @Test func `Time window with missing to`() {
         let timeWindowData: [String: Any] = [
             "from": 1234567890
         ]
@@ -159,7 +160,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(timeWindow.interval.start == timeWindow.from)
     }
     
-    func test_timeWindowWithInvalidTo() {
+    @Test func `Time window with invalid to`() {
         let timeWindowData: [String: Any] = [
             "from": 1234567890,
             "to": 100  // Earlier than 'from', simulating 1970 timestamp
@@ -174,7 +175,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(timeWindow.interval.end == timeWindow.from)
     }
     
-    func test_timeWindowComparison() {
+    @Test func `Time window comparison`() {
         let earlyData: [String: Any] = ["from": 1000, "to": 2000]
         let lateData: [String: Any] = ["from": 3000, "to": 4000]
         
@@ -185,7 +186,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(!(lateWindow < earlyWindow))
     }
     
-    func test_timeWindowEquality() {
+    @Test func `Time window equality`() {
         let data1: [String: Any] = ["from": 1000, "to": 2000]
         let data2: [String: Any] = ["from": 1000, "to": 2000]
         let data3: [String: Any] = ["from": 1000, "to": 3000]
@@ -200,7 +201,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(window1.hash != window3.hash)
     }
     
-    func test_affectedEntityDecoding() {
+    @Test func `Affected entity decoding`() {
         let entityData: [String: Any] = [
             "agencyId": "test_agency",
             "applicationId": "test_app",
@@ -220,7 +221,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(entity.tripID == "test_trip")
     }
     
-    func test_affectedEntityWithBlankValues() {
+    @Test func `Affected entity with blank values`() {
         let entityData: [String: Any] = [
             "agencyId": "",
             "applicationId": "",
@@ -240,7 +241,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(entity.tripID == nil)
     }
     
-    func test_affectedEntityEquality() {
+    @Test func `Affected entity equality`() {
         let data1: [String: Any] = ["agencyId": "a1", "routeId": "r1", "applicationId": "", "directionId": "", "stopId": "", "tripId": ""]
         let data2: [String: Any] = ["agencyId": "a1", "routeId": "r1", "applicationId": "", "directionId": "", "stopId": "", "tripId": ""]
         let data3: [String: Any] = ["agencyId": "a1", "routeId": "r2", "applicationId": "", "directionId": "", "stopId": "", "tripId": ""]
@@ -255,7 +256,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(entity1.hash != entity3.hash)
     }
     
-    func test_consequenceDecoding() {
+    @Test func `Consequence decoding`() {
         let consequenceData: [String: Any] = [
             "condition": "DETOUR",
             "conditionDetails": [
@@ -274,7 +275,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(consequence.conditionDetails?.stopIDs == ["stop1", "stop2", "stop3"])
     }
     
-    func test_consequenceWithoutDetails() {
+    @Test func `Consequence without details`() {
         let consequenceData: [String: Any] = [
             "condition": "NO_SERVICE"
         ]
@@ -285,7 +286,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(consequence.conditionDetails == nil)
     }
     
-    func test_consequenceEquality() {
+    @Test func `Consequence equality`() {
         let data1: [String: Any] = ["condition": "DETOUR"]
         let data2: [String: Any] = ["condition": "DETOUR"]
         let data3: [String: Any] = ["condition": "NO_SERVICE"]
@@ -300,7 +301,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(consequence1.hash != consequence3.hash)
     }
     
-    func test_conditionDetailsEquality() {
+    @Test func `Condition details equality`() {
         let data1: [String: Any] = [
             "diversionPath": ["points": "path1"],
             "diversionStopIds": ["stop1"]
@@ -324,7 +325,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(details1.hash != details3.hash)
     }
     
-    func test_translatedStringEquality() {
+    @Test func `Translated string equality`() {
         let str1 = ServiceAlert.TranslatedString(lang: "en", value: "Hello")
         let str2 = ServiceAlert.TranslatedString(lang: "en", value: "Hello")
         let str3 = ServiceAlert.TranslatedString(lang: "es", value: "Hola")
@@ -335,7 +336,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(str1.hash != str3.hash)
     }
     
-    func test_serviceAlertEquality() {
+    @Test func `Service alert equality`() {
         let alertData: [String: Any] = [
             "id": "alert_equality_test",
             "creationTime": 1234567890,
@@ -360,7 +361,7 @@ class ServiceAlertTests: OBATestCase {
         #expect(alert1.hash != alert3.hash)
     }
     
-    func test_hasReferencesLoadReferences() {
+    @Test func `Has references load references`() {
         let alertData: [String: Any] = [
             "id": "test_alert_references",
             "creationTime": 1234567890,

--- a/OBAKitTests/Modeling/Model Unit Tests/StopTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/StopTests.swift
@@ -7,16 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class StopTests: OBATestCase {
+@Suite(.serialized)
+final class StopTests: OBATestCase {
 
-    func test_RoundtrippingStops() {
+    @Test func `Roundtripping stops`() {
         let stopOne = try! Fixtures.loadSomeStops().first!
         let data = try! PropertyListEncoder().encode(stopOne)
         let stopTwo = try! PropertyListDecoder().decode(Stop.self, from: data)

--- a/OBAKitTests/Modeling/Model Unit Tests/TransferContextTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/TransferContextTests.swift
@@ -7,17 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class TransferContextTests: OBATestCase {
+@Suite(.serialized)
+final class TransferContextTests: OBATestCase {
 
     // MARK: - minutesUntilDeparture
 
-    func test_minutesUntilDeparture_futurePositive() {
+    @Test func `Minutes until departure future positive`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -26,10 +28,10 @@ class TransferContextTests: OBATestCase {
         )
         // Departure 10 minutes after arrival
         let departureDate = arrivalTime.addingTimeInterval(10 * 60)
-        XCTAssertEqual(context.minutesUntilDeparture(from: departureDate), 10)
+        #expect(context.minutesUntilDeparture(from: departureDate) == 10)
     }
 
-    func test_minutesUntilDeparture_pastNegative() {
+    @Test func `Minutes until departure past negative`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -38,22 +40,22 @@ class TransferContextTests: OBATestCase {
         )
         // Departure 5 minutes before arrival
         let departureDate = arrivalTime.addingTimeInterval(-5 * 60)
-        XCTAssertEqual(context.minutesUntilDeparture(from: departureDate), -5)
+        #expect(context.minutesUntilDeparture(from: departureDate) == -5)
     }
 
-    func test_minutesUntilDeparture_exactZero() {
+    @Test func `Minutes until departure exact zero`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
             fromRouteShortName: "10",
             fromTripHeadsign: "Capitol Hill"
         )
-        XCTAssertEqual(context.minutesUntilDeparture(from: arrivalTime), 0)
+        #expect(context.minutesUntilDeparture(from: arrivalTime) == 0)
     }
 
     // MARK: - temporalState
 
-    func test_temporalState_future() {
+    @Test func `Temporal state future`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -61,10 +63,10 @@ class TransferContextTests: OBATestCase {
             fromTripHeadsign: "Capitol Hill"
         )
         let departureDate = arrivalTime.addingTimeInterval(5 * 60)
-        XCTAssertEqual(context.temporalState(for: departureDate), .future)
+        #expect(context.temporalState(for: departureDate) == .future)
     }
 
-    func test_temporalState_past() {
+    @Test func `Temporal state past`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -72,22 +74,22 @@ class TransferContextTests: OBATestCase {
             fromTripHeadsign: "Capitol Hill"
         )
         let departureDate = arrivalTime.addingTimeInterval(-3 * 60)
-        XCTAssertEqual(context.temporalState(for: departureDate), .past)
+        #expect(context.temporalState(for: departureDate) == .past)
     }
 
-    func test_temporalState_present() {
+    @Test func `Temporal state present`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
             fromRouteShortName: "10",
             fromTripHeadsign: "Capitol Hill"
         )
-        XCTAssertEqual(context.temporalState(for: arrivalTime), .present)
+        #expect(context.temporalState(for: arrivalTime) == .present)
     }
 
     // MARK: - Edge cases
 
-    func test_minutesUntilDeparture_roundsTowardZero() {
+    @Test func `Minutes until departure rounds toward zero`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -96,10 +98,10 @@ class TransferContextTests: OBATestCase {
         )
         // 90 seconds = 1.5 minutes, Int truncation -> 1
         let departureDate = arrivalTime.addingTimeInterval(90)
-        XCTAssertEqual(context.minutesUntilDeparture(from: departureDate), 1)
+        #expect(context.minutesUntilDeparture(from: departureDate) == 1)
     }
 
-    func test_minutesUntilDeparture_negativeFractionalRoundsTowardZero() {
+    @Test func `Minutes until departure negative fractional rounds toward zero`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -108,10 +110,10 @@ class TransferContextTests: OBATestCase {
         )
         // -90 seconds = -1.5 minutes, Int truncation toward zero -> -1
         let departureDate = arrivalTime.addingTimeInterval(-90)
-        XCTAssertEqual(context.minutesUntilDeparture(from: departureDate), -1)
+        #expect(context.minutesUntilDeparture(from: departureDate) == -1)
     }
 
-    func test_minutesUntilDeparture_largeOffset() {
+    @Test func `Minutes until departure large offset`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
         let context = TransferContext(
             arrivalTime: arrivalTime,
@@ -120,12 +122,12 @@ class TransferContextTests: OBATestCase {
         )
         // 2 hours after arrival
         let departureDate = arrivalTime.addingTimeInterval(120 * 60)
-        XCTAssertEqual(context.minutesUntilDeparture(from: departureDate), 120)
+        #expect(context.minutesUntilDeparture(from: departureDate) == 120)
     }
 
     // MARK: - Factory method
 
-    func test_fromFactory_populatesFieldsCorrectly() {
+    @Test func `From factory populates fields correctly`() {
         let arrivalTime = Date(timeIntervalSince1970: 1_000_000)
 
         // Use the Fixtures-loaded ArrivalDeparture to test the factory.
@@ -137,13 +139,13 @@ class TransferContextTests: OBATestCase {
 
         let context = TransferContext.from(arrivalDeparture: arrDep, arrivalDate: arrivalTime)
 
-        XCTAssertEqual(context.arrivalTime, arrivalTime)
-        XCTAssertEqual(context.fromRouteShortName, arrDep.routeShortName)
-        XCTAssertEqual(context.fromTripHeadsign, arrDep.tripHeadsign ?? "")
+        #expect(context.arrivalTime == arrivalTime)
+        #expect(context.fromRouteShortName == arrDep.routeShortName)
+        #expect(context.fromTripHeadsign == (arrDep.tripHeadsign ?? ""))
         // fromRouteDisplay is now computed from the component fields.
         let expectedDisplay = [arrDep.routeShortName, arrDep.tripHeadsign ?? ""]
             .filter { !$0.isEmpty }
             .joined(separator: " - ")
-        XCTAssertEqual(context.fromRouteDisplay, expectedDisplay)
+        #expect(context.fromRouteDisplay == expectedDisplay)
     }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/TripStatusTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/TripStatusTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import Testing
 @testable import OBAKit
@@ -15,9 +14,10 @@ import Testing
 
 // swiftlint:disable force_try
 
-class TripStatusTests: OBATestCase {
+@Suite(.serialized)
+final class TripStatusTests: OBATestCase {
     
-    func test_decodeValidTripStatus() {
+    @Test func `Decode valid trip status`() {
         let statusData: [String: Any] = [
             "activeTripId": "active_trip_123",
             "blockTripSequence": 3,
@@ -80,7 +80,7 @@ class TripStatusTests: OBATestCase {
         #expect(status.vehicleID == "vehicle_789")
     }
     
-    func test_decodeMinimalTripStatus() {
+    @Test func `Decode minimal trip status`() {
         let minimalData: [String: Any] = [
             "activeTripId": "minimal_trip",
             "blockTripSequence": 1,
@@ -117,7 +117,7 @@ class TripStatusTests: OBATestCase {
         #expect(status.vehicleID == nil)
     }
     
-    func test_statusModifierDecoding() {
+    @Test func `Status modifier decoding`() {
         let statusTestCases: [(String, TripStatus.StatusModifier)] = [
             ("default", .default),
             ("canceled", .canceled),
@@ -151,7 +151,7 @@ class TripStatusTests: OBATestCase {
         }
     }
     
-    func test_locationDecoding() {
+    @Test func `Location decoding`() {
         let dataWithLocations: [String: Any] = [
             "activeTripId": "location_test",
             "blockTripSequence": 1,
@@ -189,7 +189,7 @@ class TripStatusTests: OBATestCase {
         expectClose(status.position?.coordinate.longitude, -122.654322, within: 0.000001)
     }
     
-    func test_hasReferencesLoadReferences() {
+    @Test func `Has references load references`() {
         let statusData: [String: Any] = [
             "activeTripId": "ref_trip",
             "blockTripSequence": 1,
@@ -290,7 +290,7 @@ class TripStatusTests: OBATestCase {
         #expect(status.serviceAlerts.first?.id == "ref_alert_1")
     }
     
-    func test_tripStatusEquality() {
+    @Test func `Trip status equality`() {
         let statusData: [String: Any] = [
             "activeTripId": "equality_trip",
             "blockTripSequence": 1,
@@ -325,7 +325,7 @@ class TripStatusTests: OBATestCase {
         #expect(status1.hash != status3.hash)
     }
     
-    func test_decodeFailureWhenMissingRequiredFields() {
+    @Test func `Decode failure when missing required fields`() {
         var incompleteData: [String: Any] = [
             "blockTripSequence": 1,
             "closestStop": "incomplete_stop",

--- a/OBAKitTests/Modeling/Model Unit Tests/TripTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/TripTests.swift
@@ -7,16 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class TripTests: OBATestCase {
+@Suite(.serialized)
+final class TripTests: OBATestCase {
     
-    func test_decodeValidTrip() {
+    @Test func `Decode valid trip`() {
         let tripData: [String: Any] = [
             "id": "1_18196913",
             "blockId": "7001_1001",
@@ -46,7 +46,7 @@ class TripTests: OBATestCase {
         #expect(trip.regionIdentifier == nil)
     }
     
-    func test_decodeMinimalTrip() {
+    @Test func `Decode minimal trip`() {
         let minimalData: [String: Any] = [
             "id": "minimal_trip",
             "blockId": "block_123",
@@ -70,7 +70,7 @@ class TripTests: OBATestCase {
         #expect(trip.timeZone == "UTC")
     }
     
-    func test_decodeWithBlankValues() {
+    @Test func `Decode with blank values`() {
         let dataWithBlanks: [String: Any] = [
             "id": "blank_trip",
             "blockId": "block_blank",
@@ -90,7 +90,7 @@ class TripTests: OBATestCase {
         #expect(trip.timeZone == nil)
     }
     
-    func test_hasReferencesLoadReferences() {
+    @Test func `Has references load references`() {
         let tripData: [String: Any] = [
             "id": "test_trip",
             "blockId": "test_block",
@@ -133,7 +133,7 @@ class TripTests: OBATestCase {
         #expect(trip.regionIdentifier == 456)
     }
     
-    func test_routeHeadsign() {
+    @Test func `Route headsign`() {
         let tripData: [String: Any] = [
             "id": "headsign_trip",
             "blockId": "test_block",
@@ -161,7 +161,7 @@ class TripTests: OBATestCase {
         #expect(trip.routeHeadsign == "ST Express - Bellevue TC")
     }
     
-    func test_routeHeadsignWithoutTripHeadsign() {
+    @Test func `Route headsign without trip headsign`() {
         let tripData: [String: Any] = [
             "id": "no_headsign_trip",
             "blockId": "test_block",
@@ -188,7 +188,7 @@ class TripTests: OBATestCase {
         #expect(trip.routeHeadsign == "ST Express")
     }
     
-    func test_equalityAndHash() {
+    @Test func `Equality and hash`() {
         let tripData: [String: Any] = [
             "id": "equality_test",
             "blockId": "test_block",

--- a/OBAKitTests/Modeling/MoreTabConfigurationTests.swift
+++ b/OBAKitTests/Modeling/MoreTabConfigurationTests.swift
@@ -7,29 +7,28 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKitCore
 
 @MainActor
-class MoreTabConfigurationTests: XCTestCase {
+@Suite(.serialized)
+final class MoreTabConfigurationTests {
 
     // MARK: - Default Configuration
 
-    func test_defaultConfiguration_hasExpectedValues() {
+    @Test func `Default configuration has expected values`() {
         let config = MoreTabConfiguration.default
-        XCTAssertNil(config.headerSupportText)
-        XCTAssertTrue(config.showHelpOutSection)
-        XCTAssertNil(config.translateURL)
-        XCTAssertEqual(
-            config.developURL?.absoluteString,
-            "https://github.com/oneBusAway/onebusaway-ios"
-        )
-        XCTAssertTrue(config.customLinks.isEmpty)
+        #expect(config.headerSupportText == nil)
+        #expect(config.showHelpOutSection)
+        #expect(config.translateURL == nil)
+        #expect(config.developURL?.absoluteString == "https://github.com/oneBusAway/onebusaway-ios")
+        #expect(config.customLinks.isEmpty)
     }
 
     // MARK: - Parsing from Dictionary
 
-    func test_parseFromDictionary_withAllFields() {
+    @Test func `Parse from dictionary with all fields`() {
         let dict: [AnyHashable: Any] = [
             "HeaderSupportText": "Powered by TestAgency",
             "ShowHelpOutSection": false,
@@ -43,78 +42,72 @@ class MoreTabConfigurationTests: XCTestCase {
 
         let config = MoreTabConfiguration(from: dict)
 
-        XCTAssertEqual(config.headerSupportText, "Powered by TestAgency")
-        XCTAssertFalse(config.showHelpOutSection)
-        XCTAssertEqual(config.translateURL?.absoluteString, "https://example.com/translate")
-        XCTAssertEqual(config.developURL?.absoluteString, "https://example.com/develop")
-        XCTAssertEqual(config.customLinks.count, 2)
-        XCTAssertEqual(config.customLinks[0].title, "Agency Site")
-        XCTAssertEqual(config.customLinks[0].url.absoluteString, "https://example.com")
-        XCTAssertEqual(config.customLinks[1].title, "Call Us")
-        XCTAssertEqual(config.customLinks[1].url.absoluteString, "tel:+1234567890")
+        #expect(config.headerSupportText == "Powered by TestAgency")
+        #expect(!config.showHelpOutSection)
+        #expect(config.translateURL?.absoluteString == "https://example.com/translate")
+        #expect(config.developURL?.absoluteString == "https://example.com/develop")
+        #expect(config.customLinks.count == 2)
+        #expect(config.customLinks[0].title == "Agency Site")
+        #expect(config.customLinks[0].url.absoluteString == "https://example.com")
+        #expect(config.customLinks[1].title == "Call Us")
+        #expect(config.customLinks[1].url.absoluteString == "tel:+1234567890")
     }
 
-    func test_parseFromDictionary_withMinimalFields() {
+    @Test func `Parse from dictionary with minimal fields`() {
         let dict: [AnyHashable: Any] = [:]
         let config = MoreTabConfiguration(from: dict)
 
-        XCTAssertNil(config.headerSupportText)
-        XCTAssertTrue(config.showHelpOutSection)
-        XCTAssertNil(config.translateURL)
-        XCTAssertEqual(
-            config.developURL?.absoluteString,
-            "https://github.com/oneBusAway/onebusaway-ios"
-        )
-        XCTAssertTrue(config.customLinks.isEmpty)
+        #expect(config.headerSupportText == nil)
+        #expect(config.showHelpOutSection)
+        #expect(config.translateURL == nil)
+        #expect(config.developURL?.absoluteString == "https://github.com/oneBusAway/onebusaway-ios")
+        #expect(config.customLinks.isEmpty)
     }
 
-    func test_parseFromDictionary_withPartialFields() {
+    @Test func `Parse from dictionary with partial fields`() {
         let dict: [AnyHashable: Any] = [
             "ShowHelpOutSection": false,
             "TranslateURL": "https://custom-translate.com"
         ]
         let config = MoreTabConfiguration(from: dict)
 
-        XCTAssertNil(config.headerSupportText)
-        XCTAssertFalse(config.showHelpOutSection)
-        XCTAssertEqual(config.translateURL?.absoluteString, "https://custom-translate.com")
-        XCTAssertEqual(
-            config.developURL?.absoluteString,
-            "https://github.com/oneBusAway/onebusaway-ios"
-        )
-        XCTAssertTrue(config.customLinks.isEmpty)
+        #expect(config.headerSupportText == nil)
+        #expect(!config.showHelpOutSection)
+        #expect(config.translateURL?.absoluteString == "https://custom-translate.com")
+        #expect(config.developURL?.absoluteString == "https://github.com/oneBusAway/onebusaway-ios")
+        #expect(config.customLinks.isEmpty)
     }
 
     // MARK: - MoreTabLinkItem
 
-    func test_linkItem_validDictionary_succeeds() {
+    @Test func `Link item valid dictionary succeeds`() {
         let dict: [AnyHashable: Any] = [
             "Title": "Test Link",
             "URL": "https://example.com"
         ]
         let item = MoreTabLinkItem(dictionary: dict)
 
-        XCTAssertNotNil(item)
-        XCTAssertEqual(item?.title, "Test Link")
-        XCTAssertEqual(item?.url.absoluteString, "https://example.com")
+        #expect(item != nil)
+        #expect(item?.title == "Test Link")
+        #expect(item?.url.absoluteString == "https://example.com")
     }
 
-    func test_linkItem_missingTitle_returnsNil() {
+    @Test func `Link item missing title returns nil`() {
         let dict: [AnyHashable: Any] = ["URL": "https://example.com"]
-        XCTAssertNil(MoreTabLinkItem(dictionary: dict))
+        #expect(MoreTabLinkItem(dictionary: dict) == nil)
     }
 
-    func test_linkItem_missingURL_returnsNil() {
+    @Test func `Link item missing URL returns nil`() {
         let dict: [AnyHashable: Any] = ["Title": "Test"]
-        XCTAssertNil(MoreTabLinkItem(dictionary: dict))
+        #expect(MoreTabLinkItem(dictionary: dict) == nil)
     }
 
-    func test_linkItem_emptyURL_returnsNil() {
+    @Test func `Link item empty URL returns nil`() {
         let dict: [AnyHashable: Any] = ["Title": "Test", "URL": ""]
-        XCTAssertNil(MoreTabLinkItem(dictionary: dict))
+        #expect(MoreTabLinkItem(dictionary: dict) == nil)
     }
 
-    func test_linkItem_malformedLinksFiltered_inConfiguration() {
+    @Test func `Link item malformed links filtered in configuration`() {
         let dict: [AnyHashable: Any] = [
             "CustomLinks": [
                 ["Title": "Valid", "URL": "https://example.com"],
@@ -124,14 +117,14 @@ class MoreTabConfigurationTests: XCTestCase {
             ]
         ]
         let config = MoreTabConfiguration(from: dict)
-        XCTAssertEqual(config.customLinks.count, 1)
-        XCTAssertEqual(config.customLinks[0].title, "Valid")
-        XCTAssertEqual(config.customLinks[0].url.absoluteString, "https://example.com")
+        #expect(config.customLinks.count == 1)
+        #expect(config.customLinks[0].title == "Valid")
+        #expect(config.customLinks[0].url.absoluteString == "https://example.com")
     }
 
     // MARK: - Direct Initializer
 
-    func test_directInitializer_setsAllProperties() {
+    @Test func `Direct initializer sets all properties`() {
         let config = MoreTabConfiguration(
             headerSupportText: "Custom Text",
             showHelpOutSection: false,
@@ -140,10 +133,10 @@ class MoreTabConfigurationTests: XCTestCase {
             customLinks: []
         )
 
-        XCTAssertEqual(config.headerSupportText, "Custom Text")
-        XCTAssertFalse(config.showHelpOutSection)
-        XCTAssertEqual(config.translateURL?.absoluteString, "https://translate.example.com")
-        XCTAssertNil(config.developURL)
-        XCTAssertTrue(config.customLinks.isEmpty)
+        #expect(config.headerSupportText == "Custom Text")
+        #expect(!config.showHelpOutSection)
+        #expect(config.translateURL?.absoluteString == "https://translate.example.com")
+        #expect(config.developURL == nil)
+        #expect(config.customLinks.isEmpty)
     }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AgencyAlertTranslationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AgencyAlertTranslationTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -18,7 +19,8 @@ import XCTest
 /// subset of languages, and the final tier must be deterministic — it used to
 /// be backed by a dictionary, whose arbitrary ordering made "whatever we can
 /// get our hands on" vary between processes.
-class AgencyAlertTranslationTests: OBATestCase {
+@Suite(.serialized)
+final class AgencyAlertTranslationTests: OBATestCase {
 
     private func translation(_ language: String, _ text: String) -> TransitRealtime_TranslatedString.Translation {
         var t = TransitRealtime_TranslatedString.Translation()
@@ -51,39 +53,39 @@ class AgencyAlertTranslationTests: OBATestCase {
         return try AgencyAlert(feedEntity: feedEntity, agency: nil)
     }
 
-    func test_exactLanguageMatch_wins() throws {
+    @Test func `Exact language match wins`() throws {
         let alert = try makeAlert(headerTranslations: [
             translation("en", "English title"),
             translation("fr", "Titre français")
         ])
 
-        XCTAssertEqual(alert.title(forLocale: Locale(identifier: "fr_FR")), "Titre français")
+        #expect(alert.title(forLocale: Locale(identifier: "fr_FR")) == "Titre français")
     }
 
-    func test_missingLanguage_fallsBackToEnglish() throws {
+    @Test func `Missing language falls back to english`() throws {
         let alert = try makeAlert(headerTranslations: [
             translation("fr", "Titre français"),
             translation("en", "English title")
         ])
 
-        XCTAssertEqual(alert.title(forLocale: Locale(identifier: "es_ES")), "English title")
+        #expect(alert.title(forLocale: Locale(identifier: "es_ES")) == "English title")
     }
 
-    func test_missingLanguageAndEnglish_fallsBackToFirstEntryInFeedOrder() throws {
+    @Test func `Missing language and english falls back to first entry in feed order`() throws {
         let alert = try makeAlert(headerTranslations: [
             translation("fr", "Titre français"),
             translation("de", "Deutscher Titel")
         ])
 
-        XCTAssertEqual(alert.title(forLocale: Locale(identifier: "es_ES")), "Titre français")
+        #expect(alert.title(forLocale: Locale(identifier: "es_ES")) == "Titre français")
     }
 
-    func test_duplicateLanguageEntries_firstWins() throws {
+    @Test func `Duplicate language entries first wins`() throws {
         let alert = try makeAlert(headerTranslations: [
             translation("en", "First English title"),
             translation("en", "Second English title")
         ])
 
-        XCTAssertEqual(alert.title(forLocale: Locale(identifier: "en_US")), "First English title")
+        #expect(alert.title(forLocale: Locale(identifier: "en_US")) == "First English title")
     }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AgencyVehicleModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AgencyVehicleModelOperationTests.swift
@@ -7,21 +7,22 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class AgencyVehicleModelOperationTests: OBATestCase {
-    func testSuccesfulVehicleRequest() async throws {
+@Suite(.serialized)
+final class AgencyVehicleModelOperationTests: OBATestCase {
+    @Test func `Succesful vehicle request`() async throws {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
         let apiPath = String(format: "https://alerts.example.com/api/v1/regions/%d/vehicles", obacoRegionID)
         dataLoader.mock(URLString: apiPath, with: Fixtures.loadData(file: "vehicles-query-1_1.json"))
 
         let vehicles = try await obacoService.getVehicles(matching: "1_1")
-        XCTAssertEqual(vehicles.count, 29)
-        XCTAssertEqual(vehicles.first?.agencyName, "Metro Transit")
-        XCTAssertEqual(vehicles.first?.vehicleID, "1_1156")
+        #expect(vehicles.count == 29)
+        #expect(vehicles.first?.agencyName == "Metro Transit")
+        #expect(vehicles.first?.vehicleID == "1_1156")
     }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -7,14 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try force_cast
 
-class AlarmModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class AlarmModelOperationTests: OBATestCase {
 
     /// Captures the body of the request the service actually put on the wire. Single
     /// request per test, written before the mock returns and read after the `await`
@@ -23,7 +25,7 @@ class AlarmModelOperationTests: OBATestCase {
         nonisolated(unsafe) var body: String?
     }
 
-    func testSuccessfulAlarmCreation() async throws {
+    @Test func `Successful alarm creation`() async throws {
         let data = Fixtures.loadData(file: "create_alarm.json")
         let arrivalDeparture = try Fixtures.loadRESTAPIPayload(type: ArrivalDeparture.self, fileName: "arrival-and-departure-for-stop-1_11420.json")
 
@@ -31,7 +33,7 @@ class AlarmModelOperationTests: OBATestCase {
         dataLoader.mock(URLString: "https://alerts.example.com/api/v2/regions/1/alarms", with: data)
 
         let alarm = try await obacoService.postAlarm(minutesBefore: 1, arrivalDeparture: arrivalDeparture, userPushID: "123")
-        XCTAssertEqual(alarm.url.absoluteString, "https://alerts.example.com/regions/1/alarms/1234567890")
+        #expect(alarm.url.absoluteString == "https://alerts.example.com/regions/1/alarms/1234567890")
     }
 
     /// A debug build is provisioned with the development APNs entitlement, so the token
@@ -41,7 +43,7 @@ class AlarmModelOperationTests: OBATestCase {
     ///
     /// The test suite only ever builds in Debug, so `#if DEBUG` is always true here; this
     /// pins the flag's presence and wire format, not the compile-time condition itself.
-    func testAlarmCreationFlagsDevelopmentBuilds() async throws {
+    @Test func `Alarm creation flags development builds`() async throws {
         let data = Fixtures.loadData(file: "create_alarm.json")
         let arrivalDeparture = try Fixtures.loadRESTAPIPayload(type: ArrivalDeparture.self, fileName: "arrival-and-departure-for-stop-1_11420.json")
 
@@ -57,14 +59,14 @@ class AlarmModelOperationTests: OBATestCase {
 
         _ = try await obacoService.postAlarm(minutesBefore: 1, arrivalDeparture: arrivalDeparture, userPushID: "123")
 
-        let body = try XCTUnwrap(capture.body, "Expected postAlarm to send a form-encoded body")
-        XCTAssertTrue(body.contains("apns_sandbox=1"), "Expected a debug build to flag the alarm for the APNs sandbox. Body: \(body)")
+        let body = try #require(capture.body, "Expected postAlarm to send a form-encoded body")
+        #expect(body.contains("apns_sandbox=1"), "Expected a debug build to flag the alarm for the APNs sandbox. Body: \(body)")
     }
 
     /// The sidecar answers a successful `DELETE` with an empty `204`.
-    func testSuccessfulAlarmDeletion() async throws {
+    @Test func `Successful alarm deletion`() async throws {
         let alarm = try Fixtures.loadAlarm()
-        XCTAssertNotNil(alarm)
+        #expect(alarm != nil)
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
         dataLoader.mock(data: Data(), statusCode: 204) { (request) -> Bool in
@@ -73,15 +75,15 @@ class AlarmModelOperationTests: OBATestCase {
         }
 
         let (_, response) = try await obacoService.deleteAlarm(url: alarm.url)
-        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
-        XCTAssertEqual(httpResponse.statusCode, 204)
+        let httpResponse = try #require(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
+        #expect(httpResponse.statusCode == 204)
     }
 
     /// Sidecars predating the switch to `204` answer a successful `DELETE` with an empty
     /// `200`. `APIService.data(for:)` reads an empty-bodied `200` as a disguised 404 — a
     /// workaround for the REST API's handling of bogus IDs — which turned every successful
     /// alarm cancel into a `requestNotFound` failure. That heuristic must not apply here.
-    func testSuccessfulAlarmDeletionWithEmpty200() async throws {
+    @Test func `Successful alarm deletion with empty200`() async throws {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
@@ -91,12 +93,12 @@ class AlarmModelOperationTests: OBATestCase {
         }
 
         let (_, response) = try await obacoService.deleteAlarm(url: alarm.url)
-        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
-        XCTAssertEqual(httpResponse.statusCode, 200)
+        let httpResponse = try #require(response as? HTTPURLResponse, "Expected deleteAlarm response to be of type HTTPURLResponse")
+        #expect(httpResponse.statusCode == 200)
     }
 
     /// A genuine 404 — the alarm is already gone — must still surface as `requestNotFound`.
-    func testAlarmDeletionWith404() async throws {
+    @Test func `Alarm deletion with404`() async throws {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
@@ -107,10 +109,10 @@ class AlarmModelOperationTests: OBATestCase {
 
         do {
             _ = try await obacoService.deleteAlarm(url: alarm.url)
-            XCTFail("Expected deleteAlarm to throw APIError.requestNotFound")
+            Issue.record("Expected deleteAlarm to throw APIError.requestNotFound")
         } catch let error as APIError {
             guard case .requestNotFound = error else {
-                XCTFail("Expected APIError.requestNotFound, got \(error)")
+                Issue.record("Expected APIError.requestNotFound, got \(error)")
                 return
             }
         }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -86,7 +86,7 @@ final class AlarmModelOperationTests: OBATestCase {
     /// `200`. `APIService.data(for:)` reads an empty-bodied `200` as a disguised 404 — a
     /// workaround for the REST API's handling of bogus IDs — which turned every successful
     /// alarm cancel into a `requestNotFound` failure. That heuristic must not apply here.
-    @Test func `Successful alarm deletion with empty200`() async throws {
+    @Test func `Successful alarm deletion with empty 200`() async throws {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
@@ -104,7 +104,7 @@ final class AlarmModelOperationTests: OBATestCase {
     }
 
     /// A genuine 404 — the alarm is already gone — must still surface as `requestNotFound`.
-    @Test func `Alarm deletion with404`() async throws {
+    @Test func `Alarm deletion with 404`() async throws {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/AlarmModelOperationTests.swift
@@ -69,8 +69,11 @@ final class AlarmModelOperationTests: OBATestCase {
         #expect(alarm != nil)
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        // Hoisted out of the closure: matchers are @Sendable and `Alarm` is not,
+        // so the closure must capture the string rather than the model.
+        let alarmURLString = alarm.url.absoluteString
         dataLoader.mock(data: Data(), statusCode: 204) { (request) -> Bool in
-            request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
+            request.url!.absoluteString.starts(with: alarmURLString) &&
             request.httpMethod == "DELETE"
         }
 
@@ -87,8 +90,11 @@ final class AlarmModelOperationTests: OBATestCase {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        // Hoisted out of the closure: matchers are @Sendable and `Alarm` is not,
+        // so the closure must capture the string rather than the model.
+        let alarmURLString = alarm.url.absoluteString
         dataLoader.mock(data: Data(), statusCode: 200) { (request) -> Bool in
-            request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
+            request.url!.absoluteString.starts(with: alarmURLString) &&
             request.httpMethod == "DELETE"
         }
 
@@ -102,8 +108,11 @@ final class AlarmModelOperationTests: OBATestCase {
         let alarm = try Fixtures.loadAlarm()
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        // Hoisted out of the closure: matchers are @Sendable and `Alarm` is not,
+        // so the closure must capture the string rather than the model.
+        let alarmURLString = alarm.url.absoluteString
         dataLoader.mock(data: Data(), statusCode: 404) { (request) -> Bool in
-            request.url!.absoluteString.starts(with: alarm.url.absoluteString) &&
+            request.url!.absoluteString.starts(with: alarmURLString) &&
             request.httpMethod == "DELETE"
         }
 

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
@@ -25,9 +25,12 @@ final class LiveActivityModelOperationTests: OBATestCase {
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
 
-        var capturedRequest: URLRequest?
+        // Boxed rather than a plain `var`: the matcher is @Sendable, so it cannot
+        // mutate main-actor state — which, given the target's default isolation,
+        // a local in a test body is.
+        let capturedRequest = SendableBox<URLRequest?>(nil)
         dataLoader.mock(data: data) { request in
-            capturedRequest = request
+            capturedRequest.value = request
             return request.url?.host == "alerts.example.com" &&
                 request.url?.path == "/api/v2/regions/1/live_activities" &&
                 request.httpMethod == "POST"
@@ -47,7 +50,7 @@ final class LiveActivityModelOperationTests: OBATestCase {
 
         #expect(url.absoluteString == "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")
 
-        let request = try #require(capturedRequest)
+        let request = try #require(capturedRequest.value)
         let body = try #require(request.httpBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         let params = formParams(from: bodyString)

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/LiveActivityModelOperationTests.swift
@@ -7,16 +7,18 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try force_cast
 
-class LiveActivityModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class LiveActivityModelOperationTests: OBATestCase {
 
-    func testSuccessfulLiveActivityRegistration() async throws {
+    @Test func `Successful live activity registration`() async throws {
         let data = """
         {"url": "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123"}
         """.data(using: .utf8)!
@@ -43,26 +45,26 @@ class LiveActivityModelOperationTests: OBATestCase {
             stopSequence: nil
         )
 
-        XCTAssertEqual(url.absoluteString, "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")
+        #expect(url.absoluteString == "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")
 
-        let request = try XCTUnwrap(capturedRequest)
-        let body = try XCTUnwrap(request.httpBody)
-        let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
+        let request = try #require(capturedRequest)
+        let body = try #require(request.httpBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
         let params = formParams(from: bodyString)
 
-        XCTAssertEqual(params["activity_id"], "activity-123")
-        XCTAssertEqual(params["push_token"], "push-token-abc")
-        XCTAssertEqual(params["stop_id"], "1_11420")
-        XCTAssertEqual(params["route_short_name"], "10")
-        XCTAssertEqual(params["trip_headsign"], "Downtown Seattle")
-        XCTAssertNil(params["trip_id"])
-        XCTAssertNil(params["service_date"])
-        XCTAssertNil(params["vehicle_id"])
-        XCTAssertNil(params["stop_sequence"])
-        XCTAssertEqual(params["apns_sandbox"], "1", "Expected a debug build to flag the Live Activity for the APNs sandbox, as the ActivityKit token is a sandbox token. Without this flag, server routes pushes to production APNs and they bounce.")
+        #expect(params["activity_id"] == "activity-123")
+        #expect(params["push_token"] == "push-token-abc")
+        #expect(params["stop_id"] == "1_11420")
+        #expect(params["route_short_name"] == "10")
+        #expect(params["trip_headsign"] == "Downtown Seattle")
+        #expect(params["trip_id"] == nil)
+        #expect(params["service_date"] == nil)
+        #expect(params["vehicle_id"] == nil)
+        #expect(params["stop_sequence"] == nil)
+        #expect(params["apns_sandbox"] == "1", "Expected a debug build to flag the Live Activity for the APNs sandbox, as the ActivityKit token is a sandbox token. Without this flag, server routes pushes to production APNs and they bounce.")
     }
 
-    func testSuccessfulLiveActivityDeletion() async throws {
+    @Test func `Successful live activity deletion`() async throws {
         let liveActivityURL = URL(string: "https://sidecar.onebusaway.org/api/v2/regions/1/live_activities/abc123")!
 
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
@@ -72,8 +74,8 @@ class LiveActivityModelOperationTests: OBATestCase {
         }
 
         let (_, response) = try await obacoService.deleteLiveActivity(url: liveActivityURL)
-        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse, "Expected deleteLiveActivity response to be of type HTTPURLResponse")
-        XCTAssertEqual(httpResponse.statusCode, 200)
+        let httpResponse = try #require(response as? HTTPURLResponse, "Expected deleteLiveActivity response to be of type HTTPURLResponse")
+        #expect(httpResponse.statusCode == 200)
     }
 
     // MARK: - Helpers

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/ObacoAlertModelTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/ObacoAlertModelTests.swift
@@ -7,33 +7,35 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try force_cast
 
-class ObacoAlertModelTests: OBATestCase {
-    func testSuccesfulModelRequest() async throws {
+@Suite(.serialized)
+final class ObacoAlertModelTests: OBATestCase {
+    @Test func `Succesful model request`() async throws {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
 
         let locale = Locale.current
 
         let agencies = try Fixtures.loadRESTAPIPayload(type: [AgencyWithCoverage].self, fileName: "agencies_with_coverage.json")
-        XCTAssertEqual(agencies.count, 11, "Expected agencies_with_coverage.json fixture to contain 11 agencies")
+        #expect(agencies.count == 11, "Expected agencies_with_coverage.json fixture to contain 11 agencies")
 
         let alerts = try await obacoService.getAlerts(agencies: agencies)
 
-        XCTAssertEqual(alerts.count, 20)
+        #expect(alerts.count == 20)
 
-        let alert = try XCTUnwrap(alerts.first)
-        XCTAssertEqual(alert.startDate, Date.fromComponents(year: 2018, month: 10, day: 09, hour: 15, minute: 01, second: 00))
-        XCTAssertEqual(alert.endDate, Date.fromComponents(year: 2018, month: 10, day: 09, hour: 23, minute: 01, second: 00))
-        XCTAssertEqual(alert.url(forLocale: locale)?.absoluteString, "https://m.soundtransit.org/node/19133")
-        XCTAssertEqual(alert.title(forLocale: locale), "Sounder Lakewood-Seattle - Delay - #1514 (7:20 am TAC dep)  20 minutes at Auburn Station due to a medical emergency")
+        let alert = try #require(alerts.first)
+        #expect(alert.startDate == Date.fromComponents(year: 2018, month: 10, day: 09, hour: 15, minute: 01, second: 00))
+        #expect(alert.endDate == Date.fromComponents(year: 2018, month: 10, day: 09, hour: 23, minute: 01, second: 00))
+        #expect(alert.url(forLocale: locale)?.absoluteString == "https://m.soundtransit.org/node/19133")
+        #expect(alert.title(forLocale: locale) == "Sounder Lakewood-Seattle - Delay - #1514 (7:20 am TAC dep)  20 minutes at Auburn Station due to a medical emergency")
 
-        let body = try XCTUnwrap(alert.body(forLocale: locale))
-        XCTAssertTrue(body.starts(with: "Sounder south line train #1514 (7:20 a.m. Tacoma departure)"))
+        let body = try #require(alert.body(forLocale: locale))
+        #expect(body.starts(with: "Sounder south line train #1514 (7:20 a.m. Tacoma departure)"))
     }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -134,7 +134,7 @@ final class PushRegistrationModelOperationTests: OBATestCase {
 
     /// A 404 means the token was never registered — safe for callers to ignore, but the
     /// service layer still surfaces it faithfully.
-    @Test func `Unregistration with404 throws`() async throws {
+    @Test func `Unregistration with 404 throws`() async throws {
         mockUnregistrationDELETE(statusCode: 404)
 
         do {

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/PushRegistrationModelOperationTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -15,7 +16,8 @@ import XCTest
 
 /// Tests for the OBACloud `push_registrations` API (issue #1204): registering the
 /// device's APNs token so agencies can push service alerts to opted-in riders.
-class PushRegistrationModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class PushRegistrationModelOperationTests: OBATestCase {
 
     /// Captures the body of the request the service actually put on the wire. Single
     /// request per test, written before the mock returns and read after the `await`
@@ -39,75 +41,73 @@ class PushRegistrationModelOperationTests: OBATestCase {
         return capture
     }
 
-    func testSuccessfulRegistration_sendsAllContractParams() async throws {
+    @Test func `Successful registration sends all contract params`() async throws {
         let capture = mockRegistrationPOST()
 
         try await obacoService.postPushRegistration(token: "01abff007f", locale: "es-MX", testDevice: false, description: nil)
 
-        let body = try XCTUnwrap(capture.body, "Expected postPushRegistration to send a form-encoded body")
-        XCTAssertTrue(body.contains("token=01abff007f"), "Body: \(body)")
-        XCTAssertTrue(body.contains("operating_system=ios"), "Body: \(body)")
-        XCTAssertTrue(body.contains("locale=es-MX"), "Body: \(body)")
+        let body = try #require(capture.body, "Expected postPushRegistration to send a form-encoded body")
+        #expect(body.contains("token=01abff007f"), "Body: \(body)")
+        #expect(body.contains("operating_system=ios"), "Body: \(body)")
+        #expect(body.contains("locale=es-MX"), "Body: \(body)")
         // The server upserts on every call and an omitted test_device resets the stored
         // value to false — the param's *presence* on every request is contract, not just
         // its value.
-        XCTAssertTrue(body.contains("test_device=false"), "Body: \(body)")
+        #expect(body.contains("test_device=false"), "Body: \(body)")
     }
 
-    func testRegistration_flagsTestDevices() async throws {
+    @Test func `Registration flags test devices`() async throws {
         let capture = mockRegistrationPOST()
 
         try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true, description: "Aarons iPhone")
 
-        let body = try XCTUnwrap(capture.body)
-        XCTAssertTrue(body.contains("test_device=true"), "Body: \(body)")
+        let body = try #require(capture.body)
+        #expect(body.contains("test_device=true"), "Body: \(body)")
         // NetworkHelpers.dictionary(toHTTPBodyData:) percent-encodes the space as %20 —
         // CharacterSet.urlQueryAllowed doesn't include space.
-        XCTAssertTrue(body.contains("description=Aarons%20iPhone"), "Body: \(body)")
+        #expect(body.contains("description=Aarons%20iPhone"), "Body: \(body)")
     }
 
-    func testRegistration_flagsApnsSandboxInDebugBuilds() async throws {
+    @Test func `Registration flags apns sandbox in debug builds`() async throws {
         let capture = mockRegistrationPOST()
 
         try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: true, description: "Aarons iPhone")
 
-        let body = try XCTUnwrap(capture.body)
-        XCTAssertTrue(body.contains("apns_sandbox=1"), "Expected a debug build to flag its registration for the APNs sandbox — its token is only valid there, so an unflagged test push bounces with BadDeviceToken. Body: \(body)")
+        let body = try #require(capture.body)
+        #expect(body.contains("apns_sandbox=1"), "Expected a debug build to flag its registration for the APNs sandbox — its token is only valid there, so an unflagged test push bounces with BadDeviceToken. Body: \(body)")
     }
 
     /// A blank/omitted description must never reach the wire — the server treats an empty
     /// `description` param the same as a missing one, and `test_device=false` doesn't
     /// require one at all.
-    func testRegistration_omitsBlankDescription() async throws {
+    @Test func `Registration omits blank description`() async throws {
         let capture = mockRegistrationPOST()
 
         try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false, description: nil)
 
-        let body = try XCTUnwrap(capture.body)
-        XCTAssertFalse(body.contains("description="), "Body: \(body)")
+        let body = try #require(capture.body)
+        #expect(!body.contains("description="), "Body: \(body)")
     }
 
-    func testRegistration_targetsRegionScopedURL() async throws {
+    @Test func `Registration targets region scoped URL`() async throws {
         let capture = mockRegistrationPOST()
 
         try await obacoService.postPushRegistration(token: "01abff007f", locale: "en-US", testDevice: false, description: nil)
 
-        let url = try XCTUnwrap(capture.url)
-        XCTAssertTrue(
-            url.absoluteString.starts(with: "https://alerts.example.com/api/v2/regions/1/push_registrations"),
-            "URL: \(url.absoluteString)")
+        let url = try #require(capture.url)
+        #expect(url.absoluteString.starts(with: "https://alerts.example.com/api/v2/regions/1/push_registrations"), "URL: \(url.absoluteString)")
     }
 
     /// The server answers validation failures with a 422 — that must surface as an error.
-    func testRegistrationValidationFailureThrows() async throws {
+    @Test func `Registration validation failure throws`() async throws {
         _ = mockRegistrationPOST(statusCode: 422)
 
         do {
             try await obacoService.postPushRegistration(token: "", locale: "en-US", testDevice: false, description: nil)
-            XCTFail("Expected postPushRegistration to throw APIError.requestFailure")
+            Issue.record("Expected postPushRegistration to throw APIError.requestFailure")
         } catch let error as APIError {
             guard case .requestFailure = error else {
-                XCTFail("Expected APIError.requestFailure, got \(error)")
+                Issue.record("Expected APIError.requestFailure, got \(error)")
                 return
             }
         }
@@ -124,25 +124,25 @@ class PushRegistrationModelOperationTests: OBATestCase {
         }
     }
 
-    func testSuccessfulUnregistration() async throws {
+    @Test func `Successful unregistration`() async throws {
         mockUnregistrationDELETE(statusCode: 204)
 
         let (_, response) = try await obacoService.deletePushRegistration(token: "01abff007f")
-        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
-        XCTAssertEqual(httpResponse.statusCode, 204)
+        let httpResponse = try #require(response as? HTTPURLResponse)
+        #expect(httpResponse.statusCode == 204)
     }
 
     /// A 404 means the token was never registered — safe for callers to ignore, but the
     /// service layer still surfaces it faithfully.
-    func testUnregistrationWith404Throws() async throws {
+    @Test func `Unregistration with404 throws`() async throws {
         mockUnregistrationDELETE(statusCode: 404)
 
         do {
             _ = try await obacoService.deletePushRegistration(token: "01abff007f")
-            XCTFail("Expected deletePushRegistration to throw APIError.requestNotFound")
+            Issue.record("Expected deletePushRegistration to throw APIError.requestNotFound")
         } catch let error as APIError {
             guard case .requestNotFound = error else {
-                XCTFail("Expected APIError.requestNotFound, got \(error)")
+                Issue.record("Expected APIError.requestNotFound, got \(error)")
                 return
             }
         }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/RegionWideAgencyAlertTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/RegionWideAgencyAlertTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -20,17 +21,18 @@ import XCTest
 /// `ObacoAPIService.getAlerts` silently dropped them via `try?`. The result was that
 /// high-severity region-wide alerts never reached `AgencyAlertsStore`, so the modal
 /// `AgencyAlertBulletin` never appeared.
-class RegionWideAgencyAlertTests: OBATestCase {
+@Suite(.serialized)
+final class RegionWideAgencyAlertTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -85,20 +87,20 @@ class RegionWideAgencyAlertTests: OBATestCase {
 
     // MARK: - Model Parsing
 
-    func test_emptyAgencyID_parsesAsRegionWideAlert() throws {
+    @Test func `Empty agency ID parses as region wide alert`() throws {
         let agencies = try loadAgencies()
         let feedEntity = makeRegionWideFeedEntity()
 
         let alert = try AgencyAlert(feedEntity: feedEntity, agencies: agencies)
 
-        XCTAssertNil(alert.agency, "A region-wide alert is not affiliated with any single agency")
-        XCTAssertEqual(alert.agencyID, "")
-        XCTAssertTrue(alert.isHighSeverity)
-        XCTAssertEqual(alert.title(forLocale: enUSLocale), "Get Ready for World Cup")
-        XCTAssertEqual(alert.url(forLocale: enUSLocale)?.absoluteString, "https://www.example.com/worldcup")
+        #expect(alert.agency == nil, "A region-wide alert is not affiliated with any single agency")
+        #expect(alert.agencyID == "")
+        #expect(alert.isHighSeverity)
+        #expect(alert.title(forLocale: enUSLocale) == "Get Ready for World Cup")
+        #expect(alert.url(forLocale: enUSLocale)?.absoluteString == "https://www.example.com/worldcup")
     }
 
-    func test_unknownNonEmptyAgencyID_stillThrows() throws {
+    @Test func `Unknown non empty agency ID still throws`() throws {
         let agencies = try loadAgencies()
 
         var feedEntity = makeRegionWideFeedEntity()
@@ -106,12 +108,12 @@ class RegionWideAgencyAlertTests: OBATestCase {
         entitySelector.agencyID = "not-a-real-agency"
         feedEntity.alert.informedEntity = [entitySelector]
 
-        XCTAssertThrowsError(try AgencyAlert(feedEntity: feedEntity, agencies: agencies)) { error in
-            XCTAssertEqual(error as? AgencyAlert.AlertError, .unknownAgency)
+        #expect(throws: AgencyAlert.AlertError.unknownAgency) {
+            try AgencyAlert(feedEntity: feedEntity, agencies: agencies)
         }
     }
 
-    func test_missingAgencyID_throwsInvalidAlert() throws {
+    @Test func `Missing agency ID throws invalid alert`() throws {
         let agencies = try loadAgencies()
 
         // An `informed_entity` whose `agency_id` was never set (presence bit false),
@@ -120,14 +122,14 @@ class RegionWideAgencyAlertTests: OBATestCase {
         var feedEntity = makeRegionWideFeedEntity()
         feedEntity.alert.informedEntity = [TransitRealtime_EntitySelector()]
 
-        XCTAssertThrowsError(try AgencyAlert(feedEntity: feedEntity, agencies: agencies)) { error in
-            XCTAssertEqual(error as? AgencyAlert.AlertError, .invalidAlert)
+        #expect(throws: AgencyAlert.AlertError.invalidAlert) {
+            try AgencyAlert(feedEntity: feedEntity, agencies: agencies)
         }
     }
 
     // MARK: - Obaco Service
 
-    func test_obacoGetAlerts_includesRegionWideAlerts() async throws {
+    @Test func `Obaco get alerts includes region wide alerts`() async throws {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader) // swiftlint:disable:this force_cast
         let feedData = try makeFeedData(entities: [makeRegionWideFeedEntity()])
         dataLoader.mock(data: feedData) { request in
@@ -137,15 +139,15 @@ class RegionWideAgencyAlertTests: OBATestCase {
         let agencies = try loadAgencies()
         let alerts = try await obacoService.getAlerts(agencies: agencies)
 
-        XCTAssertEqual(alerts.count, 1, "The region-wide alert must not be dropped during parsing")
+        #expect(alerts.count == 1, "The region-wide alert must not be dropped during parsing")
 
-        let alert = try XCTUnwrap(alerts.first)
-        XCTAssertNil(alert.agency)
-        XCTAssertTrue(alert.isHighSeverity)
-        XCTAssertEqual(alert.title(forLocale: enUSLocale), "Get Ready for World Cup")
+        let alert = try #require(alerts.first)
+        #expect(alert.agency == nil)
+        #expect(alert.isHighSeverity)
+        #expect(alert.title(forLocale: enUSLocale) == "Get Ready for World Cup")
     }
 
-    func test_obacoGetAlerts_oneBadEntityDoesNotDropTheRest() async throws {
+    @Test func `Obaco get alerts one bad entity does not drop the rest`() async throws {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader) // swiftlint:disable:this force_cast
 
         // A feed carrying one valid region-wide alert and one malformed entity (an
@@ -166,8 +168,8 @@ class RegionWideAgencyAlertTests: OBATestCase {
         let agencies = try loadAgencies()
         let alerts = try await obacoService.getAlerts(agencies: agencies)
 
-        XCTAssertEqual(alerts.count, 1, "The valid alert must survive even when a sibling entity fails to parse")
-        XCTAssertEqual(try XCTUnwrap(alerts.first).title(forLocale: enUSLocale), "Get Ready for World Cup")
+        #expect(alerts.count == 1, "The valid alert must survive even when a sibling entity fails to parse")
+        #expect(try #require(alerts.first).title(forLocale: enUSLocale) == "Get Ready for World Cup")
     }
 
     // MARK: - Bulletin Presentation Pipeline
@@ -176,8 +178,8 @@ class RegionWideAgencyAlertTests: OBATestCase {
     /// the API services — and asserts that a fresh region-wide WARNING alert lands in
     /// `recentUnreadHighSeverityAlerts`, the exact predicate `Application.agencyAlertsUpdated()`
     /// uses to decide whether to present the modal `AgencyAlertBulletin`.
-    @MainActor
-    func test_regionWideAlert_isSurfacedForBulletinPresentation() async throws {
+    @Test @MainActor
+    func `Region wide alert is surfaced for bulletin presentation`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
@@ -213,13 +215,10 @@ class RegionWideAgencyAlertTests: OBATestCase {
 
         try await store.update()
 
-        let alert = try XCTUnwrap(
-            store.recentUnreadHighSeverityAlerts.first,
-            "A fresh region-wide WARNING alert must qualify for bulletin presentation"
-        )
-        XCTAssertNil(alert.agency)
+        let alert = try #require(store.recentUnreadHighSeverityAlerts.first, "A fresh region-wide WARNING alert must qualify for bulletin presentation")
+        #expect(alert.agency == nil)
 
         let bulletin = AgencyAlertBulletin(agencyAlert: alert, locale: enUSLocale)
-        XCTAssertNotNil(bulletin, "The bulletin must be constructible from a region-wide alert")
+        #expect(bulletin != nil, "The bulletin must be constructible from a region-wide alert")
     }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/WeatherModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/WeatherModelOperationTests.swift
@@ -7,17 +7,18 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class WeatherOperationTests: OBATestCase {
+@Suite(.serialized)
+final class WeatherOperationTests: OBATestCase {
 
-    func testSuccessfulWeatherRequest() async throws {
+    @Test func `Successful weather request`() async throws {
         let dataLoader = (obacoService.dataLoader as! MockDataLoader)
         let data = Fixtures.loadData(file: "pugetsound-weather.json")
         dataLoader.mock(URLString: "https://alerts.example.com/api/v1/regions/1/weather.json", with: data)

--- a/OBAKitTests/Modeling/PolylineTests/FunctionalPolylineTests.swift
+++ b/OBAKitTests/Modeling/PolylineTests/FunctionalPolylineTests.swift
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 import CoreLocation
-import XCTest
+import Testing
 
 @testable import OBAKit
 @testable import OBAKitCore
@@ -30,155 +30,156 @@ import XCTest
 
 private let COORD_EPSILON: Double = 0.00001
 
-class FunctionalPolylineTests : XCTestCase {
+@Suite(.serialized)
+final class FunctionalPolylineTests {
 
     // MARK:- Encoding Coordinates
 
-    func testEmptyArrayShouldBeEmptyString() {
-        XCTAssertEqual(encodeCoordinates([]), "")
+    @Test func `Empty array should be empty string`() {
+        #expect(encodeCoordinates([]) == "")
     }
 
-    func testZeroShouldBeEncodedProperly() {
+    @Test func `Zero should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0, longitude: 0)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "??")
+        #expect(encodeCoordinates(coordinates) == "??")
     }
 
-    func testMinimalPositiveDifferenceShouldBeEncodedProperly() {
+    @Test func `Minimal positive difference should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "AA")
+        #expect(encodeCoordinates(coordinates) == "AA")
     }
 
-    func testLowRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Low rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000014, longitude: 0.000014)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "AA")
+        #expect(encodeCoordinates(coordinates) == "AA")
     }
 
-    func testMidRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Mid rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000015, longitude: 0.000015)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "CC")
+        #expect(encodeCoordinates(coordinates) == "CC")
     }
 
-    func testHighRoundedValuesShouldBeEncodedProperly() {
+    @Test func `High rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000016, longitude: 0.000016)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "CC")
+        #expect(encodeCoordinates(coordinates) == "CC")
     }
 
-    func testMinimalNegativeDifferenceShouldBeEncodedProperly() {
+    @Test func `Minimal negative difference should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.00001, longitude: -0.00001)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "@@")
+        #expect(encodeCoordinates(coordinates) == "@@")
     }
 
-    func testLowNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Low negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000014, longitude: -0.000014)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "@@")
+        #expect(encodeCoordinates(coordinates) == "@@")
     }
 
-    func testMidNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Mid negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000015, longitude: -0.000015)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "BB")
+        #expect(encodeCoordinates(coordinates) == "BB")
     }
 
-    func testHighNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `High negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000016, longitude: -0.000016)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "BB")
+        #expect(encodeCoordinates(coordinates) == "BB")
     }
 
-    func testSmallIncrementLocationArrayShouldBeEncodedProperly() {
+    @Test func `Small increment location array should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001),
             CLLocationCoordinate2D(latitude: 0.00002, longitude: 0.00002)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "AAAA")
+        #expect(encodeCoordinates(coordinates) == "AAAA")
     }
 
-    func testSmallDecrementLocationArrayShouldBeEncodedProperly() {
+    @Test func `Small decrement location array should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001),
             CLLocationCoordinate2D(latitude: 0.00000, longitude: 0.00000)]
-        XCTAssertEqual(encodeCoordinates(coordinates), "AA@@")
+        #expect(encodeCoordinates(coordinates) == "AA@@")
     }
 
     // MARK: - Decoding Coordinates
 
-    func testEmptyPolylineShouldBeEmptyLocationArray() {
+    @Test func `Empty polyline should be empty location array`() {
         let coordinates: [CLLocationCoordinate2D] = decodePolyline("")!
 
-        XCTAssertEqual(coordinates.count, 0)
+        #expect(coordinates.count == 0)
     }
 
-    func testInvalidPolylineShouldReturnEmptyLocationArray() {
-        XCTAssertNil(decodePolyline("invalidPolylineString") as [CLLocationCoordinate2D]?)
+    @Test func `Invalid polyline should return empty location array`() {
+        #expect(decodePolyline("invalidPolylineString") as [CLLocationCoordinate2D]? == nil)
     }
 
-    func testValidPolylineShouldReturnValidLocationArray() {
+    @Test func `Valid polyline should return valid location array`() {
         let coordinates: [CLLocationCoordinate2D] = decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@")!
 
-        XCTAssertEqual(coordinates.count, 3)
-        XCTAssertEqual(coordinates[0].latitude, 38.5, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[0].longitude, -120.2, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[1].latitude, 40.7, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[1].longitude, -120.95, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[2].latitude, 43.252, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[2].longitude, -126.453, accuracy: COORD_EPSILON)
+        #expect(coordinates.count == 3)
+        expectClose(coordinates[0].latitude, 38.5, within: COORD_EPSILON)
+        expectClose(coordinates[0].longitude, -120.2, within: COORD_EPSILON)
+        expectClose(coordinates[1].latitude, 40.7, within: COORD_EPSILON)
+        expectClose(coordinates[1].longitude, -120.95, within: COORD_EPSILON)
+        expectClose(coordinates[2].latitude, 43.252, within: COORD_EPSILON)
+        expectClose(coordinates[2].longitude, -126.453, within: COORD_EPSILON)
     }
 
-    func testAnotherValidPolylineShouldReturnValidLocationArray() {
+    @Test func `Another valid polyline should return valid location array`() {
         let coordinates: [CLLocationCoordinate2D] = decodePolyline("_ojiHa`tLh{IdCw{Gwc_@")!
 
-        XCTAssertEqual(coordinates.count, 3)
-        XCTAssertEqual(coordinates[0].latitude, 48.8832,  accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[0].longitude, 2.23761, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[1].latitude, 48.82747, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[1].longitude, 2.23694, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[2].latitude, 48.87303, accuracy: COORD_EPSILON)
-        XCTAssertEqual(coordinates[2].longitude, 2.40154, accuracy: COORD_EPSILON)
+        #expect(coordinates.count == 3)
+        expectClose(coordinates[0].latitude, 48.8832, within: COORD_EPSILON)
+        expectClose(coordinates[0].longitude, 2.23761, within: COORD_EPSILON)
+        expectClose(coordinates[1].latitude, 48.82747, within: COORD_EPSILON)
+        expectClose(coordinates[1].longitude, 2.23694, within: COORD_EPSILON)
+        expectClose(coordinates[2].latitude, 48.87303, within: COORD_EPSILON)
+        expectClose(coordinates[2].longitude, 2.40154, within: COORD_EPSILON)
     }
 
     // MARK:- Encoding levels
 
-    func testEmptylevelsShouldBeEmptyString() {
-        XCTAssertEqual(encodeLevels([]), "")
+    @Test func `Emptylevels should be empty string`() {
+        #expect(encodeLevels([]) == "")
     }
 
-    func testValidlevelsShouldBeEncodedProperly() {
-        XCTAssertEqual(encodeLevels([0,1,2,3]), "?@AB")
+    @Test func `Validlevels should be encoded properly`() {
+        #expect(encodeLevels([0,1,2,3]) == "?@AB")
     }
 
     // MARK:- Decoding levels
 
-    func testEmptyLevelsShouldBeEmptyLevelArray() {
+    @Test func `Empty levels should be empty level array`() {
         if let resultArray = decodeLevels("") {
-            XCTAssertEqual(resultArray.count, 0)
+            #expect(resultArray.count == 0)
         } else {
-            XCTFail("Level array should not be nil for empty string")
+            Issue.record("Level array should not be nil for empty string")
         }
     }
 
-    func testInvalidLevelsShouldReturnNilLevelArray() {
+    @Test func `Invalid levels should return nil level array`() {
         if let _ = decodeLevels("invalidLevelString") {
-            XCTFail("Level array should be nil for invalid string")
+            Issue.record("Level array should be nil for invalid string")
         } else {
             //Success
         }
     }
 
-    func testValidLevelsShouldReturnValidLevelArray() {
+    @Test func `Valid levels should return valid level array`() {
         if let resultArray = decodeLevels("?@AB~F") {
-            XCTAssertEqual(resultArray.count, 5)
-            XCTAssertEqual(resultArray[0], UInt32(0))
-            XCTAssertEqual(resultArray[1], UInt32(1))
-            XCTAssertEqual(resultArray[2], UInt32(2))
-            XCTAssertEqual(resultArray[3], UInt32(3))
-            XCTAssertEqual(resultArray[4], UInt32(255))
+            #expect(resultArray.count == 5)
+            #expect(resultArray[0] == UInt32(0))
+            #expect(resultArray[1] == UInt32(1))
+            #expect(resultArray[2] == UInt32(2))
+            #expect(resultArray[3] == UInt32(3))
+            #expect(resultArray[4] == UInt32(255))
 
         } else {
-            XCTFail("Valid Levels should be decoded properly")
+            Issue.record("Valid Levels should be decoded properly")
         }
     }
 
     // MARK: - Encoding Locations
-    func testLocationsArrayShouldBeEncodedProperly() {
+    @Test func `Locations array should be encoded properly`() {
         let locations = [CLLocation(latitude: 0.00001, longitude: 0.00001),
             CLLocation(latitude: 0.00000, longitude: 0.00000)]
 
-        XCTAssertEqual(encodeLocations(locations), "AA@@")
+        #expect(encodeLocations(locations) == "AA@@")
     }
 
 }

--- a/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
+++ b/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import CoreLocation
+import Testing
 import XCTest
 
 @testable import OBAKit
@@ -31,290 +32,284 @@ import XCTest
 private let COORD_EPSILON_1e5: Double = 0.00001
 private let COORD_EPSILON_1e6: Double = 0.000001
 
-class PolylineTests:XCTestCase {
+@Suite(.serialized)
+final class PolylineTests {
 
     // MARK:- Encoding Coordinates
 
-    func testEmptyArrayShouldBeEmptyString() {
+    @Test func `Empty array should be empty string`() {
         let sut = Polyline(coordinates: [])
-        XCTAssertEqual(sut.encodedPolyline, "")
+        #expect(sut.encodedPolyline == "")
     }
 
-    func testZeroShouldBeEncodedProperly() {
+    @Test func `Zero should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0, longitude: 0)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "??")
+        #expect(sut.encodedPolyline == "??")
     }
 
-    func testMinimalPositiveDifferenceShouldBeEncodedProperly() {
+    @Test func `Minimal positive difference should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "AA")
+        #expect(sut.encodedPolyline == "AA")
     }
 
-    func testLowRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Low rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000014, longitude: 0.000014)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "AA")
+        #expect(sut.encodedPolyline == "AA")
     }
 
-    func testMidRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Mid rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000015, longitude: 0.000015)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "CC")
+        #expect(sut.encodedPolyline == "CC")
     }
 
-    func testHighRoundedValuesShouldBeEncodedProperly() {
+    @Test func `High rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.000016, longitude: 0.000016)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "CC")
+        #expect(sut.encodedPolyline == "CC")
     }
 
-    func testMinimalNegativeDifferenceShouldBeEncodedProperly() {
+    @Test func `Minimal negative difference should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.00001, longitude: -0.00001)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "@@")
+        #expect(sut.encodedPolyline == "@@")
     }
 
-    func testLowNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Low negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000014, longitude: -0.000014)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "@@")
+        #expect(sut.encodedPolyline == "@@")
     }
 
-    func testMidNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `Mid negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000015, longitude: -0.000015)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "BB")
+        #expect(sut.encodedPolyline == "BB")
     }
 
-    func testHighNegativeRoundedValuesShouldBeEncodedProperly() {
+    @Test func `High negative rounded values should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: -0.000016, longitude: -0.000016)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "BB")
+        #expect(sut.encodedPolyline == "BB")
     }
 
-    func testSmallIncrementLocationArrayShouldBeEncodedProperly() {
+    @Test func `Small increment location array should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001),
             CLLocationCoordinate2D(latitude: 0.00002, longitude: 0.00002)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "AAAA")
+        #expect(sut.encodedPolyline == "AAAA")
     }
 
-    func testSmallDecrementLocationArrayShouldBeEncodedProperly() {
+    @Test func `Small decrement location array should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 0.00001, longitude: 0.00001),
             CLLocationCoordinate2D(latitude: 0.00000, longitude: 0.00000)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "AA@@")
+        #expect(sut.encodedPolyline == "AA@@")
     }
 
-    func testPrecisionShouldBeUsedProperlyInEncoding() {
+    @Test func `Precision should be used properly in encoding`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 10.1234567, longitude:10.1234567)]
 
         var sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "sfx|@sfx|@")
+        #expect(sut.encodedPolyline == "sfx|@sfx|@")
 
         sut = Polyline(coordinates: coordinates, precision: 1e5)
-        XCTAssertEqual(sut.encodedPolyline, "sfx|@sfx|@")
+        #expect(sut.encodedPolyline == "sfx|@sfx|@")
 
         sut = Polyline(coordinates: coordinates, precision: 1e6)
-        XCTAssertEqual(sut.encodedPolyline, "ak{hRak{hR")
+        #expect(sut.encodedPolyline == "ak{hRak{hR")
     }
 
     // MARK:- Decoding Coordinates
 
-    func testEmptyPolylineShouldBeEmptyLocationArray() {
+    @Test func `Empty polyline should be empty location array`() {
         let sut = Polyline(encodedPolyline: "")
-        XCTAssertTrue(sut.coordinates != nil)
-        XCTAssertEqual((sut.coordinates!).count, 0)
+        #expect(sut.coordinates != nil)
+        #expect((sut.coordinates!).count == 0)
     }
 
-    func testInvalidPolylineShouldReturnNil() {
+    @Test func `Invalid polyline should return nil`() {
         let sut = Polyline(encodedPolyline: "invalidPolylineString")
-        XCTAssertTrue(sut.coordinates == nil)
+        #expect(sut.coordinates == nil)
     }
 
-    func testValidPolylineShouldReturnValidLocationArray() {
+    @Test func `Valid polyline should return valid location array`() {
         let sut = Polyline(encodedPolyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@")
 
         let coordinates = sut.coordinates!
 
-        XCTAssertEqual(coordinates.count, 3)
-        XCTAssertEqual(coordinates[0].latitude, 38.5, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[0].longitude, -120.2, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[1].latitude, 40.7, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[1].longitude, -120.95, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[2].latitude, 43.252, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[2].longitude, -126.453, accuracy: COORD_EPSILON_1e5)
+        #expect(coordinates.count == 3)
+        expectClose(coordinates[0].latitude, 38.5, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[0].longitude, -120.2, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[1].latitude, 40.7, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[1].longitude, -120.95, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[2].latitude, 43.252, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[2].longitude, -126.453, within: COORD_EPSILON_1e5)
     }
 
-    func testAnotherValidPolylineShouldReturnValidLocationArray() {
+    @Test func `Another valid polyline should return valid location array`() {
         let sut = Polyline(encodedPolyline: "_ojiHa`tLh{IdCw{Gwc_@")
 
         let coordinates = sut.coordinates!
 
-        XCTAssertEqual(coordinates.count, 3)
-        XCTAssertEqual(coordinates[0].latitude, 48.8832,  accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[0].longitude, 2.23761, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[1].latitude, 48.82747, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[1].longitude, 2.23694, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[2].latitude, 48.87303, accuracy: COORD_EPSILON_1e5)
-        XCTAssertEqual(coordinates[2].longitude, 2.40154, accuracy: COORD_EPSILON_1e5)
+        #expect(coordinates.count == 3)
+        expectClose(coordinates[0].latitude, 48.8832, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[0].longitude, 2.23761, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[1].latitude, 48.82747, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[1].longitude, 2.23694, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[2].latitude, 48.87303, within: COORD_EPSILON_1e5)
+        expectClose(coordinates[2].longitude, 2.40154, within: COORD_EPSILON_1e5)
     }
 
-    func testPrecisionShouldBeUsedProperlyInDecoding() {
+    @Test func `Precision should be used properly in decoding`() {
 
         var sut = Polyline(encodedPolyline: "sfx|@sfx|@")
 
         var coordinates = sut.coordinates!
 
-        XCTAssertEqual(coordinates.count, 1)
-        XCTAssertEqual(coordinates[0].latitude, 10.1234567,  accuracy: COORD_EPSILON_1e5)
+        #expect(coordinates.count == 1)
+        expectClose(coordinates[0].latitude, 10.1234567, within: COORD_EPSILON_1e5)
 
         sut = Polyline(encodedPolyline: "sfx|@sfx|@", precision: 1e5)
 
         coordinates = sut.coordinates!
 
-        XCTAssertEqual(coordinates.count, 1)
-        XCTAssertEqual(coordinates[0].latitude, 10.1234567, accuracy: COORD_EPSILON_1e5)
+        #expect(coordinates.count == 1)
+        expectClose(coordinates[0].latitude, 10.1234567, within: COORD_EPSILON_1e5)
 
         sut = Polyline(encodedPolyline: "ak{hRak{hR", precision: 1e6)
 
         coordinates = sut.coordinates!
 
-        XCTAssertEqual(coordinates.count, 1)
-        XCTAssertEqual(coordinates[0].latitude, 10.1234567, accuracy: COORD_EPSILON_1e6)
+        #expect(coordinates.count == 1)
+        expectClose(coordinates[0].latitude, 10.1234567, within: COORD_EPSILON_1e6)
 
     }
 
     // MARK:- Encoding levels
 
-    func testEmptylevelsShouldBeEmptyString() {
+    @Test func `Emptylevels should be empty string`() {
         let sut = Polyline(locations: [], levels: [])
 
-        XCTAssertTrue(sut.encodedLevels != nil)
-        XCTAssertEqual(sut.encodedLevels!, "")
+        #expect(sut.encodedLevels != nil)
+        #expect(sut.encodedLevels! == "")
     }
 
-    func testNillevelsShouldBeNil() {
+    @Test func `Nillevels should be nil`() {
         let sut = Polyline(locations: [], levels: nil)
 
-        XCTAssertTrue(sut.encodedLevels == nil)
+        #expect(sut.encodedLevels == nil)
     }
 
-    func testValidlevelsShouldBeEncodedProperly() {
+    @Test func `Validlevels should be encoded properly`() {
         let sut = Polyline(locations: [], levels: [0,1,2,3])
 
-        XCTAssertEqual(sut.encodedLevels!, "?@AB")
+        #expect(sut.encodedLevels! == "?@AB")
     }
 
     // MARK:- Decoding levels
 
-    func testEmptyLevelsShouldBeEmptyLevelArray() {
+    @Test func `Empty levels should be empty level array`() {
         let sut = Polyline(encodedPolyline: "", encodedLevels: "")
 
-        XCTAssertTrue(sut.levels != nil,"Level array should not be nil for empty string")
-        XCTAssertEqual((sut.levels!).count, 0)
+        #expect(sut.levels != nil, "Level array should not be nil for empty string")
+        #expect((sut.levels!).count == 0)
     }
 
-    func testInvalidLevelsShouldReturnNilLevelArray() {
+    @Test func `Invalid levels should return nil level array`() {
         let sut = Polyline(encodedPolyline: "", encodedLevels: "invalidLevelString")
 
-        XCTAssertTrue(sut.levels == nil, "Level array should be nil for invalid string")
+        #expect(sut.levels == nil, "Level array should be nil for invalid string")
     }
 
-    func testValidLevelsShouldReturnValidLevelArray() {
+    @Test func `Valid levels should return valid level array`() {
         let sut = Polyline(encodedPolyline: "", encodedLevels: "?@AB~F")
 
         if let resultArray = sut.levels {
-            XCTAssertEqual(resultArray.count, 5)
-            XCTAssertEqual(resultArray[0], UInt32(0))
-            XCTAssertEqual(resultArray[1], UInt32(1))
-            XCTAssertEqual(resultArray[2], UInt32(2))
-            XCTAssertEqual(resultArray[3], UInt32(3))
-            XCTAssertEqual(resultArray[4], UInt32(255))
+            #expect(resultArray.count == 5)
+            #expect(resultArray[0] == UInt32(0))
+            #expect(resultArray[1] == UInt32(1))
+            #expect(resultArray[2] == UInt32(2))
+            #expect(resultArray[3] == UInt32(3))
+            #expect(resultArray[4] == UInt32(255))
 
         } else {
-            XCTFail("Valid Levels should be decoded properly")
+            Issue.record("Valid Levels should be decoded properly")
         }
     }
 
     // MARK:- Encoding Locations
-    func testLocationsArrayShouldBeEncodedProperly() {
+    @Test func `Locations array should be encoded properly`() {
         let locations = [CLLocation(latitude: 0.00001, longitude: 0.00001),
             CLLocation(latitude: 0.00000, longitude: 0.00000)]
 
         let sut = Polyline(locations: locations)
-        XCTAssertEqual(sut.encodedPolyline, "AA@@")
+        #expect(sut.encodedPolyline == "AA@@")
     }
 
     // MARK:- Issues non-regression tests
 
     // Github Issue 1
-    func testSmallNegativeDifferencesShouldBeEncodedProperly() {
+    @Test func `Small negative differences should be encoded properly`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 37.32721043, longitude: 122.02685069),
             CLLocationCoordinate2D(latitude: 37.32727259, longitude: 122.02685280),
             CLLocationCoordinate2D(latitude: 37.32733398, longitude: 122.02684998)]
 
         let sut = Polyline(coordinates: coordinates)
-        XCTAssertEqual(sut.encodedPolyline, "anybFyjxgVK?K?")
+        #expect(sut.encodedPolyline == "anybFyjxgVK?K?")
     }
 
     // Github Issue 3
-    func testLimitValueIsProperlyEncoded() {
+    @Test func `Limit value is properly encoded`() {
         let sourceCoordinates = [CLLocationCoordinate2D(latitude: 0.00016, longitude: -0.00032)]
 
         let sut = Polyline(coordinates: sourceCoordinates)
-        XCTAssertEqual(sut.encodedPolyline, "_@~@")
+        #expect(sut.encodedPolyline == "_@~@")
     }
 
     // Github issue 4
-    func testPrecisionIsUsedProperly() {
+    @Test func `Precision is used properly`() {
         let encoded = "}gqefAridwgFrYEAhfA{@jDsAxBoBzBaDtB{iAX{c@EsU]uf@?_WR~@tPlTFfg@?jUNj|@eBtu@K?z]cAjLkDlJuFjGyG`IyCjIsAlM?|k@v@|dArQbv@k@jIpA?"
         let sut : [CLLocationCoordinate2D] = decodePolyline(encoded, precision: 1e6)!
 
-        XCTAssertEqual(sut.count, 30)
-        XCTAssertEqual(sut[0].latitude, 37.332111, accuracy: COORD_EPSILON_1e6)
-        XCTAssertEqual(sut[0].longitude, -122.030762, accuracy: COORD_EPSILON_1e6)
-    }
-
-    // Github Issue 8
-    func testPerformances() {
-        self.measure {
-            let _ = Polyline(encodedPolyline:"wamrIo{gnAnG_CVIm@{NEsDFgAHu@^{C`@sC@_As@eWEoBIw@?QDYd@oB@Uv@eDHOViAPwB@_ACUGQIcDYiIsA{a@EcB?iBD]JyBV}C@GJKDOCUMOO@MLy@@}ATI@McEQsLCcC?}@De@BQNe@gDcEgBsCSa@Yy@QiAS{D?gAJ_APmAt@wD`@eDDq@?aCk@uTcBif@KiBSkBa@wBUu@u@yB}CmHo@oAw@kA_@g@y@s@w@i@eJiF}BcB_BwAoCsDaB_DwLsWaBaDyB}Dm@qA_AcDEOIq@Sy@AuBBu@LgAR}@|@kCt@}Ab@s@^g@hAoAb@]jBkAdHqDt@[~@QxABNEHEdA}@TYbAyATQXKdC[n@Sr@c@r@}@|BwE~@eBjAyAvAaAlCaBlCoAjC_A|Cu@lLeBnDcAxBy@xDmBlEkCvDcCrFaEHGxAg@nAYf@Cz@@hCd@zAHj@MTIf@c@T]Zo@b@iBFo@DgA?k@CgAEa@Y_BoBeHo@sC{@iFg@qBk@aDqBeJaBcG}E_P{AsFq@kCk@eCwAmIm@yEk@cFg@eHU{FAiBMaIIiHImDSwF_@gGc@wFq@_G]aCc@yCcAsFiAeFCQ}FgUcEaRmBsJ_C}M_BaK{A{KsC_V_Gil@WqDy@kJk@eHyAeSu@mL]{Ha@kNI_GEkKFcV?mHKeHK}Cg@eKa@cFWmCm@}Ea@uCcCqMm@mCmAoEq@wBuA{DuAmD_BiDeDkG]u@{AwC{BaFiA_Dy@gCiA_Em@cCeAyEo@oDs@yEq@wFm@iHIyA]qIQiJIiBAkBDg@Ru@DOJSFc@Bc@AUIg@M[]aDIsAWyUs@cx@MqJ[wL_@gLg@uLo@oLiAkRo@_Iy@kH_@uCy@}Ey@mDaBcGkDsIgBkDgAaBiDiEkBqB}AkAmCaBaImDkAs@{BeBaBkBmBqCaCoEy@sBw@}Bq@aCoA{EeA_Fg@qCsAaJ_@sC]}CUqC_@qFIuAUkGQeIG}QCsRFuD?_CDgIAoJMyMUaLq@mO[wF}@uMe@oFc@kDu@wF{@{E_BwH[wAmDkL{HaToC}HwA{DiAkD_AuDyA_Ig@}Dg@wCyCiTi@cDy@qGcAeGkHyi@oAcJwBoPwAyJs@yFy@kFoFy_@wBeNkA}HcEuZeBqKOyAs@kEk@qEq@qE[cBWkBoAmHsBeOCQCuD\\{Bd@_Cz@aAbDuC~HuH|BsCjBqCdAgBrAgC~AwDjA{ClA}DrAmFf@_Cz@yE^aCh@_EVaCl@eHPcCp@qNbAuPf@_HtA}Nr@gG|@}GfAmHbB_JrAqG~AoItFkX`@_Cd@uDb@iEb@mFTiEXmJDyDAkDGeD]sIe@oG_A_Ko@gGaA{HwAyJi@eDqAoHiCiMmByH_EmOoCkIaGyR]_A}AcF_AiD}@_DwAiHc@oCa@kDa@gGQaEEwJFoD^}Ib@gF^kCZeCT}@x@oE\\yAtCaOb@iCv@qGV{CXwEJwE\\gh@RaMZsIv@iMX}CXyBnAeIj@qCx@cDrCkJrIeWdAmDp@mC`AsE\\gC~AeJTqBJq@VeDd@yH`@qMZaNx@c\\DaCDiAjAmc@f@iOjDwy@RqC|AcR|@}HtAiK~@oGn@oD|Hoa@vAwJ\\oCl@sGb@cF`@kHF_C`@iKJiH?gJIiDCoBo@yRsBga@[cREsFBeU`@sOTwGFeC~@cWf@wK~@_WbAu[vEmuAfAoXHiLHmTKe]GiCYoHY_Ew@aH}CmSwBkQgBcPw@uKScFCwCHeHZcIx@iOf@cMF}Bn@s^v@k\\n@i[j@aRNwGf@aPNsHb@kP|@yWp@wPLiFLqCbBej@?m@f@sQnAi_@b@mNlAg[VqE\\yELaCLuAdAmKXqB`@{D~BcTn@aGDm@NiATqC@i@F_BCeBOqDK}@e@yCAUDYBQFKn@Er@Bt@Jb@ApBS`CHfFIpEo@lFgB`FwC|@u@vCoCxA}AdEsG`CgFr@kBnAcE`BcHd@uCb@{Dj@kHNsCrAq`@T}ZFSFkAR_BBQDIrBwB|Ca@fGKhADbLfBlD`AhCz@pExBtBpAxCtBt@b@dBr@|@TjBTnBCbAK^IxCeAp@]xC}Bv@u@rCuDxSo\\jBsCfnAgnB|TiZjD}Df@a@bD{BpDsBfIyCvh@yXzB}@pAYnEi@tGArD}@nOsFxJuFjLeIvF}C`GkEtBmA|AUn@AdQP~Fo@zBNtO~B`CV`@@b@I~@o@d@i@|@gB`IeT|C{Ib@aB^iB~DmS`AsD~@eCb@_AXe@lBmCjd@m`@rJcIxKgKbEcDzQmS|CyCfDiCbDmBjBy@tEaBfIqAnQmBbA[|AY|EgBdF_CxH_GtAmAbDsDd@o@|e@mt@vCaEhHqIbL{KvF}DrNmJl@El@c@v@g@\\s@~@o@tG_E\\AbEiCZe@dB}@hGsA^EdCBfC[zNy@`Di@fAM`@Mz@_@~UcIdHcB~CWdACx]nAnFl@pBh@fEvBjRfKrP~IvGlCfB\\rF^n@@~AKpC]fYeH`@EfECrDZ`Ej@xFp@rBFtBErAKnCe@~Ae@lBu@~HcEjF{BpJkDzJaDpCmAtDiC|BqBhEaFbCeCXChBuApBcAb@EJ@RBPEFQh@a@pBq@R@RJL@H?Jd@Xf@TFNATONSDKz@o@XMp@OTMpBUfAQjDoA|BwAv@o@j@]~A_BtIyJtEcGpC_EHKLNNEDKBOC[tDqFtAaBt@u@jAeAfBuALKfA_BjDoEfDiC~@a@BCYyDYsBCQz@aAHIP~@")
-        }
+        #expect(sut.count == 30)
+        expectClose(sut[0].latitude, 37.332111, within: COORD_EPSILON_1e6)
+        expectClose(sut[0].longitude, -122.030762, within: COORD_EPSILON_1e6)
     }
 
     // MARK:- README code samples
 
-    func testCoordinatesEncoding() {
+    @Test func `Coordinates encoding`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 40.2349727, longitude: -3.7707443),
             CLLocationCoordinate2D(latitude: 44.3377999, longitude: 1.2112933)]
 
         let polyline = Polyline(coordinates: coordinates)
-        XCTAssertEqual(polyline.encodedPolyline, "qkqtFbn_Vui`Xu`l]")
+        #expect(polyline.encodedPolyline == "qkqtFbn_Vui`Xu`l]")
     }
 
-    func testLocationsEncoding() {
+    @Test func `Locations encoding`() {
         let locations = [CLLocation(latitude: 40.2349727, longitude: -3.7707443),
             CLLocation(latitude: 44.3377999, longitude: 1.2112933)]
 
         let polyline = Polyline(locations: locations)
-        XCTAssertEqual(polyline.encodedPolyline, "qkqtFbn_Vui`Xu`l]")
+        #expect(polyline.encodedPolyline == "qkqtFbn_Vui`Xu`l]")
     }
 
-    func testLevelEncoding() {
+    @Test func `Level encoding`() {
         let coordinates = [CLLocationCoordinate2D(latitude: 40.2349727, longitude: -3.7707443),
             CLLocationCoordinate2D(latitude: 44.3377999, longitude: 1.2112933)]
 
@@ -324,52 +319,68 @@ class PolylineTests:XCTestCase {
         let _ : String? = polyline.encodedLevels
     }
 
-    func testPolylineDecodingToCoordinate() {
+    @Test func `Polyline decoding to coordinate`() {
         let polyline = Polyline(encodedPolyline: "qkqtFbn_Vui`Xu`l]")
 
         let decodedCoordinates: [CLLocationCoordinate2D]? = polyline.coordinates
-        XCTAssertEqual(2, decodedCoordinates!.count)
+        #expect(2 == decodedCoordinates!.count)
     }
 
-    func testPolylineDecodingToLocations() {
+    @Test func `Polyline decoding to locations`() {
         let polyline = Polyline(encodedPolyline: "qkqtFbn_Vui`Xu`l]")
         let decodedLocations: [CLLocation]? = polyline.locations
 
-        XCTAssertEqual(2, decodedLocations!.count)
+        #expect(2 == decodedLocations!.count)
     }
 
-    func testLevelDecoding() {
+    @Test func `Level decoding`() {
         let polyline = Polyline(encodedPolyline: "qkqtFbn_Vui`Xu`l]", encodedLevels: "BA")
         let decodedLevels: [UInt32]? = polyline.levels
 
-        XCTAssertEqual(2, decodedLevels!.count)
+        #expect(2 == decodedLevels!.count)
     }
 
-    func testPrecision() {
+    @Test func `Precision`() {
         // OSRM uses a 6 digit precision
         let _ = Polyline(encodedPolyline: "ak{hRak{hR", precision: 1e6)
     }
 
-    @available(tvOS 9.2, *)
-    func testPolylineConvertionToMKPolyline() {
+    @Test @available(tvOS 9.2, *)
+    func `Polyline convertion to MK polyline`() {
         let polyline = Polyline(encodedPolyline: "qkqtFbn_Vui`Xu`l]")
 
         let mkPolyline = polyline.mkPolyline
-        XCTAssertNotNil(mkPolyline)
-        XCTAssertTrue(polyline.coordinates?.count == mkPolyline?.pointCount)
+        #expect(mkPolyline != nil)
+        #expect(polyline.coordinates?.count == mkPolyline?.pointCount)
     }
 
-    @available(tvOS 9.2, *)
-    func testPolylineConvertionToMKPolylineWhenEncodingFailed() {
+    @Test @available(tvOS 9.2, *)
+    func `Polyline convertion to MK polyline when encoding failed`() {
         let polyline = Polyline(encodedPolyline: "invalidPolylineString")
         let mkPolyline = polyline.mkPolyline
-        XCTAssertNil(mkPolyline)
+        #expect(mkPolyline == nil)
     }
 
-    @available(tvOS 9.2, *)
-    func testEmptyPolylineConvertionShouldBeEmptyMKPolyline() {
+    @Test @available(tvOS 9.2, *)
+    func `Empty polyline convertion should be empty MK polyline`() {
         let polyline = Polyline(encodedPolyline: "")
         let mkPolyline = polyline.mkPolyline
-        XCTAssertTrue(mkPolyline?.pointCount == 0)
+        #expect(mkPolyline?.pointCount == 0)
+    }
+}
+
+// MARK: - Performance
+
+/// Stays on XCTest: Swift Testing has no equivalent of `measure`, so this is the
+/// one test in this file that cannot become a `@Test`. It is deliberately *not*
+/// `@MainActor` — a main-actor XCTestCase is what blocks the Swift 6 language
+/// mode for this target (docs/swift6-migration-plan.md, "Phase 4 status").
+final class PolylinePerformanceTests: XCTestCase {
+
+    // Github Issue 8
+    func testPerformances() {
+        self.measure {
+            let _ = Polyline(encodedPolyline:"wamrIo{gnAnG_CVIm@{NEsDFgAHu@^{C`@sC@_As@eWEoBIw@?QDYd@oB@Uv@eDHOViAPwB@_ACUGQIcDYiIsA{a@EcB?iBD]JyBV}C@GJKDOCUMOO@MLy@@}ATI@McEQsLCcC?}@De@BQNe@gDcEgBsCSa@Yy@QiAS{D?gAJ_APmAt@wD`@eDDq@?aCk@uTcBif@KiBSkBa@wBUu@u@yB}CmHo@oAw@kA_@g@y@s@w@i@eJiF}BcB_BwAoCsDaB_DwLsWaBaDyB}Dm@qA_AcDEOIq@Sy@AuBBu@LgAR}@|@kCt@}Ab@s@^g@hAoAb@]jBkAdHqDt@[~@QxABNEHEdA}@TYbAyATQXKdC[n@Sr@c@r@}@|BwE~@eBjAyAvAaAlCaBlCoAjC_A|Cu@lLeBnDcAxBy@xDmBlEkCvDcCrFaEHGxAg@nAYf@Cz@@hCd@zAHj@MTIf@c@T]Zo@b@iBFo@DgA?k@CgAEa@Y_BoBeHo@sC{@iFg@qBk@aDqBeJaBcG}E_P{AsFq@kCk@eCwAmIm@yEk@cFg@eHU{FAiBMaIIiHImDSwF_@gGc@wFq@_G]aCc@yCcAsFiAeFCQ}FgUcEaRmBsJ_C}M_BaK{A{KsC_V_Gil@WqDy@kJk@eHyAeSu@mL]{Ha@kNI_GEkKFcV?mHKeHK}Cg@eKa@cFWmCm@}Ea@uCcCqMm@mCmAoEq@wBuA{DuAmD_BiDeDkG]u@{AwC{BaFiA_Dy@gCiA_Em@cCeAyEo@oDs@yEq@wFm@iHIyA]qIQiJIiBAkBDg@Ru@DOJSFc@Bc@AUIg@M[]aDIsAWyUs@cx@MqJ[wL_@gLg@uLo@oLiAkRo@_Iy@kH_@uCy@}Ey@mDaBcGkDsIgBkDgAaBiDiEkBqB}AkAmCaBaImDkAs@{BeBaBkBmBqCaCoEy@sBw@}Bq@aCoA{EeA_Fg@qCsAaJ_@sC]}CUqC_@qFIuAUkGQeIG}QCsRFuD?_CDgIAoJMyMUaLq@mO[wF}@uMe@oFc@kDu@wF{@{E_BwH[wAmDkL{HaToC}HwA{DiAkD_AuDyA_Ig@}Dg@wCyCiTi@cDy@qGcAeGkHyi@oAcJwBoPwAyJs@yFy@kFoFy_@wBeNkA}HcEuZeBqKOyAs@kEk@qEq@qE[cBWkBoAmHsBeOCQCuD\\{Bd@_Cz@aAbDuC~HuH|BsCjBqCdAgBrAgC~AwDjA{ClA}DrAmFf@_Cz@yE^aCh@_EVaCl@eHPcCp@qNbAuPf@_HtA}Nr@gG|@}GfAmHbB_JrAqG~AoItFkX`@_Cd@uDb@iEb@mFTiEXmJDyDAkDGeD]sIe@oG_A_Ko@gGaA{HwAyJi@eDqAoHiCiMmByH_EmOoCkIaGyR]_A}AcF_AiD}@_DwAiHc@oCa@kDa@gGQaEEwJFoD^}Ib@gF^kCZeCT}@x@oE\\yAtCaOb@iCv@qGV{CXwEJwE\\gh@RaMZsIv@iMX}CXyBnAeIj@qCx@cDrCkJrIeWdAmDp@mC`AsE\\gC~AeJTqBJq@VeDd@yH`@qMZaNx@c\\DaCDiAjAmc@f@iOjDwy@RqC|AcR|@}HtAiK~@oGn@oD|Hoa@vAwJ\\oCl@sGb@cF`@kHF_C`@iKJiH?gJIiDCoBo@yRsBga@[cREsFBeU`@sOTwGFeC~@cWf@wK~@_WbAu[vEmuAfAoXHiLHmTKe]GiCYoHY_Ew@aH}CmSwBkQgBcPw@uKScFCwCHeHZcIx@iOf@cMF}Bn@s^v@k\\n@i[j@aRNwGf@aPNsHb@kP|@yWp@wPLiFLqCbBej@?m@f@sQnAi_@b@mNlAg[VqE\\yELaCLuAdAmKXqB`@{D~BcTn@aGDm@NiATqC@i@F_BCeBOqDK}@e@yCAUDYBQFKn@Er@Bt@Jb@ApBS`CHfFIpEo@lFgB`FwC|@u@vCoCxA}AdEsG`CgFr@kBnAcE`BcHd@uCb@{Dj@kHNsCrAq`@T}ZFSFkAR_BBQDIrBwB|Ca@fGKhADbLfBlD`AhCz@pExBtBpAxCtBt@b@dBr@|@TjBTnBCbAK^IxCeAp@]xC}Bv@u@rCuDxSo\\jBsCfnAgnB|TiZjD}Df@a@bD{BpDsBfIyCvh@yXzB}@pAYnEi@tGArD}@nOsFxJuFjLeIvF}C`GkEtBmA|AUn@AdQP~Fo@zBNtO~B`CV`@@b@I~@o@d@i@|@gB`IeT|C{Ib@aB^iB~DmS`AsD~@eCb@_AXe@lBmCjd@m`@rJcIxKgKbEcDzQmS|CyCfDiCbDmBjBy@tEaBfIqAnQmBbA[|AY|EgBdF_CxH_GtAmAbDsDd@o@|e@mt@vCaEhHqIbL{KvF}DrNmJl@El@c@v@g@\\s@~@o@tG_E\\AbEiCZe@dB}@hGsA^EdCBfC[zNy@`Di@fAM`@Mz@_@~UcIdHcB~CWdACx]nAnFl@pBh@fEvBjRfKrP~IvGlCfB\\rF^n@@~AKpC]fYeH`@EfECrDZ`Ej@xFp@rBFtBErAKnCe@~Ae@lBu@~HcEjF{BpJkDzJaDpCmAtDiC|BqBhEaFbCeCXChBuApBcAb@EJ@RBPEFQh@a@pBq@R@RJL@H?Jd@Xf@TFNATONSDKz@o@XMp@OTMpBUfAQjDoA|BwAv@o@j@]~A_BtIyJtEcGpC_EHKLNNEDKBOC[tDqFtAaBt@u@jAeAfBuALKfA_BjDoEfDiC~@a@BCYyDYsBCQz@aAHIP~@")
+        }
     }
 }

--- a/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
+++ b/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
@@ -139,7 +139,7 @@ final class PolylineTests {
     @Test func `Empty polyline should be empty location array`() {
         let sut = Polyline(encodedPolyline: "")
         #expect(sut.coordinates != nil)
-        #expect((sut.coordinates!).count == 0)
+        #expect(sut.coordinates?.isEmpty == true)
     }
 
     @Test func `Invalid polyline should return nil`() {
@@ -227,7 +227,7 @@ final class PolylineTests {
         let sut = Polyline(encodedPolyline: "", encodedLevels: "")
 
         #expect(sut.levels != nil, "Level array should not be nil for empty string")
-        #expect((sut.levels!).count == 0)
+        #expect(sut.levels?.isEmpty == true)
     }
 
     @Test func `Invalid levels should return nil level array`() {
@@ -340,7 +340,7 @@ final class PolylineTests {
         #expect(2 == decodedLevels!.count)
     }
 
-    @Test func `Precision`() {
+    @Test func precision() {
         // OSRM uses a 6 digit precision
         let _ = Polyline(encodedPolyline: "ak{hRak{hR", precision: 1e6)
     }

--- a/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
+++ b/OBAKitTests/Modeling/PolylineTests/PolylineTests.swift
@@ -372,10 +372,17 @@ final class PolylineTests {
 // MARK: - Performance
 
 /// Stays on XCTest: Swift Testing has no equivalent of `measure`, so this is the
-/// one test in this file that cannot become a `@Test`. It is deliberately *not*
-/// `@MainActor` — a main-actor XCTestCase is what blocks the Swift 6 language
-/// mode for this target (docs/swift6-migration-plan.md, "Phase 4 status").
-final class PolylinePerformanceTests: XCTestCase {
+/// one test in this file that cannot become a `@Test`.
+///
+/// `nonisolated` is load-bearing, and it is not enough to merely omit
+/// `@MainActor`. The target sets `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so
+/// an unannotated class is main-actor — and a main-actor XCTestCase does not
+/// compile in the Swift 6 language mode: `XCTestCase`'s designated initializers
+/// are nonisolated, and the synthesized overrides of `init()`,
+/// `init(selector:)`, and `init(invocation:)` then mismatch. Opting this one
+/// class out is what lets the whole target build in Swift 6 mode.
+/// See docs/swift6-migration-plan.md, "Phase 4".
+nonisolated final class PolylinePerformanceTests: XCTestCase {
 
     // Github Issue 8
     func testPerformances() {

--- a/OBAKitTests/Modeling/REST Model Service Tests/AgenciesWithCoverageModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/AgenciesWithCoverageModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
 import Testing
@@ -16,8 +15,9 @@ import Testing
 
 // swiftlint:disable force_cast
 
-class AgenciesWithCoverageModelOperationTests: OBATestCase {
-    func testLoading_success() async throws {
+@Suite(.serialized)
+final class AgenciesWithCoverageModelOperationTests: OBATestCase {
+    @Test func `Loading success`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         let data = Fixtures.loadData(file: "agencies_with_coverage.json")
         dataLoader.mock(URLString: "https://www.example.com/api/where/agencies-with-coverage.json", with: data)
@@ -25,7 +25,7 @@ class AgenciesWithCoverageModelOperationTests: OBATestCase {
         let response = try await restService.getAgenciesWithCoverage()
 
         let agencies = response.list
-        let childrens = try XCTUnwrap(agencies.first)
+        let childrens = try #require(agencies.first)
 
         #expect(agencies.count == 11)
 

--- a/OBAKitTests/Modeling/REST Model Service Tests/ArrivalDepartureDeduplicationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/ArrivalDepartureDeduplicationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -19,7 +18,8 @@ import Testing
 /// Validates the deduplication logic that removes visually identical
 /// arrival/departure rows caused by terminal stops returning both an arrival
 /// and a departure entry for the same trip at the same stop.
-class ArrivalDepartureDeduplicationTests: OBATestCase {
+@Suite(.serialized)
+final class ArrivalDepartureDeduplicationTests: OBATestCase {
 
     // MARK: - Fixture Setup
 
@@ -30,8 +30,8 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
         "https://www.example.com/api/where/arrivals-and-departures-for-stop/\(stopID).json"
     }
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
@@ -49,14 +49,14 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     // MARK: - Basic Behavior
 
     /// An empty array returns an empty array without crashing.
-    func test_filteringTerminalDuplicates_handlesEmptyArray() {
+    @Test func `Filtering terminal duplicates handles empty array`() {
         let empty: [ArrivalDeparture] = []
         let filtered = empty.filteringTerminalDuplicates()
         #expect(filtered.isEmpty)
     }
 
     /// A single-element array passes through unchanged.
-    func test_filteringTerminalDuplicates_handlesSingleElement() async throws {
+    @Test func `Filtering terminal duplicates handles single element`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: campusParkwayStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -74,7 +74,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     /// The Galer fixture has entries that share a vehicleID but have different tripIDs.
     /// These are different trips on the same vehicle block — NOT terminal duplicates.
     /// The filter must preserve all of them.
-    func test_filteringTerminalDuplicates_preservesDifferentTripsOnSameVehicle() async throws {
+    @Test func `Filtering terminal duplicates preserves different trips on same vehicle`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: galerStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -95,7 +95,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     }
 
     /// A fixture with no terminal duplicates should pass through completely unchanged.
-    func test_filteringTerminalDuplicates_noFalsePositivesOnCleanData() async throws {
+    @Test func `Filtering terminal duplicates no false positives on clean data`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: campusParkwayStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -113,7 +113,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     /// When two entries share the exact same (tripID, stopID, routeID),
     /// only one should survive. This simulates the terminal duplicate scenario
     /// by appending the same ArrivalDeparture entry to the array.
-    func test_filteringTerminalDuplicates_removesDuplicateVisits() async throws {
+    @Test func `Filtering terminal duplicates removes duplicate visits`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: campusParkwayStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -135,7 +135,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
 
     /// When multiple distinct entries exist alongside a duplicate pair,
     /// only the duplicate pair is merged. All other entries are preserved.
-    func test_filteringTerminalDuplicates_mergesOnlyDuplicatesAmongDistinctEntries() async throws {
+    @Test func `Filtering terminal duplicates merges only duplicates among distinct entries`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: galerStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -157,7 +157,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     // MARK: - Ordering
 
     /// The relative order of entries is preserved after filtering.
-    func test_filteringTerminalDuplicates_preservesOriginalOrder() async throws {
+    @Test func `Filtering terminal duplicates preserves original order`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: galerStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -169,7 +169,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
         var lastInputIndex = -1
         for filteredID in filteredIDs {
             guard let inputIndex = arrDeps.firstIndex(where: { $0.id == filteredID }) else {
-                XCTFail("Filtered entry with id \(filteredID) not found in original array")
+                Issue.record("Filtered entry with id \(filteredID) not found in original array")
                 continue
             }
             #expect(inputIndex > lastInputIndex, "Original ordering must be preserved")
@@ -180,7 +180,7 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     // MARK: - Idempotency
 
     /// Applying the filter twice produces the same result as applying it once.
-    func test_filteringTerminalDuplicates_isIdempotent() async throws {
+    @Test func `Filtering terminal duplicates is idempotent`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: galerStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
@@ -200,14 +200,14 @@ class ArrivalDepartureDeduplicationTests: OBATestCase {
     /// The real-time vs scheduled preference path isn't exercised here because
     /// ArrivalDeparture properties are immutable — testing that would require
     /// a fixture with both predicted and non-predicted entries for the same trip.
-    func test_filteringTerminalDuplicates_mergesIdenticalDuplicates() async throws {
+    @Test func `Filtering terminal duplicates merges identical duplicates`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(
             id: campusParkwayStopID, minutesBefore: 5, minutesAfter: 30
         ).entry
 
         let arrDeps = arrivals.arrivalsAndDepartures
         guard let entry = arrDeps.first else {
-            XCTFail("Fixture must contain at least one ArrivalDeparture")
+            Issue.record("Fixture must contain at least one ArrivalDeparture")
             return
         }
 

--- a/OBAKitTests/Modeling/REST Model Service Tests/CurrentTimeModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/CurrentTimeModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,9 +14,10 @@ import CoreLocation
 
 // swiftlint:disable force_cast
 
-class CurrentTimeModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class CurrentTimeModelOperationTests: OBATestCase {
 
-    func testCurrentTime_success() async throws {
+    @Test func `Current time success`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
         dataLoader.mock(

--- a/OBAKitTests/Modeling/REST Model Service Tests/RegionalAlertsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/RegionalAlertsModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,8 +14,9 @@ import CoreLocation
 
 // swiftlint:disable force_try force_cast
 
-class RegionalAlertsModelOperationTests: OBATestCase {
-    func testSuccessfulRequest() async throws {
+@Suite(.serialized)
+final class RegionalAlertsModelOperationTests: OBATestCase {
+    @Test func `Successful request`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         stubAgenciesWithCoverage(dataLoader: dataLoader)
         Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)

--- a/OBAKitTests/Modeling/REST Model Service Tests/RouteSearchModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/RouteSearchModelOperationTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 import MapKit
@@ -16,13 +16,14 @@ import MapKit
 
 // swiftlint:disable force_cast
 
-class RouteSearchModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class RouteSearchModelOperationTests: OBATestCase {
     let query = "Link"
     let center = CLLocationCoordinate2D(latitude: 47.0, longitude: -122)
     let radius = 5000.0
     lazy var region = CLCircularRegion(center: center, radius: radius, identifier: "identifier")
 
-    func testLoading_success() async throws {
+    @Test func `Loading success`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         let data = Fixtures.loadData(file: "routes-for-location-10.json")
         dataLoader.mock(URLString: "https://www.example.com/api/where/routes-for-location.json", with: data)
@@ -32,7 +33,7 @@ class RouteSearchModelOperationTests: OBATestCase {
 
         #expect(routes.count == 1)
 
-        let route = try XCTUnwrap(routes.first)
+        let route = try #require(routes.first)
 
         #expect(route.agency.id == "1")
         #expect(route.agency.name == "Metro Transit")

--- a/OBAKitTests/Modeling/REST Model Service Tests/ScheduleForRouteTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/ScheduleForRouteTests.swift
@@ -7,18 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class ScheduleForRouteTests: OBATestCase {
+@Suite(.serialized)
+final class ScheduleForRouteTests: OBATestCase {
     let routeID = "1_100223"
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         dataLoader.mock(
@@ -29,12 +30,12 @@ class ScheduleForRouteTests: OBATestCase {
 
     // MARK: - URL Builder Tests
 
-    func test_urlBuilder_generatesCorrectURL() {
+    @Test func `Url builder generates correct URL`() {
         let url = restService.urlBuilder.getScheduleForRoute(id: routeID)
         #expect(url.absoluteString.contains("/api/where/schedule-for-route/\(routeID).json"))
     }
 
-    func test_urlBuilder_withDate_includesDateParameter() {
+    @Test func `Url builder with date includes date parameter`() {
         let date = Date(timeIntervalSince1970: 1765008000) // 2025-12-06
         let url = restService.urlBuilder.getScheduleForRoute(id: routeID, date: date)
         #expect(url.absoluteString.contains("date="))
@@ -42,7 +43,7 @@ class ScheduleForRouteTests: OBATestCase {
 
     // MARK: - Model Decoding Tests
 
-    func test_loading_success() async throws {
+    @Test func `Loading success`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
         let schedule = response.entry
 
@@ -51,35 +52,35 @@ class ScheduleForRouteTests: OBATestCase {
         #expect(!schedule.stopTripGroupings.isEmpty)
     }
 
-    func test_stopTripGroupings_parsing() async throws {
+    @Test func `Stop trip groupings parsing`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
         let schedule = response.entry
 
-        let grouping = try XCTUnwrap(schedule.stopTripGroupings.first)
+        let grouping = try #require(schedule.stopTripGroupings.first)
         #expect(!grouping.stopIDs.isEmpty)
         #expect(!grouping.tripHeadsigns.isEmpty)
         #expect(!grouping.tripIDs.isEmpty)
         #expect(!grouping.tripsWithStopTimes.isEmpty)
     }
 
-    func test_tripsWithStopTimes_parsing() async throws {
+    @Test func `Trips with stop times parsing`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
         let schedule = response.entry
 
-        let grouping = try XCTUnwrap(schedule.stopTripGroupings.first)
-        let tripWithStopTimes = try XCTUnwrap(grouping.tripsWithStopTimes.first)
+        let grouping = try #require(schedule.stopTripGroupings.first)
+        let tripWithStopTimes = try #require(grouping.tripsWithStopTimes.first)
 
         #expect(!tripWithStopTimes.tripID.isEmpty)
         #expect(!tripWithStopTimes.stopTimes.isEmpty)
     }
 
-    func test_stopTimes_parsing() async throws {
+    @Test func `Stop times parsing`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
         let schedule = response.entry
 
-        let grouping = try XCTUnwrap(schedule.stopTripGroupings.first)
-        let tripWithStopTimes = try XCTUnwrap(grouping.tripsWithStopTimes.first)
-        let stopTime = try XCTUnwrap(tripWithStopTimes.stopTimes.first)
+        let grouping = try #require(schedule.stopTripGroupings.first)
+        let tripWithStopTimes = try #require(grouping.tripsWithStopTimes.first)
+        let stopTime = try #require(tripWithStopTimes.stopTimes.first)
 
         #expect(!stopTime.stopID.isEmpty)
         #expect(!stopTime.tripID.isEmpty)
@@ -90,13 +91,13 @@ class ScheduleForRouteTests: OBATestCase {
         #expect(stopTime.departureEnabled)
     }
 
-    func test_arrivalTime_isSecondsFromMidnight() async throws {
+    @Test func `Arrival time is seconds from midnight`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
         let schedule = response.entry
 
-        let grouping = try XCTUnwrap(schedule.stopTripGroupings.first)
-        let tripWithStopTimes = try XCTUnwrap(grouping.tripsWithStopTimes.first)
-        let stopTime = try XCTUnwrap(tripWithStopTimes.stopTimes.first)
+        let grouping = try #require(schedule.stopTripGroupings.first)
+        let tripWithStopTimes = try #require(grouping.tripsWithStopTimes.first)
+        let stopTime = try #require(tripWithStopTimes.stopTimes.first)
 
         // The fixture has arrivalTime: 31500 which equals 8:45 AM (31500 / 3600 = 8.75 hours)
         // Times should be between 0 (midnight) and 86400 (next midnight) or slightly beyond for overnight routes
@@ -106,14 +107,14 @@ class ScheduleForRouteTests: OBATestCase {
 
     // MARK: - References Tests
 
-    func test_references_containsRoutes() async throws {
+    @Test func `References contains routes`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
 
         #expect(response.references != nil)
         #expect(response.references?.routes.isEmpty == false)
     }
 
-    func test_references_containsStops() async throws {
+    @Test func `References contains stops`() async throws {
         let response = try await restService.getScheduleForRoute(routeID: routeID)
 
         #expect(response.references != nil)

--- a/OBAKitTests/Modeling/REST Model Service Tests/ScheduleForStopTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/ScheduleForStopTests.swift
@@ -7,18 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class ScheduleForStopTests: OBATestCase {
+@Suite(.serialized)
+final class ScheduleForStopTests: OBATestCase {
     let stopID = "1_75403"
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         dataLoader.mock(
@@ -29,12 +30,12 @@ class ScheduleForStopTests: OBATestCase {
 
     // MARK: - URL Builder Tests
 
-    func test_urlBuilder_generatesCorrectURL() {
+    @Test func `Url builder generates correct URL`() {
         let url = restService.urlBuilder.getScheduleForStop(id: stopID)
         #expect(url.absoluteString.contains("/api/where/schedule-for-stop/\(stopID).json"))
     }
 
-    func test_urlBuilder_withDate_includesDateParameter() {
+    @Test func `Url builder with date includes date parameter`() {
         let date = Date(timeIntervalSince1970: 1765008000) // 2025-12-06
         let url = restService.urlBuilder.getScheduleForStop(id: stopID, date: date)
         #expect(url.absoluteString.contains("date="))
@@ -42,7 +43,7 @@ class ScheduleForStopTests: OBATestCase {
 
     // MARK: - Model Decoding Tests
 
-    func test_loading_success() async throws {
+    @Test func `Loading success`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
@@ -50,36 +51,36 @@ class ScheduleForStopTests: OBATestCase {
         #expect(!schedule.stopRouteSchedules.isEmpty)
     }
 
-    func test_stopRouteSchedules_parsing() async throws {
+    @Test func `Stop route schedules parsing`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
         // The fixture has multiple routes at this stop
         #expect(schedule.stopRouteSchedules.count >= 1)
 
-        let routeSchedule = try XCTUnwrap(schedule.stopRouteSchedules.first)
+        let routeSchedule = try #require(schedule.stopRouteSchedules.first)
         #expect(!routeSchedule.routeID.isEmpty)
         #expect(!routeSchedule.stopRouteDirectionSchedules.isEmpty)
     }
 
-    func test_stopRouteDirectionSchedules_parsing() async throws {
+    @Test func `Stop route direction schedules parsing`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
-        let routeSchedule = try XCTUnwrap(schedule.stopRouteSchedules.first)
-        let directionSchedule = try XCTUnwrap(routeSchedule.stopRouteDirectionSchedules.first)
+        let routeSchedule = try #require(schedule.stopRouteSchedules.first)
+        let directionSchedule = try #require(routeSchedule.stopRouteDirectionSchedules.first)
 
         #expect(!directionSchedule.tripHeadsign.isEmpty)
         #expect(!directionSchedule.scheduleStopTimes.isEmpty)
     }
 
-    func test_scheduleStopTimes_parsing() async throws {
+    @Test func `Schedule stop times parsing`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
-        let routeSchedule = try XCTUnwrap(schedule.stopRouteSchedules.first)
-        let directionSchedule = try XCTUnwrap(routeSchedule.stopRouteDirectionSchedules.first)
-        let stopTime = try XCTUnwrap(directionSchedule.scheduleStopTimes.first)
+        let routeSchedule = try #require(schedule.stopRouteSchedules.first)
+        let directionSchedule = try #require(routeSchedule.stopRouteDirectionSchedules.first)
+        let stopTime = try #require(directionSchedule.scheduleStopTimes.first)
 
         #expect(!stopTime.tripID.isEmpty)
         #expect(!stopTime.serviceID.isEmpty)
@@ -90,13 +91,13 @@ class ScheduleForStopTests: OBATestCase {
         #expect(stopTime.departureEnabled)
     }
 
-    func test_arrivalTime_isUnixTimestampInMilliseconds() async throws {
+    @Test func `Arrival time is unix timestamp in milliseconds`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
-        let routeSchedule = try XCTUnwrap(schedule.stopRouteSchedules.first)
-        let directionSchedule = try XCTUnwrap(routeSchedule.stopRouteDirectionSchedules.first)
-        let stopTime = try XCTUnwrap(directionSchedule.scheduleStopTimes.first)
+        let routeSchedule = try #require(schedule.stopRouteSchedules.first)
+        let directionSchedule = try #require(routeSchedule.stopRouteDirectionSchedules.first)
+        let stopTime = try #require(directionSchedule.scheduleStopTimes.first)
 
         // The fixture has arrivalTime like 1765029720000 (milliseconds)
         // This should be a reasonable timestamp (after year 2000, before year 2100)
@@ -107,13 +108,13 @@ class ScheduleForStopTests: OBATestCase {
         #expect(stopTime.arrivalTime < maxTimestamp)
     }
 
-    func test_arrivalDate_convertsCorrectly() async throws {
+    @Test func `Arrival date converts correctly`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
         let schedule = response.entry
 
-        let routeSchedule = try XCTUnwrap(schedule.stopRouteSchedules.first)
-        let directionSchedule = try XCTUnwrap(routeSchedule.stopRouteDirectionSchedules.first)
-        let stopTime = try XCTUnwrap(directionSchedule.scheduleStopTimes.first)
+        let routeSchedule = try #require(schedule.stopRouteSchedules.first)
+        let directionSchedule = try #require(routeSchedule.stopRouteDirectionSchedules.first)
+        let stopTime = try #require(directionSchedule.scheduleStopTimes.first)
 
         let arrivalDate = stopTime.arrivalDate
 
@@ -124,21 +125,21 @@ class ScheduleForStopTests: OBATestCase {
 
     // MARK: - References Tests
 
-    func test_references_containsRoutes() async throws {
+    @Test func `References contains routes`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
 
         #expect(response.references != nil)
         #expect(response.references?.routes.isEmpty == false)
     }
 
-    func test_references_containsStops() async throws {
+    @Test func `References contains stops`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
 
         #expect(response.references != nil)
         #expect(response.references?.stops.isEmpty == false)
     }
 
-    func test_references_containsAgencies() async throws {
+    @Test func `References contains agencies`() async throws {
         let response = try await restService.getScheduleForStop(stopID: stopID)
 
         #expect(response.references != nil)

--- a/OBAKitTests/Modeling/REST Model Service Tests/ShapeModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/ShapeModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
 import Testing
@@ -16,17 +15,18 @@ import Testing
 
 // swiftlint:disable force_cast
 
-class ShapeModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class ShapeModelOperationTests: OBATestCase {
     let shapeID = "shape_1_20010002"
 
-    func testLoading_success() async throws {
+    @Test func `Loading success`() async throws {
         let dataLoader = restService.dataLoader as! MockDataLoader
 
         let data = Fixtures.loadData(file: "shape_1_20010002.json")
         dataLoader.mock(URLString: "https://www.example.com/api/where/shape/\(shapeID).json", with: data)
 
         let response = try await restService.getShape(id: shapeID)
-        let polyline = try XCTUnwrap(response.entry.polyline)
+        let polyline = try #require(response.entry.polyline)
         let coordinate = polyline.coordinate
         expectClose(coordinate.latitude, 47.6229)
         expectClose(coordinate.longitude, -122.3225)

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopArrivalsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopArrivalsModelOperationTests.swift
@@ -7,16 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable function_body_length force_cast
 
-class StopArrivalsModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class StopArrivalsModelOperationTests: OBATestCase {
     let campusParkwayStopID = "1_10914"
     let galerStopID = "1_11370"
     let rvtdStopID = "1739_d1e8e68e-83f8-487f-baf5-f465fe70fc84.json"
@@ -26,8 +27,8 @@ class StopArrivalsModelOperationTests: OBATestCase {
         "https://www.example.com/api/where/arrivals-and-departures-for-stop/\(stopID).json"
     }
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
@@ -52,7 +53,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
         )
     }
 
-    func test_arrivalAndDepartureStatus() async throws {
+    @Test func `Arrival and departure status`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(id: galerStopID, minutesBefore: 5, minutesAfter: 30).entry
 
         #expect(arrivals.arrivalsAndDepartures.count == 5)
@@ -68,12 +69,12 @@ class StopArrivalsModelOperationTests: OBATestCase {
         #expect(arrivals.arrivalsAndDepartures[4].arrivalDepartureStatus == .arriving)
     }
 
-    func testLoading_success() async throws {
+    @Test func `Loading success`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(id: campusParkwayStopID, minutesBefore: 5, minutesAfter: 30).entry
 
         #expect(arrivals.nearbyStops.count == 4)
         #expect(arrivals.nearbyStops.count == 4)
-        #expect(try XCTUnwrap(arrivals.nearbyStops.first).name == "15th Ave NE & NE Campus Pkwy")
+        #expect(try #require(arrivals.nearbyStops.first).name == "15th Ave NE & NE Campus Pkwy")
 
         #expect(arrivals.serviceAlerts.count == 0)
 
@@ -82,7 +83,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
 
         #expect(arrivals.arrivalsAndDepartures.count == 1)
 
-        let arrDep = try XCTUnwrap(arrivals.arrivalsAndDepartures.first)
+        let arrDep = try #require(arrivals.arrivalsAndDepartures.first)
         #expect(arrDep.arrivalEnabled)
         #expect(arrDep.blockTripSequence == 9)
         #expect(arrDep.departureEnabled)
@@ -123,7 +124,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
         #expect(arrDep.trip.shortName == "LOCAL")
 
         #expect(arrDep.tripStatus != nil)
-        let tripStatus = try XCTUnwrap(arrDep.tripStatus)
+        let tripStatus = try #require(arrDep.tripStatus)
         #expect(tripStatus.activeTrip.id == "1_40984840")
 
         #expect(arrDep.vehicleID == "1_4559")
@@ -133,7 +134,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
     /// server emit two `arrivalAndDeparture` entries for one trip visit (identical stop,
     /// trip, route, service date, and stop sequence — i.e. identical `ArrivalDeparture.id`).
     /// Ingestion must collapse these to a single entry, keeping the most recent report.
-    func testLoading_duplicateTripVisits_collapsedToFreshestReport() async throws {
+    @Test func `Loading duplicate trip visits collapsed to freshest report`() async throws {
         let arrivals = try await restService.getArrivalsAndDeparturesForStop(id: duplicatesStopID, minutesBefore: 5, minutesAfter: 30).entry
 
         // The fixture contains three entries: trip 1_40984902 reported twice
@@ -145,7 +146,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
 
         // The duplicated trip keeps its original (first-occurrence) position, but is
         // represented by the report with the newer lastUpdateTime.
-        let deduped = try XCTUnwrap(arrivals.arrivalsAndDepartures.first)
+        let deduped = try #require(arrivals.arrivalsAndDepartures.first)
         #expect(deduped.tripID == "1_40984902")
         #expect(deduped.vehicleID == "1_8109999")
         #expect(deduped.occupancyStatus == .empty)
@@ -153,7 +154,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
         #expect(arrivals.arrivalsAndDepartures.last?.tripID == "1_40984903")
     }
 
-    func testLoading_rogueValley() async throws {
+    @Test func `Loading rogue valley`() async throws {
         // There are some indications that the data shape from RVTD is different from some other regions.
         // This test is meant to ensure that these different data sources work equally well.
 
@@ -166,7 +167,7 @@ class StopArrivalsModelOperationTests: OBATestCase {
 
         #expect(arrivals.arrivalsAndDepartures.count == 1)
 
-        let arrDep = try XCTUnwrap(arrivals.arrivalsAndDepartures.first)
+        let arrDep = try #require(arrivals.arrivalsAndDepartures.first)
         #expect(arrDep.arrivalEnabled)
         #expect(arrDep.blockTripSequence == 2)
         #expect(arrDep.departureEnabled)

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopProblemModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopProblemModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,7 +14,8 @@ import CoreLocation
 
 // swiftlint:disable force_cast
 
-class StopProblemModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class StopProblemModelOperationTests: OBATestCase {
     let stopID = "1_1234"
     let comment = "comment comment comment"
     let location = CLLocation(latitude: 47.1, longitude: -122.1)
@@ -26,7 +26,7 @@ class StopProblemModelOperationTests: OBATestCase {
         "userLon": "-122.1"
     ]
 
-    func testSuccessfulRequest() async throws {
+    @Test func `Successful request`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
         dataLoader.mock(data: Fixtures.loadData(file: "report_stop_problem.json")) { request -> Bool in

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopProblemModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopProblemModelOperationTests.swift
@@ -29,10 +29,13 @@ final class StopProblemModelOperationTests: OBATestCase {
     @Test func `Successful request`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
+        // Hoisted: the matcher is @Sendable, so it must not capture `self` — the
+        // suite is main-actor isolated and `expectedParams` with it.
+        let expectedParams = self.expectedParams
         dataLoader.mock(data: Fixtures.loadData(file: "report_stop_problem.json")) { request -> Bool in
             let url = request.url!
             return url.absoluteString.starts(with: "https://www.example.com/api/where/report-problem-with-stop/1_1234.json")
-            && url.containsQueryParams(self.expectedParams)
+            && url.containsQueryParams(expectedParams)
         }
 
         let report = RESTAPIService.StopProblemReport(stopID: stopID, code: .locationWrong, comment: comment, location: location)

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopsForRouteModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopsForRouteModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 import MapKit
@@ -16,10 +15,11 @@ import MapKit
 
 // swiftlint:disable force_cast
 
-class StopsForRouteModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class StopsForRouteModelOperationTests: OBATestCase {
     let routeID = "12345"
 
-    func testLoading_success() async throws {
+    @Test func `Loading success`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         dataLoader.mock(
             URLString: "https://www.example.com/api/where/stops-for-route/\(routeID).json",

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopsModelOperationTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
 import Testing
@@ -16,14 +15,16 @@ import Testing
 
 // swiftlint:disable force_cast
 
-class StopsModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class StopsModelOperationTests: OBATestCase {
     let coordinate = CLLocationCoordinate2D(latitude: 47.6230999, longitude: -122.3132122)
     let urlString = "https://www.example.com/api/where/stops-for-location.json"
 
     var dataLoader: MockDataLoader!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         dataLoader = (restService.dataLoader as! MockDataLoader)
     }
 
@@ -59,27 +60,27 @@ class StopsModelOperationTests: OBATestCase {
         #expect(stop.regionIdentifier == pugetSoundRegionIdentifier)
     }
 
-    func testLoading_coordinate_success() async throws {
+    @Test func `Loading coordinate success`() async throws {
         stubApiCall()
 
         self.checkExpectations(try await restService.getStops(coordinate: coordinate))
     }
 
-    func testLoading_region_success() async throws {
+    @Test func `Loading region success`() async throws {
         stubApiCall()
 
         let region = MKCoordinateRegion(center: self.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1))
         self.checkExpectations(try await restService.getStops(region: region))
     }
 
-    func testLoading_circularRegion_success() async throws {
+    @Test func `Loading circular region success`() async throws {
         stubApiCall()
 
         let circularRegion = CLCircularRegion(center: self.coordinate, radius: 100.0, identifier: "query")
         self.checkExpectations(try await restService.getStops(circularRegion: circularRegion, query: "query"))
     }
 
-    func testLoading_specificID_success() async throws {
+    @Test func `Loading specific ID success`() async throws {
         stubApiCall()
 
         let stop = try await restService.getStop(id: "1_29270").entry

--- a/OBAKitTests/Modeling/REST Model Service Tests/TripArrivalsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/TripArrivalsModelOperationTests.swift
@@ -7,20 +7,21 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast function_body_length
 
-class TripArrivalsModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class TripArrivalsModelOperationTests: OBATestCase {
     let stopID = "1_10914"
     lazy var apiPath = "https://www.example.com/api/where/arrival-and-departure-for-stop/\(stopID).json"
 
-    func testLoading_success() async throws {
+    @Test func `Loading success`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
         let data = Fixtures.loadData(file: "arrival-and-departure-for-stop-MTS_11589.json")
         dataLoader.mock(URLString: apiPath, with: data)
@@ -53,9 +54,9 @@ class TripArrivalsModelOperationTests: OBATestCase {
 
         #expect(arrDep.serviceAlerts.count == 1)
 
-        let situation = try XCTUnwrap(arrDep.serviceAlerts.first)
-        let situationSummary = try XCTUnwrap(situation.summary)
-        let firstConsequence = try XCTUnwrap(situation.consequences.first)
+        let situation = try #require(arrDep.serviceAlerts.first)
+        let situationSummary = try #require(situation.summary)
+        let firstConsequence = try #require(situation.consequences.first)
 
         #expect(situationSummary.value == "Washington St. ramp from Pac Hwy Closed")
         #expect(firstConsequence.condition == "detour")
@@ -76,7 +77,7 @@ class TripArrivalsModelOperationTests: OBATestCase {
         #expect(arrDep.trip.shortName == nil)
 
         #expect(arrDep.tripStatus != nil)
-        let tripStatus = try XCTUnwrap(arrDep.tripStatus)
+        let tripStatus = try #require(arrDep.tripStatus)
         #expect(tripStatus.activeTrip.id == "MTS_13405160")
 
         #expect(arrDep.vehicleID == "MTS_806")

--- a/OBAKitTests/Modeling/REST Model Service Tests/TripDetailsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/TripDetailsModelOperationTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,7 +15,8 @@ import CoreLocation
 
 // swiftlint:disable force_cast
 
-class TripDetailsModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class TripDetailsModelOperationTests: OBATestCase {
     let vehicleID = "1_1234"
     let tripID = "1_18196913"
     lazy var vehicleTripAPIPath = "https://www.example.com/api/where/trip-for-vehicle/\(vehicleID).json"
@@ -23,8 +24,9 @@ class TripDetailsModelOperationTests: OBATestCase {
 
     var dataLoader: MockDataLoader!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         dataLoader = (restService.dataLoader as! MockDataLoader)
     }
 
@@ -56,7 +58,7 @@ class TripDetailsModelOperationTests: OBATestCase {
         #expect(tripDetails.serviceAlerts.count == 0)
     }
 
-    func testLoading_vehicleDetails_success() async throws {
+    @Test func `Loading vehicle details success`() async throws {
         let data = Fixtures.loadData(file: "trip_details_1_18196913.json")
         dataLoader.mock(URLString: vehicleTripAPIPath, with: data)
 
@@ -64,7 +66,7 @@ class TripDetailsModelOperationTests: OBATestCase {
         self.checkExpectations(trip)
     }
 
-    func testLoading_tripDetails_success() async throws {
+    @Test func `Loading trip details success`() async throws {
         let data = Fixtures.loadData(file: "trip_details_1_18196913.json")
         dataLoader.mock(URLString: tripDetailsAPIPath, with: data)
 

--- a/OBAKitTests/Modeling/REST Model Service Tests/TripProblemModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/TripProblemModelOperationTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,7 +15,8 @@ import CoreLocation
 
 // swiftlint:disable force_cast
 
-class TripProblemModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class TripProblemModelOperationTests: OBATestCase {
     let tripID = "123456"
     let serviceDate = Date(timeIntervalSince1970: 101010101)
     let vehicleID = "987654321"
@@ -36,7 +37,7 @@ class TripProblemModelOperationTests: OBATestCase {
         "userLon": "-122.1"
     ]
 
-    func testSuccessfulRequest() async throws {
+    @Test func `Successful request`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
         dataLoader.mock(data: Fixtures.loadData(file: "report_trip_problem.json")) { request -> Bool in

--- a/OBAKitTests/Modeling/REST Model Service Tests/TripProblemModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/TripProblemModelOperationTests.swift
@@ -40,10 +40,13 @@ final class TripProblemModelOperationTests: OBATestCase {
     @Test func `Successful request`() async throws {
         let dataLoader = (restService.dataLoader as! MockDataLoader)
 
+        // Hoisted: the matcher is @Sendable, so it must not capture `self` — the
+        // suite is main-actor isolated and `expectedParams` with it.
+        let expectedParams = self.expectedParams
         dataLoader.mock(data: Fixtures.loadData(file: "report_trip_problem.json")) { request -> Bool in
             let url = request.url!
             return url.absoluteString.starts(with: "https://www.example.com/api/where/report-problem-with-trip.json")
-            && url.containsQueryParams(self.expectedParams)
+            && url.containsQueryParams(expectedParams)
         }
 
         let report = RESTAPIService.TripProblemReport(tripID: tripID, serviceDate: serviceDate, vehicleID: vehicleID, stopID: stopID, code: code, comment: comment, userOnVehicle: userOnVehicle, location: location)

--- a/OBAKitTests/Modeling/REST Model Service Tests/VehicleStatusModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/VehicleStatusModelOperationTests.swift
@@ -7,22 +7,23 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable function_body_length force_cast
 
-class VehicleStatusModelOperationTests: OBATestCase {
+@Suite(.serialized)
+final class VehicleStatusModelOperationTests: OBATestCase {
     let vehicleID = "1_4351"
     lazy var apiPath = "https://www.example.com/api/where/vehicle/\(vehicleID).json"
 
     var dataLoader: MockDataLoader!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         dataLoader = (restService.dataLoader as! MockDataLoader)
     }
@@ -43,25 +44,24 @@ class VehicleStatusModelOperationTests: OBATestCase {
 
     // MARK: - Vehicle Status
 
-    func testLoading_vehicleStatus_failure_garbageData() async throws {
+    @Test func `Loading vehicle status failure garbage data`() async throws {
         stubVehicle14351CaptivePortal()
 
-        // TODO: XCTAssertThrowsError does not support async. Make a XCTAssertThrowsAPIError helper method.
-        do {
+        // The do/catch this replaces carried a TODO asking for an
+        // XCTAssertThrowsAPIError helper, because XCTAssertThrowsError could not
+        // take an async expression. #expect(throws:) can, so the helper is moot.
+        // APIError isn't Equatable, so match the case rather than the value.
+        let thrown = await #expect(throws: APIError.self) {
             _ = try await restService.getVehicle(vehicleID: vehicleID)
-            XCTFail("Expected a captive portal response to throw an error.")
-        } catch(let error as APIError) {
-            if case APIError.captivePortal = error {
-                return // Success
-            } else {
-                XCTFail("Expected captive portal response to throw APIError.CaptivePortal. Actual value: \(error)")
-            }
-        } catch {
-            XCTFail("Expected captive portal response to throw an APIError. Actual value: \(error)")
+        }
+
+        guard case .captivePortal? = thrown else {
+            Issue.record("Expected APIError.captivePortal, got \(String(describing: thrown))")
+            return
         }
     }
 
-    func testLoading_vehicleStatus_success() async throws {
+    @Test func `Loading vehicle status success`() async throws {
         stubVehicle14351Success()
 
         let vehicle = try await restService.getVehicle(vehicleID: vehicleID).entry
@@ -75,7 +75,7 @@ class VehicleStatusModelOperationTests: OBATestCase {
 
     // MARK: - Trip Status
 
-    func testLoading_tripStatus_success() async throws {
+    @Test func `Loading trip status success`() async throws {
         stubVehicle14351Success()
 
         let vehicle = try await restService.getVehicle(vehicleID: vehicleID).entry
@@ -132,11 +132,11 @@ class VehicleStatusModelOperationTests: OBATestCase {
 
     // MARK: - References
 
-    func testLoading_references_success() async throws {
+    @Test func `Loading references success`() async throws {
         stubVehicle14351Success()
 
         let response = try await restService.getVehicle(vehicleID: vehicleID)
-        let references = try XCTUnwrap(response.references)
+        let references = try #require(response.references)
         #expect(references.agencies.count == 1)
         #expect(references.routes.count == 3)
         #expect(references.serviceAlerts.count == 1)
@@ -146,12 +146,12 @@ class VehicleStatusModelOperationTests: OBATestCase {
 
     // MARK: - Frequency
 
-    func testLoading_frequency_success() async throws {
+    @Test func `Loading frequency success`() async throws {
         let data = Fixtures.loadData(file: "frequency-vehicle.json")
         dataLoader.mock(URLString: "https://www.example.com/api/where/vehicle/\(vehicleID).json", with: data)
 
         let response = try await restService.getVehicle(vehicleID: vehicleID)
-        let frequency = try XCTUnwrap(response.entry.tripStatus.frequency)
+        let frequency = try #require(response.entry.tripStatus.frequency)
 
         #expect(frequency.startTime == Date.fromComponents(year: 2010, month: 11, day: 12, hour: 16, minute: 30, second: 00))
 

--- a/OBAKitTests/Modeling/Regions Model Service Tests/RegionsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/Regions Model Service Tests/RegionsModelOperationTests.swift
@@ -7,17 +7,18 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import MapKit
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable function_body_length force_cast
 
-class RegionsModelOperationTests: OBATestCase {
-    func testSuccessfulRequest() async throws {
+@Suite(.serialized)
+final class RegionsModelOperationTests: OBATestCase {
+    @Test func `Successful request`() async throws {
         let dataLoader = regionsAPIService.dataLoader as! MockDataLoader
         stubRegions(dataLoader: dataLoader)
 
@@ -26,7 +27,7 @@ class RegionsModelOperationTests: OBATestCase {
         let regions = response.list
         #expect(regions.count == 17)
 
-        let tampa = try XCTUnwrap(regions.first)
+        let tampa = try #require(regions.first)
 
         #expect(tampa.regionIdentifier == 0)
         #expect(tampa.name == "Tampa Bay")
@@ -57,7 +58,7 @@ class RegionsModelOperationTests: OBATestCase {
         #expect(tampa.paymentiOSAppStoreIdentifier == "1487465395")
         #expect(tampa.paymentiOSAppURLScheme == "fb313213768708402HART")
 
-        let open311 = try XCTUnwrap(tampa.open311Servers?.first)
+        let open311 = try #require(tampa.open311Servers?.first)
         #expect(open311.jurisdictionID == nil)
         #expect(open311.apiKey == "937033cad3054ec58a1a8156dcdd6ad8a416af2f")
         #expect(open311.baseURL == URL(string: "https://seeclickfix.com/open311/v2/")!)

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyExternalSurveyTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyExternalSurveyTests.swift
@@ -7,17 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKitCore
 
 /// Tests for `Survey.isExternalSurvey`, which keys off the hero question
 /// (the question at `position == 1`).
 @MainActor
-final class SurveyExternalSurveyTests: XCTestCase {
+@Suite(.serialized)
+final class SurveyExternalSurveyTests {
 
     // Positive: the hero question is an external survey.
-    func test_isExternalSurvey_whenHeroQuestionIsExternal_returnsTrue() {
+    @Test func `Is external survey when hero question is external returns true`() {
         let hero = SurveysTestHelpers.makeSurveyQuestion(
             position: 1,
             type: .externalSurvey,
@@ -29,7 +29,7 @@ final class SurveyExternalSurveyTests: XCTestCase {
     }
 
     // Negative: the hero question exists but is an in-app question type.
-    func test_isExternalSurvey_whenHeroQuestionIsNotExternal_returnsFalse() {
+    @Test func `Is external survey when hero question is not external returns false`() {
         let hero = SurveysTestHelpers.makeSurveyQuestion(
             position: 1,
             type: .radio,
@@ -45,7 +45,7 @@ final class SurveyExternalSurveyTests: XCTestCase {
     // non-empty list (with an external question at a non-hero position) locks
     // in the `position == 1` lookup that `isExternalSurvey` depends on, rather
     // than only exercising the empty-array path.
-    func test_isExternalSurvey_whenNoHeroQuestion_returnsFalse() {
+    @Test func `Is external survey when no hero question returns false`() {
         let nonHero = SurveysTestHelpers.makeSurveyQuestion(
             position: 2,
             type: .externalSurvey,

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceAppearanceTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceAppearanceTests.swift
@@ -7,30 +7,31 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class SurveyServiceAppearanceTests: OBATestCase {
 
     nonisolated(unsafe) private var testUserDefaults: UserDefaults!
     nonisolated(unsafe) private var store: UserDefaultsStore!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).appearance")
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).appearance")
         store = UserDefaultsStore(userDefaults: testUserDefaults)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).appearance")
-        try await super.tearDown()
     }
 
     // MARK: - visibleSurveys filtering (date activity) ----------------------
 
-    func test_fetch_mixedActiveAndExpired_visibleSurveysExcludesExpired() async {
+    @Test func `Fetch mixed active and expired visible surveys excludes expired`() async {
         let service = await fetchService([
             makeSurvey(id: 1),                                   // active
             makeSurvey(id: 2, startDate: hoursAgo(2), endDate: hoursAgo(1)), // expired
@@ -41,7 +42,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.visibleSurveys.map(\.id) == [1])
     }
 
-    func test_fetch_allInactive_visibleEmpty_andFindReturnsNil() async {
+    @Test func `Fetch all inactive visible empty and find returns nil`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, startDate: hoursAgo(2), endDate: hoursAgo(1)),
             makeSurvey(id: 2, showOnStops: true, startDate: hoursFromNow(1), endDate: hoursFromNow(2))
@@ -53,7 +54,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForStop(stopID: "STOP_A", routeIDs: ["R1"]) == nil)
     }
 
-    func test_fetch_surveyWithOpenEndedDates_isActive() async {
+    @Test func `Fetch survey with open ended dates is active`() async {
         // nil start + nil end => always within range.
         let service = await fetchService([makeSurvey(id: 1, startDate: nil, endDate: nil)])
         #expect(service.findSurveyForMap()?.id == 1)
@@ -61,21 +62,21 @@ final class SurveyServiceAppearanceTests: OBATestCase {
 
     // MARK: - Stop targeting matrix ----------------------------------------
 
-    func test_findSurveyForStop_nilStopList_nilRouteList_showsAtAnyStop() async {
+    @Test func `Find survey for stop nil stop list nil route list shows at any stop`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: nil, routesList: nil)
         ])
         #expect(service.findSurveyForStop(stopID: "ANY_STOP", routeIDs: []).map(\.id) == 1)
     }
 
-    func test_findSurveyForStop_stopInList_shows() async {
+    @Test func `Find survey for stop stop in list shows`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A", "STOP_B"])
         ])
         #expect(service.findSurveyForStop(stopID: "STOP_B", routeIDs: []).map(\.id) == 1)
     }
 
-    func test_findSurveyForStop_stopNotInList_routeMatches_shows() async {
+    @Test func `Find survey for stop stop not in list route matches shows`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: ["R9"])
         ])
@@ -83,14 +84,14 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: ["R9"]).map(\.id) == 1)
     }
 
-    func test_findSurveyForStop_stopNotInList_routeNotInList_returnsNil() async {
+    @Test func `Find survey for stop stop not in list route not in list returns nil`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: ["R9"])
         ])
         #expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: ["R1"]) == nil)
     }
 
-    func test_findSurveyForStop_showOnStopsFalse_returnsNil() async {
+    @Test func `Find survey for stop show on stops false returns nil`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnMap: true, showOnStops: false)
         ])
@@ -100,7 +101,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
     // An empty stop/route list means "no restriction" — identical to nil — so a
     // stops-enabled survey with both lists empty appears on every stop,
     // regardless of the stop's routes.
-    func test_findSurveyForStop_emptyStopAndRouteLists_showsAtAnyStop() async {
+    @Test func `Find survey for stop empty stop and route lists shows at any stop`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: [], routesList: [])
         ])
@@ -112,7 +113,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
     // route list) must NOT leak onto stops outside its list. A nil/empty route
     // list means "no route-based targeting" — it contributes nothing — not
     // "every route".
-    func test_findSurveyForStop_stopScoped_nilRouteList_doesNotLeakToUnlistedStop() async {
+    @Test func `Find survey for stop stop scoped nil route list does not leak to unlisted stop`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: ["STOP_A"], routesList: nil)
         ])
@@ -123,7 +124,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForStop(stopID: "STOP_Z", routeIDs: []) == nil)
     }
 
-    func test_findSurveyForStop_routeScoped_nilStopList_showsOnlyOnServedStops() async {
+    @Test func `Find survey for stop route scoped nil stop list shows only on served stops`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnStops: true, stopList: nil, routesList: ["R9"])
         ])
@@ -136,14 +137,14 @@ final class SurveyServiceAppearanceTests: OBATestCase {
 
     // MARK: - Map targeting -------------------------------------------------
 
-    func test_findSurveyForMap_showOnMapFalse_returnsNil() async {
+    @Test func `Find survey for map show on map false returns nil`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnMap: false, showOnStops: true)
         ])
         #expect(service.findSurveyForMap() == nil)
     }
 
-    func test_findSurveyForMap_skipsStopOnlySurvey_returnsMapSurvey() async {
+    @Test func `Find survey for map skips stop only survey returns map survey`() async {
         let service = await fetchService([
             makeSurvey(id: 1, showOnMap: false, showOnStops: true),
             makeSurvey(id: 2, showOnMap: true, showOnStops: false)
@@ -153,7 +154,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
 
     // MARK: - Empty-question gating ----------------------------------------
 
-    func test_findSurvey_skipsSurveyWithNoQuestions_returnsNextValidSurvey() async {
+    @Test func `Find survey skips survey with no questions returns next valid survey`() async {
         let service = await fetchService([
             makeSurvey(id: 1, questions: []),                  // no questions -> skipped
             makeSurvey(id: 2, questions: makeQuestions())      // valid
@@ -161,7 +162,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForMap()?.id == 2)
     }
 
-    func test_findSurvey_onlySurveyHasNoQuestions_returnsNil() async {
+    @Test func `Find survey only survey has no questions returns nil`() async {
         let service = await fetchService([makeSurvey(id: 1, questions: [])])
         #expect(service.findSurveyForMap() == nil)
     }
@@ -171,7 +172,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
     // Always-visible single-response surveys are documented as the highest
     // priority and are returned immediately — even when an incomplete one-time
     // survey appears earlier in the list. This pins that ordering contract.
-    func test_priority_alwaysVisibleSingle_beatsEarlierOneTime() async {
+    @Test func `Priority always visible single beats earlier one time`() async {
         let service = await fetchService([
             makeSurvey(id: 1),                          // one-time, incomplete (earlier)
             makeSurvey(id: 2, alwaysVisible: true)      // always-visible single (later)
@@ -179,7 +180,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForMap()?.id == 2)
     }
 
-    func test_priority_completedAlwaysVisibleSingle_fallsThroughToOneTime() async {
+    @Test func `Priority completed always visible single falls through to one time`() async {
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 2, userIdentifier: userID)
 
@@ -191,7 +192,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForMap()?.id == 1)
     }
 
-    func test_priority_oneTimeIncomplete_beatsAlwaysVisibleMulti() async {
+    @Test func `Priority one time incomplete beats always visible multi`() async {
         let service = await fetchService([
             makeSurvey(id: 1, multipleResponses: true, alwaysVisible: true), // lowest priority
             makeSurvey(id: 2)                                                 // one-time incomplete
@@ -201,7 +202,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
 
     // MARK: - Completion / dismissal ---------------------------------------
 
-    func test_dismissSurvey_hidesOneTimeSurvey() async {
+    @Test func `Dismiss survey hides one time survey`() async {
         let service = await fetchService([makeSurvey(id: 1)])
         #expect(service.findSurveyForMap()?.id == 1)
 
@@ -209,7 +210,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForMap() == nil)
     }
 
-    func test_markCompleted_hidesOneTime_butMultiResponseStillShows() async {
+    @Test func `Mark completed hides one time but multi response still shows`() async {
         let service = await fetchService([
             makeSurvey(id: 1, multipleResponses: true, alwaysVisible: true)
         ])
@@ -221,7 +222,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
     // `markSurveyForLater` is self-contained: it defers the survey at the
     // `findSurvey` level (no dependency on the global reminder gate). The
     // deferred survey is hidden until it is due to reappear.
-    func test_markSurveyForLater_hidesSurveyUntilDue() async {
+    @Test func `Mark survey for later hides survey until due`() async {
         let service = await fetchService([makeSurvey(id: 1)])
         #expect(service.findSurveyForMap()?.id == 1)
 
@@ -233,7 +234,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
         #expect(service.findSurveyForMap() == nil)
     }
 
-    func test_markSurveyForLater_reappearsAfterThreeLaunches() async {
+    @Test func `Mark survey for later reappears after three launches`() async {
         let service = await fetchService([makeSurvey(id: 1)])
         service.markSurveyForLater(service.allSurveys[0])
         #expect(service.findSurveyForMap() == nil)
@@ -246,7 +247,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
 
     // MARK: - Fetch state ---------------------------------------------------
 
-    func test_fetchSurveys_successAfterFailure_clearsLastError() async {
+    @Test func `Fetch surveys success after failure clears last error`() async {
         let userID = store.surveyUserIdentifier
         let mockLoader = MockDataLoader(testName: name)
 
@@ -278,7 +279,7 @@ final class SurveyServiceAppearanceTests: OBATestCase {
     // subsequent `fetchSurveys()` hits the network again. Pinned as behavior:
     // a non-forced re-fetch after an empty response *does* run and can pick up
     // newly-published surveys immediately (no 5-minute wait).
-    func test_fetchSurveys_emptyResponse_doesNotEngageCooldown_characterization() async {
+    @Test func `Fetch surveys empty response does not engage cooldown characterization`() async {
         let userID = store.surveyUserIdentifier
         let mockLoader = MockDataLoader(testName: name)
         let urlString = "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=\(userID)"

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceExternalURLTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceExternalURLTests.swift
@@ -3,10 +3,11 @@
 //  OBAKitTests
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class SurveyServiceExternalURLTests: OBATestCase {
 
     nonisolated(unsafe) private var testUserDefaults: UserDefaults!
@@ -14,8 +15,9 @@ final class SurveyServiceExternalURLTests: OBATestCase {
     nonisolated(unsafe) private var context: MockSurveyURLApplicationContext!
     nonisolated(unsafe) private var service: SurveyService!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).exturl")
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).exturl")
         store = UserDefaultsStore(userDefaults: testUserDefaults)
@@ -24,12 +26,11 @@ final class SurveyServiceExternalURLTests: OBATestCase {
         service = SurveyService(apiService: nil, userDataStore: store, application: context)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).exturl")
-        try await super.tearDown()
     }
 
-    func test_externalSurveyURL_wiresBuilder_appendingUserIDAndRegion() {
+    @Test func `External survey URL wires builder appending user ID and region`() {
         context.currentRegionIdentifier = 7
         let survey = SurveysTestHelpers.makeSurvey(questions: [
             SurveysTestHelpers.makeSurveyQuestion(url: "https://oba.co/s", embeddedDataFields: ["user_id", "region_id"])
@@ -44,7 +45,7 @@ final class SurveyServiceExternalURLTests: OBATestCase {
         #expect(items.first { $0.name == "region_id" }?.value == "7")
     }
 
-    func test_externalSurveyURL_buildsWithoutContext_omittingOnlyContextFields() {
+    @Test func `External survey URL builds without context omitting only context fields`() {
         // No application context: the URL still builds, but the context-dependent
         // embedded fields (region_id, current_location) are omitted while
         // non-context fields (user_id) are still appended.

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServicePrioritizationTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServicePrioritizationTests.swift
@@ -5,27 +5,28 @@
 //  Created by Mohamed Sliem on 06/12/2025.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class SurveyServicePrioritizationTests: OBATestCase {
 
     nonisolated(unsafe) private var surveyService: SurveyService!
     nonisolated(unsafe) private var testUserDefaults: UserDefaults!
     nonisolated(unsafe) private var testUserDataStore: UserDefaultsStore!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).prioritization")
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).prioritization")
         testUserDataStore = UserDefaultsStore(userDefaults: testUserDefaults)
         surveyService = SurveyService(apiService: nil, userDataStore: testUserDataStore)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).prioritization")
-        try await super.tearDown()
     }
 
     // MARK: - Helpers
@@ -69,13 +70,13 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Empty/No Questions
 
-    func test_findSurveyForMap_whenEmpty_returnsNil() async {
+    @Test func `Find survey for map when empty returns nil`() async {
         let service = await fetchAndReturnService(surveys: [])
         let result = service.findSurveyForMap()
         #expect(result == nil)
     }
 
-    func test_findSurveyForStop_whenNoQuestions_returnsNil() async {
+    @Test func `Find survey for stop when no questions returns nil`() async {
         let surveys = [
             makeSurvey(id: 0, showOnStops: false),
             makeSurvey(id: 1, showOnMap: false),
@@ -87,7 +88,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Map Context
 
-    func test_findSurveyForMap_returnsMapVisibleSurvey() async {
+    @Test func `Find survey for map returns map visible survey`() async {
         let surveys = [
             makeSurvey(id: 0, showOnStops: false),
             makeSurvey(id: 1, showOnMap: false),
@@ -98,7 +99,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 2)
     }
 
-    func test_findSurveyForMap_returnsFirstVisible() async {
+    @Test func `Find survey for map returns first visible`() async {
         let surveys = [
             makeSurvey(id: 0, showOnStops: false, questions: makeQuestions(count: 5)),
             makeSurvey(id: 1, showOnMap: false, questions: makeQuestions(count: 4)),
@@ -109,7 +110,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 0)
     }
 
-    func test_findSurveyForMap_whenNoMapVisible_returnsNil() async {
+    @Test func `Find survey for map when no map visible returns nil`() async {
         let surveys = [
             makeSurvey(id: 0, showOnMap: false, questions: makeQuestions()),
             makeSurvey(id: 1, showOnMap: false, questions: makeQuestions()),
@@ -121,7 +122,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Stop Context
 
-    func test_findSurveyForStop_returnsStopVisibleSurvey() async {
+    @Test func `Find survey for stop returns stop visible survey`() async {
         let surveys = [
             makeSurvey(id: 0, showOnStops: false, questions: makeQuestions()),
             makeSurvey(id: 1, questions: makeQuestions()),
@@ -131,7 +132,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 1)
     }
 
-    func test_findSurveyForStop_matchesStopInList() async {
+    @Test func `Find survey for stop matches stop in list`() async {
         let surveys = [
             makeSurvey(id: 0, stopList: ["STOP_A", "STOP_B"], questions: makeQuestions()),
             makeSurvey(id: 1, stopList: ["STOP_C"], questions: makeQuestions()),
@@ -141,7 +142,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 1)
     }
 
-    func test_findSurveyForStop_matchesRouteID() async {
+    @Test func `Find survey for stop matches route ID`() async {
         let surveys = [
             makeSurvey(id: 0, stopList: ["STOP_X"], routesList: ["1_300"], questions: makeQuestions()),
             makeSurvey(id: 1, stopList: ["STOP_X"], routesList: ["1_309"], questions: makeQuestions()),
@@ -151,7 +152,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 1)
     }
 
-    func test_findSurveyForStop_noMatch_returnsNil() async {
+    @Test func `Find survey for stop no match returns nil`() async {
         let surveys = [
             makeSurvey(id: 0, stopList: ["STOP_A"], routesList: ["1_300"], questions: makeQuestions()),
         ]
@@ -162,7 +163,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Priority: Always Visible
 
-    func test_alwaysVisible_notCompleted_returnedImmediately() async {
+    @Test func `Always visible not completed returned immediately`() async {
         let store = UserDefaultsStore(userDefaults: testUserDefaults)
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 0, userIdentifier: userID)
@@ -177,7 +178,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 1)
     }
 
-    func test_alwaysVisible_allCompleted_returnsNil() async {
+    @Test func `Always visible all completed returns nil`() async {
         let store = UserDefaultsStore(userDefaults: testUserDefaults)
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 0, userIdentifier: userID)
@@ -194,7 +195,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Priority: Multiple Responses
 
-    func test_multipleResponses_returnsEvenWhenCompleted() async {
+    @Test func `Multiple responses returns even when completed`() async {
         let store = UserDefaultsStore(userDefaults: testUserDefaults)
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 0, userIdentifier: userID)
@@ -211,7 +212,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Priority: One-Time Incomplete
 
-    func test_oneTimeIncomplete_prioritizedOverMultipleResponses() async {
+    @Test func `One time incomplete prioritized over multiple responses`() async {
         let surveys = [
             makeSurvey(id: 0, multipleResponses: true, alwaysVisible: true, questions: makeQuestions()),
             makeSurvey(id: 1, questions: makeQuestions()),
@@ -222,7 +223,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result?.id == 1)
     }
 
-    func test_allCompleted_regularSurveys_returnsNil() async {
+    @Test func `All completed regular surveys returns nil`() async {
         let store = UserDefaultsStore(userDefaults: testUserDefaults)
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 0, userIdentifier: userID)
@@ -239,7 +240,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Issue 1: Expired surveys should not be returned
 
-    func test_findSurveyForStop_expiredSurvey_returnsNil() async {
+    @Test func `Find survey for stop expired survey returns nil`() async {
         let surveys = [
             makeSurvey(
                 id: 0,
@@ -255,7 +256,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
         #expect(result == nil)
     }
 
-    func test_findSurveyForMap_expiredSurvey_returnsNil() async {
+    @Test func `Find survey for map expired survey returns nil`() async {
         let surveys = [
             makeSurvey(
                 id: 0,
@@ -272,7 +273,7 @@ final class SurveyServicePrioritizationTests: OBATestCase {
 
     // MARK: - Mark For Later
 
-    func test_markedForLater_showsAgainAtCorrectLaunchCount() async {
+    @Test func `Marked for later shows again at correct launch count`() async {
         let store = UserDefaultsStore(userDefaults: testUserDefaults)
         let userID = store.surveyUserIdentifier
         store.markSurveyCompleted(surveyId: 0, userIdentifier: userID)

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceStateTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceStateTests.swift
@@ -5,32 +5,33 @@
 //  Created by Mohamed Sliem on 13/12/2025.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class SurveyServiceStateTests: OBATestCase {
 
     nonisolated(unsafe) private var surveyService: SurveyService!
     nonisolated(unsafe) private var testUserDefaults: UserDefaults!
     nonisolated(unsafe) private var testUserDataStore: UserDefaultsStore!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).state")
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).state")
         testUserDataStore = UserDefaultsStore(userDefaults: testUserDefaults)
         surveyService = SurveyService(apiService: nil, userDataStore: testUserDataStore)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).state")
-        try await super.tearDown()
     }
 
     // MARK: - shouldShowSurvey
 
-    func test_shouldShowSurvey_returnsFalse_whenFeatureDisabled() {
+    @Test func `Should show survey returns false when feature disabled`() {
         testUserDataStore.isSurveyEnabled = false
         // Even with correct launch count, disabled means no survey
         setAppLaunchCount(3)
@@ -39,7 +40,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(!result)
     }
 
-    func test_shouldShowSurvey_returnsFalse_whenAppLaunchIsZero() {
+    @Test func `Should show survey returns false when app launch is zero`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(0)
 
@@ -47,7 +48,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(!result)
     }
 
-    func test_shouldShowSurvey_returnsFalse_whenLaunchCountNotMultipleOfThree() {
+    @Test func `Should show survey returns false when launch count not multiple of three`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(4)
 
@@ -55,7 +56,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(!result)
     }
 
-    func test_shouldShowSurvey_returnsTrue_whenLaunchCountIsMultipleOfThree() {
+    @Test func `Should show survey returns true when launch count is multiple of three`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(6)
 
@@ -63,7 +64,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(result)
     }
 
-    func test_shouldShowSurvey_returnsFalse_whenNextReminderDateIsInFuture() {
+    @Test func `Should show survey returns false when next reminder date is in future`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(6)
         testUserDataStore.nextSurveyReminderDate = Date().addingTimeInterval(3600)
@@ -72,7 +73,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(!result)
     }
 
-    func test_shouldShowSurvey_returnsTrue_whenNextReminderDateIsInPast() {
+    @Test func `Should show survey returns true when next reminder date is in past`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(6)
         testUserDataStore.nextSurveyReminderDate = Date().addingTimeInterval(-300)
@@ -81,7 +82,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(result)
     }
 
-    func test_shouldShowSurvey_returnsTrue_whenReminderDateIsNil() {
+    @Test func `Should show survey returns true when reminder date is nil`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(6)
         testUserDataStore.nextSurveyReminderDate = nil
@@ -92,7 +93,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - Issue 9: alwaysShowSurveysOnStops should not bypass isSurveyEnabled
 
-    func test_shouldShowSurvey_returnsFalse_whenDisabled_evenIfAlwaysShowIsOn() {
+    @Test func `Should show survey returns false when disabled even if always show is on`() {
         testUserDataStore.isSurveyEnabled = false
         testUserDataStore.alwaysShowSurveysOnStops = true
         setAppLaunchCount(3)
@@ -101,7 +102,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(!result)
     }
 
-    func test_shouldShowSurvey_returnsTrue_whenEnabledAndAlwaysShowIsOn() {
+    @Test func `Should show survey returns true when enabled and always show is on`() {
         testUserDataStore.isSurveyEnabled = true
         testUserDataStore.alwaysShowSurveysOnStops = true
         // Launch count 1 — NOT a multiple of 3, but alwaysShow should bypass that
@@ -113,7 +114,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - setNextReminderDate
 
-    func test_setNextReminderDate_setsDateThreeDaysAhead() {
+    @Test func `Set next reminder date sets date three days ahead`() {
         let now = Date()
 
         surveyService.setNextReminderDate()
@@ -125,7 +126,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(diff == 3)
     }
 
-    func test_setNextReminderDate_overwritesExistingDate() {
+    @Test func `Set next reminder date overwrites existing date`() {
         testUserDataStore.nextSurveyReminderDate = Date().addingTimeInterval(-50)
 
         surveyService.setNextReminderDate()
@@ -139,7 +140,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - markSurveyCompleted
 
-    func test_markSurveyCompleted_tracksSurvey() {
+    @Test func `Mark survey completed tracks survey`() {
         let survey = makeSurvey(id: 7)
         surveyService.markSurveyCompleted(survey)
 
@@ -149,7 +150,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - markSurveyForLater
 
-    func test_markSurveyForLater_tracksSurvey() {
+    @Test func `Mark survey for later tracks survey`() {
         let survey = makeSurvey(id: 9)
         surveyService.markSurveyForLater(survey)
 
@@ -160,14 +161,14 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - Combined Behavior
 
-    func test_shouldShowSurvey_minimumValidCase() {
+    @Test func `Should show survey minimum valid case`() {
         testUserDataStore.isSurveyEnabled = true
         setAppLaunchCount(3)
 
         #expect(self.surveyService.shouldShowSurvey())
     }
 
-    func test_shouldShowSurvey_whenLaunchIsThirdButFeatureDisabled_returnsFalse() {
+    @Test func `Should show survey when launch is third but feature disabled returns false`() {
         testUserDataStore.isSurveyEnabled = false
         setAppLaunchCount(3)
 
@@ -176,24 +177,24 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - formatCheckboxAnswer
 
-    func test_formatCheckboxAnswer_normalCase() throws {
+    @Test func `Format checkbox answer normal case`() throws {
         let result = try SurveyService.formatCheckboxAnswer(["Option A", "Option B"])
         #expect(result == "[\"Option A\",\"Option B\"]")
     }
 
-    func test_formatCheckboxAnswer_emptyArray() throws {
+    @Test func `Format checkbox answer empty array`() throws {
         let result = try SurveyService.formatCheckboxAnswer([])
         #expect(result == "[]")
     }
 
-    func test_formatCheckboxAnswer_singleItem() throws {
+    @Test func `Format checkbox answer single item`() throws {
         let result = try SurveyService.formatCheckboxAnswer(["Only"])
         #expect(result == "[\"Only\"]")
     }
 
     // MARK: - createQuestionResponse
 
-    func test_createQuestionResponse_returnsCorrectFields() {
+    @Test func `Create question response returns correct fields`() {
         let question = SurveyQuestion(
             id: 42,
             position: 1,
@@ -209,7 +210,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(response.answer == "Great")
     }
 
-    func test_createQuestionResponse_radioType() {
+    @Test func `Create question response radio type`() {
         let question = SurveyQuestion(
             id: 10,
             position: 2,
@@ -225,7 +226,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - Submit methods with nil apiService
 
-    func test_submitHeroQuestion_nilApiService_throws() async {
+    @Test func `Submit hero question nil api service throws`() async {
         let survey = makeSurvey(id: 1, questions: makeQuestions())
         let response = SurveyService.createQuestionResponse(
             question: survey.questions[0],
@@ -247,7 +248,7 @@ final class SurveyServiceStateTests: OBATestCase {
         }
     }
 
-    func test_submitAdditionalQuestions_nilApiService_throws() async {
+    @Test func `Submit additional questions nil api service throws`() async {
         let thrown = await #expect(throws: APIError.self) {
             _ = try await self.surveyService.submitAdditionalQuestions(
                 responseID: "some-id",
@@ -262,7 +263,7 @@ final class SurveyServiceStateTests: OBATestCase {
 
     // MARK: - visibleSurveys re-filter on state changes
 
-    func test_markSurveyCompleted_updatesVisibleSurveys() async {
+    @Test func `Mark survey completed updates visible surveys`() async {
         let service = await buildServiceWithLoadedSurveys()
         let initialVisible = service.visibleSurveys.count
 
@@ -276,7 +277,7 @@ final class SurveyServiceStateTests: OBATestCase {
         #expect(service.visibleSurveys.count == initialVisible)
     }
 
-    func test_markSurveyForLater_updatesVisibleSurveys() async {
+    @Test func `Mark survey for later updates visible surveys`() async {
         let service = await buildServiceWithLoadedSurveys()
         let initialVisible = service.visibleSurveys.count
 

--- a/OBAKitTests/Modeling/Surveys Tests/SurveyServiceTests.swift
+++ b/OBAKitTests/Modeling/Surveys Tests/SurveyServiceTests.swift
@@ -5,10 +5,11 @@
 //  Created by Mohamed Sliem on 04/12/2025.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Helpers
@@ -16,8 +17,9 @@ final class SurveyServiceTests: OBATestCase {
     private var mockDataLoader: MockDataLoader!
     private var testRESTService: RESTAPIService!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         mockDataLoader = MockDataLoader(testName: name)
         let config = APIServiceConfiguration(
             baseURL: baseURL,
@@ -42,7 +44,7 @@ final class SurveyServiceTests: OBATestCase {
         return try await testRESTService.getSurveys(userID: uuid)
     }
 
-    func test_getSurveys_success_metadata() async throws {
+    @Test func `Get surveys success metadata`() async throws {
         let response = try await loadSurveys()
 
         #expect(response.region.name == "Puget Sound")
@@ -51,7 +53,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(response.surveys.count == 5)
     }
 
-    func test_firstSurvey_basicProperties() async throws {
+    @Test func `First survey basic properties`() async throws {
         let response = try await loadSurveys()
         let survey = response.surveys.first
 
@@ -69,7 +71,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(survey?.questions.count == 5)
     }
 
-    func test_firstSurvey_questionDecoding() async throws {
+    @Test func `First survey question decoding`() async throws {
         let response = try await loadSurveys()
         let survey = response.surveys.first!
 
@@ -98,7 +100,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(q4.content.surveyProvider == "google_forms")
     }
 
-    func test_firstSurvey_getQuestions_filtersCorrectly() async throws {
+    @Test func `First survey get questions filters correctly`() async throws {
         let response = try await loadSurveys()
         let survey = response.surveys.first!
 
@@ -112,7 +114,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Survey Hero Question Submission
 
-    func test_submitSurvey_first_question() async throws {
+    @Test func `Submit survey first question`() async throws {
         setupMockSubmissionSuccess()
 
         let submissionModel = makeFirstQuestionSubmissionModel()
@@ -149,7 +151,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Submit Additional Questions
 
-    func test_submitSurvey_additional_questions() async throws {
+    @Test func `Submit survey additional questions`() async throws {
         setupMockSubmissionSuccess("surveyResponseId")
 
         let additionalResponses: [QuestionAnswerSubmission] = [
@@ -170,7 +172,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Error Scenarios
 
-    func test_get_surveys_captive_portal() async throws {
+    @Test func `Get surveys captive portal`() async throws {
         let data = Fixtures.loadData(file: "captive_portal.html")
         let url = URL(string: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=12345-12345-12345-12345-12345")!
         let error = NSError(domain: NSCocoaErrorDomain, code: 3840, userInfo: nil)
@@ -181,11 +183,12 @@ final class SurveyServiceTests: OBATestCase {
             try await self.testRESTService.getSurveys(userID: self.uuid)
         }
         guard case .captivePortal = thrown else {
-            return XCTFail("Expected APIError.captivePortal, got \(String(describing: thrown))")
+            Issue.record("Expected APIError.captivePortal, got \(String(describing: thrown))")
+            return
         }
     }
 
-    func test_get_surveys_malformed_response_data() async throws {
+    @Test func `Get surveys malformed response data`() async throws {
         let malformedJsonResponse = Fixtures.loadData(file: "surveys_malformed_response.json")
         let url = URL(string: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=12345-12345-12345-12345-12345")!
 
@@ -203,7 +206,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_get_surveys_internal_server_error() async throws {
+    @Test func `Get surveys internal server error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=12345-12345-12345-12345-12345")!
 
@@ -218,7 +221,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_get_surveys_not_found_error() async throws {
+    @Test func `Get surveys not found error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/regions/1/surveys.json?user_id=12345-12345-12345-12345-12345")!
 
@@ -235,7 +238,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Submit First Question Failures
 
-    func test_submit_first_question_malformed_response_data() async throws {
+    @Test func `Submit first question malformed response data`() async throws {
         let response = Fixtures.loadData(file: "survey_submission_malformed_response.json")
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/")!
 
@@ -254,7 +257,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_first_question_captive_portal() async throws {
+    @Test func `Submit first question captive portal`() async throws {
         let data = Fixtures.loadData(file: "captive_portal.html")
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/")!
         let error = NSError(domain: NSCocoaErrorDomain, code: 3840, userInfo: nil)
@@ -271,7 +274,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_first_question_internal_server_error() async throws {
+    @Test func `Submit first question internal server error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/")!
 
@@ -287,7 +290,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_first_question_not_found_error() async throws {
+    @Test func `Submit first question not found error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/")!
 
@@ -305,7 +308,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Submit Additional Question Failures
 
-    func test_submit_additional_question_malformed_response_data() async throws {
+    @Test func `Submit additional question malformed response data`() async throws {
         let response = Fixtures.loadData(file: "survey_submission_malformed_response.json")
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/surveyResponseId")!
 
@@ -326,7 +329,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_additional_question_captive_portal() async throws {
+    @Test func `Submit additional question captive portal`() async throws {
         let data = Fixtures.loadData(file: "captive_portal.html")
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/surveyResponseId")!
         let error = NSError(domain: NSCocoaErrorDomain, code: 3840, userInfo: nil)
@@ -345,7 +348,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_additional_question_internal_server_error() async throws {
+    @Test func `Submit additional question internal server error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/surveyResponseId")!
 
@@ -363,7 +366,7 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    func test_submit_additional_question_not_found_error() async throws {
+    @Test func `Submit additional question not found error`() async throws {
         let response = Data()
         let url = URL(string: "https://onebusaway.co/api/v1/survey_responses/surveyResponseId")!
 
@@ -383,7 +386,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - isActive
 
-    func test_isActive_withinDateRange_returnsTrue() {
+    @Test func `Is active within date range returns true`() {
         let survey = makeSurveyForIsActive(
             startDate: Date().addingTimeInterval(-3600),
             endDate: Date().addingTimeInterval(3600)
@@ -391,7 +394,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(survey.isActive)
     }
 
-    func test_isActive_pastEndDate_returnsFalse() {
+    @Test func `Is active past end date returns false`() {
         let survey = makeSurveyForIsActive(
             startDate: Date().addingTimeInterval(-7200),
             endDate: Date().addingTimeInterval(-3600)
@@ -399,7 +402,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(!survey.isActive)
     }
 
-    func test_isActive_futureStartDate_returnsFalse() {
+    @Test func `Is active future start date returns false`() {
         let survey = makeSurveyForIsActive(
             startDate: Date().addingTimeInterval(3600),
             endDate: Date().addingTimeInterval(7200)
@@ -407,7 +410,7 @@ final class SurveyServiceTests: OBATestCase {
         #expect(!survey.isActive)
     }
 
-    func test_isActive_nilDates_returnsTrue() {
+    @Test func `Is active nil dates returns true`() {
         let survey = makeSurveyForIsActive(startDate: nil, endDate: nil)
         #expect(survey.isActive)
     }
@@ -426,7 +429,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Issue 8: SurveySubmission encodes responses as JSON string
 
-    func test_surveySubmission_encodesResponsesToJSONString() throws {
+    @Test func `Survey submission encodes responses to JSON string`() throws {
         let submission = SurveySubmission(
             userIdentifier: "user-1",
             surveyId: 42,
@@ -456,7 +459,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Missing Optional Fields
 
-    func test_getSurveys_missingOptionalBooleans_defaultsToFalse() async throws {
+    @Test func `Get surveys missing optional booleans defaults to false`() async throws {
         let data = Fixtures.loadData(file: "surveys_missing_optional_fields.json")
 
         mockDataLoader.mock(
@@ -473,7 +476,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - getSurveys nil region
 
-    func test_getSurveys_nilRegionIdentifier_throwsNoRegionSelected() async {
+    @Test func `Get surveys nil region identifier throws no region selected`() async {
         let config = APIServiceConfiguration(
             baseURL: baseURL,
             apiKey: apiKey,
@@ -495,7 +498,7 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - remainingQuestions
 
-    func test_remainingQuestions_doesNotDropQuestionsWithSamePositionAsHero() {
+    @Test func `Remaining questions does not drop questions with same position as hero`() {
         let q1 = SurveyQuestion(id: 10, position: 1, required: true, content: QuestionContent(labelText: "Hero", type: .text))
         let q2 = SurveyQuestion(id: 20, position: 1, required: false, content: QuestionContent(labelText: "Also position 1", type: .label))
         let q3 = SurveyQuestion(id: 30, position: 2, required: false, content: QuestionContent(labelText: "Position 2", type: .radio, options: ["A", "B"]))
@@ -516,22 +519,22 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - heroQuestionTitle
 
-    func test_heroQuestionTitle_returnsTrimmedHeroText() {
+    @Test func `Hero question title returns trimmed hero text`() {
         let survey = makeSurveyWithHero(labelText: "  Help us improve transit  ")
         #expect(survey.heroQuestionTitle == "Help us improve transit")
     }
 
-    func test_heroQuestionTitle_nilWhenHeroTextIsEmpty() {
+    @Test func `Hero question title nil when hero text is empty`() {
         let survey = makeSurveyWithHero(labelText: "")
         #expect(survey.heroQuestionTitle == nil)
     }
 
-    func test_heroQuestionTitle_nilWhenHeroTextIsWhitespaceOnly() {
+    @Test func `Hero question title nil when hero text is whitespace only`() {
         let survey = makeSurveyWithHero(labelText: "   \n\t ")
         #expect(survey.heroQuestionTitle == nil)
     }
 
-    func test_heroQuestionTitle_nilWhenNoHeroQuestion() {
+    @Test func `Hero question title nil when no hero question`() {
         // Only a non-hero (position != 1) question exists.
         let survey = makeSurveyWithHero(labelText: "Question", position: 2)
         #expect(survey.heroQuestionTitle == nil)
@@ -562,8 +565,8 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - SurveyService.fetchSurveys()
 
-    @MainActor
-    func test_fetchSurveys_nilApiService_setsError() async {
+    @Test @MainActor
+    func `Fetch surveys nil api service sets error`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let service = SurveyService(apiService: nil, userDataStore: store)
 
@@ -580,8 +583,8 @@ final class SurveyServiceTests: OBATestCase {
         }
     }
 
-    @MainActor
-    func test_fetchSurveys_success_populatesSurveys() async {
+    @Test @MainActor
+    func `Fetch surveys success populates surveys`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let data = Fixtures.loadData(file: "surveys_always_visible_one_time.json")
         let userID = store.surveyUserIdentifier
@@ -600,8 +603,8 @@ final class SurveyServiceTests: OBATestCase {
         #expect(!service.isLoading)
     }
 
-    @MainActor
-    func test_fetchSurveys_failure_clearsWhenEmpty() async {
+    @Test @MainActor
+    func `Fetch surveys failure clears when empty`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let userID = store.surveyUserIdentifier
 
@@ -619,8 +622,8 @@ final class SurveyServiceTests: OBATestCase {
 
     // MARK: - Staleness / Cooldown Tests
 
-    @MainActor
-    func test_fetchSurveys_cooldownSkipsSecondFetch() async {
+    @Test @MainActor
+    func `Fetch surveys cooldown skips second fetch`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let userID = store.surveyUserIdentifier
 
@@ -648,8 +651,8 @@ final class SurveyServiceTests: OBATestCase {
         #expect(service.lastError == nil)  // no error because fetch was skipped
     }
 
-    @MainActor
-    func test_fetchSurveys_forceBypassesCooldown() async {
+    @Test @MainActor
+    func `Fetch surveys force bypasses cooldown`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let userID = store.surveyUserIdentifier
 
@@ -673,8 +676,8 @@ final class SurveyServiceTests: OBATestCase {
         #expect(service.lastError == nil)
     }
 
-    @MainActor
-    func test_fetchSurveys_emptySurveysBypassesCooldown() async {
+    @Test @MainActor
+    func `Fetch surveys empty surveys bypasses cooldown`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let userID = store.surveyUserIdentifier
 
@@ -703,8 +706,8 @@ final class SurveyServiceTests: OBATestCase {
         #expect(service.lastError == nil)
     }
 
-    @MainActor
-    func test_fetchSurveys_failure_preservesExistingSurveys() async {
+    @Test @MainActor
+    func `Fetch surveys failure preserves existing surveys`() async {
         let store = UserDefaultsStore(userDefaults: userDefaults)
         let userID = store.surveyUserIdentifier
 

--- a/OBAKitTests/Modeling/UserData/ArrivalDepartureDeepLinkTests.swift
+++ b/OBAKitTests/Modeling/UserData/ArrivalDepartureDeepLinkTests.swift
@@ -8,18 +8,18 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ArrivalDepartureDeepLinkTests: OBATestCase {
+@Suite(.serialized)
+final class ArrivalDepartureDeepLinkTests: OBATestCase {
 
     // MARK: - Codable Round-Trip
 
-    func test_roundTripping_success() {
+    @Test func `Round tripping success`() {
         let deepLink1 = ArrivalDepartureDeepLink(title: "Title", regionID: 1, stopID: "1234", tripID: "9876", serviceDate: Date(timeIntervalSinceReferenceDate: 0), stopSequence: 7, vehicleID: "3456")
         let deepLink2 = try! Fixtures.roundtripCodable(type: ArrivalDepartureDeepLink.self, model: deepLink1)
 
@@ -34,7 +34,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
         #expect(deepLink2.vehicleID == deepLink1.vehicleID)
     }
 
-    func test_roundTripping_withDestinationStopID() {
+    @Test func `Round tripping with destination stop ID`() {
         let deepLink1 = ArrivalDepartureDeepLink(
             title: "Route 550 - Bellevue",
             regionID: 1,
@@ -58,7 +58,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
         #expect(deepLink2.vehicleID == "1_v100")
     }
 
-    func test_roundTripping_withoutDestinationStopID_isNil() {
+    @Test func `Round tripping without destination stop ID is nil`() {
         let deepLink1 = ArrivalDepartureDeepLink(
             title: "Route 545",
             regionID: 2,
@@ -77,7 +77,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
 
     // MARK: - Equality
 
-    func test_isEqual_matchingDestinationStopID() {
+    @Test func `Is equal matching destination stop ID`() {
         let link1 = ArrivalDepartureDeepLink(
             title: "10", regionID: 1, stopID: "A", tripID: "T",
             serviceDate: Date(timeIntervalSince1970: 1_500_000_000),
@@ -91,7 +91,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
         #expect(link1.isEqual(link2) == true)
     }
 
-    func test_isEqual_differentDestinationStopID() {
+    @Test func `Is equal different destination stop ID`() {
         let link1 = ArrivalDepartureDeepLink(
             title: "10", regionID: 1, stopID: "A", tripID: "T",
             serviceDate: Date(timeIntervalSince1970: 1_500_000_000),
@@ -105,7 +105,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
         #expect(link1.isEqual(link2) == false)
     }
 
-    func test_isEqual_nilVsNonNilDestinationStopID() {
+    @Test func `Is equal nil vs non nil destination stop ID`() {
         let link1 = ArrivalDepartureDeepLink(
             title: "10", regionID: 1, stopID: "A", tripID: "T",
             serviceDate: Date(timeIntervalSince1970: 1_500_000_000),
@@ -121,7 +121,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
 
     // MARK: - Hashing
 
-    func test_hash_includesDestinationStopID() {
+    @Test func `Hash includes destination stop ID`() {
         let link1 = ArrivalDepartureDeepLink(
             title: "10", regionID: 1, stopID: "A", tripID: "T",
             serviceDate: Date(timeIntervalSince1970: 1_500_000_000),
@@ -135,7 +135,7 @@ class ArrivalDepartureDeepLinkTests: OBATestCase {
         #expect(link1.hash != link2.hash)
     }
 
-    func test_hash_nilDestinationStopID_consistentWithEquality() {
+    @Test func `Hash nil destination stop ID consistent with equality`() {
         let link1 = ArrivalDepartureDeepLink(
             title: "10", regionID: 1, stopID: "A", tripID: "T",
             serviceDate: Date(timeIntervalSince1970: 1_500_000_000),

--- a/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkGroupTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkGroupTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,14 +14,15 @@ import CoreLocation
 
 // swiftlint:disable force_try
 
-class BookmarkGroupTests: OBATestCase {
+@Suite(.serialized)
+final class BookmarkGroupTests: OBATestCase {
 
-    func testCreation() {
+    @Test func `Creation`() {
         let group = BookmarkGroup(name: "Group 1", sortOrder: 0)
         #expect(group.name == "Group 1")
     }
 
-    func testCodableRoundtripping() {
+    @Test func `Codable roundtripping`() {
         let group = BookmarkGroup(name: "Group 1", sortOrder: 10)
         let decoded = try! Fixtures.roundtripCodable(type: BookmarkGroup.self, model: group)
 

--- a/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkGroupTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkGroupTests.swift
@@ -17,7 +17,7 @@ import CoreLocation
 @Suite(.serialized)
 final class BookmarkGroupTests: OBATestCase {
 
-    @Test func `Creation`() {
+    @Test func creation() {
         let group = BookmarkGroup(name: "Group 1", sortOrder: 0)
         #expect(group.name == "Group 1")
     }

--- a/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,19 +14,20 @@ import CoreLocation
 
 // swiftlint:disable force_try
 
-class BookmarkTests: OBATestCase {
+@Suite(.serialized)
+final class BookmarkTests: OBATestCase {
 
     var region: Region!
     var stops: [Stop]!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
 
         region = try! Fixtures.loadSomeRegions()[1]
         stops = try! Fixtures.loadSomeStops()
     }
 
-    func testCreation() {
+    @Test func `Creation`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stop)
         #expect(bookmark.name == "BM 1")
@@ -36,7 +36,7 @@ class BookmarkTests: OBATestCase {
         #expect(bookmark.stop == stop)
     }
 
-    func testCodableRoundtripping() {
+    @Test func `Codable roundtripping`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stop)
         let roundtripped = try! Fixtures.roundtripCodable(type: Bookmark.self, model: bookmark)
@@ -46,7 +46,7 @@ class BookmarkTests: OBATestCase {
         #expect(roundtripped.stop == stop)
     }
 
-    func testUpdatingStopPropertyWithRightStop() {
+    @Test func `Updating stop property with right stop`() {
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
         #expect(bookmark.stop.routes.count > 1)
         let stop = stops[0]
@@ -56,7 +56,7 @@ class BookmarkTests: OBATestCase {
         #expect(bookmark.stop.routes.count == 0)
     }
 
-    func testUpdatingStopPropertyWithWrongStop() {
+    @Test func `Updating stop property with wrong stop`() {
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
         bookmark.stop = stops[1]
 

--- a/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
@@ -27,7 +27,7 @@ final class BookmarkTests: OBATestCase {
         stops = try! Fixtures.loadSomeStops()
     }
 
-    @Test func `Creation`() {
+    @Test func creation() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stop)
         #expect(bookmark.name == "BM 1")

--- a/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
@@ -27,9 +27,6 @@ final class UserDefaultsStore_BookmarksTests: OBATestCase {
         stops = try! Fixtures.loadSomeStops()
     }
 
-    isolated deinit {
-    }
-
     // MARK: - Bookmark Groups
 
     @Test func `Bookmark groups round tripping`() {

--- a/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -15,23 +15,24 @@ import CoreLocation
 
 // swiftlint:disable force_try type_name
 
-class UserDefaultsStore_BookmarksTests: OBATestCase {
+@Suite(.serialized)
+final class UserDefaultsStore_BookmarksTests: OBATestCase {
     var userDefaultsStore: UserDefaultsStore!
     var stops: [Stop]!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         userDefaultsStore = UserDefaultsStore(userDefaults: userDefaults)
         stops = try! Fixtures.loadSomeStops()
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
     }
 
     // MARK: - Bookmark Groups
 
-    func test_bookmarkGroups_roundTripping() {
+    @Test func `Bookmark groups round tripping`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
 
         #expect(self.userDefaultsStore.bookmarkGroups == [])
@@ -39,7 +40,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarkGroups == [group])
     }
 
-    func test_bookmarkGroups_addDuplicate() {
+    @Test func `Bookmark groups add duplicate`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
 
         userDefaultsStore.upsert(bookmarkGroup: group)
@@ -47,21 +48,21 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarkGroups == [group])
     }
 
-    func test_bookmarkGroups_delete() {
+    @Test func `Bookmark groups delete`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group)
         userDefaultsStore.deleteGroup(group)
         #expect(self.userDefaultsStore.bookmarkGroups == [])
     }
 
-    func test_bookmarkGroups_deleteByID() {
+    @Test func `Bookmark groups delete by ID`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group)
         userDefaultsStore.deleteGroup(id: group.id)
         #expect(self.userDefaultsStore.bookmarkGroups == [])
     }
 
-    func test_bookmarkGroups_deleteNonexistent() {
+    @Test func `Bookmark groups delete nonexistent`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 1)
         let group2 = BookmarkGroup(name: "Group!", sortOrder: 2)
         userDefaultsStore.upsert(bookmarkGroup: group)
@@ -69,7 +70,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarkGroups == [group])
     }
 
-    func test_bookmarkGroups_findByID() {
+    @Test func `Bookmark groups find by ID`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 1)
         userDefaultsStore.upsert(bookmarkGroup: group)
 
@@ -80,7 +81,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(found == group)
     }
 
-    func test_bookmarkGroups_replacement() {
+    @Test func `Bookmark groups replacement`() {
         // Create and populate
         let keptGroup = BookmarkGroup(name: "kept", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: keptGroup)
@@ -110,7 +111,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
 
     // MARK: - Bookmarks
 
-    func test_bookmarks_retrieval_notInGroup() {
+    @Test func `Bookmarks retrieval not in group`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group)
 
@@ -125,7 +126,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(nil) == [bookmark2])
     }
 
-    func test_bookmarks_retrieval_inGroup() {
+    @Test func `Bookmarks retrieval in group`() {
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group)
 
@@ -140,35 +141,35 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(group) == [bookmark])
     }
 
-    func test_bookmarks_propertyRoundTripping() {
+    @Test func `Bookmarks property round tripping`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         userDefaultsStore.add(bookmark)
         #expect(self.userDefaultsStore.bookmarks == [bookmark])
     }
 
-    func test_bookmark_findByID() {
+    @Test func `Bookmark find by ID`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         userDefaultsStore.add(bookmark)
         #expect(self.userDefaultsStore.findBookmark(id: bookmark.id) == bookmark)
     }
 
-    func test_bookmark_findByStopID() {
+    @Test func `Bookmark find by stop ID`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         userDefaultsStore.add(bookmark)
         #expect(self.userDefaultsStore.findBookmark(stopID: stop.id) == bookmark)
     }
 
-    func test_bookmark_find_noMatch() {
+    @Test func `Bookmark find no match`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         userDefaultsStore.add(bookmark)
         #expect(self.userDefaultsStore.findBookmark(id: UUID()) == nil)
     }
 
-    func test_bookmark_addToGroup_groupUnregistered() {
+    @Test func `Bookmark add to group group unregistered`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         let group = BookmarkGroup(name: "My Group", sortOrder: 0)
@@ -179,7 +180,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(group) == [bookmark])
     }
 
-    func test_bookmark_changeGroup() {
+    @Test func `Bookmark change group`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
 
@@ -197,7 +198,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(group2).first!.id == bookmark.id)
     }
 
-    func test_bookmark_removeFromGroup() {
+    @Test func `Bookmark remove from group`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
 
@@ -211,7 +212,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(group) == [])
     }
 
-    func test_bookmark_addToGroup_groupRegistered() {
+    @Test func `Bookmark add to group group registered`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         let group = BookmarkGroup(name: "My Group", sortOrder: 0)
@@ -223,7 +224,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarksInGroup(group) == [bookmark])
     }
 
-    func test_bookmark_addDuplicate() {
+    @Test func `Bookmark add duplicate`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
 
@@ -233,7 +234,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarks == [bookmark])
     }
 
-    func test_bookmark_delete() {
+    @Test func `Bookmark delete`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
 
@@ -243,7 +244,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarks == [])
     }
 
-    func test_bookmark_deleteNonexistent() {
+    @Test func `Bookmark delete nonexistent`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
         let bookmark2 = Bookmark(name: "My Bookmark 2", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
@@ -254,7 +255,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarks == [bookmark])
     }
 
-    func test_bookmark_add_existingRecord() {
+    @Test func `Bookmark add existing record`() {
         let stop = stops[0]
 
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
@@ -268,7 +269,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
 
     // MARK: - Bookmark Sort Order
 
-    func test_bookmark_sortOrder_noGroup() {
+    @Test func `Bookmark sort order no group`() {
         let stop = stops[0]
 
         var bookmark0 = Bookmark(name: "Bookmark 0", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
@@ -304,7 +305,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(bookmark1.sortOrder == 1)
     }
 
-    func test_bookmark_sortOrder_inGroup() {
+    @Test func `Bookmark sort order in group`() {
         let stop = stops[0]
         let group = BookmarkGroup(name: "Group!", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group)
@@ -342,7 +343,7 @@ class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(bookmark1.sortOrder == 1)
     }
 
-    func test_bookmark_sortOrder_acrossGroups() {
+    @Test func `Bookmark sort order across groups`() {
         let stop = stops[0]
         let group1 = BookmarkGroup(name: "Group 1", sortOrder: 0)
         userDefaultsStore.upsert(bookmarkGroup: group1)

--- a/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
+++ b/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
@@ -7,26 +7,28 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class ProximityAlertTests: OBATestCase {
+@Suite(.serialized)
+final class ProximityAlertTests: OBATestCase {
 
     var stop: Stop!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         stop = try! Fixtures.loadSomeStops().first!
     }
 
     // MARK: - Model Init
 
-    func test_init_setsPropertiesFromStop() {
+    @Test func `Init sets properties from stop`() {
         let alert = ProximityAlert(stop: stop)
 
         #expect(alert.stopID == stop.id)
@@ -36,13 +38,13 @@ class ProximityAlertTests: OBATestCase {
         #expect(alert.radiusMeters == 200.0)
     }
 
-    func test_init_customRadius() {
+    @Test func `Init custom radius`() {
         let alert = ProximityAlert(stop: stop, radiusMeters: 500.0)
 
         #expect(alert.radiusMeters == 500.0)
     }
 
-    func test_coordinate_returnsCorrectValue() {
+    @Test func `Coordinate returns correct value`() {
         let alert = ProximityAlert(stop: stop)
 
         #expect(alert.coordinate.latitude == stop.location.coordinate.latitude)
@@ -51,7 +53,7 @@ class ProximityAlertTests: OBATestCase {
 
     // MARK: - Codable Round-Trip
 
-    func test_codable_roundTrip() {
+    @Test func `Codable round trip`() {
         let alert = ProximityAlert(stop: stop, radiusMeters: 350.0)
         let roundtripped = try! Fixtures.roundtripCodable(type: ProximityAlert.self, model: alert)
 
@@ -64,7 +66,7 @@ class ProximityAlertTests: OBATestCase {
         expectClose(roundtripped.createdAt.timeIntervalSince1970, alert.createdAt.timeIntervalSince1970, within: 1.0)
     }
 
-    func test_codable_roundTrip_preservesCoordinate() {
+    @Test func `Codable round trip preserves coordinate`() {
         let alert = ProximityAlert(stop: stop)
         let roundtripped = try! Fixtures.roundtripCodable(type: ProximityAlert.self, model: alert)
 
@@ -74,20 +76,20 @@ class ProximityAlertTests: OBATestCase {
 
     // MARK: - Expiration
 
-    func test_isExpired_falseWhenFresh() {
+    @Test func `Is expired false when fresh`() {
         let alert = ProximityAlert(stop: stop)
 
         #expect(!alert.isExpired)
     }
 
-    func test_isExpired_trueWhenOlderThan24Hours() {
+    @Test func `Is expired true when older than24 hours`() {
         let expiredDate = Date().addingTimeInterval(-25 * 60 * 60)
         let alert = ProximityAlert(stop: stop, createdAt: expiredDate)
 
         #expect(alert.isExpired)
     }
 
-    func test_isExpired_falseJustUnder24Hours() {
+    @Test func `Is expired false just under24 hours`() {
         let justUnderDate = Date().addingTimeInterval(-24 * 60 * 60 + 5) // 5 seconds under 24 hours
         let alert = ProximityAlert(stop: stop, createdAt: justUnderDate)
 
@@ -96,20 +98,20 @@ class ProximityAlertTests: OBATestCase {
 
     // MARK: - Equality
 
-    func test_equality_sameID() {
+    @Test func `Equality same ID`() {
         let alert = ProximityAlert(stop: stop)
 
         #expect(alert.isEqual(alert))
     }
 
-    func test_equality_differentID() {
+    @Test func `Equality different ID`() {
         let alert1 = ProximityAlert(stop: stop)
         let alert2 = ProximityAlert(stop: stop)
 
         #expect(!alert1.isEqual(alert2))
     }
 
-    func test_equality_nonProximityAlertObject() {
+    @Test func `Equality non proximity alert object`() {
         let alert = ProximityAlert(stop: stop)
 
         #expect(!alert.isEqual("not an alert"))
@@ -118,26 +120,28 @@ class ProximityAlertTests: OBATestCase {
 
 // MARK: - UserDefaultsStore Integration
 
-class ProximityAlertStoreTests: OBATestCase {
+@Suite(.serialized)
+final class ProximityAlertStoreTests: OBATestCase {
 
     var userDefaultsStore: UserDefaultsStore!
     var stop: Stop!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         userDefaultsStore = UserDefaultsStore(userDefaults: userDefaults)
         stop = try! Fixtures.loadSomeStops().first!
     }
 
     // MARK: - Empty State
 
-    func test_proximityAlerts_emptyByDefault() {
+    @Test func `Proximity alerts empty by default`() {
         #expect(self.userDefaultsStore.proximityAlerts.isEmpty)
     }
 
     // MARK: - Add
 
-    func test_add_storesAlert() {
+    @Test func `Add stores alert`() {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
@@ -146,7 +150,7 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.first?.stopID == stop.id)
     }
 
-    func test_add_multipleAlerts() {
+    @Test func `Add multiple alerts`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -159,7 +163,7 @@ class ProximityAlertStoreTests: OBATestCase {
 
     // MARK: - Delete
 
-    func test_delete_removesAlert() {
+    @Test func `Delete removes alert`() {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
@@ -168,7 +172,7 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.isEmpty)
     }
 
-    func test_delete_nonexistentAlert_isNoOp() {
+    @Test func `Delete nonexistent alert is no op`() {
         let alert1 = ProximityAlert(stop: stop)
         let alert2 = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert1)
@@ -179,7 +183,7 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.first?.id == alert1.id)
     }
 
-    func test_delete_onlyRemovesTargetAlert() {
+    @Test func `Delete only removes target alert`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -195,7 +199,7 @@ class ProximityAlertStoreTests: OBATestCase {
 
     // MARK: - Delete All
 
-    func test_deleteAll_removesAllAlerts() {
+    @Test func `Delete all removes all alerts`() {
         let stops = try! Fixtures.loadSomeStops()
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
@@ -210,7 +214,7 @@ class ProximityAlertStoreTests: OBATestCase {
 
     // MARK: - Expired Alerts
 
-    func test_deleteExpired_keepsNonExpiredAlerts() {
+    @Test func `Delete expired keeps non expired alerts`() {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
@@ -219,7 +223,7 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.count == 1)
     }
 
-    func test_deleteExpired_removesExpiredAlerts() {
+    @Test func `Delete expired removes expired alerts`() {
         let expiredDate = Date().addingTimeInterval(-25 * 60 * 60) // 25 hours ago
         let expiredAlert = ProximityAlert(stop: stop, createdAt: expiredDate)
         let freshAlert = ProximityAlert(stop: stop)
@@ -232,7 +236,7 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.first?.id == freshAlert.id)
     }
 
-    func test_deleteExpired_removesAllWhenAllExpired() {
+    @Test func `Delete expired removes all when all expired`() {
         let stops = try! Fixtures.loadSomeStops()
         let expiredDate = Date().addingTimeInterval(-25 * 60 * 60)
         let alert1 = ProximityAlert(stop: stops[0], createdAt: expiredDate)
@@ -245,32 +249,28 @@ class ProximityAlertStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.proximityAlerts.isEmpty)
     }
 
-    func test_deleteExpired_doesNotPostNotification_whenNothingExpired() {
+    @Test func `Delete expired does not post notification when nothing expired`() async {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
-        let notificationExpectation = expectation(forNotification: .proximityAlertsDidChange, object: userDefaultsStore)
-        notificationExpectation.isInverted = true
-
-        userDefaultsStore.deleteExpiredProximityAlerts()
-
-        waitForExpectations(timeout: 0.5)
+        await expectProximityAlertsNotification(count: 0) {
+            userDefaultsStore.deleteExpiredProximityAlerts()
+        }
     }
 
-    func test_deleteExpired_postsNotification_whenExpiredAlertsRemoved() {
+    @Test func `Delete expired posts notification when expired alerts removed`() async {
         let expiredDate = Date().addingTimeInterval(-25 * 60 * 60)
         let alert = ProximityAlert(stop: stop, createdAt: expiredDate)
         userDefaultsStore.add(proximityAlert: alert)
 
-        expectation(forNotification: .proximityAlertsDidChange, object: userDefaultsStore)
-        userDefaultsStore.deleteExpiredProximityAlerts()
-
-        waitForExpectations(timeout: 1.0)
+        await expectProximityAlertsNotification {
+            userDefaultsStore.deleteExpiredProximityAlerts()
+        }
     }
 
     // MARK: - Persistence Across Stores
 
-    func test_persistsAcrossStoreInstances() {
+    @Test func `Persists across store instances`() {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
@@ -287,32 +287,54 @@ class ProximityAlertStoreTests: OBATestCase {
 
     // MARK: - Notification
 
-    func test_add_postsNotification() {
+    @Test func `Add posts notification`() async {
         let alert = ProximityAlert(stop: stop)
 
-        expectation(forNotification: .proximityAlertsDidChange, object: userDefaultsStore)
-        userDefaultsStore.add(proximityAlert: alert)
-
-        waitForExpectations(timeout: 1.0)
+        await expectProximityAlertsNotification {
+            userDefaultsStore.add(proximityAlert: alert)
+        }
     }
 
-    func test_delete_postsNotification() {
-        let alert = ProximityAlert(stop: stop)
-        userDefaultsStore.add(proximityAlert: alert)
-
-        expectation(forNotification: .proximityAlertsDidChange, object: userDefaultsStore)
-        userDefaultsStore.delete(proximityAlert: alert)
-
-        waitForExpectations(timeout: 1.0)
-    }
-
-    func test_deleteAll_postsNotification() {
+    @Test func `Delete posts notification`() async {
         let alert = ProximityAlert(stop: stop)
         userDefaultsStore.add(proximityAlert: alert)
 
-        expectation(forNotification: .proximityAlertsDidChange, object: userDefaultsStore)
-        userDefaultsStore.deleteAllProximityAlerts()
-
-        waitForExpectations(timeout: 1.0)
+        await expectProximityAlertsNotification {
+            userDefaultsStore.delete(proximityAlert: alert)
+        }
     }
+
+    @Test func `Delete all posts notification`() async {
+        let alert = ProximityAlert(stop: stop)
+        userDefaultsStore.add(proximityAlert: alert)
+
+        await expectProximityAlertsNotification {
+            userDefaultsStore.deleteAllProximityAlerts()
+        }
+    }
+
+    /// Confirms `.proximityAlertsDidChange` is posted while `body` runs — or,
+    /// with `count: 0`, that it isn't.
+    ///
+    /// Replaces `expectation(forNotification:object:)`. `UserDataStore` posts
+    /// synchronously, so there is nothing to wait for; the old
+    /// `waitForExpectations(timeout:)` calls were burning their timeout on the
+    /// inverted case and returning immediately on the rest.
+    private func expectProximityAlertsNotification(
+        count: Int = 1,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        during body: () -> Void
+    ) async {
+        await confirmation(expectedCount: count, sourceLocation: sourceLocation) { posted in
+            let token = NotificationCenter.default.addObserver(
+                forName: .proximityAlertsDidChange,
+                object: userDefaultsStore,
+                queue: nil
+            ) { _ in posted() }
+            defer { NotificationCenter.default.removeObserver(token) }
+
+            body()
+        }
+    }
+
 }

--- a/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
+++ b/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
@@ -82,14 +82,14 @@ final class ProximityAlertTests: OBATestCase {
         #expect(!alert.isExpired)
     }
 
-    @Test func `Is expired true when older than24 hours`() {
+    @Test func `Is expired true when older than 24 hours`() {
         let expiredDate = Date().addingTimeInterval(-25 * 60 * 60)
         let alert = ProximityAlert(stop: stop, createdAt: expiredDate)
 
         #expect(alert.isExpired)
     }
 
-    @Test func `Is expired false just under24 hours`() {
+    @Test func `Is expired false just under 24 hours`() {
         let justUnderDate = Date().addingTimeInterval(-24 * 60 * 60 + 5) // 5 seconds under 24 hours
         let alert = ProximityAlert(stop: stop, createdAt: justUnderDate)
 

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -7,31 +7,32 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class UserDefaultsStoreTests: OBATestCase {
+@Suite(.serialized)
+final class UserDefaultsStoreTests: OBATestCase {
     var userDefaultsStore: UserDefaultsStore!
     var region: Region!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         userDefaultsStore = UserDefaultsStore(userDefaults: userDefaults)
         region = try! Fixtures.loadSomeRegions()[1]
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
     }
 
     // MARK: - Core
 
-    func test_garbageData_doesNotBreakApp() {
+    @Test func `Garbage data does not break app`() {
         let garbageDefaults = UserDefaults(suiteName: "garbage data test")!
         garbageDefaults.set("garbage data", forKey: "bookmarkGroups")
         let garbageStore = UserDefaultsStore(userDefaults: garbageDefaults)
@@ -41,7 +42,7 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Recent Stops
 
-    func test_recentStops_addStop() {
+    @Test func `Recent stops add stop`() {
         let stops = try! Fixtures.loadSomeStops()
         let stop = stops.first!
         userDefaultsStore.addRecentStop(stop, region: region)
@@ -49,7 +50,7 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.recentStops == [stop])
     }
 
-    func test_recentStops_uniqueStops() {
+    @Test func `Recent stops unique stops`() {
         let stops = try! Fixtures.loadSomeStops()
         let stop = stops.first!
         userDefaultsStore.addRecentStop(stop, region: region)
@@ -58,7 +59,7 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.recentStops == [stop])
     }
 
-    func test_recentStops_maxCount() {
+    @Test func `Recent stops max count`() {
         let stops = try! Fixtures.loadSomeStops()
         #expect(stops.count > userDefaultsStore.maximumRecentStopsCount)
 
@@ -69,7 +70,7 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.recentStops.count == userDefaultsStore.maximumRecentStopsCount)
     }
 
-    func test_recentStops_search() {
+    @Test func `Recent stops search`() {
         let stops = try! Fixtures.loadSomeStops()
 
         for s in stops {
@@ -85,7 +86,7 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(filtered.first! == stop)
     }
 
-    func test_recentStops_removeAll() {
+    @Test func `Recent stops remove all`() {
         let stops = try! Fixtures.loadSomeStops()
         let stop = stops.first!
         userDefaultsStore.addRecentStop(stop, region: region)
@@ -95,7 +96,7 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.recentStops.count == 0)
     }
 
-    func test_recentStops_removeStop() {
+    @Test func `Recent stops remove stop`() {
         let stops = try! Fixtures.loadSomeStops().prefix(20)
         let stop = stops.first!
 
@@ -110,7 +111,7 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Alarms
 
-    func test_alarms_deleteMissingTripDate() {
+    @Test func `Alarms delete missing trip date`() {
         let missingDataAlarm = try! Fixtures.loadAlarm(id: "1")
 
         let futureAlarm = try! Fixtures.loadAlarm(id: "2")
@@ -129,7 +130,7 @@ class UserDefaultsStoreTests: OBATestCase {
 
     }
 
-    func test_alarms_deleteExpired() {
+    @Test func `Alarms delete expired`() {
         let expiredAlarm = try! Fixtures.loadAlarm(id: "1")
         expiredAlarm.set(tripDate: Date(timeIntervalSinceReferenceDate: 0), alarmOffset: 5)
 
@@ -154,7 +155,7 @@ class UserDefaultsStoreTests: OBATestCase {
     /// so the reloaded Alarm would no longer compare equal to its in-memory original — and
     /// any equality-based delete would silently no-op. This test persists, reloads, then
     /// deletes by the round-tripped instance to anchor the fix path to a named test.
-    func test_alarms_delete_afterUserDefaultsRoundTrip() {
+    @Test func `Alarms delete after user defaults round trip`() {
         let alarm = try! Fixtures.loadAlarm(id: "round-trip")
         alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
 
@@ -173,27 +174,27 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Selected Tab Index
 
-    func test_selectedTabIndex_mapSelectedByDefault() {
+    @Test func `Selected tab index map selected by default`() {
         #expect(self.userDefaultsStore.lastSelectedView == SelectedTab.map)
     }
 
-    func test_selectedTabIndex_changingDefaults() {
+    @Test func `Selected tab index changing defaults`() {
         userDefaultsStore.lastSelectedView = .bookmarks
         #expect(self.userDefaultsStore.lastSelectedView == SelectedTab.bookmarks)
     }
 
-    func test_selectedTabIndex_invalidRawValueFallsBackToMap() {
+    @Test func `Selected tab index invalid raw value falls back to map`() {
         userDefaults.set(999, forKey: "UserDataStore.lastSelectedView")
         #expect(self.userDefaultsStore.lastSelectedView == SelectedTab.map)
     }
 
     // MARK: - Debug Mode
 
-    func test_debugMode_defaultValue() {
+    @Test func `Debug mode default value`() {
         #expect(!self.userDefaultsStore.debugMode)
     }
 
-    func test_debugMode_setValue() {
+    @Test func `Debug mode set value`() {
         self.userDefaultsStore.debugMode = true
         #expect(self.userDefaultsStore.debugMode)
 
@@ -203,11 +204,11 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Stop UI Reduced Colors
 
-    func test_stopUIReducedColors_defaultValue() {
+    @Test func `Stop UI reduced colors default value`() {
         #expect(!self.userDefaultsStore.stopUIReducedColors)
     }
 
-    func test_stopUIReducedColors_setValue_persistsUnderTheAppStorageKey() {
+    @Test func `Stop UI reduced colors set value persists under the app storage key`() {
         userDefaultsStore.stopUIReducedColors = true
         #expect(self.userDefaultsStore.stopUIReducedColors)
         // The @AppStorage readers and the Eureka form must see the same key,
@@ -218,12 +219,12 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Survey Properties
 
-    func test_surveyUserIdentifier_generatesUUID() {
+    @Test func `Survey user identifier generates UUID`() {
         let id = userDefaultsStore.surveyUserIdentifier
         #expect(!id.isEmpty)
     }
 
-    func test_surveyUserIdentifier_persistsBetweenCalls() {
+    @Test func `Survey user identifier persists between calls`() {
         let first = userDefaultsStore.surveyUserIdentifier
         let second = userDefaultsStore.surveyUserIdentifier
         #expect(first == second)
@@ -231,11 +232,11 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - App Launch Counter
 
-    func test_appLaunchCount_defaultValueIsZero() {
+    @Test func `App launch count default value is zero`() {
         #expect(self.userDefaultsStore.appLaunchCount == 0)
     }
 
-    func test_appLaunchCount_incrementsCorrectly() {
+    @Test func `App launch count increments correctly`() {
         userDefaultsStore.incrementAppLaunchCount()
         #expect(self.userDefaultsStore.appLaunchCount == 1)
 
@@ -245,11 +246,11 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Survey Enabled
 
-    func test_isSurveyEnabled_defaultsToTrue() {
+    @Test func `Is survey enabled defaults to true`() {
         #expect(self.userDefaultsStore.isSurveyEnabled)
     }
 
-    func test_isSurveyEnabled_persistsValue() {
+    @Test func `Is survey enabled persists value`() {
         userDefaultsStore.isSurveyEnabled = false
         #expect(!self.userDefaultsStore.isSurveyEnabled)
 
@@ -259,11 +260,11 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Next Survey Reminder Date
 
-    func test_nextSurveyReminderDate_defaultsToNil() {
+    @Test func `Next survey reminder date defaults to nil`() {
         #expect(self.userDefaultsStore.nextSurveyReminderDate == nil)
     }
 
-    func test_nextSurveyReminderDate_persistsValue() {
+    @Test func `Next survey reminder date persists value`() {
         let date = Date().addingTimeInterval(3600)
         userDefaultsStore.nextSurveyReminderDate = date
         expectClose(self.userDefaultsStore.nextSurveyReminderDate, date, within: 1)
@@ -271,13 +272,13 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Survey Completion Tracking
 
-    func test_markSurveyCompleted_tracksCompletedSurvey() {
+    @Test func `Mark survey completed tracks completed survey`() {
         userDefaultsStore.markSurveyCompleted(surveyId: 1, userIdentifier: "user1")
         #expect(self.userDefaultsStore.isSurveyCompleted(surveyId: 1, userIdentifier: "user1"))
         #expect(!self.userDefaultsStore.isSurveyCompleted(surveyId: 2, userIdentifier: "user1"))
     }
 
-    func test_markSurveyForLater_tracksLaterSurvey() {
+    @Test func `Mark survey for later tracks later survey`() {
         userDefaultsStore.markSurveyForLater(surveyId: 1, userIdentifier: "user1")
         // Immediately after marking, shouldShowSurveyLater returns false (0 launches since marking)
         #expect(!self.userDefaultsStore.shouldShowSurveyLater(surveyId: 1, userIdentifier: "user1"))
@@ -285,11 +286,11 @@ class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Walking Speed
 
-    func test_walkingSpeed_defaultValue() {
+    @Test func `Walking speed default value`() {
         expectClose(self.userDefaultsStore.walkingSpeedMetersPerSecond, 1.4)
     }
 
-    func test_walkingSpeed_roundTrip() {
+    @Test func `Walking speed round trip`() {
         userDefaultsStore.walkingSpeedMetersPerSecond = 0.9
         expectClose(self.userDefaultsStore.walkingSpeedMetersPerSecond, 0.9)
 
@@ -300,11 +301,11 @@ class UserDefaultsStoreTests: OBATestCase {
         expectClose(newStore.walkingSpeedMetersPerSecond, 1.8)
     }
 
-    func test_walkingSpeedSource_defaultValue() {
+    @Test func `Walking speed source default value`() {
         #expect(self.userDefaultsStore.walkingSpeedSource == .manual)
     }
 
-    func test_walkingSpeedSource_roundTrip() {
+    @Test func `Walking speed source round trip`() {
         userDefaultsStore.walkingSpeedSource = .healthKit
         #expect(self.userDefaultsStore.walkingSpeedSource == .healthKit)
 
@@ -312,23 +313,23 @@ class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.walkingSpeedSource == .manual)
     }
 
-    func test_walkingSpeedMetersPerSecond_clampsBelowRange() {
+    @Test func `Walking speed meters per second clamps below range`() {
         userDefaultsStore.walkingSpeedMetersPerSecond = 0.1
         expectClose(self.userDefaultsStore.walkingSpeedMetersPerSecond, WalkingSpeed.validRange.lowerBound)
     }
 
-    func test_walkingSpeedMetersPerSecond_clampsAboveRange() {
+    @Test func `Walking speed meters per second clamps above range`() {
         userDefaultsStore.walkingSpeedMetersPerSecond = 10.0
         expectClose(self.userDefaultsStore.walkingSpeedMetersPerSecond, WalkingSpeed.validRange.upperBound)
     }
 
     // MARK: - Default Alarm Lead Time
 
-    func test_defaultAlarmLeadTime_is10Minutes() {
+    @Test func `Default alarm lead time is10 minutes`() {
         #expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes == 10)
     }
 
-    func test_defaultAlarmLeadTime_ignoresAndClearsLegacyStoredValue() {
+    @Test func `Default alarm lead time ignores and clears legacy stored value`() {
         userDefaults.set(2, forKey: "UserDataStore.defaultAlarmLeadTimeMinutes")
 
         let newStore = UserDefaultsStore(userDefaults: userDefaults)

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -27,9 +27,6 @@ final class UserDefaultsStoreTests: OBATestCase {
         region = try! Fixtures.loadSomeRegions()[1]
     }
 
-    isolated deinit {
-    }
-
     // MARK: - Core
 
     @Test func `Garbage data does not break app`() {

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -325,7 +325,7 @@ final class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Default Alarm Lead Time
 
-    @Test func `Default alarm lead time is10 minutes`() {
+    @Test func `Default alarm lead time is 10 minutes`() {
         #expect(self.userDefaultsStore.defaultAlarmLeadTimeMinutes == 10)
     }
 

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingDirectionsTests.swift
@@ -7,14 +7,14 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-class WalkingDirectionsTests: XCTestCase {
+@Suite(.serialized)
+final class WalkingDirectionsTests {
 
     // Two locations exactly 140 meters apart
     private let locationA = CLLocation(latitude: 47.6062, longitude: -122.3321)
@@ -29,7 +29,7 @@ class WalkingDirectionsTests: XCTestCase {
 
     // MARK: - Default Velocity
 
-    func test_travelTime_defaultVelocity() {
+    @Test func `Travel time default velocity`() {
         let time = WalkingDirections.travelTime(from: locationA, to: locationB)
         #expect(time != nil)
         expectClose(time, knownDistance / WalkingSpeed.defaultMetersPerSecond, within: 0.01)
@@ -37,7 +37,7 @@ class WalkingDirectionsTests: XCTestCase {
 
     // MARK: - Custom Velocity
 
-    func test_travelTime_customVelocity() {
+    @Test func `Travel time custom velocity`() {
         let slowTime = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 0.9)
         let fastTime = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 1.8)
 
@@ -52,29 +52,29 @@ class WalkingDirectionsTests: XCTestCase {
 
     // MARK: - Nil Locations
 
-    func test_travelTime_nilFromLocation() {
+    @Test func `Travel time nil from location`() {
         let time = WalkingDirections.travelTime(from: nil, to: locationB)
         #expect(time == nil)
     }
 
-    func test_travelTime_nilToLocation() {
+    @Test func `Travel time nil to location`() {
         let time = WalkingDirections.travelTime(from: locationA, to: nil)
         #expect(time == nil)
     }
 
-    func test_travelTime_bothNil() {
+    @Test func `Travel time both nil`() {
         let time = WalkingDirections.travelTime(from: nil, to: nil)
         #expect(time == nil)
     }
 
     // MARK: - Invalid Velocity
 
-    func test_travelTime_zeroVelocity_returnsNil() {
+    @Test func `Travel time zero velocity returns nil`() {
         let time = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: 0)
         #expect(time == nil)
     }
 
-    func test_travelTime_negativeVelocity_returnsNil() {
+    @Test func `Travel time negative velocity returns nil`() {
         let time = WalkingDirections.travelTime(from: locationA, to: locationB, velocity: -1.5)
         #expect(time == nil)
     }

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedManagerTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedManagerTests.swift
@@ -7,11 +7,11 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class WalkingSpeedManagerTests: OBATestCase {
 
     private struct FakeProvider: WalkingSpeedHealthKitProviding {
@@ -38,7 +38,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
 
     // MARK: - requestHealthKitAuthorizationAndSync
 
-    func test_requestAndSync_whenSampleMissing_returnsFalseAndForcesManual() async {
+    @Test func `Request and sync when sample missing returns false and forces manual`() async {
         store.walkingSpeedSource = .healthKit
         store.walkingSpeedMetersPerSecond = 1.6
 
@@ -55,7 +55,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         expectClose(self.store.walkingSpeedMetersPerSecond, 1.6)
     }
 
-    func test_requestAndSync_whenSampleInRange_writesValueAndMarksHealthKit() async {
+    @Test func `Request and sync when sample in range writes value and marks health kit`() async {
         store.walkingSpeedSource = .manual
         store.walkingSpeedMetersPerSecond = 1.4
 
@@ -71,7 +71,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         expectClose(self.store.walkingSpeedMetersPerSecond, 1.65)
     }
 
-    func test_requestAndSync_whenSampleOutOfRange_doesNotWriteAndForcesManual() async {
+    @Test func `Request and sync when sample out of range does not write and forces manual`() async {
         store.walkingSpeedSource = .healthKit
         store.walkingSpeedMetersPerSecond = 1.4
 
@@ -89,7 +89,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         expectClose(self.store.walkingSpeedMetersPerSecond, 1.4)
     }
 
-    func test_requestAndSync_whenAuthorizationThrows_forcesManual() async {
+    @Test func `Request and sync when authorization throws forces manual`() async {
         store.walkingSpeedSource = .healthKit
 
         let manager = WalkingSpeedManager(
@@ -103,7 +103,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         #expect(self.store.walkingSpeedSource == .manual)
     }
 
-    func test_requestAndSync_whenHealthKitUnavailable_forcesManual() async {
+    @Test func `Request and sync when health kit unavailable forces manual`() async {
         store.walkingSpeedSource = .healthKit
 
         let manager = WalkingSpeedManager(
@@ -119,7 +119,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
 
     // MARK: - refreshFromHealthKitIfPossible
 
-    func test_passiveRefresh_withNoSample_leavesSourceAndSpeedUntouched() async {
+    @Test func `Passive refresh with no sample leaves source and speed untouched`() async {
         store.walkingSpeedSource = .healthKit
         store.walkingSpeedMetersPerSecond = 1.65
 
@@ -135,7 +135,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         expectClose(self.store.walkingSpeedMetersPerSecond, 1.65)
     }
 
-    func test_passiveRefresh_withInRangeSample_updatesSpeed() async {
+    @Test func `Passive refresh with in range sample updates speed`() async {
         store.walkingSpeedSource = .healthKit
         store.walkingSpeedMetersPerSecond = 1.4
 
@@ -150,7 +150,7 @@ final class WalkingSpeedManagerTests: OBATestCase {
         expectClose(self.store.walkingSpeedMetersPerSecond, 1.7)
     }
 
-    func test_passiveRefresh_withOutOfRangeSample_isNoOp() async {
+    @Test func `Passive refresh with out of range sample is no op`() async {
         store.walkingSpeedSource = .healthKit
         store.walkingSpeedMetersPerSecond = 1.4
 

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedPresetTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedPresetTests.swift
@@ -7,20 +7,20 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 
 @MainActor
-class WalkingSpeedPresetTests: XCTestCase {
+@Suite(.serialized)
+final class WalkingSpeedPresetTests {
 
-    func test_nearest_exactMatch() {
+    @Test func `Nearest exact match`() {
         #expect(WalkingSpeedPreset.nearest(to: 0.9) == .slow)
         #expect(WalkingSpeedPreset.nearest(to: 1.4) == .average)
         #expect(WalkingSpeedPreset.nearest(to: 1.8) == .fast)
     }
 
-    func test_nearest_picksClosestPreset() {
+    @Test func `Nearest picks closest preset`() {
         // 1.0 → halfway-ish, closer to 0.9 (slow)
         #expect(WalkingSpeedPreset.nearest(to: 1.0) == .slow)
         // 1.3 closer to 1.4 (average)
@@ -29,7 +29,7 @@ class WalkingSpeedPresetTests: XCTestCase {
         #expect(WalkingSpeedPreset.nearest(to: 1.7) == .fast)
     }
 
-    func test_nearest_outOfRange_clampsToNearestEnd() {
+    @Test func `Nearest out of range clamps to nearest end`() {
         // Below slow → still slow
         #expect(WalkingSpeedPreset.nearest(to: 0.1) == .slow)
         // Above fast → still fast

--- a/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedSettingsDecisionTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/WalkingSpeedSettingsDecisionTests.swift
@@ -7,17 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 @MainActor
-final class WalkingSpeedSettingsDecisionTests: XCTestCase {
+@Suite(.serialized)
+final class WalkingSpeedSettingsDecisionTests {
 
     // MARK: - Toggle absent (form row not shown)
 
-    func test_noToggle_segmentSpeed_updatesManualSpeed() {
+    @Test func `No toggle segment speed updates manual speed`() {
         let decision = WalkingSpeedSettingsDecision.compute(
             currentSource: .manual,
             currentSpeed: 1.4,
@@ -28,7 +28,7 @@ final class WalkingSpeedSettingsDecisionTests: XCTestCase {
         expectClose(decision.speed, 0.9)
     }
 
-    func test_noToggle_noSegmentSpeed_leavesEverythingUntouched() {
+    @Test func `No toggle no segment speed leaves everything untouched`() {
         let decision = WalkingSpeedSettingsDecision.compute(
             currentSource: .healthKit,
             currentSpeed: 1.65,
@@ -41,7 +41,7 @@ final class WalkingSpeedSettingsDecisionTests: XCTestCase {
 
     // MARK: - Toggle ON
 
-    func test_toggleOn_keepsCurrentSpeedAndSwitchesToHealthKit() {
+    @Test func `Toggle on keeps current speed and switches to health kit`() {
         // When HK is toggled on, the manager has already written the synced speed.
         // saveWalkingSpeedValues must not overwrite it with the (now-disabled) segment value.
         let decision = WalkingSpeedSettingsDecision.compute(
@@ -56,7 +56,7 @@ final class WalkingSpeedSettingsDecisionTests: XCTestCase {
 
     // MARK: - Toggle OFF
 
-    func test_toggleOff_snapsCurrentSpeedToNearestPreset() {
+    @Test func `Toggle off snaps current speed to nearest preset`() {
         let decision = WalkingSpeedSettingsDecision.compute(
             currentSource: .healthKit,
             currentSpeed: 1.73,   // closer to .fast (1.8)
@@ -67,7 +67,7 @@ final class WalkingSpeedSettingsDecisionTests: XCTestCase {
         expectClose(decision.speed, WalkingSpeedPreset.fast.rawValue)
     }
 
-    func test_toggleOff_withSegmentSpeed_prefersSegmentThenSnaps() {
+    @Test func `Toggle off with segment speed prefers segment then snaps`() {
         // When the toggle flips off, the segment row also has whatever the user landed on —
         // it should win over currentSpeed, then snap.
         let decision = WalkingSpeedSettingsDecision.compute(

--- a/OBAKitTests/Models/TripActivityPresenterTests.swift
+++ b/OBAKitTests/Models/TripActivityPresenterTests.swift
@@ -7,11 +7,13 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKitCore
 
 @MainActor
-class TripActivityPresenterTests: XCTestCase {
+@Suite(.serialized)
+final class TripActivityPresenterTests {
     private let presenter = TripActivityPresenter(
         formatters: Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
     )
@@ -30,36 +32,33 @@ class TripActivityPresenterTests: XCTestCase {
     /// just under the offset and shift the minute math down by one.
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
 
-    func testMinuteTextForFutureDeparture() {
+    @Test func `Minute text for future departure`() {
         let text = presenter.minuteText(for: arrival(offsetSeconds: 300, now: now), now: now)
-        XCTAssertTrue(text.contains("5"), "expected a 5-minute chip, got \(text)")
+        #expect(text.contains("5"), "expected a 5-minute chip, got \(text)")
     }
 
-    func testColorMatchesFormattersScheduleStatusColor() {
+    @Test func `Color matches formatters schedule status color`() {
         let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
-        XCTAssertEqual(
-            presenter.color(for: arrival(offsetSeconds: 300, status: .delayed, now: now)),
-            formatters.colorForScheduleStatus(.delayed)
-        )
+        #expect(presenter.color(for: arrival(offsetSeconds: 300, status: .delayed, now: now)) == formatters.colorForScheduleStatus(.delayed))
     }
 
-    func testStatusTextForUnknownStatusSaysScheduled() {
+    @Test func `Status text for unknown status says scheduled`() {
         let text = presenter.statusText(for: arrival(offsetSeconds: 300, status: .unknown, now: now), now: now)
-        XCTAssertTrue(text.contains(Strings.scheduledNotRealTime))
+        #expect(text.contains(Strings.scheduledNotRealTime))
     }
 
     /// Server-pushed deviations are raw seconds (e.g. 95s). Truncating division
     /// would report "1 min late"; the app-wide convention (see
     /// ArrivalDeparture.deviationFromScheduleInMinutes) is to round, which for
     /// 95s should report "2 min late".
-    func testStatusTextRoundsDeviationMinutes() {
+    @Test func `Status text rounds deviation minutes`() {
         let text = presenter.statusText(for: arrival(offsetSeconds: 300, status: .delayed, deviation: 95, now: now), now: now)
-        XCTAssertTrue(text.contains("2 min late"), "95s should round to 2 min late, got \(text)")
+        #expect(text.contains("2 min late"), "95s should round to 2 min late, got \(text)")
     }
 
-    func testPrimaryColorForEmptyArrivalsIsUnknownStatusColor() {
+    @Test func `Primary color for empty arrivals is unknown status color`() {
         let formatters = Formatters(locale: Locale(identifier: "en_US"), calendar: Calendar(identifier: .gregorian), themeColors: ThemeColors.shared)
         let state = TripAttributes.ContentState(arrivals: [])
-        XCTAssertEqual(presenter.primaryColor(for: state), formatters.colorForScheduleStatus(.unknown))
+        #expect(presenter.primaryColor(for: state) == formatters.colorForScheduleStatus(.unknown))
     }
 }

--- a/OBAKitTests/Models/TripAttributesContentStateTests.swift
+++ b/OBAKitTests/Models/TripAttributesContentStateTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKitCore
 
 /// Contract test: decodes the exact fixture that obacloud's
@@ -15,30 +16,31 @@ import XCTest
 /// repos). Uses a default-configuration JSONDecoder because Apple decodes
 /// pushed content-state with default strategies — no convertFromSnakeCase.
 @MainActor
-class TripAttributesContentStateTests: XCTestCase {
-    func testDecodesServerFixtureWithDefaultDecoder() throws {
+@Suite(.serialized)
+final class TripAttributesContentStateTests {
+    @Test func `Decodes server fixture with default decoder`() throws {
         let url = Bundle(for: type(of: self)).url(forResource: "live_activity_content_state", withExtension: "json")!
         let data = try Data(contentsOf: url)
 
         let state = try JSONDecoder().decode(TripAttributes.ContentState.self, from: data)
 
-        XCTAssertEqual(state.arrivals.count, 3)
+        #expect(state.arrivals.count == 3)
 
         let first = state.arrivals[0]
-        XCTAssertEqual(first.departureTime, 1767980460)
-        XCTAssertEqual(first.scheduleStatus, .onTime)
-        XCTAssertEqual(first.scheduleDeviation, 60)
-        XCTAssertFalse(first.isArrival)
-        XCTAssertEqual(first.departureDate, Date(timeIntervalSince1970: 1767980460))
+        #expect(first.departureTime == 1767980460)
+        #expect(first.scheduleStatus == .onTime)
+        #expect(first.scheduleDeviation == 60)
+        #expect(!first.isArrival)
+        #expect(first.departureDate == Date(timeIntervalSince1970: 1767980460))
 
-        XCTAssertEqual(state.arrivals[1].scheduleStatus, .delayed)
-        XCTAssertEqual(state.arrivals[2].scheduleStatus, .unknown)
+        #expect(state.arrivals[1].scheduleStatus == .delayed)
+        #expect(state.arrivals[2].scheduleStatus == .unknown)
     }
 
-    func testScheduleStatusBridgesToExistingEnum() {
-        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.onTime.scheduleStatus, ScheduleStatus.onTime)
-        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.early.scheduleStatus, ScheduleStatus.early)
-        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.delayed.scheduleStatus, ScheduleStatus.delayed)
-        XCTAssertEqual(TripAttributes.ContentState.ScheduleStatusValue.unknown.scheduleStatus, ScheduleStatus.unknown)
+    @Test func `Schedule status bridges to existing enum`() {
+        #expect(TripAttributes.ContentState.ScheduleStatusValue.onTime.scheduleStatus == ScheduleStatus.onTime)
+        #expect(TripAttributes.ContentState.ScheduleStatusValue.early.scheduleStatus == ScheduleStatus.early)
+        #expect(TripAttributes.ContentState.ScheduleStatusValue.delayed.scheduleStatus == ScheduleStatus.delayed)
+        #expect(TripAttributes.ContentState.ScheduleStatusValue.unknown.scheduleStatus == ScheduleStatus.unknown)
     }
 }

--- a/OBAKitTests/Models/TripAttributesIdentityTests.swift
+++ b/OBAKitTests/Models/TripAttributesIdentityTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Testing
 @testable import OBAKitCore
 
 /// Covers the identity rule behind the duplicate-Live-Activity guard.
@@ -16,7 +16,8 @@ import XCTest
 /// ActivityKit's static `activities` isn't injectable — so these tests pin the
 /// comparison it delegates to, which is where the actual decision lives.
 @MainActor
-class TripAttributesIdentityTests: XCTestCase {
+@Suite(.serialized)
+final class TripAttributesIdentityTests {
 
     private func staticData(
         routeShortName: String = "49",
@@ -34,66 +35,66 @@ class TripAttributesIdentityTests: XCTestCase {
         )
     }
 
-    func testMatchesWhenStopRouteAndHeadsignAreEqual() {
-        XCTAssertTrue(staticData().tracksSameTrip(as: staticData()))
+    @Test func `Matches when stop route and headsign are equal`() {
+        #expect(staticData().tracksSameTrip(as: staticData()))
     }
 
-    func testDoesNotMatchOnDifferentStop() {
-        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(stopID: "1_99999")))
+    @Test func `Does not match on different stop`() {
+        #expect(!staticData().tracksSameTrip(as: staticData(stopID: "1_99999")))
     }
 
-    func testDoesNotMatchOnDifferentRoute() {
-        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(routeShortName: "8")))
+    @Test func `Does not match on different route`() {
+        #expect(!staticData().tracksSameTrip(as: staticData(routeShortName: "8")))
     }
 
     /// Two directions of the same route at one stop are different trips, so
     /// tracking one must not suppress starting the other.
-    func testDoesNotMatchOnDifferentHeadsign() {
-        XCTAssertFalse(staticData().tracksSameTrip(as: staticData(routeHeadsign: "University District")))
+    @Test func `Does not match on different headsign`() {
+        #expect(!staticData().tracksSameTrip(as: staticData(routeHeadsign: "University District")))
     }
 
     /// The route colour arrives with the first arrivals payload and is nil until
     /// then. If it were part of identity, a second tap before data loaded would
     /// be treated as a different trip and would start a duplicate — the exact
     /// case the guard exists to prevent.
-    func testMatchesWhenOnlyRouteColorDiffers() {
-        XCTAssertTrue(staticData(routeColorHex: nil).tracksSameTrip(as: staticData(routeColorHex: "FF0000")))
+    @Test func `Matches when only route color differs`() {
+        #expect(staticData(routeColorHex: nil).tracksSameTrip(as: staticData(routeColorHex: "FF0000")))
     }
 
     /// `regionID` is routing metadata for the widget deep link, not identity —
     /// and excluding it keeps this rule identical to the stop/route/headsign
     /// match `updateRunningLiveActivities()` already uses.
-    func testMatchesWhenOnlyRegionDiffers() {
-        XCTAssertTrue(staticData(regionID: 1).tracksSameTrip(as: staticData(regionID: 5)))
+    @Test func `Matches when only region differs`() {
+        #expect(staticData(regionID: 1).tracksSameTrip(as: staticData(regionID: 5)))
     }
 
     /// Symmetry is pinned with concrete values in both directions — asserting
     /// the two calls equal each other would also pass if both directions were
     /// wrong in the same way.
-    func testIsSymmetric() {
+    @Test func `Is symmetric`() {
         let a = staticData()
         let b = staticData(routeShortName: "8")
-        XCTAssertFalse(a.tracksSameTrip(as: b))
-        XCTAssertFalse(b.tracksSameTrip(as: a))
+        #expect(!a.tracksSameTrip(as: b))
+        #expect(!b.tracksSameTrip(as: a))
 
         let plain = staticData(routeColorHex: nil)
         let colored = staticData(routeColorHex: "FF0000")
-        XCTAssertTrue(plain.tracksSameTrip(as: colored))
-        XCTAssertTrue(colored.tracksSameTrip(as: plain))
+        #expect(plain.tracksSameTrip(as: colored))
+        #expect(colored.tracksSameTrip(as: plain))
     }
 
     /// Empty headsign is the fallback both start paths use when a bookmark or
     /// departure has none, so it has to compare cleanly rather than being
     /// treated as "unknown, therefore different".
-    func testMatchesWhenBothHeadsignsAreEmpty() {
-        XCTAssertTrue(staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "")))
+    @Test func `Matches when both headsigns are empty`() {
+        #expect(staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "")))
     }
 
     /// A record with no stored headsign ("" after the `tripHeadsign ?? ""`
     /// fallback) is deliberately not treated as the same trip as one with a
     /// specific headsign — that's the boundary of the guard's cross-screen
     /// dedupe, pinned here so it can't change silently.
-    func testDoesNotMatchWhenOneHeadsignIsEmpty() {
-        XCTAssertFalse(staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "Downtown")))
+    @Test func `Does not match when one headsign is empty`() {
+        #expect(!staticData(routeHeadsign: "").tracksSameTrip(as: staticData(routeHeadsign: "Downtown")))
     }
 }

--- a/OBAKitTests/NearbyTripMatcherTests.swift
+++ b/OBAKitTests/NearbyTripMatcherTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -21,14 +21,16 @@ import CoreLocation
 /// - Stop `1_10020` serving routes `1_30`, `1_65`, `1_74`
 /// - 4 arrivals: 2 on route `1_30`, 2 on route `1_65`
 /// - All have `predicted: true` (isRealTime) and vehicle positions
-class NearbyTripMatcherTests: OBATestCase {
+@Suite(.serialized)
+final class NearbyTripMatcherTests: OBATestCase {
     /// Near stop 1_10020 in the fixture (NE 55th & 37th Ave NE).
     let userLocation = CLLocation(latitude: 47.6685, longitude: -122.2883)
 
     var dataLoader: MockDataLoader!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         dataLoader = (restService.dataLoader as! MockDataLoader)
     }
 
@@ -65,7 +67,7 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - Positive Match
 
-    func test_findTrips_returnsMatchesForRoute30() async throws {
+    @Test func `Find trips returns matches for route30`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -84,7 +86,7 @@ class NearbyTripMatcherTests: OBATestCase {
         #expect(vehicleIDs.contains("1_7022"))
     }
 
-    func test_findTrips_returnsMatchesForRoute65() async throws {
+    @Test func `Find trips returns matches for route65`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -105,7 +107,7 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - Route Filtering
 
-    func test_findTrips_nonexistentRoute_throwsNoStopsNearby() async {
+    @Test func `Find trips nonexistent route throws no stops nearby`() async {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -125,17 +127,17 @@ class NearbyTripMatcherTests: OBATestCase {
                 stops: stops,
                 maxDistance: 500_000
             )
-            XCTFail("Expected MatchError.noStopsNearby")
+            Issue.record("Expected MatchError.noStopsNearby")
         } catch let error as NearbyTripMatcher.MatchError {
             #expect(error == .noStopsNearby)
         } catch {
-            XCTFail("Unexpected error: \(error)")
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
     // MARK: - Distance Filtering
 
-    func test_findTrips_tightDistance_excludesFarVehicles() async throws {
+    @Test func `Find trips tight distance excludes far vehicles`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -163,7 +165,7 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - Sorting
 
-    func test_findTrips_sortsByDistanceClosestFirst() async throws {
+    @Test func `Find trips sorts by distance closest first`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -183,7 +185,7 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - Empty Stops
 
-    func test_findTrips_emptyStopsAndAPI_throwsNoStopsNearby() async {
+    @Test func `Find trips empty stops and API throws no stops nearby`() async {
         let data = Fixtures.loadData(file: "stops_for_location_outofrange.json")
         dataLoader.mock(data: data) { request in
             request.url?.absoluteString.contains("stops-for-location") ?? false
@@ -197,17 +199,17 @@ class NearbyTripMatcherTests: OBATestCase {
                 stops: [],
                 maxDistance: 500
             )
-            XCTFail("Expected MatchError.noStopsNearby")
+            Issue.record("Expected MatchError.noStopsNearby")
         } catch let error as NearbyTripMatcher.MatchError {
             #expect(error == .noStopsNearby)
         } catch {
-            XCTFail("Unexpected error: \(error)")
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
     // MARK: - All Stops Fail
 
-    func test_findTrips_allStopsFail_rethrowsError() async {
+    @Test func `Find trips all stops fail rethrows error`() async {
         let stops = stopsFromArrivalsFixture()
 
         // Mock arrivals endpoint to return a 500 server error.
@@ -228,9 +230,9 @@ class NearbyTripMatcherTests: OBATestCase {
                 stops: stops,
                 maxDistance: 500_000
             )
-            XCTFail("Expected error to be rethrown when all stops fail")
+            Issue.record("Expected error to be rethrown when all stops fail")
         } catch is NearbyTripMatcher.MatchError {
-            XCTFail("Should rethrow the server error, not a MatchError")
+            Issue.record("Should rethrow the server error, not a MatchError")
         } catch {
             // Expected: the server error is rethrown, not swallowed. Reaching
             // this branch at all *is* the assertion — the `catch is MatchError`
@@ -246,7 +248,7 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - No Realtime Data
 
-    func test_findTrips_noRealtimeData_throwsNoRealtimeError() async {
+    @Test func `Find trips no realtime data throws no realtime error`() async {
         let stops = stopsFromArrivalsFixture()
 
         // Use the fixture where all `predicted` fields are false (no real-time data).
@@ -263,17 +265,17 @@ class NearbyTripMatcherTests: OBATestCase {
                 stops: stops,
                 maxDistance: 500_000
             )
-            XCTFail("Expected MatchError.noRealtimeData")
+            Issue.record("Expected MatchError.noRealtimeData")
         } catch let error as NearbyTripMatcher.MatchError {
             #expect(error == .noRealtimeData)
         } catch {
-            XCTFail("Unexpected error: \(error)")
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
     // MARK: - Deduplication
 
-    func test_findTrips_deduplicatesSameVehicleAcrossStops() async throws {
+    @Test func `Find trips deduplicates same vehicle across stops`() async throws {
         // Pass the same stop twice so fetchArrivals returns duplicate arrivals.
         let stops = stopsFromArrivalsFixture()
         let duplicatedStops = stops + stops
@@ -296,12 +298,12 @@ class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - MatchError
 
-    func test_matchError_noStopsNearby_localizedDescription() {
+    @Test func `Match error no stops nearby localized description`() {
         let error = NearbyTripMatcher.MatchError.noStopsNearby
         #expect(!error.localizedDescription.isEmpty)
     }
 
-    func test_matchError_noRealtimeData_localizedDescription() {
+    @Test func `Match error no realtime data localized description`() {
         let error = NearbyTripMatcher.MatchError.noRealtimeData
         #expect(!error.localizedDescription.isEmpty)
     }

--- a/OBAKitTests/NearbyTripMatcherTests.swift
+++ b/OBAKitTests/NearbyTripMatcherTests.swift
@@ -67,7 +67,7 @@ final class NearbyTripMatcherTests: OBATestCase {
 
     // MARK: - Positive Match
 
-    @Test func `Find trips returns matches for route30`() async throws {
+    @Test func `Find trips returns matches for route 30`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 
@@ -86,7 +86,7 @@ final class NearbyTripMatcherTests: OBATestCase {
         #expect(vehicleIDs.contains("1_7022"))
     }
 
-    @Test func `Find trips returns matches for route65`() async throws {
+    @Test func `Find trips returns matches for route 65`() async throws {
         let stops = stopsFromArrivalsFixture()
         stubArrivals()
 

--- a/OBAKitTests/Networking/AgencyAlertsStoreConcurrencyTests.swift
+++ b/OBAKitTests/Networking/AgencyAlertsStoreConcurrencyTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -21,17 +21,18 @@ import Testing
 /// hoisting a mutation out of its critical section should surface here under Thread
 /// Sanitizer (preferred CI run) — and without TSan, an unhandled race typically
 /// still manifests as a crash or a count mismatch when the fanout is wide enough.
-class AgencyAlertsStoreConcurrencyTests: OBATestCase {
+@Suite(.serialized)
+final class AgencyAlertsStoreConcurrencyTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -69,7 +70,7 @@ class AgencyAlertsStoreConcurrencyTests: OBATestCase {
     /// the 8-hour recency filter exercised by `recentHighSeverityAlerts`.
     private func makeRecentHighSeverityAlerts(count: Int) throws -> [AgencyAlert] {
         let agencies = try Fixtures.loadRESTAPIPayload(type: [AgencyWithCoverage].self, fileName: "agencies_with_coverage.json")
-        let agency = try XCTUnwrap(agencies.first)
+        let agency = try #require(agencies.first)
 
         var period = TransitRealtime_TimeRange()
         period.start = UInt64(Date().timeIntervalSince1970)
@@ -96,8 +97,8 @@ class AgencyAlertsStoreConcurrencyTests: OBATestCase {
     /// `markAlertRead`, `isAlertUnread`, `recentHighSeverityAlerts`, and `agencyAlerts`.
     /// If the lock is missing or held inconsistently, TSan will flag the data race;
     /// without TSan, a corrupted `Set<AgencyAlert>` typically crashes the run.
-    @MainActor
-    func test_concurrentReadsAndWrites_doNotCrashOrCorruptState() async throws {
+    @Test @MainActor
+    func `Concurrent reads and writes do not crash or corrupt state`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let store = app.alertsStore

--- a/OBAKitTests/Networking/DecodingErrorReporterTests.swift
+++ b/OBAKitTests/Networking/DecodingErrorReporterTests.swift
@@ -4,11 +4,13 @@
 //
 //  Created by Divesh Patil on 29/01/26.
 //
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKitCore
 
 @MainActor
-final class DecodingErrorReporterTests: XCTestCase {
+@Suite(.serialized)
+final class DecodingErrorReporterTests {
 
     // MARK: - Test Models
     
@@ -23,14 +25,13 @@ final class DecodingErrorReporterTests: XCTestCase {
         let count: Int
     }
 
-    override func tearDown() async throws {
+    deinit {
         DecodingErrorReporter.reportHandler = nil
-        try await super.tearDown()
     }
 
     // MARK: - keyNotFound Tests
     
-    func testKeyNotFound() throws {
+    @Test func `Key not found`() throws {
         let json = """
         {
             "id": 123,
@@ -43,18 +44,16 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Missing key: 'name'"),
-                         "Message should contain the missing key name")
-            XCTAssertTrue(message.contains("Path:"),
-                         "Message should contain path information")
+            #expect(message.contains("Missing key: 'name'"), "Message should contain the missing key name")
+            #expect(message.contains("Path:"), "Message should contain path information")
         }
     }
     
-    func testKeyNotFoundWithNestedPath() throws {
+    @Test func `Key not found with nested path`() throws {
         struct Model: Decodable {
             let data: DataWrapper
         }
@@ -80,20 +79,18 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(Model.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Missing key: 'required'"),
-                         "Message should contain the missing key")
-            XCTAssertTrue(message.contains("data → items → Index 0") || message.contains("data → items"),
-                         "Message should contain the full path: \(message)")
+            #expect(message.contains("Missing key: 'required'"), "Message should contain the missing key")
+            #expect(message.contains("data → items → Index 0") || message.contains("data → items"), "Message should contain the full path: \(message)")
         }
     }
 
     // MARK: - typeMismatch Tests
     
-    func testTypeMismatch() throws {
+    @Test func `Type mismatch`() throws {
         let json = """
         {
             "id": "not_a_number",
@@ -107,20 +104,17 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Type mismatch"),
-                         "Message should indicate type mismatch")
-            XCTAssertTrue(message.contains("Int") || message.contains("expected"),
-                         "Message should mention expected type")
-            XCTAssertTrue(message.contains("Path:"),
-                         "Message should contain path")
+            #expect(message.contains("Type mismatch"), "Message should indicate type mismatch")
+            #expect(message.contains("Int") || message.contains("expected"), "Message should mention expected type")
+            #expect(message.contains("Path:"), "Message should contain path")
         }
     }
     
-    func testTypeMismatchInNestedObject() throws {
+    @Test func `Type mismatch in nested object`() throws {
         let json = """
         {
             "id": 123,
@@ -134,20 +128,18 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Type mismatch"),
-                         "Message should indicate type mismatch")
-            XCTAssertTrue(message.contains("nested"),
-                         "Message should show nested path")
+            #expect(message.contains("Type mismatch"), "Message should indicate type mismatch")
+            #expect(message.contains("nested"), "Message should show nested path")
         }
     }
 
     // MARK: - valueNotFound Tests
     
-    func testValueNotFound() throws {
+    @Test func `Value not found`() throws {
         let json = """
         {
             "id": 123,
@@ -161,22 +153,19 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Missing value"),
-                         "Message should indicate missing value")
-            XCTAssertTrue(message.contains("String") || message.contains("expected"),
-                         "Message should mention expected type")
-            XCTAssertTrue(message.contains("Path:"),
-                         "Message should contain path")
+            #expect(message.contains("Missing value"), "Message should indicate missing value")
+            #expect(message.contains("String") || message.contains("expected"), "Message should mention expected type")
+            #expect(message.contains("Path:"), "Message should contain path")
         }
     }
 
     // MARK: - dataCorrupted Tests
     
-    func testDataCorrupted() throws {
+    @Test func `Data corrupted`() throws {
         struct DateModel: Decodable {
             let timestamp: Date
         }
@@ -192,36 +181,32 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try decoder.decode(DateModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Data corrupted") || message.contains("corrupted"),
-                         "Message should indicate data corruption")
-            XCTAssertTrue(message.contains("Path:"),
-                         "Message should contain path")
+            #expect(message.contains("Data corrupted") || message.contains("corrupted"), "Message should indicate data corruption")
+            #expect(message.contains("Path:"), "Message should contain path")
         }
     }
 
     // MARK: - Path Formatting Tests
     
-    func testRootPath() throws {
+    @Test func `Root path`() throws {
         let json = "{}".data(using: .utf8)!
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Path:"),
-                         "Message should contain path information")
-            XCTAssertTrue(message.contains("Path: root"),
-                         "Empty coding path should display 'root'")
+            #expect(message.contains("Path:"), "Message should contain path information")
+            #expect(message.contains("Path: root"), "Empty coding path should display 'root'")
         }
     }
     
-    func testNestedPathFormatting() throws {
+    @Test func `Nested path formatting`() throws {
         struct DeepModel: Decodable {
             let level1: Level1
         }
@@ -247,18 +232,17 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(DeepModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("→") || message.contains("level1") && message.contains("level2") && message.contains("level3"),
-                         "Message should show nested path with arrow separator: \(message)")
+            #expect(message.contains("→") || message.contains("level1") && message.contains("level2") && message.contains("level3"), "Message should show nested path with arrow separator: \(message)")
         }
     }
 
     // MARK: - Context Information Tests
     
-    func testContextInformation() throws {
+    @Test func `Context information`() throws {
         let json = """
         {
             "id": 123,
@@ -271,77 +255,80 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         do {
             _ = try JSONDecoder().decode(TestModel.self, from: json)
-            XCTFail("Expected decoding to fail")
+            Issue.record("Expected decoding to fail")
         } catch let error as DecodingError {
             let message = DecodingErrorReporter.message(from: error)
             
-            XCTAssertTrue(message.contains("Context:"),
-                         "Message should include context section")
+            #expect(message.contains("Context:"), "Message should include context section")
         }
     }
     
     // MARK: - Handler Verification Tests
     
-    func testReportHandlerCapturesErrorType() {
+    @Test func `Report handler captures error type`() async {
         let testCases: [(DecodingError, String)] = [
             (.keyNotFound(TestCodingKey(stringValue: "test"), .init(codingPath: [], debugDescription: "Missing")), "keyNotFound"),
             (.typeMismatch(String.self, .init(codingPath: [], debugDescription: "Wrong type")), "typeMismatch"),
             (.valueNotFound(String.self, .init(codingPath: [], debugDescription: "Null value")), "valueNotFound"),
             (.dataCorrupted(.init(codingPath: [], debugDescription: "Corrupted")), "dataCorrupted")
         ]
-        
+
         for (error, expectedType) in testCases {
-            let expectation = self.expectation(description: "Handler called for \(expectedType)")
             let capturedError = SendableBox<DecodingError?>(nil)
-            
-            DecodingErrorReporter.reportHandler = { error, _, _, _ in
-                capturedError.value = error
-                expectation.fulfill()
+
+            // `report` invokes the handler synchronously, so this is satisfied
+            // before the closure returns. It replaces an XCTestExpectation
+            // whose `waitForExpectations(timeout: 1.0)` never actually waited —
+            // the confirmation states the real contract: called exactly once.
+            await confirmation("Handler called for \(expectedType)") { handlerCalled in
+                DecodingErrorReporter.reportHandler = { error, _, _, _ in
+                    capturedError.value = error
+                    handlerCalled()
+                }
+
+                let mockURL = URL(string: "https://api.onebusaway.org/test")!
+                DecodingErrorReporter.report(error: error, url: mockURL, httpMethod: "GET")
             }
-            
-            let mockURL = URL(string: "https://api.onebusaway.org/test")!
-            DecodingErrorReporter.report(error: error, url: mockURL, httpMethod: "GET")
-            
-            waitForExpectations(timeout: 1.0)
-            XCTAssertNotNil(capturedError.value, "Should capture \(expectedType) error")
+
+            #expect(capturedError.value != nil, "Should capture \(expectedType) error")
             
             switch capturedError.value {
             case .keyNotFound where expectedType == "keyNotFound":
-                XCTAssertTrue(true)
+                #expect(true)
             case .typeMismatch where expectedType == "typeMismatch":
-                XCTAssertTrue(true)
+                #expect(true)
             case .valueNotFound where expectedType == "valueNotFound":
-                XCTAssertTrue(true)
+                #expect(true)
             case .dataCorrupted where expectedType == "dataCorrupted":
-                XCTAssertTrue(true)
+                #expect(true)
             default:
-                XCTFail("Error type mismatch for \(expectedType)")
+                Issue.record("Error type mismatch for \(expectedType)")
             }
         }
     }
     
-    func testReportHandlerWithDifferentHTTPMethods() {
-        let postExpectation = self.expectation(description: "POST handler called")
+    @Test func `Report handler with different HTTP methods`() async {
         let capturedMethod = SendableBox<String?>(nil)
-        
-        DecodingErrorReporter.reportHandler = { _, _, httpMethod, _ in
-            capturedMethod.value = httpMethod
-            postExpectation.fulfill()
+
+        await confirmation("POST handler called") { handlerCalled in
+            DecodingErrorReporter.reportHandler = { _, _, httpMethod, _ in
+                capturedMethod.value = httpMethod
+                handlerCalled()
+            }
+
+            let mockURL = URL(string: "https://api.onebusaway.org/stops")!
+            let mockError = DecodingError.keyNotFound(
+                TestCodingKey(stringValue: "id"),
+                .init(codingPath: [], debugDescription: "Missing id")
+            )
+
+            DecodingErrorReporter.report(error: mockError, url: mockURL, httpMethod: "POST")
         }
-        
-        let mockURL = URL(string: "https://api.onebusaway.org/stops")!
-        let mockError = DecodingError.keyNotFound(
-            TestCodingKey(stringValue: "id"),
-            .init(codingPath: [], debugDescription: "Missing id")
-        )
-        
-        DecodingErrorReporter.report(error: mockError, url: mockURL, httpMethod: "POST")
-        
-        waitForExpectations(timeout: 1.0)
-        XCTAssertEqual(capturedMethod.value, "POST", "Should capture POST method correctly")
+
+        #expect(capturedMethod.value == "POST", "Should capture POST method correctly")
     }
     
-    func testReportHandlerNotCalledWhenNil() {
+    @Test func `Report handler not called when nil`() {
         DecodingErrorReporter.reportHandler = nil
         
         let mockURL = URL(string: "https://api.onebusaway.org/test")!
@@ -349,10 +336,10 @@ final class DecodingErrorReporterTests: XCTestCase {
         
         DecodingErrorReporter.report(error: mockError, url: mockURL, httpMethod: "GET")
         
-        XCTAssertTrue(true, "Should handle nil handler gracefully")
+        #expect(true, "Should handle nil handler gracefully")
     }
 
-    func testReportHandlerCapturesURLCorrectly() {
+    @Test func `Report handler captures URL correctly`() {
         let capturedURL = SendableBox<URL?>(nil)
         let testURL = URL(string: "https://api.onebusaway.org/api/where/stops?key=TEST")!
 
@@ -363,10 +350,10 @@ final class DecodingErrorReporterTests: XCTestCase {
         let error = DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Test"))
         DecodingErrorReporter.report(error: error, url: testURL, httpMethod: "GET")
 
-        XCTAssertEqual(capturedURL.value, testURL)
+        #expect(capturedURL.value == testURL)
     }
 
-    func testReportHandlerCapturesMessageCorrectly() {
+    @Test func `Report handler captures message correctly`() {
         let capturedMessage = SendableBox<String?>(nil)
         let testURL = URL(string: "https://api.onebusaway.org/api/where/stops?key=TEST")!
 
@@ -380,8 +367,8 @@ final class DecodingErrorReporterTests: XCTestCase {
         )
         DecodingErrorReporter.report(error: error, url: testURL, httpMethod: "GET")
 
-        XCTAssertNotNil(capturedMessage.value)
-        XCTAssertTrue(capturedMessage.value!.contains("Missing key: 'fare'"))
+        #expect(capturedMessage.value != nil)
+        #expect(capturedMessage.value!.contains("Missing key: 'fare'"))
     }
     
     // MARK: - Helper Types

--- a/OBAKitTests/Networking/DecodingErrorReporterTests.swift
+++ b/OBAKitTests/Networking/DecodingErrorReporterTests.swift
@@ -373,11 +373,6 @@ final class DecodingErrorReporterTests {
     
     // MARK: - Helper Types
 
-    final class SendableBox<T>: @unchecked Sendable {
-        var value: T
-        init(_ value: T) { self.value = value }
-    }
-    
     struct TestCodingKey: CodingKey {
         var stringValue: String
         var intValue: Int?

--- a/OBAKitTests/Networking/ErrorClassifierTests.swift
+++ b/OBAKitTests/Networking/ErrorClassifierTests.swift
@@ -7,16 +7,17 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
 @MainActor
-class ErrorClassifierTests: XCTestCase {
+@Suite(.serialized)
+final class ErrorClassifierTests {
 
     // MARK: - APIError Pass-Through
 
-    func test_classify_captivePortal_passesThrough() {
+    @Test func `Classify captive portal passes through`() {
         let error = APIError.captivePortal
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound")
 
@@ -33,7 +34,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestNotFound_passesThrough() {
+    @Test func `Classify request not found passes through`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stop/1_75403.json")!
         let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestNotFound(response)
@@ -52,7 +53,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_noResponseBody_passesThrough() {
+    @Test func `Classify no response body passes through`() {
         let error = APIError.noResponseBody
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound")
 
@@ -69,7 +70,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_invalidContentType_passesThrough() {
+    @Test func `Classify invalid content type passes through`() {
         let error = APIError.invalidContentType(
             originalError: nil,
             expectedContentType: "application/json",
@@ -92,7 +93,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - Server Error Classification (500 vs other 5xx)
 
-    func test_classify_requestFailure500_becomesServerError() {
+    @Test func `Classify request failure500 becomes server error`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -111,7 +112,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_serverError_errorDescription_suggestsRetry() {
+    @Test func `Server error error description suggests retry`() {
         let error = APIError.serverError(regionName: "Puget Sound")
         let description = error.localizedDescription
 
@@ -119,7 +120,7 @@ class ErrorClassifierTests: XCTestCase {
         #expect(description.contains("try again"))
     }
 
-    func test_classify_requestFailure502_becomesServerUnavailable() {
+    @Test func `Classify request failure502 becomes server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 502, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -139,7 +140,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestFailure503_becomesServerUnavailable() {
+    @Test func `Classify request failure503 becomes server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -159,7 +160,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestFailure501_doesNotBecomeServerUnavailable() {
+    @Test func `Classify request failure501 does not become server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 501, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -178,7 +179,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestFailure500_withoutRegionName_staysAsRequestFailure() {
+    @Test func `Classify request failure500 without region name stays as request failure`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -197,7 +198,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestFailure503_withoutRegionName_staysAsRequestFailure() {
+    @Test func `Classify request failure503 without region name stays as request failure`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -216,7 +217,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_requestFailure400_doesNotBecomeServerUnavailable() {
+    @Test func `Classify request failure400 does not become server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -237,7 +238,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - Cellular Data Restriction (Injectable)
 
-    func test_classify_networkFailure_withCellularRestricted_becomesCellularDataRestricted() {
+    @Test func `Classify network failure with cellular restricted becomes cellular data restricted`() {
         let error = APIError.networkFailure(nil)
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound", isCellularDataRestricted: true)
 
@@ -254,7 +255,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_networkFailure_withoutCellularRestricted_staysAsNetworkFailure() {
+    @Test func `Classify network failure without cellular restricted stays as network failure`() {
         let error = APIError.networkFailure(nil)
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound", isCellularDataRestricted: false)
 
@@ -271,7 +272,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_urlErrorNotConnected_withCellularRestricted_becomesCellularDataRestricted() {
+    @Test func `Classify url error not connected with cellular restricted becomes cellular data restricted`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: "Puget Sound", isCellularDataRestricted: true)
 
@@ -290,7 +291,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - DecodingError Classification
 
-    func test_classify_decodingError_withRegionName_becomesServerUnavailable() {
+    @Test func `Classify decoding error with region name becomes server unavailable`() {
         let decodingError = DecodingError.keyNotFound(
             AnyCodingKey(stringValue: "data")!,
             DecodingError.Context(codingPath: [], debugDescription: "No value associated with key")
@@ -311,7 +312,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_decodingError_withoutRegionName_returnsUserFriendlyError() {
+    @Test func `Classify decoding error without region name returns user friendly error`() {
         let decodingError = DecodingError.dataCorrupted(
             DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.")
         )
@@ -324,7 +325,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - NSURLError Classification
 
-    func test_classify_urlErrorTimedOut_withRegionName_becomesServerUnavailable() {
+    @Test func `Classify url error timed out with region name becomes server unavailable`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: "York Region")
 
@@ -341,7 +342,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_urlErrorCannotConnectToHost_withRegionName_becomesServerUnavailable() {
+    @Test func `Classify url error cannot connect to host with region name becomes server unavailable`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: "Tampa")
 
@@ -358,7 +359,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_urlErrorCannotFindHost_withRegionName_becomesServerUnavailable() {
+    @Test func `Classify url error cannot find host with region name becomes server unavailable`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotFindHost, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: "San Diego")
 
@@ -375,7 +376,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_urlErrorTimedOut_withoutRegionName_becomesNetworkFailure() {
+    @Test func `Classify url error timed out without region name becomes network failure`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: nil)
 
@@ -392,7 +393,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_urlErrorUnknownCode_becomesNetworkFailure() {
+    @Test func `Classify url error unknown code becomes network failure`() {
         let urlError = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
         let result = ErrorClassifier.classify(urlError, regionName: "Puget Sound")
 
@@ -411,7 +412,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - Idempotency (already-classified errors pass through unchanged)
 
-    func test_classify_serverError_passesThrough() {
+    @Test func `Classify server error passes through`() {
         let error = APIError.serverError(regionName: "Puget Sound")
         let result = ErrorClassifier.classify(error, regionName: "Tampa")
 
@@ -428,7 +429,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_serverUnavailable_passesThrough() {
+    @Test func `Classify server unavailable passes through`() {
         let error = APIError.serverUnavailable(regionName: "Puget Sound", statusCode: 503)
         let result = ErrorClassifier.classify(error, regionName: "Tampa")
 
@@ -446,7 +447,7 @@ class ErrorClassifierTests: XCTestCase {
         }
     }
 
-    func test_classify_cellularDataRestricted_passesThrough() {
+    @Test func `Classify cellular data restricted passes through`() {
         let error = APIError.cellularDataRestricted
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound")
 
@@ -465,7 +466,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - Non-Network Errors Pass Through
 
-    func test_classify_arbitraryError_passesThrough() {
+    @Test func `Classify arbitrary error passes through`() {
         let error = NSError(domain: "com.example.test", code: 42, userInfo: [
             NSLocalizedDescriptionKey: "Something unrelated happened"
         ])
@@ -476,7 +477,7 @@ class ErrorClassifierTests: XCTestCase {
 
     // MARK: - Error Description Verification
 
-    func test_serverUnavailable_errorDescription_containsRegionName() {
+    @Test func `Server unavailable error description contains region name`() {
         let error = APIError.serverUnavailable(regionName: "Puget Sound", statusCode: 502)
         let description = error.localizedDescription
 
@@ -484,7 +485,7 @@ class ErrorClassifierTests: XCTestCase {
         #expect(description.contains("down"))
     }
 
-    func test_cellularDataRestricted_errorDescription_mentionsSettings() {
+    @Test func `Cellular data restricted error description mentions settings`() {
         let error = APIError.cellularDataRestricted
         let description = error.localizedDescription
 

--- a/OBAKitTests/Networking/ErrorClassifierTests.swift
+++ b/OBAKitTests/Networking/ErrorClassifierTests.swift
@@ -93,7 +93,7 @@ final class ErrorClassifierTests {
 
     // MARK: - Server Error Classification (500 vs other 5xx)
 
-    @Test func `Classify request failure500 becomes server error`() {
+    @Test func `Classify request failure 500 becomes server error`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -120,7 +120,7 @@ final class ErrorClassifierTests {
         #expect(description.contains("try again"))
     }
 
-    @Test func `Classify request failure502 becomes server unavailable`() {
+    @Test func `Classify request failure 502 becomes server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 502, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -140,7 +140,7 @@ final class ErrorClassifierTests {
         }
     }
 
-    @Test func `Classify request failure503 becomes server unavailable`() {
+    @Test func `Classify request failure 503 becomes server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -160,7 +160,7 @@ final class ErrorClassifierTests {
         }
     }
 
-    @Test func `Classify request failure501 does not become server unavailable`() {
+    @Test func `Classify request failure 501 does not become server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 501, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -179,7 +179,7 @@ final class ErrorClassifierTests {
         }
     }
 
-    @Test func `Classify request failure500 without region name stays as request failure`() {
+    @Test func `Classify request failure 500 without region name stays as request failure`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -198,7 +198,7 @@ final class ErrorClassifierTests {
         }
     }
 
-    @Test func `Classify request failure503 without region name stays as request failure`() {
+    @Test func `Classify request failure 503 without region name stays as request failure`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)
@@ -217,7 +217,7 @@ final class ErrorClassifierTests {
         }
     }
 
-    @Test func `Classify request failure400 does not become server unavailable`() {
+    @Test func `Classify request failure 400 does not become server unavailable`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops.json")!
         let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestFailure(response)

--- a/OBAKitTests/Networking/Helper Tests/NetworkHelperTests.swift
+++ b/OBAKitTests/Networking/Helper Tests/NetworkHelperTests.swift
@@ -8,7 +8,6 @@
 //
 
 import Foundation
-import XCTest
 import Testing
 import CoreLocation
 import MapKit
@@ -16,8 +15,9 @@ import MapKit
 @testable import OBAKit
 @testable import OBAKitCore
 
-class NetworkHelperTests: OBATestCase {
-    func testDictionaryToQueryItems_success() {
+@Suite(.serialized)
+final class NetworkHelperTests: OBATestCase {
+    @Test func `Dictionary to query items success`() {
         let dict: [String: Any] = ["one": 2, "three": "four"]
         let queryItems = NetworkHelpers.dictionary(toQueryItems: dict).sorted(by: { $0.name < $1.name })
 
@@ -34,7 +34,7 @@ class NetworkHelperTests: OBATestCase {
     /// Tests that Double values use period (.) as decimal separator regardless of locale.
     /// This is critical for API compatibility - servers expect US-style decimal formatting.
     /// Bug: https://github.com/OneBusAway/onebusaway-iphone/issues/1024
-    func testDictionaryToQueryItems_doubleValuesUseLocaleIndependentFormatting() {
+    @Test func `Dictionary to query items double values use locale independent formatting`() {
         // Simulate a German locale where decimal separator is comma
         let germanLocale = Locale(identifier: "de_DE")
 
@@ -73,7 +73,7 @@ class NetworkHelperTests: OBATestCase {
     }
 
     /// Tests that Float values also use locale-independent formatting
-    func testDictionaryToQueryItems_floatValuesUseLocaleIndependentFormatting() {
+    @Test func `Dictionary to query items float values use locale independent formatting`() {
         let dict: [String: Any] = [
             "value": Float(3.14159)
         ]
@@ -86,7 +86,7 @@ class NetworkHelperTests: OBATestCase {
     }
 
     /// Tests the actual URL building for stops-for-location endpoint
-    func testRESTAPIURLBuilder_stopsForLocation_usesCorrectDecimalFormat() {
+    @Test func `RESTAPIURL builder stops for location uses correct decimal format`() {
         let baseURL = URL(string: "https://api.example.com")!
         let queryItems = [URLQueryItem(name: "key", value: "test")]
         let urlBuilder = RESTAPIURLBuilder(baseURL: baseURL, defaultQueryItems: queryItems)
@@ -112,7 +112,7 @@ class NetworkHelperTests: OBATestCase {
         #expect(urlString.contains("lonSpan=0.008"))
     }
 
-    func testDictionaryToHTTPBodyData() {
+    @Test func `Dictionary to HTTP body data`() {
         let dict: [String: Any] = ["one": 2, "three": "four"]
         let data = NetworkHelpers.dictionary(toHTTPBodyData: dict)
 
@@ -126,7 +126,7 @@ class NetworkHelperTests: OBATestCase {
     }
 
     /// Tests that Double values in HTTP body use period as decimal separator regardless of locale
-    func testDictionaryToHTTPBodyData_doubleValuesUseLocaleIndependentFormatting() {
+    @Test func `Dictionary to HTTP body data double values use locale independent formatting`() {
         let dict: [String: Any] = [
             "lat": 47.61098,
             "lon": -122.33845
@@ -147,7 +147,7 @@ class NetworkHelperTests: OBATestCase {
     /// to prevent server-side locale-dependent number parsing issues.
     /// Bug: Server returns 400 when Accept-Language is non-English because it
     /// parses lat/lon with locale-aware number parsing.
-    func testRESTAPIService_setsAcceptLanguageHeader() async throws {
+    @Test func `RESTAPI service sets accept language header`() async throws {
         var capturedRequest: URLRequest?
 
         let mockDataLoader = MockDataLoader(testName: name)

--- a/OBAKitTests/Networking/Helper Tests/NetworkHelperTests.swift
+++ b/OBAKitTests/Networking/Helper Tests/NetworkHelperTests.swift
@@ -148,7 +148,8 @@ final class NetworkHelperTests: OBATestCase {
     /// Bug: Server returns 400 when Accept-Language is non-English because it
     /// parses lat/lon with locale-aware number parsing.
     @Test func `RESTAPI service sets accept language header`() async throws {
-        var capturedRequest: URLRequest?
+        // Boxed: the matcher is @Sendable and cannot write to a main-actor local.
+        let capturedRequest = SendableBox<URLRequest?>(nil)
 
         let mockDataLoader = MockDataLoader(testName: name)
         // Set up a matcher that captures the request for inspection
@@ -162,7 +163,7 @@ final class NetworkHelperTests: OBATestCase {
             ),
             error: nil
         ) { request in
-            capturedRequest = request
+            capturedRequest.value = request
             return request.url?.path.contains("stops-for-location") == true
         }
         mockDataLoader.mock(response: mockResponse)
@@ -173,8 +174,8 @@ final class NetworkHelperTests: OBATestCase {
         _ = try? await restService.getStops(coordinate: coordinate)
 
         // Verify Accept-Language header is set to en-US
-        #expect(capturedRequest != nil)
-        let acceptLanguage = capturedRequest?.value(forHTTPHeaderField: "Accept-Language")
+        #expect(capturedRequest.value != nil)
+        let acceptLanguage = capturedRequest.value?.value(forHTTPHeaderField: "Accept-Language")
         #expect(acceptLanguage == "en-US")
     }
 }

--- a/OBAKitTests/Onboarding/OnboardingRegistryTests.swift
+++ b/OBAKitTests/Onboarding/OnboardingRegistryTests.swift
@@ -7,27 +7,25 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 
 @MainActor
-final class OnboardingRegistryTests: XCTestCase {
-    private var store: OnboardingStepStore!
-    private var suiteName: String!
+@Suite(.serialized)
+final class OnboardingRegistryTests {
+    private let store: OnboardingStepStore
 
-    override func setUp() async throws {
-        try await super.setUp()
-        let name = "OnboardingRegistryTests-\(UUID().uuidString)"
-        await MainActor.run {
-            suiteName = name
-            store = OnboardingStepStore(userDefaults: UserDefaults(suiteName: name)!)
-        }
+    /// `nonisolated` so `deinit` can read it without hopping to the main actor.
+    private nonisolated let suiteName: String
+
+    init() {
+        suiteName = "OnboardingRegistryTests-\(UUID().uuidString)"
+        store = OnboardingStepStore(userDefaults: UserDefaults(suiteName: suiteName)!)
     }
 
-    override func tearDown() async throws {
-        let name = await MainActor.run { suiteName }
-        UserDefaults().removePersistentDomain(forName: name!)
-        try await super.tearDown()
+    deinit {
+        UserDefaults().removePersistentDomain(forName: suiteName)
     }
 
     /// Environment helper: a brand-new install with everything available.
@@ -44,46 +42,46 @@ final class OnboardingRegistryTests: XCTestCase {
         OnboardingRegistry.flow(environment: environment, store: store).map(\.id)
     }
 
-    func test_newUser_getsFullOrderedFlow() {
-        XCTAssertEqual(flowIDs(newUserEnvironment()), [.welcome, .location, .region, .notifications, .done])
+    @Test func `New user gets full ordered flow`() {
+        #expect(flowIDs(newUserEnvironment()) == [.welcome, .location, .region, .notifications, .done])
     }
 
-    func test_migratingUser_getsMigrationFirst() {
+    @Test func `Migrating user gets migration first`() {
         var env = newUserEnvironment()
         env.hasDataToMigrate = true
         env.shouldPerformMigration = true
-        XCTAssertEqual(flowIDs(env), [.migration, .welcome, .location, .region, .notifications, .done])
+        #expect(flowIDs(env) == [.migration, .welcome, .location, .region, .notifications, .done])
     }
 
-    func test_backfilledExistingUser_getsExactlyNotifications() {
+    @Test func `Backfilled existing user gets exactly notifications`() {
         store.backfillIfNeeded(hasCurrentRegion: true)
-        XCTAssertEqual(flowIDs(newUserEnvironment()), [.notifications])
+        #expect(flowIDs(newUserEnvironment()) == [.notifications])
     }
 
-    func test_noPushProvider_hidesNotificationsStep() {
+    @Test func `No push provider hides notifications step`() {
         var env = newUserEnvironment()
         env.isPushServiceConfigured = false
-        XCTAssertEqual(flowIDs(env), [.welcome, .location, .region, .done])
+        #expect(flowIDs(env) == [.welcome, .location, .region, .done])
     }
 
-    func test_determinedNotificationPermission_hidesNotificationsStep() {
+    @Test func `Determined notification permission hides notifications step`() {
         var env = newUserEnvironment()
         env.notificationAuthorizationDetermined = true
-        XCTAssertEqual(flowIDs(env), [.welcome, .location, .region, .done])
+        #expect(flowIDs(env) == [.welcome, .location, .region, .done])
     }
 
-    func test_determinedLocationPermission_hidesLocationStep() {
+    @Test func `Determined location permission hides location step`() {
         var env = newUserEnvironment()
         env.locationAuthorizationDetermined = true
-        XCTAssertEqual(flowIDs(env), [.welcome, .region, .notifications, .done])
+        #expect(flowIDs(env) == [.welcome, .region, .notifications, .done])
     }
 
-    func test_versionBump_reshowsOnlyThatStep() {
+    @Test func `Version bump reshows only that step`() {
         store.backfillIfNeeded(hasCurrentRegion: true)
         store.markSeen(.notifications, version: 1)
         let env = newUserEnvironment()
 
-        XCTAssertEqual(flowIDs(env), [])
+        #expect(flowIDs(env) == [])
 
         // Simulate a future release bumping the location step to v2.
         let bumped = OnboardingRegistry.steps.map { step in
@@ -92,33 +90,33 @@ final class OnboardingRegistryTests: XCTestCase {
                 : step
         }
         let flow = OnboardingRegistry.flow(steps: bumped, environment: env, store: store)
-        XCTAssertEqual(flow.map(\.id), [.location])
+        #expect(flow.map(\.id) == [.location])
     }
 
-    func test_migration_ignoresSeenState() {
+    @Test func `Migration ignores seen state`() {
         var env = newUserEnvironment()
         env.hasDataToMigrate = true
         env.shouldPerformMigration = true
         store.markSeen(.migration, version: 99)
-        XCTAssertTrue(flowIDs(env).contains(.migration))
+        #expect(flowIDs(env).contains(.migration))
     }
 
-    func test_allowOnceReversion_stepSeenSoNotReshown() {
+    @Test func `Allow once reversion step seen so not reshown`() {
         // "Allow Once" reverts location auth to .notDetermined after use, but a seen step stays hidden.
         var env = newUserEnvironment()
         env.locationAuthorizationDetermined = false
         store.markSeen(.location, version: 1)
-        XCTAssertFalse(flowIDs(env).contains(.location))
+        #expect(!flowIDs(env).contains(.location))
     }
 
-    func test_registry_stepIDsAndWeightsAreUnique() {
-        XCTAssertEqual(Set(OnboardingRegistry.steps.map(\.id)).count, OnboardingRegistry.steps.count)
-        XCTAssertEqual(Set(OnboardingRegistry.steps.map(\.weight)).count, OnboardingRegistry.steps.count)
+    @Test func `Registry step IDs and weights are unique`() {
+        #expect(Set(OnboardingRegistry.steps.map(\.id)).count == OnboardingRegistry.steps.count)
+        #expect(Set(OnboardingRegistry.steps.map(\.weight)).count == OnboardingRegistry.steps.count)
     }
 
-    func test_flow_sortsByWeightNotDeclarationOrder() {
+    @Test func `Flow sorts by weight not declaration order`() {
         let reversed = Array(OnboardingRegistry.steps.reversed())
         let flow = OnboardingRegistry.flow(steps: reversed, environment: newUserEnvironment(), store: store)
-        XCTAssertEqual(flow.map(\.id), [.welcome, .location, .region, .notifications, .done])
+        #expect(flow.map(\.id) == [.welcome, .location, .region, .notifications, .done])
     }
 }

--- a/OBAKitTests/Onboarding/OnboardingStepStoreTests.swift
+++ b/OBAKitTests/Onboarding/OnboardingStepStoreTests.swift
@@ -7,70 +7,68 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 
 @MainActor
-final class OnboardingStepStoreTests: XCTestCase {
-    private var userDefaults: UserDefaults!
-    private var store: OnboardingStepStore!
-    private var suiteName: String!
+@Suite(.serialized)
+final class OnboardingStepStoreTests {
+    private let userDefaults: UserDefaults
+    private let store: OnboardingStepStore
 
-    override func setUp() async throws {
-        try await super.setUp()
-        let name = "OnboardingStepStoreTests-\(UUID().uuidString)"
-        await MainActor.run {
-            suiteName = name
-            userDefaults = UserDefaults(suiteName: name)
-            store = OnboardingStepStore(userDefaults: userDefaults)
-        }
+    /// `nonisolated` so `deinit` can read it without hopping to the main actor.
+    private nonisolated let suiteName: String
+
+    init() {
+        suiteName = "OnboardingStepStoreTests-\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        store = OnboardingStepStore(userDefaults: userDefaults)
     }
 
-    override func tearDown() async throws {
-        let name = await MainActor.run { suiteName }
-        UserDefaults().removePersistentDomain(forName: name!)
-        try await super.tearDown()
+    deinit {
+        UserDefaults().removePersistentDomain(forName: suiteName)
     }
 
-    func test_unseenStep_hasVersionZero() {
-        XCTAssertEqual(store.seenVersion(of: .notifications), 0)
-        XCTAssertTrue(store.isEmpty)
+    @Test func `Unseen step has version zero`() {
+        #expect(store.seenVersion(of: .notifications) == 0)
+        #expect(store.isEmpty)
     }
 
-    func test_markSeen_roundTripsThroughUserDefaults() {
+    @Test func `Mark seen round trips through user defaults`() {
         store.markSeen(.welcome, version: 1)
-        XCTAssertEqual(store.seenVersion(of: .welcome), 1)
-        XCTAssertFalse(store.isEmpty)
+        #expect(store.seenVersion(of: .welcome) == 1)
+        #expect(!store.isEmpty)
 
         // A second store over the same defaults sees the same data.
         let rehydrated = OnboardingStepStore(userDefaults: userDefaults)
-        XCTAssertEqual(rehydrated.seenVersion(of: .welcome), 1)
+        #expect(rehydrated.seenVersion(of: .welcome) == 1)
     }
 
-    func test_markSeen_neverLowersVersion() {
+    @Test func `Mark seen never lowers version`() {
         store.markSeen(.location, version: 3)
         store.markSeen(.location, version: 1)
-        XCTAssertEqual(store.seenVersion(of: .location), 3)
+        #expect(store.seenVersion(of: .location) == 3)
     }
 
-    func test_backfill_existingUser_marksLegacyStepsButNotNotifications() {
-        XCTAssertTrue(store.backfillIfNeeded(hasCurrentRegion: true))
-        XCTAssertEqual(store.seenVersion(of: .welcome), 1)
-        XCTAssertEqual(store.seenVersion(of: .location), 1)
-        XCTAssertEqual(store.seenVersion(of: .region), 1)
-        XCTAssertEqual(store.seenVersion(of: .done), 1)
-        XCTAssertEqual(store.seenVersion(of: .notifications), 0)
-        XCTAssertEqual(store.seenVersion(of: .migration), 0)
+    @Test func `Backfill existing user marks legacy steps but not notifications`() {
+        #expect(store.backfillIfNeeded(hasCurrentRegion: true))
+        #expect(store.seenVersion(of: .welcome) == 1)
+        #expect(store.seenVersion(of: .location) == 1)
+        #expect(store.seenVersion(of: .region) == 1)
+        #expect(store.seenVersion(of: .done) == 1)
+        #expect(store.seenVersion(of: .notifications) == 0)
+        #expect(store.seenVersion(of: .migration) == 0)
     }
 
-    func test_backfill_newUser_doesNothing() {
-        XCTAssertFalse(store.backfillIfNeeded(hasCurrentRegion: false))
-        XCTAssertTrue(store.isEmpty)
+    @Test func `Backfill new user does nothing`() {
+        #expect(!store.backfillIfNeeded(hasCurrentRegion: false))
+        #expect(store.isEmpty)
     }
 
-    func test_backfill_nonEmptyStore_neverRunsAgain() {
+    @Test func `Backfill non empty store never runs again`() {
         store.markSeen(.welcome, version: 1)
-        XCTAssertFalse(store.backfillIfNeeded(hasCurrentRegion: true))
-        XCTAssertEqual(store.seenVersion(of: .region), 0)
+        #expect(!store.backfillIfNeeded(hasCurrentRegion: true))
+        #expect(store.seenVersion(of: .region) == 0)
     }
 }

--- a/OBAKitTests/Onboarding/RegionCustomFormTests.swift
+++ b/OBAKitTests/Onboarding/RegionCustomFormTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -15,38 +15,39 @@ import Testing
 /// Tests for `RegionCustomForm.normalizeBaseURL(_:)`, the sole gatekeeper for
 /// the Base URL a custom region is saved with.
 @MainActor
-class RegionCustomFormTests: XCTestCase {
+@Suite(.serialized)
+final class RegionCustomFormTests {
 
     private func normalize(_ string: String) -> String? {
         RegionCustomForm.normalizeBaseURL(string)?.absoluteString
     }
 
-    func test_normalizeBaseURL_prependsHTTPS() {
+    @Test func `Normalize base URL prepends HTTPS`() {
         #expect(self.normalize("api.tampa.onebusaway.org") == "https://api.tampa.onebusaway.org")
     }
 
-    func test_normalizeBaseURL_preservesExplicitScheme() {
+    @Test func `Normalize base URL preserves explicit scheme`() {
         #expect(self.normalize("http://example.com") == "http://example.com")
         #expect(self.normalize("https://example.com") == "https://example.com")
     }
 
-    func test_normalizeBaseURL_stripsWhitespace() {
+    @Test func `Normalize base URL strips whitespace`() {
         #expect(self.normalize("  api.example.com \n") == "https://api.example.com")
     }
 
     /// The field's help text promises `/api/where` is appended automatically,
     /// so a pasted full API URL must not end up with the path doubled.
-    func test_normalizeBaseURL_stripsTrailingAPIWhere() {
+    @Test func `Normalize base URL strips trailing API where`() {
         #expect(self.normalize("https://api.tampa.onebusaway.org/api/where") == "https://api.tampa.onebusaway.org")
         #expect(self.normalize("api.tampa.onebusaway.org/api/where/") == "https://api.tampa.onebusaway.org")
         #expect(self.normalize("example.com/API/WHERE") == "https://example.com")
     }
 
-    func test_normalizeBaseURL_stripsTrailingSlashes() {
+    @Test func `Normalize base URL strips trailing slashes`() {
         #expect(self.normalize("https://example.com/") == "https://example.com")
     }
 
-    func test_normalizeBaseURL_rejectsInvalidInput() {
+    @Test func `Normalize base URL rejects invalid input`() {
         #expect(self.normalize("") == nil)
         #expect(self.normalize("   ") == nil)
         #expect(self.normalize("ftp://example.com") == nil)
@@ -65,24 +66,24 @@ class RegionCustomFormTests: XCTestCase {
         RegionCustomForm.normalizeURL(string)?.absoluteString
     }
 
-    func test_normalizeURL_prependsHTTPS() {
+    @Test func `Normalize URL prepends HTTPS`() {
         #expect(self.normalizeGeneral("obaco.example.com") == "https://obaco.example.com")
     }
 
-    func test_normalizeURL_preservesExplicitScheme() {
+    @Test func `Normalize URL preserves explicit scheme`() {
         #expect(self.normalizeGeneral("http://example.com") == "http://example.com")
     }
 
-    func test_normalizeURL_stripsWhitespaceAndTrailingSlashes() {
+    @Test func `Normalize URL strips whitespace and trailing slashes`() {
         #expect(self.normalizeGeneral("  analytics.example.com/ \n") == "https://analytics.example.com")
     }
 
     /// Unlike the Base URL field, general URLs keep an `/api/where` path verbatim.
-    func test_normalizeURL_doesNotStripAPIWhere() {
+    @Test func `Normalize URL does not strip API where`() {
         #expect(self.normalizeGeneral("example.com/api/where") == "https://example.com/api/where")
     }
 
-    func test_normalizeURL_rejectsInvalidInput() {
+    @Test func `Normalize URL rejects invalid input`() {
         #expect(self.normalizeGeneral("") == nil)
         #expect(self.normalizeGeneral("   ") == nil)
         #expect(self.normalizeGeneral("ftp://example.com") == nil)

--- a/OBAKitTests/Persistence/StopCacheRepositoryTests.swift
+++ b/OBAKitTests/Persistence/StopCacheRepositoryTests.swift
@@ -7,29 +7,30 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import CoreLocation
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
 @MainActor
-class StopCacheRepositoryTests: XCTestCase {
+@Suite(.serialized)
+final class StopCacheRepositoryTests {
 
-    var database: StopCacheDatabase!
-    var repository: StopCacheRepository!
+    let database: StopCacheDatabase
+    let repository: StopCacheRepository
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         database = try! StopCacheDatabase(inMemory: true)
         repository = StopCacheRepository(database: database)
     }
 
-    override func tearDown() async throws {
-        repository = nil
-        database = nil
-        try await super.tearDown()
-    }
+    // `tearDown` nilled both properties out. That was housekeeping XCTest
+    // needed because it keeps test-case instances alive for the whole run;
+    // Swift Testing releases the suite instance after each test, so letting
+    // ARC do it is equivalent — and a `deinit` that only assigns nil to
+    // properties of the object being destroyed is a no-op anyway.
 
     // MARK: - Helpers
 
@@ -65,29 +66,29 @@ class StopCacheRepositoryTests: XCTestCase {
 
     // MARK: - Save and Retrieve
 
-    func test_saveAndRetrieveStops_roundTripsCorrectly() {
+    @Test func `Save and retrieve stops round trips correctly`() {
         let stop = makeStop(id: "1_75403", code: "75403", name: "E Pine St & 15th Ave", lat: 47.6153, lon: -122.3148, direction: "W", routeIDs: ["1_10", "1_49"])
 
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
 
-        XCTAssertEqual(results.count, 1)
+        #expect(results.count == 1)
 
         let cached = results[0]
-        XCTAssertEqual(cached.id, "1_75403")
-        XCTAssertEqual(cached.code, "75403")
-        XCTAssertEqual(cached.name, "E Pine St & 15th Ave")
-        XCTAssertEqual(cached.location.coordinate.latitude, 47.6153, accuracy: 0.0001)
-        XCTAssertEqual(cached.location.coordinate.longitude, -122.3148, accuracy: 0.0001)
-        XCTAssertEqual(cached.direction, .w)
-        XCTAssertEqual(cached.locationType, .stop)
-        XCTAssertEqual(cached.routeIDs, ["1_10", "1_49"])
-        XCTAssertEqual(cached.wheelchairBoarding, .unknown)
-        XCTAssertEqual(cached.regionIdentifier, 1)
+        #expect(cached.id == "1_75403")
+        #expect(cached.code == "75403")
+        #expect(cached.name == "E Pine St & 15th Ave")
+        expectClose(cached.location.coordinate.latitude, 47.6153, within: 0.0001)
+        expectClose(cached.location.coordinate.longitude, -122.3148, within: 0.0001)
+        #expect(cached.direction == .w)
+        #expect(cached.locationType == .stop)
+        #expect(cached.routeIDs == ["1_10", "1_49"])
+        #expect(cached.wheelchairBoarding == .unknown)
+        #expect(cached.regionIdentifier == 1)
     }
 
-    func test_saveStops_upsertsOnCompositeKey() {
+    @Test func `Save stops upserts on composite key`() {
         let original = makeStop(id: "1_100", name: "Original Name", lat: 47.6, lon: -122.3)
         repository.saveStops([original], regionId: 1)
 
@@ -95,11 +96,11 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.saveStops([updated], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].name, "Updated Name")
+        #expect(results.count == 1)
+        #expect(results[0].name == "Updated Name")
     }
 
-    func test_sameStopId_differentRegions_storedSeparately() {
+    @Test func `Same stop id different regions stored separately`() {
         let stop = makeStop(id: "1_100", name: "Seattle Stop", lat: 47.6, lon: -122.3)
         repository.saveStops([stop], regionId: 1)
 
@@ -107,57 +108,57 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.saveStops([sameIdDifferentRegion], regionId: 2)
 
         let seattleResults = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(seattleResults.count, 1)
-        XCTAssertEqual(seattleResults[0].name, "Seattle Stop")
+        #expect(seattleResults.count == 1)
+        #expect(seattleResults[0].name == "Seattle Stop")
 
         let tampaResults = repository.stopsInRegion(minLat: 27.0, maxLat: 28.0, minLon: -83.0, maxLon: -82.0, regionId: 2)
-        XCTAssertEqual(tampaResults.count, 1)
-        XCTAssertEqual(tampaResults[0].name, "Tampa Stop")
+        #expect(tampaResults.count == 1)
+        #expect(tampaResults[0].name == "Tampa Stop")
     }
 
     // MARK: - Bounding Box Query
 
-    func test_stopsInRegion_onlyReturnsStopsWithinBounds() {
+    @Test func `Stops in region only returns stops within bounds`() {
         let inside = makeStop(id: "inside", lat: 47.61, lon: -122.33)
         let outside = makeStop(id: "outside", lat: 48.50, lon: -121.00)
 
         repository.saveStops([inside, outside], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.5, maxLat: 47.7, minLon: -122.5, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].id, "inside")
+        #expect(results.count == 1)
+        #expect(results[0].id == "inside")
     }
 
-    func test_stopsInRegion_returnsEmptyForNoMatches() {
+    @Test func `Stops in region returns empty for no matches`() {
         let stop = makeStop(id: "1_100", lat: 47.6, lon: -122.3)
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 0.0, maxLat: 1.0, minLon: 0.0, maxLon: 1.0, regionId: 1)
-        XCTAssertEqual(results.count, 0)
+        #expect(results.count == 0)
     }
 
-    func test_stopsInRegion_filtersByRegionId() {
+    @Test func `Stops in region filters by region id`() {
         let stop = makeStop(id: "1_100", lat: 47.6, lon: -122.3)
         repository.saveStops([stop], regionId: 1)
 
         // Same bounding box, different region — should return nothing
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 999)
-        XCTAssertEqual(results.count, 0)
+        #expect(results.count == 0)
     }
 
-    func test_stopsInRegion_includesStopsOnBoundary() {
+    @Test func `Stops in region includes stops on boundary`() {
         let edgeStop = makeStop(id: "edge", lat: 47.5, lon: -122.5)
         repository.saveStops([edgeStop], regionId: 1)
 
         // Query with bounds exactly matching the stop's coordinates
         let results = repository.stopsInRegion(minLat: 47.5, maxLat: 47.5, minLon: -122.5, maxLon: -122.5, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].id, "edge")
+        #expect(results.count == 1)
+        #expect(results[0].id == "edge")
     }
 
     // MARK: - Purge Stale Data
 
-    func test_deleteStopsOlderThan_removesStaleEntries() {
+    @Test func `Delete stops older than removes stale entries`() {
         let stop = makeStop(id: "old_stop", lat: 47.6, lon: -122.3)
         repository.saveStops([stop], regionId: 1)
 
@@ -166,10 +167,10 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.deleteStopsOlderThan(futureDate, regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 0)
+        #expect(results.count == 0)
     }
 
-    func test_deleteStopsOlderThan_preservesFreshEntries() {
+    @Test func `Delete stops older than preserves fresh entries`() {
         let stop = makeStop(id: "fresh_stop", lat: 47.6, lon: -122.3)
         repository.saveStops([stop], regionId: 1)
 
@@ -178,11 +179,11 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.deleteStopsOlderThan(pastDate, regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].id, "fresh_stop")
+        #expect(results.count == 1)
+        #expect(results[0].id == "fresh_stop")
     }
 
-    func test_deleteStopsOlderThan_scopedToRegion() {
+    @Test func `Delete stops older than scoped to region`() {
         let stop1 = makeStop(id: "1_100", lat: 47.6, lon: -122.3)
         let stop2 = makeStop(id: "2_100", lat: 27.9, lon: -82.5)
 
@@ -194,16 +195,16 @@ class StopCacheRepositoryTests: XCTestCase {
 
         // Region 1 should be empty
         let region1Results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(region1Results.count, 0)
+        #expect(region1Results.count == 0)
 
         // Region 2 should be untouched
         let region2Results = repository.stopsInRegion(minLat: 27.0, maxLat: 28.0, minLon: -83.0, maxLon: -82.0, regionId: 2)
-        XCTAssertEqual(region2Results.count, 1)
+        #expect(region2Results.count == 1)
     }
 
     // MARK: - Clear Cache
 
-    func test_clearCache_removesAllStopsForRegion_andPreservesOtherRegions() {
+    @Test func `Clear cache removes all stops for region and preserves other regions`() {
         let region1Stops = (1...5).map { makeStop(id: "stop_\($0)", lat: 47.6 + Double($0) * 0.001, lon: -122.3) }
         repository.saveStops(region1Stops, regionId: 1)
 
@@ -213,26 +214,26 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.clearCache(regionId: 1)
 
         let region1Results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(region1Results.count, 0)
+        #expect(region1Results.count == 0)
 
         // Region 2 should be untouched
         let region2Results = repository.stopsInRegion(minLat: 27.0, maxLat: 28.0, minLon: -83.0, maxLon: -82.0, regionId: 2)
-        XCTAssertEqual(region2Results.count, 1)
-        XCTAssertEqual(region2Results[0].id, "region2_stop")
+        #expect(region2Results.count == 1)
+        #expect(region2Results[0].id == "region2_stop")
     }
 
     // MARK: - Direction Handling
 
-    func test_stopWithNilDirection_roundTripsAsUnknown() {
+    @Test func `Stop with nil direction round trips as unknown`() {
         let stop = makeStop(id: "no_dir", direction: nil)
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].direction, .unknown)
+        #expect(results.count == 1)
+        #expect(results[0].direction == .unknown)
     }
 
-    func test_allDirections_roundTripCorrectly() {
+    @Test func `All directions round trip correctly`() {
         let directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
         let expectedDirections: [Direction] = [.n, .ne, .e, .se, .s, .sw, .w, .nw]
 
@@ -242,39 +243,39 @@ class StopCacheRepositoryTests: XCTestCase {
 
             let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
             let match = results.first { $0.id == "dir_\(dir)" }
-            XCTAssertNotNil(match, "Stop with direction \(dir) should exist in cache")
-            XCTAssertEqual(match?.direction, expectedDirections[index], "Direction \(dir) should round-trip to \(expectedDirections[index])")
+            #expect(match != nil, "Stop with direction \(dir) should exist in cache")
+            #expect(match?.direction == expectedDirections[index], "Direction \(dir) should round-trip to \(expectedDirections[index])")
         }
     }
 
     // MARK: - Routes Safety
 
-    func test_cachedStop_routesIsNotNil_afterRoundTrip() {
+    @Test func `Cached stop routes is not nil after round trip`() {
         let stop = makeStop(id: "1_100")
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
+        #expect(results.count == 1)
 
         // Stop.routes is [Route]! — if this is nil, the next line would crash.
-        XCTAssertNotNil(results[0].routes)
+        #expect(results[0].routes != nil)
         // Accessing prioritizedRouteTypeForDisplay exercises routes.map internally.
-        XCTAssertEqual(results[0].prioritizedRouteTypeForDisplay, .unknown)
+        #expect(results[0].prioritizedRouteTypeForDisplay == .unknown)
     }
 
-    func test_cachedStop_emptyRouteIDs_roundTripsCorrectly() {
+    @Test func `Cached stop empty route IDs round trips correctly`() {
         let stop = makeStop(id: "no_routes", routeIDs: [])
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertNotNil(results[0].routes)
-        XCTAssertEqual(results[0].routeIDs, [])
+        #expect(results.count == 1)
+        #expect(results[0].routes != nil)
+        #expect(results[0].routeIDs == [])
     }
 
     // MARK: - Corrupted Data
 
-    func test_stopsInRegion_gracefullyHandlesCorruptedStopData() throws {
+    @Test func `Stops in region gracefully handles corrupted stop data`() throws {
         // Insert a record with invalid blob data directly via GRDB
         try database.dbQueue.write { db in
             try db.execute(
@@ -292,13 +293,13 @@ class StopCacheRepositoryTests: XCTestCase {
 
         // The corrupted record should be silently filtered out by compactMap in stopsInRegion
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].id, "valid_1")
+        #expect(results.count == 1)
+        #expect(results[0].id == "valid_1")
     }
 
     // MARK: - Nil Direction / WheelchairBoarding
 
-    func test_stopWithNilDirectionAndWheelchairBoarding_roundTripsCorrectly() {
+    @Test func `Stop with nil direction and wheelchair boarding round trips correctly`() {
         // direction=nil and wheelchairBoarding=nil should round-trip cleanly
         // through Stop's own Codable (no manual dictionary involved).
         let dict: [String: Any] = [
@@ -317,14 +318,14 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.saveStops([stop], regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results[0].id, "nil_fields")
-        XCTAssertEqual(results[0].direction, .unknown)
+        #expect(results.count == 1)
+        #expect(results[0].id == "nil_fields")
+        #expect(results[0].direction == .unknown)
     }
 
     // MARK: - Failable Init
 
-    func test_saveStops_persistsAllValidStops() {
+    @Test func `Save stops persists all valid stops`() {
         // Verifies the failable CachedStop.init? doesn't accidentally skip valid stops.
         // Note: The encoding-failure path (init? returning nil) isn't practically testable
         // because Stop always encodes successfully. The read-side filtering of corrupted
@@ -333,19 +334,19 @@ class StopCacheRepositoryTests: XCTestCase {
         repository.saveStops(stops, regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 5)
+        #expect(results.count == 5)
     }
 
     // MARK: - Multiple Stops
 
-    func test_saveMultipleStops_allPersisted() {
+    @Test func `Save multiple stops all persisted`() {
         let stops = (1...50).map {
             makeStop(id: "stop_\($0)", lat: 47.6 + Double($0) * 0.001, lon: -122.3)
         }
         repository.saveStops(stops, regionId: 1)
 
         let results = repository.stopsInRegion(minLat: 47.0, maxLat: 48.0, minLon: -123.0, maxLon: -122.0, regionId: 1)
-        XCTAssertEqual(results.count, 50)
+        #expect(results.count == 50)
     }
 }
 

--- a/OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/OBACloudPushServiceTests.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -18,12 +18,14 @@ import XCTest
 /// delivery, and failure handling. They deliberately avoid asserting on anything
 /// driven by `UNUserNotificationCenter.requestAuthorization`, whose behavior is
 /// simulator- and permission-state-dependent.
-class OBACloudPushServiceTests: OBATestCase {
+@Suite(.serialized)
+final class OBACloudPushServiceTests: OBATestCase {
 
     private var service: OBACloudPushService!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         service = OBACloudPushService()
         // The real handlers are installed by PushService during init. Install benign
         // defaults so an async authorization denial can never crash a test.
@@ -33,53 +35,53 @@ class OBACloudPushServiceTests: OBATestCase {
 
     // MARK: - Token Conversion
 
-    func test_didRegister_convertsTokenDataToLowercaseHexString() {
+    @Test func `Did register converts token data to lowercase hex string`() {
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0x01, 0xAB, 0xFF, 0x00, 0x7F]))
 
-        XCTAssertEqual(service.pushUserID, "01abff007f")
-        XCTAssertTrue(service.isRegisteredForRemoteNotifications)
+        #expect(service.pushUserID == "01abff007f")
+        #expect(service.isRegisteredForRemoteNotifications)
     }
 
-    func test_beforeRegistration_noTokenIsAvailable() {
-        XCTAssertNil(service.pushUserID)
-        XCTAssertFalse(service.isRegisteredForRemoteNotifications)
+    @Test func `Before registration no token is available`() {
+        #expect(service.pushUserID == nil)
+        #expect(!service.isRegisteredForRemoteNotifications)
     }
 
     // MARK: - Callback Delivery
 
-    func test_requestPushID_withExistingToken_invokesCallbackImmediately() {
+    @Test func `Request push ID with existing token invokes callback immediately`() {
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xDE, 0xAD]))
 
         var receivedTokens: [String] = []
         service.requestPushID { receivedTokens.append($0) }
 
-        XCTAssertEqual(receivedTokens, ["dead"])
+        #expect(receivedTokens == ["dead"])
     }
 
-    func test_didRegister_deliversAllPendingCallbacksExactlyOnce() {
+    @Test func `Did register delivers all pending callbacks exactly once`() {
         var firstTokens: [String] = []
         var secondTokens: [String] = []
         service.requestPushID { firstTokens.append($0) }
         service.requestPushID { secondTokens.append($0) }
 
-        XCTAssertTrue(firstTokens.isEmpty, "Callbacks must not fire before a token arrives")
+        #expect(firstTokens.isEmpty, "Callbacks must not fire before a token arrives")
 
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xBE, 0xEF]))
 
-        XCTAssertEqual(firstTokens, ["beef"])
-        XCTAssertEqual(secondTokens, ["beef"])
+        #expect(firstTokens == ["beef"])
+        #expect(secondTokens == ["beef"])
 
         // A re-registration (token rotation) must not re-invoke already-delivered callbacks.
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xCA, 0xFE]))
 
-        XCTAssertEqual(firstTokens, ["beef"])
-        XCTAssertEqual(secondTokens, ["beef"])
-        XCTAssertEqual(service.pushUserID, "cafe")
+        #expect(firstTokens == ["beef"])
+        #expect(secondTokens == ["beef"])
+        #expect(service.pushUserID == "cafe")
     }
 
     // MARK: - Failure Handling
 
-    func test_didFail_forwardsErrorAndClearsPendingCallbacks() {
+    @Test func `Did fail forwards error and clears pending callbacks`() {
         var receivedErrors: [Error] = []
         service.errorHandler = { receivedErrors.append($0) }
 
@@ -89,17 +91,17 @@ class OBACloudPushServiceTests: OBATestCase {
         let registrationError = NSError(domain: "test", code: 3000, userInfo: nil)
         service.didFailToRegisterForRemoteNotifications(withError: registrationError)
 
-        XCTAssertEqual(receivedErrors.count, 1)
-        XCTAssertEqual((receivedErrors.first as NSError?)?.code, 3000)
+        #expect(receivedErrors.count == 1)
+        #expect((receivedErrors.first as NSError?)?.code == 3000)
 
         // A token arriving after failure must not invoke the cleared callbacks.
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0x11]))
-        XCTAssertTrue(receivedTokens.isEmpty)
+        #expect(receivedTokens.isEmpty)
     }
 
     // MARK: - Token Update Handler
 
-    func test_didRegister_invokesDeviceTokenUpdatedHandlerOnEveryRegistration() {
+    @Test func `Did register invokes device token updated handler on every registration`() {
         var receivedTokens: [String] = []
         service.deviceTokenUpdatedHandler = { receivedTokens.append($0) }
 
@@ -107,6 +109,6 @@ class OBACloudPushServiceTests: OBATestCase {
         // Token rotation (restore/reinstall) re-fires the handler with the new token.
         service.didRegisterForRemoteNotifications(withDeviceToken: Data([0xCA, 0xFE]))
 
-        XCTAssertEqual(receivedTokens, ["beef", "cafe"])
+        #expect(receivedTokens == ["beef", "cafe"])
     }
 }

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import UserNotifications
 @testable import OBAKit
 @testable import OBAKitCore
@@ -16,7 +17,8 @@ import UserNotifications
 /// registered with the current region's OBACloud server — deduplicated, daily-refreshed,
 /// and gated on notification authorization.
 @MainActor
-class PushRegistrationManagerTests: OBATestCase {
+@Suite(.serialized)
+final class PushRegistrationManagerTests: OBATestCase {
 
     /// Mutable state shared with the manager's injected closures. `@unchecked Sendable`
     /// because tests mutate it only between awaited calls.
@@ -40,8 +42,9 @@ class PushRegistrationManagerTests: OBATestCase {
     private var currentService: ObacoAPIService?
     private var defaults: UserDefaults!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         controls = Controls()
         dataLoader = MockDataLoader(testName: name)
         currentService = buildObacoService(dataLoader: dataLoader)
@@ -107,69 +110,69 @@ class PushRegistrationManagerTests: OBATestCase {
 
     // MARK: - Registration
 
-    func test_registerIfNeeded_postsTokenOnce() async {
+    @Test func `Register if needed posts token once`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
 
         // Nothing changed: an immediate second call must not hit the network again.
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
-    func test_registerIfNeeded_withoutToken_doesNothing() async {
+    @Test func `Register if needed without token does nothing`() async {
         let manager = makeManager()
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(registrationRequestCount == 0)
     }
 
-    func test_registerIfNeeded_withoutAuthorization_doesNothing() async {
+    @Test func `Register if needed without authorization does nothing`() async {
         controls.authorizationStatus = .denied
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(registrationRequestCount == 0)
     }
 
     /// Provisionally-authorized users receive quiet notifications — they count as opted in.
-    func test_registerIfNeeded_registersWithProvisionalAuthorization() async {
+    @Test func `Register if needed registers with provisional authorization`() async {
         controls.authorizationStatus = .provisional
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
     /// `CoreApplication.refreshObacoService()` leaves the previous region's service in place
     /// when the user switches to a region without a sidecar — never register against a region
     /// the user has left.
-    func test_registerIfNeeded_skipsWhenObacoServiceRegionIsStale() async {
+    @Test func `Register if needed skips when obaco service region is stale`() async {
         controls.currentRegionID = 99
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(registrationRequestCount == 0)
     }
 
-    func test_registerIfNeeded_withoutObacoService_doesNothing() async {
+    @Test func `Register if needed without obaco service does nothing`() async {
         currentService = nil
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(registrationRequestCount == 0)
     }
 
     // MARK: - Re-registration triggers
 
-    func test_registerIfNeeded_repostsWhenTokenRotates() async {
+    @Test func `Register if needed reposts when token rotates`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -178,10 +181,10 @@ class PushRegistrationManagerTests: OBATestCase {
         manager.updateDeviceToken("cafed00d")
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2)
+        #expect(registrationRequestCount == 2)
     }
 
-    func test_registerIfNeeded_repostsWhenLocaleChanges() async {
+    @Test func `Register if needed reposts when locale changes`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -190,10 +193,10 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.locale = "es-MX"
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2)
+        #expect(registrationRequestCount == 2)
     }
 
-    func test_registerIfNeeded_repostsWhenTestDeviceFlagChanges() async {
+    @Test func `Register if needed reposts when test device flag changes`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -206,13 +209,13 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.testDeviceDescription = "Aarons iPhone"
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2)
+        #expect(registrationRequestCount == 2)
     }
 
     /// The server rejects `test_device=true` without a `description` — a test device that
     /// hasn't been named yet must register as a regular device rather than POST a
     /// guaranteed 422.
-    func test_registerIfNeeded_downgradesTestDeviceWithoutDescription() async {
+    @Test func `Register if needed downgrades test device without description`() async {
         let capture = mockRegistrationResponseCapturingBody()
         controls.testDevice = true
         controls.testDeviceDescription = nil
@@ -221,17 +224,17 @@ class PushRegistrationManagerTests: OBATestCase {
 
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 1)
-        let body = try? XCTUnwrap(capture.bodies.first)
-        XCTAssertEqual(capture.bodies.count, 1)
-        XCTAssertTrue(body?.contains("test_device=false") ?? false, "Body: \(String(describing: body))")
-        XCTAssertFalse(body?.contains("description=") ?? true, "Body: \(String(describing: body))")
+        #expect(registrationRequestCount == 1)
+        let body = try? #require(capture.bodies.first)
+        #expect(capture.bodies.count == 1)
+        #expect(body?.contains("test_device=false") ?? false, "Body: \(String(describing: body))")
+        #expect(!(body?.contains("description=") ?? true), "Body: \(String(describing: body))")
     }
 
     /// A changed description is a real change to the wire payload (it identifies the device
     /// to admins), so it must trigger a re-POST even though token/region/locale/testDevice
     /// are unchanged.
-    func test_registerIfNeeded_repostsWhenDescriptionChanges() async {
+    @Test func `Register if needed reposts when description changes`() async {
         mockRegistrationResponse()
         controls.testDevice = true
         controls.testDeviceDescription = "A"
@@ -242,15 +245,15 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.testDeviceDescription = "B"
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2)
+        #expect(registrationRequestCount == 2)
     }
 
-    func test_registerIfNeeded_repostsWhenRegionChanges() async {
+    @Test func `Register if needed reposts when region changes`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
 
         // Same host, different region — mirrors CoreApplication rebuilding obacoService
         // after a region switch.
@@ -259,13 +262,13 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.currentRegionID = 2
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 2)
-        XCTAssertTrue(dataLoader.recordedRequestURLs.contains { $0.path.hasSuffix("/regions/2/push_registrations") })
+        #expect(registrationRequestCount == 2)
+        #expect(dataLoader.recordedRequestURLs.contains { $0.path.hasSuffix("/regions/2/push_registrations") })
     }
 
     /// The server prunes tokens it hasn't seen recently; an unchanged registration is
     /// therefore re-POSTed once its age exceeds the refresh interval.
-    func test_registerIfNeeded_repostsWhenStale() async {
+    @Test func `Register if needed reposts when stale`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -274,11 +277,11 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.now = controls.now.addingTimeInterval(PushRegistrationManager.refreshInterval + 60)
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2)
+        #expect(registrationRequestCount == 2)
     }
 
     /// Dedupe state persists across manager instances (i.e., app launches).
-    func test_registerIfNeeded_dedupeSurvivesRelaunch() async {
+    @Test func `Register if needed dedupe survives relaunch`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -288,13 +291,13 @@ class PushRegistrationManagerTests: OBATestCase {
         relaunched.updateDeviceToken("01abff007f")
         await relaunched.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
     // MARK: - Failure handling
 
     /// A failed POST must not be recorded as a successful registration — the next call retries.
-    func test_registerIfNeeded_doesNotPersistOnServerError() async {
+    @Test func `Register if needed does not persist on server error`() async {
         mockRegistrationResponse(statusCode: 422)
 
         let manager = makeManager()
@@ -302,7 +305,7 @@ class PushRegistrationManagerTests: OBATestCase {
         await manager.registerIfNeeded()
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 2, "Expected a retry because the first POST failed")
+        #expect(registrationRequestCount == 2, "Expected a retry because the first POST failed")
     }
 
     // MARK: - Coalescing
@@ -310,7 +313,7 @@ class PushRegistrationManagerTests: OBATestCase {
     /// On the first foreground after a permission grant, the becomeActive trigger and the
     /// APNs token callback can both call `registerIfNeeded()` before either finishes — the
     /// second caller must coalesce into the first instead of double-POSTing.
-    func test_registerIfNeeded_coalescesConcurrentCalls() async {
+    @Test func `Register if needed coalesces concurrent calls`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -328,40 +331,40 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.authGate = nil
         _ = await first.value
 
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
     // MARK: - refreshRegistration
 
-    func test_refreshRegistration_requestsAPNsRegistrationWhenAuthorized() async {
+    @Test func `Refresh registration requests APNs registration when authorized`() async {
         let manager = makeManager()
         await manager.refreshRegistration()
-        XCTAssertEqual(controls.remoteRegistrationRequests, 1)
+        #expect(controls.remoteRegistrationRequests == 1)
     }
 
-    func test_refreshRegistration_skipsAPNsRegistrationWhenDenied() async {
+    @Test func `Refresh registration skips APNs registration when denied`() async {
         controls.authorizationStatus = .denied
         let manager = makeManager()
         await manager.refreshRegistration()
-        XCTAssertEqual(controls.remoteRegistrationRequests, 0)
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(controls.remoteRegistrationRequests == 0)
+        #expect(registrationRequestCount == 0)
     }
 
     /// The foreground refresh must POST the already-known token itself — APNs is not
     /// guaranteed to re-deliver a token callback, so this is what keeps `last_seen_at` fresh.
-    func test_refreshRegistration_postsAlreadyKnownToken() async {
+    @Test func `Refresh registration posts already known token`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.refreshRegistration()
 
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
     /// A token that rotates while a registration is in flight must be registered by the
     /// coalescing loop's follow-up pass — and recorded, so it isn't re-POSTed again.
-    func test_registerIfNeeded_registersRotatedTokenArrivingMidFlight() async {
+    @Test func `Register if needed registers rotated token arriving mid flight`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
@@ -377,14 +380,14 @@ class PushRegistrationManagerTests: OBATestCase {
         controls.authGate = nil
         _ = await first.value
 
-        XCTAssertEqual(registrationRequestCount, 2, "Expected the follow-up pass to register the rotated token")
+        #expect(registrationRequestCount == 2, "Expected the follow-up pass to register the rotated token")
 
         await manager.registerIfNeeded()
-        XCTAssertEqual(registrationRequestCount, 2, "Expected the rotated token to be recorded as registered")
+        #expect(registrationRequestCount == 2, "Expected the rotated token to be recorded as registered")
     }
 
     /// Corrupted persisted state must degrade to "never registered", not crash or skip.
-    func test_registerIfNeeded_recoversFromCorruptedPersistedState() async {
+    @Test func `Register if needed recovers from corrupted persisted state`() async {
         defaults.set("not a plist blob", forKey: PushRegistrationManager.lastRegistrationUserDefaultsKey)
         mockRegistrationResponse()
         let manager = makeManager()
@@ -392,29 +395,29 @@ class PushRegistrationManagerTests: OBATestCase {
 
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 1)
+        #expect(registrationRequestCount == 1)
     }
 
-    func test_updateDeviceToken_ignoresEmptyToken() async {
+    @Test func `Update device token ignores empty token`() async {
         mockRegistrationResponse()
         let manager = makeManager()
         manager.updateDeviceToken("")
 
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(registrationRequestCount, 0)
+        #expect(registrationRequestCount == 0)
     }
 
     /// Server rejections reach the injected error reporter (Crashlytics in production);
     /// registrations are the server's only audience source, so fleet-wide failures must
     /// be observable somewhere.
-    func test_registerIfNeeded_reportsServerRejectionsToErrorReporter() async {
+    @Test func `Register if needed reports server rejections to error reporter`() async {
         mockRegistrationResponse(statusCode: 422)
         let manager = makeManager()
         manager.updateDeviceToken("01abff007f")
 
         await manager.registerIfNeeded()
 
-        XCTAssertEqual(controls.reportedErrors.count, 1)
+        #expect(controls.reportedErrors.count == 1)
     }
 }

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -53,7 +53,7 @@ final class PushRegistrationManagerTests: OBATestCase {
     }
 
     /// Mocks the `POST /push_registrations` response. Installed per-test rather than in
-    /// `setUp` because `MockDataLoader` matching is first-added-wins and the
+    /// `init()` because `MockDataLoader` matching is first-added-wins and the
     /// failure-handling test needs a non-204 answer.
     private func mockRegistrationResponse(statusCode: Int = 204) {
         dataLoader.mock(data: Data(), statusCode: statusCode) { request in

--- a/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
+++ b/OBAKitTests/PushNotifications/PushRegistrationManagerTests.swift
@@ -90,7 +90,11 @@ final class PushRegistrationManagerTests: OBATestCase {
             testDeviceProvider: { controls.testDevice },
             testDeviceDescriptionProvider: { controls.testDeviceDescription },
             currentRegionIdentifierProvider: { controls.currentRegionID },
-            authorizationStatusProvider: {
+            // Explicitly `@MainActor`: unlike the other providers, which inherit
+            // the manager's isolation, AuthorizationStatusProvider is declared
+            // `@Sendable`, so this closure is nonisolated by default and could
+            // not touch main-actor-isolated `Controls`.
+            authorizationStatusProvider: { @MainActor in
                 if controls.holdNextAuthCheck {
                     controls.holdNextAuthCheck = false
                     await withCheckedContinuation { controls.authGate = $0 }

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -63,14 +63,16 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
 /// Tests for `PushService`'s routing of incoming push notification payloads:
 /// alarm (`arrival_and_departure`) payload decoding, donation prompts, and
 /// graceful handling of malformed payloads.
-class PushServiceTests: OBATestCase {
+@Suite(.serialized)
+final class PushServiceTests: OBATestCase {
 
     private var provider: RecordingPushServiceProvider!
     private var delegate: PushServiceDelegateRecorder!
     private var pushService: PushService!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         provider = RecordingPushServiceProvider()
         delegate = PushServiceDelegateRecorder()
         pushService = PushService(serviceProvider: provider, delegate: delegate)
@@ -89,71 +91,71 @@ class PushServiceTests: OBATestCase {
 
     // MARK: - Wiring
 
-    func test_init_installsHandlersOnProvider() {
-        XCTAssertNotNil(provider.notificationReceivedHandler)
-        XCTAssertNotNil(provider.errorHandler)
+    @Test func `Init installs handlers on provider`() {
+        #expect(provider.notificationReceivedHandler != nil)
+        #expect(provider.errorHandler != nil)
     }
 
-    func test_start_forwardsLaunchOptionsToProvider() {
+    @Test func `Start forwards launch options to provider`() {
         pushService.start(launchOptions: ["key": "value"])
-        XCTAssertEqual(provider.startedLaunchOptions?["key"] as? String, "value")
+        #expect((provider.startedLaunchOptions?["key"] as? String) == "value")
     }
 
-    func test_passthroughProperties_reflectProvider() {
-        XCTAssertTrue(pushService.isRegisteredForRemoteNotifications)
-        XCTAssertEqual(pushService.pushUserID, "mock-token")
+    @Test func `Passthrough properties reflect provider`() {
+        #expect(pushService.isRegisteredForRemoteNotifications)
+        #expect(pushService.pushUserID == "mock-token")
 
         provider.stubbedPushUserID = nil
         provider.isRegisteredForRemoteNotifications = false
 
-        XCTAssertFalse(pushService.isRegisteredForRemoteNotifications)
-        XCTAssertNil(pushService.pushUserID)
+        #expect(!pushService.isRegisteredForRemoteNotifications)
+        #expect(pushService.pushUserID == nil)
     }
 
-    func test_pushID_asyncReturnsProviderToken() async {
+    @Test func `Push ID async returns provider token`() async {
         let token = await pushService.pushID()
-        XCTAssertEqual(token, "mock-token")
+        #expect(token == "mock-token")
     }
 
-    func test_deviceTokenUpdates_areForwardedToDelegate() {
-        XCTAssertNotNil(provider.deviceTokenUpdatedHandler, "PushService must install the token handler during init")
+    @Test func `Device token updates are forwarded to delegate`() {
+        #expect(provider.deviceTokenUpdatedHandler != nil, "PushService must install the token handler during init")
 
         provider.deviceTokenUpdatedHandler?("01abff007f")
 
-        XCTAssertEqual(delegate.receivedDeviceTokens, ["01abff007f"])
+        #expect(delegate.receivedDeviceTokens == ["01abff007f"])
     }
 
     // MARK: - Alarm Payloads
 
-    func test_alarmPayload_isDecodedAndForwardedToDelegate() {
+    @Test func `Alarm payload is decoded and forwarded to delegate`() {
         provider.notificationReceivedHandler("Your bus is arriving soon!", ["arrival_and_departure": validAlarmPayload])
 
-        XCTAssertEqual(delegate.receivedAlarms.count, 1)
+        #expect(delegate.receivedAlarms.count == 1)
 
         let alarm = delegate.receivedAlarms[0]
-        XCTAssertEqual(alarm.tripID, "1_604387101")
-        XCTAssertEqual(alarm.stopID, "1_75403")
-        XCTAssertEqual(alarm.regionID, 1)
-        XCTAssertEqual(alarm.vehicleID, "1_4361")
-        XCTAssertEqual(alarm.stopSequence, 7)
-        XCTAssertEqual(alarm.serviceDateEpochTimestamp, 1717027200000)
-        XCTAssertEqual(alarm.serviceDate, Date(timeIntervalSince1970: 1717027200))
+        #expect(alarm.tripID == "1_604387101")
+        #expect(alarm.stopID == "1_75403")
+        #expect(alarm.regionID == 1)
+        #expect(alarm.vehicleID == "1_4361")
+        #expect(alarm.stopSequence == 7)
+        #expect(alarm.serviceDateEpochTimestamp == 1717027200000)
+        #expect(alarm.serviceDate == Date(timeIntervalSince1970: 1717027200))
     }
 
-    func test_alarmPayload_withoutOptionalVehicleID_stillDecodes() {
+    @Test func `Alarm payload without optional vehicle ID still decodes`() {
         var payload = validAlarmPayload
         payload.removeValue(forKey: "vehicle_id")
 
         provider.notificationReceivedHandler("Arriving", ["arrival_and_departure": payload])
 
-        XCTAssertEqual(delegate.receivedAlarms.count, 1)
-        XCTAssertNil(delegate.receivedAlarms[0].vehicleID)
+        #expect(delegate.receivedAlarms.count == 1)
+        #expect(delegate.receivedAlarms[0].vehicleID == nil)
     }
 
-    func test_malformedAlarmPayload_doesNotCallDelegateOrCrash() {
+    @Test func `Malformed alarm payload does not call delegate or crash`() {
         provider.notificationReceivedHandler("Arriving", ["arrival_and_departure": ["trip_id": "only-this"]])
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
     }
 
     /// Real remote notifications always include `aps` alongside the custom
@@ -161,97 +163,97 @@ class PushServiceTests: OBATestCase {
     /// which forwards the entire `UNNotificationContent.userInfo`). This
     /// mirrors that wire shape to guard against regressing to a strict
     /// single-key count.
-    func test_alarmPayloadWithAPSSibling_isDecodedAndForwardedToDelegate() {
+    @Test func `Alarm payload with APS sibling is decoded and forwarded to delegate`() {
         provider.notificationReceivedHandler("Your bus is arriving soon!", [
             "aps": ["alert": ["body": "Your bus is arriving soon!"]],
             "arrival_and_departure": validAlarmPayload
         ])
 
-        XCTAssertEqual(delegate.receivedAlarms.count, 1)
+        #expect(delegate.receivedAlarms.count == 1)
 
         let alarm = delegate.receivedAlarms[0]
-        XCTAssertEqual(alarm.tripID, "1_604387101")
-        XCTAssertEqual(alarm.stopID, "1_75403")
-        XCTAssertEqual(alarm.regionID, 1)
-        XCTAssertEqual(alarm.vehicleID, "1_4361")
-        XCTAssertEqual(alarm.stopSequence, 7)
-        XCTAssertEqual(alarm.serviceDateEpochTimestamp, 1717027200000)
-        XCTAssertEqual(alarm.serviceDate, Date(timeIntervalSince1970: 1717027200))
+        #expect(alarm.tripID == "1_604387101")
+        #expect(alarm.stopID == "1_75403")
+        #expect(alarm.regionID == 1)
+        #expect(alarm.vehicleID == "1_4361")
+        #expect(alarm.stopSequence == 7)
+        #expect(alarm.serviceDateEpochTimestamp == 1717027200000)
+        #expect(alarm.serviceDate == Date(timeIntervalSince1970: 1717027200))
     }
 
     // MARK: - Donation Payloads
 
-    func test_donationPayload_forwardsTestIDToDelegate() {
+    @Test func `Donation payload forwards test ID to delegate`() {
         provider.notificationReceivedHandler("Please donate", ["donation": "experiment-42"])
 
-        XCTAssertEqual(delegate.receivedDonationPromptIDs.count, 1)
-        XCTAssertEqual(delegate.receivedDonationPromptIDs[0], "experiment-42")
+        #expect(delegate.receivedDonationPromptIDs.count == 1)
+        #expect(delegate.receivedDonationPromptIDs[0] == "experiment-42")
     }
 
-    func test_donationPayload_withNonStringValue_forwardsNilTestID() {
+    @Test func `Donation payload with non string value forwards nil test ID`() {
         provider.notificationReceivedHandler("Please donate", ["donation": 123])
 
-        XCTAssertEqual(delegate.receivedDonationPromptIDs.count, 1)
-        XCTAssertNil(delegate.receivedDonationPromptIDs[0])
+        #expect(delegate.receivedDonationPromptIDs.count == 1)
+        #expect(delegate.receivedDonationPromptIDs[0] == nil)
     }
 
     /// Real remote notifications always include `aps` alongside the custom
     /// data key. Mirrors the wire shape delivered by
     /// `OBACloudPushService.userNotificationCenter(_:didReceive:...)`.
-    func test_donationPayloadWithAPSSibling_forwardsTestIDToDelegate() {
+    @Test func `Donation payload with APS sibling forwards test ID to delegate`() {
         provider.notificationReceivedHandler("Please donate", [
             "aps": ["alert": ["body": "Please donate"]],
             "donation": "experiment-42"
         ])
 
-        XCTAssertEqual(delegate.receivedDonationPromptIDs.count, 1)
-        XCTAssertEqual(delegate.receivedDonationPromptIDs[0], "experiment-42")
+        #expect(delegate.receivedDonationPromptIDs.count == 1)
+        #expect(delegate.receivedDonationPromptIDs[0] == "experiment-42")
     }
 
     // MARK: - Fallback Paths
 
-    func test_multiKeyPayload_doesNotRouteToAlarmOrDonation() {
+    @Test func `Multi key payload does not route to alarm or donation`() {
         provider.notificationReceivedHandler("Hello", ["a": 1, "b": 2])
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
-        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 
-    func test_nilAdditionalData_doesNotRouteToAlarmOrDonation() {
+    @Test func `Nil additional data does not route to alarm or donation`() {
         provider.notificationReceivedHandler("Hello", nil)
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
-        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 
-    func test_unknownSingleKeyPayload_doesNotRouteToAlarmOrDonation() {
+    @Test func `Unknown single key payload does not route to alarm or donation`() {
         provider.notificationReceivedHandler("Hello", ["unknown_key": "whatever"])
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
-        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 
     /// A plain service alert notification has no custom data key at all —
     /// just the standard `aps` payload — and should fall through to display.
-    func test_apsOnlyPayload_doesNotRouteToAlarmOrDonation() {
+    @Test func `Aps only payload does not route to alarm or donation`() {
         provider.notificationReceivedHandler("Service alert", [
             "aps": ["alert": ["body": "Service alert"]]
         ])
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
-        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 
     /// Two custom keys alongside `aps` is an ambiguous payload; it should
     /// still fall through to display rather than guessing which key wins.
-    func test_twoCustomKeysWithAPSSibling_doesNotRouteToAlarmOrDonation() {
+    @Test func `Two custom keys with APS sibling does not route to alarm or donation`() {
         provider.notificationReceivedHandler("Hello", [
             "aps": ["alert": ["body": "Hello"]],
             "arrival_and_departure": validAlarmPayload,
             "donation": "experiment-42"
         ])
 
-        XCTAssertTrue(delegate.receivedAlarms.isEmpty)
-        XCTAssertTrue(delegate.receivedDonationPromptIDs.isEmpty)
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 }

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -196,10 +196,11 @@ final class RecentStopsViewModelTests: OBATestCase {
         // Track whether the remote DELETE actually hit the stub. The catch-all matcher
         // pattern from the local-only test would silently disable obaco; we want this
         // test to *fail* if the remote call is short-circuited.
-        var didHitRemote = false
+        // Boxed: the matcher is @Sendable and cannot write to a main-actor local.
+        let didHitRemote = SendableBox(false)
         dataLoader.mock(data: Data(), matcher: { req in
             if req.url?.path.contains("/alarms/") == true {
-                didHitRemote = true
+                didHitRemote.value = true
                 return true
             }
             return false
@@ -213,7 +214,7 @@ final class RecentStopsViewModelTests: OBATestCase {
         await viewModel.delete(alarm: alarm).value
 
         #expect(!viewModel.alarms.map(\.url).contains(alarm.url))
-        #expect(didHitRemote)
+        #expect(didHitRemote.value)
     }
 
     @Test @MainActor

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -181,7 +181,7 @@ final class RecentStopsViewModelTests: OBATestCase {
         #expect(viewModel.alarms.map(\.url).contains(alarm.url))
 
         // Await the returned Task so the remote DELETE completes inside the test
-        // boundary — otherwise it races past tearDown.
+        // boundary — otherwise it races past the end of the test.
         await viewModel.delete(alarm: alarm).value
 
         #expect(!viewModel.alarms.map(\.url).contains(alarm.url))

--- a/OBAKitTests/Recent/RecentStopsViewModelTests.swift
+++ b/OBAKitTests/Recent/RecentStopsViewModelTests.swift
@@ -7,25 +7,26 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import CoreLocation
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class RecentStopsViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class RecentStopsViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -62,16 +63,16 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - Initial State
 
-    @MainActor
-    func test_init_alarmsIsEmpty() {
+    @Test @MainActor
+    func `Init alarms is empty`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let viewModel = RecentStopsViewModel(application: app)
 
         #expect(viewModel.alarms.isEmpty)
     }
 
-    @MainActor
-    func test_init_recentStopsIsEmpty() {
+    @Test @MainActor
+    func `Init recent stops is empty`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let viewModel = RecentStopsViewModel(application: app)
 
@@ -80,8 +81,8 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - loadData
 
-    @MainActor
-    func test_loadData_populatesRecentStopsForCurrentRegion() {
+    @Test @MainActor
+    func `Load data populates recent stops for current region`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let stop = try! Fixtures.loadSomeStops().first!
         stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
@@ -93,8 +94,8 @@ class RecentStopsViewModelTests: OBATestCase {
         #expect(viewModel.recentStops.contains(stop))
     }
 
-    @MainActor
-    func test_loadData_excludesStopsFromOtherRegions() {
+    @Test @MainActor
+    func `Load data excludes stops from other regions`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let stop = try! Fixtures.loadSomeStops().first!
         stop.regionIdentifier = Fixtures.tampaRegion.regionIdentifier
@@ -106,8 +107,8 @@ class RecentStopsViewModelTests: OBATestCase {
         #expect(viewModel.recentStops.isEmpty)
     }
 
-    @MainActor
-    func test_loadData_populatesAlarms() {
+    @Test @MainActor
+    func `Load data populates alarms`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let alarm = try! Fixtures.loadAlarm()
         alarm.set(tripDate: Date(timeIntervalSinceNow: 300), alarmOffset: 2)
@@ -121,8 +122,8 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - deleteAllRecentStops
 
-    @MainActor
-    func test_deleteAllRecentStops_emptiesRecentStops() {
+    @Test @MainActor
+    func `Delete all recent stops empties recent stops`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let stops = try! Fixtures.loadSomeStops()
         stops.prefix(3).forEach {
@@ -140,8 +141,8 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - delete(recentStop:)
 
-    @MainActor
-    func test_delete_recentStop_removesItAndKeepsOthers() {
+    @Test @MainActor
+    func `Delete recent stop removes it and keeps others`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let stops = try! Fixtures.loadSomeStops()
         let stopA = stops[0]
@@ -161,8 +162,8 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - delete(alarm:)
 
-    @MainActor
-    func test_delete_alarm_removesItLocally() async {
+    @Test @MainActor
+    func `Delete alarm removes it locally`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alarm = try! Fixtures.loadAlarm()
@@ -186,8 +187,8 @@ class RecentStopsViewModelTests: OBATestCase {
         #expect(!viewModel.alarms.map(\.url).contains(alarm.url))
     }
 
-    @MainActor
-    func test_delete_alarm_remoteSuccess_keepsLocalRemoval() async {
+    @Test @MainActor
+    func `Delete alarm remote success keeps local removal`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alarm = try! Fixtures.loadAlarm()
@@ -215,8 +216,8 @@ class RecentStopsViewModelTests: OBATestCase {
         #expect(didHitRemote)
     }
 
-    @MainActor
-    func test_delete_alarm_remoteFailure_keepsLocalRemoval() async {
+    @Test @MainActor
+    func `Delete alarm remote failure keeps local removal`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alarm = try! Fixtures.loadAlarm()
@@ -242,8 +243,8 @@ class RecentStopsViewModelTests: OBATestCase {
 
     // MARK: - loadData / nil currentRegion
 
-    @MainActor
-    func test_loadData_nilCurrentRegion_recentStopsIsEmpty() {
+    @Test @MainActor
+    func `Load data nil current region recent stops is empty`() {
         // Use "Null Island" (0, 0) which is in the Gulf of Guinea — not covered by any
         // transit region — so application.currentRegion is nil when loadData() runs.
         let dataLoader = MockDataLoader(testName: name)

--- a/OBAKitTests/Schedules/ScheduleForRouteViewModelTests.swift
+++ b/OBAKitTests/Schedules/ScheduleForRouteViewModelTests.swift
@@ -7,25 +7,26 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class ScheduleForRouteViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class ScheduleForRouteViewModelTests: OBATestCase {
     let routeID = "1_100223"
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -69,8 +70,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Initialization Tests
 
-    @MainActor
-    func test_init_setsRouteID() {
+    @Test @MainActor
+    func `Init sets route ID`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -80,8 +81,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.routeID == routeID)
     }
 
-    @MainActor
-    func test_init_setsInitialDate() {
+    @Test @MainActor
+    func `Init sets initial date`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -92,8 +93,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(Calendar.current.isDate(viewModel.selectedDate, inSameDayAs: testDate))
     }
 
-    @MainActor
-    func test_init_defaultsSelectedDirectionIndexToZero() {
+    @Test @MainActor
+    func `Init defaults selected direction index to zero`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -105,8 +106,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Route Name Tests
 
-    @MainActor
-    func test_routeName_beforeFetch_returnsRouteID() {
+    @Test @MainActor
+    func `Route name before fetch returns route ID`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -117,8 +118,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Directions Tests
 
-    @MainActor
-    func test_directions_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Directions before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -127,8 +128,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.directions.isEmpty)
     }
 
-    @MainActor
-    func test_currentDirection_beforeFetch_returnsNil() {
+    @Test @MainActor
+    func `Current direction before fetch returns nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -139,8 +140,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Headsign Tests
 
-    @MainActor
-    func test_currentHeadsign_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Current headsign before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -151,8 +152,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Stop Names and IDs Tests
 
-    @MainActor
-    func test_stopNames_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Stop names before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -161,8 +162,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.stopNames.isEmpty)
     }
 
-    @MainActor
-    func test_stopIDs_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Stop IDs before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -173,8 +174,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Departure Times Tests
 
-    @MainActor
-    func test_departureTimes_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Departure times before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -183,8 +184,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.departureTimes.isEmpty)
     }
 
-    @MainActor
-    func test_sortedDepartureTimes_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Sorted departure times before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -193,8 +194,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.sortedDepartureTimes.isEmpty)
     }
 
-    @MainActor
-    func test_departureTimesDisplay_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Departure times display before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -205,8 +206,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Time Formatting Tests
 
-    @MainActor
-    func test_formatTime_withDate_returnsFormattedString() {
+    @Test @MainActor
+    func `Format time with date returns formatted string`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -224,8 +225,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(result.count == 5)
     }
 
-    @MainActor
-    func test_formatTime_midnight_returns0000() {
+    @Test @MainActor
+    func `Format time midnight returns0000`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -241,8 +242,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(result == "00:00")
     }
 
-    @MainActor
-    func test_formatTime_noon_returns1200() {
+    @Test @MainActor
+    func `Format time noon returns1200`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -258,8 +259,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(result == "12:00")
     }
 
-    @MainActor
-    func test_formatTime_nilDate_returnsDash() {
+    @Test @MainActor
+    func `Format time nil date returns dash`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -270,8 +271,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(result == "-")
     }
 
-    @MainActor
-    func test_formatTimeAccessible_withDate_returnsReadableTime() {
+    @Test @MainActor
+    func `Format time accessible with date returns readable time`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -287,8 +288,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(result != "-")
     }
 
-    @MainActor
-    func test_formatTimeAccessible_nilDate_returnsNoDepartureText() {
+    @Test @MainActor
+    func `Format time accessible nil date returns no departure text`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -303,8 +304,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
 
     // MARK: - Loading State Tests
 
-    @MainActor
-    func test_isLoading_initiallyFalse() {
+    @Test @MainActor
+    func `Is loading initially false`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -313,8 +314,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_error_initiallyNil() {
+    @Test @MainActor
+    func `Error initially nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -323,8 +324,8 @@ class ScheduleForRouteViewModelTests: OBATestCase {
         #expect(viewModel.error == nil)
     }
 
-    @MainActor
-    func test_scheduleData_initiallyNil() {
+    @Test @MainActor
+    func `Schedule data initially nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/Schedules/ScheduleForRouteViewModelTests.swift
+++ b/OBAKitTests/Schedules/ScheduleForRouteViewModelTests.swift
@@ -226,7 +226,7 @@ final class ScheduleForRouteViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Format time midnight returns0000`() {
+    func `Format time midnight returns 0000`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -243,7 +243,7 @@ final class ScheduleForRouteViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Format time noon returns1200`() {
+    func `Format time noon returns 1200`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForRoute(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/Schedules/ScheduleForStopViewModelTests.swift
+++ b/OBAKitTests/Schedules/ScheduleForStopViewModelTests.swift
@@ -7,25 +7,26 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_cast
 
-class ScheduleForStopViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class ScheduleForStopViewModelTests: OBATestCase {
     let stopID = "1_75403"
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -69,8 +70,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
 
     // MARK: - Initialization Tests
 
-    @MainActor
-    func test_init_setsStopID() {
+    @Test @MainActor
+    func `Init sets stop ID`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -80,8 +81,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
         #expect(viewModel.stopID == stopID)
     }
 
-    @MainActor
-    func test_init_setsInitialDate() {
+    @Test @MainActor
+    func `Init sets initial date`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -92,8 +93,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
         #expect(Calendar.current.isDate(viewModel.selectedDate, inSameDayAs: testDate))
     }
 
-    @MainActor
-    func test_init_selectedRouteIDIsNil() {
+    @Test @MainActor
+    func `Init selected route IDIs nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -105,8 +106,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
 
     // MARK: - Stop Name Tests
 
-    @MainActor
-    func test_stopName_beforeFetch_returnsStopID() {
+    @Test @MainActor
+    func `Stop name before fetch returns stop ID`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -117,8 +118,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
 
     // MARK: - Available Routes Tests
 
-    @MainActor
-    func test_availableRoutes_beforeFetch_isEmpty() {
+    @Test @MainActor
+    func `Available routes before fetch is empty`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -129,8 +130,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
 
     // MARK: - Route Selection Tests
 
-    @MainActor
-    func test_selectRoute_updatesSelectedRouteID() {
+    @Test @MainActor
+    func `Select route updates selected route ID`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -142,8 +143,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
         #expect(viewModel.selectedRouteID == testRouteID)
     }
 
-    @MainActor
-    func test_selectRoute_canBeCalledMultipleTimes() {
+    @Test @MainActor
+    func `Select route can be called multiple times`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -161,8 +162,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
 
     // MARK: - Loading State Tests
 
-    @MainActor
-    func test_isLoading_initiallyFalse() {
+    @Test @MainActor
+    func `Is loading initially false`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -171,8 +172,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_error_initiallyNil() {
+    @Test @MainActor
+    func `Error initially nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -181,8 +182,8 @@ class ScheduleForStopViewModelTests: OBATestCase {
         #expect(viewModel.error == nil)
     }
 
-    @MainActor
-    func test_scheduleData_initiallyNil() {
+    @Test @MainActor
+    func `Schedule data initially nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/Schedules/ScheduleForStopViewModelTests.swift
+++ b/OBAKitTests/Schedules/ScheduleForStopViewModelTests.swift
@@ -94,7 +94,7 @@ final class ScheduleForStopViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Init selected route IDIs nil`() {
+    func `Init selected route ID is nil`() {
         let dataLoader = MockDataLoader(testName: name)
         stubScheduleForStop(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -7,15 +7,16 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import MapKit
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 // swiftlint:disable force_try
 
-class SearchViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class SearchViewModelTests: OBATestCase {
 
     // MARK: - Helpers
 
@@ -58,34 +59,34 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - Subtitle
 
-    @MainActor
-    func test_subtitle_address_isQueryVerbatim() {
+    @Test @MainActor
+    func `Subtitle address is query verbatim`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address, query: "Seattle, WA"), apiService: nil)
         #expect(vm.subtitle == "Seattle, WA")
     }
 
-    @MainActor
-    func test_subtitle_route_prefixedWithRoute() {
+    @Test @MainActor
+    func `Subtitle route prefixed with route`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .route, query: "44"), apiService: nil)
         #expect(vm.subtitle == "Route 44")
     }
 
-    @MainActor
-    func test_subtitle_stopNumber_prefixedWithStopNumber() {
+    @Test @MainActor
+    func `Subtitle stop number prefixed with stop number`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, query: "1234"), apiService: nil)
         #expect(vm.subtitle == "Stop number 1234")
     }
 
-    @MainActor
-    func test_subtitle_vehicleID_prefixedWithVehicleID() {
+    @Test @MainActor
+    func `Subtitle vehicle ID prefixed with vehicle ID`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID, query: "XYZ"), apiService: nil)
         #expect(vm.subtitle == "Vehicle ID XYZ")
     }
 
     // MARK: - results
 
-    @MainActor
-    func test_results_matchesSearchResponseResults() throws {
+    @Test @MainActor
+    func `Results matches search response results`() throws {
         let stop = try Fixtures.loadSomeStops().first!
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, results: [stop]), apiService: nil)
         #expect(vm.results.count == 1)
@@ -94,8 +95,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - response(substituting:)
 
-    @MainActor
-    func test_responseSubstituting_singleResultIsSubstitute() throws {
+    @Test @MainActor
+    func `Response substituting single result is substitute`() throws {
         let stops = try Fixtures.loadSomeStops()
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .stopNumber, results: [stops[0]]), apiService: nil)
 
@@ -105,16 +106,16 @@ class SearchViewModelTests: OBATestCase {
         #expect((substituted.results.first as? Stop) === stops[1])
     }
 
-    @MainActor
-    func test_responseSubstituting_preservesOriginalRequest() throws {
+    @Test @MainActor
+    func `Response substituting preserves original request`() throws {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .route, query: "44"), apiService: nil)
         let substituted = vm.response(substituting: "anything")
         #expect(substituted.request.query == "44")
         #expect(substituted.request.searchType == .route)
     }
 
-    @MainActor
-    func test_responseSubstituting_preservesBoundingRegion() {
+    @Test @MainActor
+    func `Response substituting preserves bounding region`() {
         let region = MKCoordinateRegion(
             center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
             span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
@@ -129,8 +130,8 @@ class SearchViewModelTests: OBATestCase {
         #expect(substituted.boundingRegion?.center.longitude == -122.3)
     }
 
-    @MainActor
-    func test_responseSubstituting_preservesError() {
+    @Test @MainActor
+    func `Response substituting preserves error`() {
         let searchResponse = SearchResponse(request: SearchRequest(query: "test", type: .address), results: [], boundingRegion: nil, error: SearchError.noTripsAvailable)
         let vm = SearchViewModel(searchResponse: searchResponse, apiService: nil)
 
@@ -141,29 +142,29 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - Initial State
 
-    @MainActor
-    func test_init_vehicleSearchResponseIsNil() {
+    @Test @MainActor
+    func `Init vehicle search response is nil`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address), apiService: nil)
         #expect(vm.vehicleSearchResponse == nil)
     }
 
-    @MainActor
-    func test_init_vehicleErrorIsNil() {
+    @Test @MainActor
+    func `Init vehicle error is nil`() {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .address), apiService: nil)
         #expect(vm.vehicleError == nil)
     }
 
     // MARK: - selectVehicle / nil apiService
 
-    @MainActor
-    func test_selectVehicle_nilApiService_vehicleSearchResponseRemainsNil() async {
+    @Test @MainActor
+    func `Select vehicle nil api service vehicle search response remains nil`() async {
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
         await vm.selectVehicle(vehicleID: vehicleID)
         #expect(vm.vehicleSearchResponse == nil)
     }
 
-    @MainActor
-    func test_selectVehicle_nilApiService_setsVehicleError() async {
+    @Test @MainActor
+    func `Select vehicle nil api service sets vehicle error`() async {
         // Without an API service, the call would otherwise silently no-op. Surface the
         // misconfiguration through `vehicleError` so the existing error sink can present it.
         let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
@@ -173,8 +174,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - selectVehicle / success
 
-    @MainActor
-    func test_selectVehicle_success_vehicleSearchResponseIsSet() async {
+    @Test @MainActor
+    func `Select vehicle success vehicle search response is set`() async {
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
             apiService: buildRESTService(dataLoader: makeSuccessLoader())
@@ -186,8 +187,8 @@ class SearchViewModelTests: OBATestCase {
         #expect(vm.vehicleError == nil)
     }
 
-    @MainActor
-    func test_selectVehicle_success_responseContainsSingleVehicleStatusResult() async {
+    @Test @MainActor
+    func `Select vehicle success response contains single vehicle status result`() async {
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
             apiService: buildRESTService(dataLoader: makeSuccessLoader())
@@ -199,8 +200,8 @@ class SearchViewModelTests: OBATestCase {
         #expect((vm.vehicleSearchResponse?.results.first as? VehicleStatus) != nil)
     }
 
-    @MainActor
-    func test_selectVehicle_success_preservesOriginalRequest() async {
+    @Test @MainActor
+    func `Select vehicle success preserves original request`() async {
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
             apiService: buildRESTService(dataLoader: makeSuccessLoader())
@@ -214,8 +215,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - selectVehicle / network error
 
-    @MainActor
-    func test_selectVehicle_networkError_setsVehicleError() async {
+    @Test @MainActor
+    func `Select vehicle network error sets vehicle error`() async {
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID),
             apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
@@ -229,8 +230,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - selectVehicle / keyNotFound → noTripsAvailable
 
-    @MainActor
-    func test_selectVehicle_keyNotFoundDecoding_setsNoTripsAvailableError() async {
+    @Test @MainActor
+    func `Select vehicle key not found decoding sets no trips available error`() async {
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID),
             apiService: buildRESTService(dataLoader: makeKeyNotFoundLoader())
@@ -244,8 +245,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - selectVehicle / concurrent-call guard
 
-    @MainActor
-    func test_selectVehicle_guard_preventsConcurrentCalls() async {
+    @Test @MainActor
+    func `Select vehicle guard prevents concurrent calls`() async {
         let mockLoader = makeSuccessLoader()
         let countingLoader = CountingDataLoader(mockLoader)
         let config = APIServiceConfiguration(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL)
@@ -266,8 +267,8 @@ class SearchViewModelTests: OBATestCase {
 
     // MARK: - selectVehicle / state transitions
 
-    @MainActor
-    func test_selectVehicle_errorThenSuccess_vehicleErrorIsCleared() async {
+    @Test @MainActor
+    func `Select vehicle error then success vehicle error is cleared`() async {
         let loader = makeNetworkErrorLoader()
         let vm = SearchViewModel(
             searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),

--- a/OBAKitTests/Settings/SettingsExperimentalFlagsTests.swift
+++ b/OBAKitTests/Settings/SettingsExperimentalFlagsTests.swift
@@ -8,9 +8,9 @@
 //
 
 import Eureka
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
+import Foundation
 import Testing
 
 /// The Experimental toggles are the only writers of their feature-flag defaults, and the section's
@@ -18,22 +18,23 @@ import Testing
 /// *before* the screen goes away: these tests flip the switch and read UserDefaults back without
 /// dismissing anything.
 @MainActor
+@Suite(.serialized)
 final class SettingsExperimentalFlagsTests: OBATestCase {
 
     private var queue: OperationQueue!
     private var application: Application!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         queue.cancelAllOperations()
         queue = nil
         application = nil
-        try await super.tearDown()
     }
 
     private func makeLoadedController() -> SettingsViewController {
@@ -43,12 +44,12 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
     }
 
     private func row(_ controller: SettingsViewController, _ tag: String) throws -> SwitchRow {
-        try XCTUnwrap(controller.form.rowBy(tag: tag) as? SwitchRow)
+        try #require(controller.form.rowBy(tag: tag) as? SwitchRow)
     }
 
     // MARK: - New stop page
 
-    func test_newStopPage_seedsOnByDefault() throws {
+    @Test func `New stop page seeds on by default`() throws {
         let controller = makeLoadedController()
         // `value` is Eureka's `Bool?`; `== true` keeps Nimble's beTrue semantics,
         // where a nil value is a failure rather than a pass.
@@ -57,14 +58,14 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
 
     /// The failing case before this was fixed: toggle off, then kill the app to "restart to apply"
     /// without ever dismissing Settings. `viewWillDisappear` never runs, so nothing was written.
-    func test_newStopPage_togglingOffPersistsImmediately() throws {
+    @Test func `New stop page toggling off persists immediately`() throws {
         let controller = makeLoadedController()
         try row(controller, FeatureFlags.useNewStopPageKey).value = false
 
         #expect(!FeatureFlags.isNewStopPageEnabled(userDefaults: self.application.userDefaults))
     }
 
-    func test_newStopPage_togglingBackOnPersistsImmediately() throws {
+    @Test func `New stop page toggling back on persists immediately`() throws {
         application.userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
         let controller = makeLoadedController()
         try row(controller, FeatureFlags.useNewStopPageKey).value = true
@@ -72,7 +73,7 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
         #expect(FeatureFlags.isNewStopPageEnabled(userDefaults: self.application.userDefaults))
     }
 
-    func test_newStopPage_stillPersistsOnDismissal() throws {
+    @Test func `New stop page still persists on dismissal`() throws {
         let controller = makeLoadedController()
         try row(controller, FeatureFlags.useNewStopPageKey).value = false
         controller.viewWillDisappear(false)
@@ -82,7 +83,7 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
 
     // MARK: - Map panel
 
-    func test_mapPanel_togglingOnPersistsImmediately() throws {
+    @Test func `Map panel toggling on persists immediately`() throws {
         let controller = makeLoadedController()
         try row(controller, FeatureFlags.useMapPanelExperienceKey).value = true
 
@@ -93,7 +94,7 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
 
     /// This row was wired to neither `setValues` nor `saveFormValues`, so it always drew "off" and
     /// never wrote anything.
-    func test_voiceoverFullSheet_roundTripsThroughTheForm() throws {
+    @Test func `Voiceover full sheet round trips through the form`() throws {
         application.userDefaults.set(true, forKey: OBAFloatingPanelController.AlwaysShowFullSheetOnVoiceoverUserDefaultsKey)
         let controller = makeLoadedController()
         let switchRow = try row(controller, OBAFloatingPanelController.AlwaysShowFullSheetOnVoiceoverUserDefaultsKey)

--- a/OBAKitTests/Settings/SettingsExperimentalFlagsTests.swift
+++ b/OBAKitTests/Settings/SettingsExperimentalFlagsTests.swift
@@ -33,8 +33,6 @@ final class SettingsExperimentalFlagsTests: OBATestCase {
 
     isolated deinit {
         queue.cancelAllOperations()
-        queue = nil
-        application = nil
     }
 
     private func makeLoadedController() -> SettingsViewController {

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -15,11 +14,12 @@ import Testing
 /// Pure-enum tests for `AppSheetRoute`: stable identifiers,
 /// stacking preference, and per-detent configuration.
 @MainActor
-final class AppSheetRouteTests: XCTestCase {
+@Suite(.serialized)
+final class AppSheetRouteTests {
 
     // MARK: - Identifiers
 
-    func test_id_isStableForCaselessRoutes() {
+    @Test func `Id is stable for caseless routes`() {
         #expect(AppSheetRoute.home.id == "home")
         #expect(AppSheetRoute.search.id == "search")
         #expect(AppSheetRoute.nearbyAll.id == "nearbyAll")
@@ -31,7 +31,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(AppSheetRoute.settings.id == "settings")
     }
 
-    func test_id_embedsAssociatedValues() throws {
+    @Test func `Id embeds associated values`() throws {
         #expect(AppSheetRoute.stopDetails(stopID: "1_75403").id == "stopDetails-1_75403")
         #expect(AppSheetRoute.tripDetails(tripID: "trip_42").id == "tripDetails-trip_42")
         let route = try Fixtures.createRoute(id: "route_8")
@@ -39,7 +39,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(AppSheetRoute.transitAlert(alertID: "alert_99").id == "transitAlert-alert_99")
     }
 
-    func test_id_differsBetweenInstancesOfSameCase() {
+    @Test func `Id differs between instances of same case`() {
         let a = AppSheetRoute.stopDetails(stopID: "1_75403")
         let b = AppSheetRoute.stopDetails(stopID: "1_75404")
         #expect(a.id != b.id)
@@ -47,13 +47,13 @@ final class AppSheetRouteTests: XCTestCase {
 
     // MARK: - Stacking preference
 
-    func test_prefersStacking_baseLayerRoutes() {
+    @Test func `Prefers stacking base layer routes`() {
         #expect(AppSheetRoute.home.prefersStacking == false)
         #expect(AppSheetRoute.search.prefersStacking == false)
         #expect(AppSheetRoute.routePicker.prefersStacking == false)
     }
 
-    func test_prefersStacking_stackedLayerRoutes() throws {
+    @Test func `Prefers stacking stacked layer routes`() throws {
         #expect(AppSheetRoute.stopDetails(stopID: "1").prefersStacking == true)
         #expect(AppSheetRoute.tripPlanner.prefersStacking == true)
         #expect(AppSheetRoute.tripDetails(tripID: "t").prefersStacking == true)
@@ -69,7 +69,7 @@ final class AppSheetRouteTests: XCTestCase {
 
     // MARK: - Detent configuration
 
-    func test_homeDetent_startsAtSmallAndOffersAllThree() {
+    @Test func `Home detent starts at small and offers all three`() {
         let config = AppSheetRoute.home.detentConfiguration
         #expect(config.detents == [.height(80), .medium, AppSheetRoute.largeDetent])
         #expect(config.initialDetent == .height(80))
@@ -77,7 +77,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(config.isDismissDisabled == true)
     }
 
-    func test_homeDetent_flipsToFullScreenAtLargeDetent() {
+    @Test func `Home detent flips to full screen at large detent`() {
         // `upThrough:` isn't honored with custom `.height` detents, so the home
         // route flips background interaction to `.disabled` only when parked at
         // `largeDetent` via `fullScreenDetent`.
@@ -85,7 +85,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(config.fullScreenDetent == AppSheetRoute.largeDetent)
     }
 
-    func test_searchDetent_isFullLargeAndDismissDisabled() {
+    @Test func `Search detent is full large and dismiss disabled`() {
         let config = AppSheetRoute.search.detentConfiguration
         #expect(config.detents == [.large])
         #expect(config.initialDetent == .large)
@@ -93,7 +93,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(config.fullScreenDetent == nil)
     }
 
-    func test_stackedAllListRoutes_shareLargeAndAllowDismiss() {
+    @Test func `Stacked all list routes share large and allow dismiss`() {
         // These all-list routes are stacked sheets, so the OS owns dismissal
         // and `isDismissDisabled` must be `false` for `truncateStacked` to stay
         // in sync with the drag-down gesture.
@@ -106,7 +106,7 @@ final class AppSheetRouteTests: XCTestCase {
         }
     }
 
-    func test_stopDetailsDetent_startsMediumAndIsInteractivelyDismissible() {
+    @Test func `Stop details detent starts medium and is interactively dismissible`() {
         let config = AppSheetRoute.stopDetails(stopID: "1").detentConfiguration
         #expect(config.detents == [.medium, .large])
         #expect(config.initialDetent == .medium)
@@ -114,7 +114,7 @@ final class AppSheetRouteTests: XCTestCase {
         #expect(config.fullScreenDetent == nil)
     }
 
-    func test_stackedDetailRoutes_shareLargeStartAndAllowDismiss() throws {
+    @Test func `Stacked detail routes share large start and allow dismiss`() throws {
         let currentTripRoute = try Fixtures.createRoute(id: "r")
         let routes: [AppSheetRoute] = [
             .tripPlanner,
@@ -135,7 +135,7 @@ final class AppSheetRouteTests: XCTestCase {
         }
     }
 
-    func test_allRoutes_showDragIndicator() throws {
+    @Test func `All routes show drag indicator`() throws {
         // No route currently opts out of the drag indicator; this guards against
         // an accidental flip when adding a new case.
         let currentTripRoute = try Fixtures.createRoute(id: "r")
@@ -150,11 +150,11 @@ final class AppSheetRouteTests: XCTestCase {
         }
     }
 
-    func test_largeDetent_isFractionedJustBelowFullScreen() {
+    @Test func `Large detent is fractioned just below full screen`() {
         #expect(AppSheetRoute.largeDetent == .fraction(0.99))
     }
 
-    func test_homeCollapsedHeight_matchesMapBottomInset() {
+    @Test func `Home collapsed height matches map bottom inset`() {
         // Shared with `MapPanelRootView` so the map's bottom safe-area padding
         // matches the collapsed sheet — keep the constant pinned.
         #expect(AppSheetRoute.homeCollapsedHeight == 80)
@@ -162,7 +162,7 @@ final class AppSheetRouteTests: XCTestCase {
 
     // MARK: - SheetDetentConfiguration defaults
 
-    func test_sheetDetentConfiguration_appliesDefaultsForOptionalFields() {
+    @Test func `Sheet detent configuration applies defaults for optional fields`() {
         let config = SheetDetentConfiguration(
             detents: [.medium],
             initialDetent: .medium,
@@ -179,18 +179,18 @@ final class AppSheetRouteTests: XCTestCase {
     /// The override predicate is the testable surface here;
     /// `PresentationBackgroundInteraction` is opaque and can't be compared
     /// directly, so the modifier itself stays out of the test.
-    func test_shouldDisableBackgroundForFullScreen_homeAtLargeDetentIsTrue() {
+    @Test func `Should disable background for full screen home at large detent is true`() {
         let config = AppSheetRoute.home.detentConfiguration
         #expect(config.shouldDisableBackgroundForFullScreen(at: AppSheetRoute.largeDetent) == true)
     }
 
-    func test_shouldDisableBackgroundForFullScreen_homeBelowLargeDetentIsFalse() {
+    @Test func `Should disable background for full screen home below large detent is false`() {
         let config = AppSheetRoute.home.detentConfiguration
         #expect(config.shouldDisableBackgroundForFullScreen(at: .medium) == false)
         #expect(config.shouldDisableBackgroundForFullScreen(at: .height(AppSheetRoute.homeCollapsedHeight)) == false)
     }
 
-    func test_shouldDisableBackgroundForFullScreen_isFalseWhenFullScreenDetentNotConfigured() {
+    @Test func `Should disable background for full screen is false when full screen detent not configured`() {
         // `.search` does not set `fullScreenDetent`, so the predicate must
         // return `false` regardless of the current detent.
         let config = AppSheetRoute.search.detentConfiguration
@@ -200,19 +200,19 @@ final class AppSheetRouteTests: XCTestCase {
 
     // MARK: - Hashable / Equatable
 
-    func test_equality_sameCaseSameAssociatedValueAreEqual() {
+    @Test func `Equality same case same associated value are equal`() {
         #expect(AppSheetRoute.stopDetails(stopID: "1_1") == AppSheetRoute.stopDetails(stopID: "1_1"))
         #expect(AppSheetRoute.tripDetails(tripID: "t") == AppSheetRoute.tripDetails(tripID: "t"))
     }
 
-    func test_equality_differentAssociatedValuesAreNotEqual() throws {
+    @Test func `Equality different associated values are not equal`() throws {
         #expect(AppSheetRoute.stopDetails(stopID: "1_1") != AppSheetRoute.stopDetails(stopID: "1_2"))
         let route1 = try Fixtures.createRoute(id: "r1")
         let route2 = try Fixtures.createRoute(id: "r2")
         #expect(AppSheetRoute.currentTrip(route: route1) != AppSheetRoute.currentTrip(route: route2))
     }
 
-    func test_hash_consistency_forValueEqualRoutes() throws {
+    @Test func `Hash consistency for value equal routes`() throws {
         let route1 = try Fixtures.createRoute(id: "r1")
         let route2 = try Fixtures.createRoute(id: "r1")
         let sheetRoute1 = AppSheetRoute.currentTrip(route: route1)

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -7,8 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import SwiftUI
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -17,23 +17,24 @@ import Testing
 /// (i.e. removed from the shared `unimplementedView` catch-all) gets a
 /// dedicated test so a future refactor that accidentally drops the branch
 /// back into the catch-all fails the suite.
+@Suite(.serialized)
 final class AppSheetViewFactoryTests: OBATestCase {
 
     private var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
-    @MainActor
-    func test_moreView_returnsMoreSheetHostForwardingApplication() {
+    @Test @MainActor
+    func `More view returns more sheet host forwarding application`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 

--- a/OBAKitTests/Sheet/MoreSheetHostTests.swift
+++ b/OBAKitTests/Sheet/MoreSheetHostTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -17,23 +17,24 @@ import Testing
 /// tests drive the representable through its `internal`
 /// `makeNavigationController(application:)` factory seam and inspect the
 /// resulting controller hierarchy — no `UIHostingController` needed.
+@Suite(.serialized)
 final class MoreSheetHostTests: OBATestCase {
 
     private var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
-    @MainActor
-    func test_makeNavigationController_wrapsMoreViewControllerInNav() {
+    @Test @MainActor
+    func `Make navigation controller wraps more view controller in nav`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -7,30 +7,30 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 @testable import OBAKit
 
 /// Behavior tests for `SheetCoordinator`'s content-swap and stacked navigation,
 /// using `AppSheetRoute` as the concrete `SheetRouteable` driver.
 @MainActor
-final class SheetCoordinatorTests: XCTestCase {
+@Suite(.serialized)
+final class SheetCoordinatorTests {
 
     // MARK: - Init
 
-    func test_init_seedsRouteStackWithRoot() {
+    @Test func `Init seeds route stack with root`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.routeStack.count == 1)
         #expect(coordinator.currentRoute == .home)
         #expect(coordinator.canPop == false)
     }
 
-    func test_init_setsCurrentDetentToRootInitialDetent() {
+    @Test func `Init sets current detent to root initial detent`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.currentDetent == AppSheetRoute.home.detentConfiguration.initialDetent)
     }
 
-    func test_init_stackedLayerStartsEmpty() {
+    @Test func `Init stacked layer starts empty`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.stackedRoutes.isEmpty)
         #expect(coordinator.stackedDetents.isEmpty)
@@ -38,7 +38,7 @@ final class SheetCoordinatorTests: XCTestCase {
 
     // MARK: - Push dispatches by prefersStacking
 
-    func test_push_nonStackingRoute_appendsContentStackAndResetsDetent() {
+    @Test func `Push non stacking route appends content stack and resets detent`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
 
@@ -49,7 +49,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.currentDetent == AppSheetRoute.search.detentConfiguration.initialDetent)
     }
 
-    func test_push_stackingRoute_appendsToStackedAndLeavesContentStackAlone() {
+    @Test func `Push stacking route appends to stacked and leaves content stack alone`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
 
@@ -61,7 +61,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedDetents == [AppSheetRoute.tripPlanner.detentConfiguration.initialDetent])
     }
 
-    func test_push_stackingRoute_stacksMultipleSheets() {
+    @Test func `Push stacking route stacks multiple sheets`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.recentStopsAll)
         coordinator.push(.stopDetails(stopID: "1_75403"))
@@ -77,7 +77,7 @@ final class SheetCoordinatorTests: XCTestCase {
 
     // MARK: - Pop removes topmost layer
 
-    func test_pop_withStackedPresented_removesTopStackedAndPreservesContentStack() {
+    @Test func `Pop with stacked presented removes top stacked and preserves content stack`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
         coordinator.push(.tripPlanner)
@@ -91,7 +91,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.currentRoute == .search)
     }
 
-    func test_pop_lastStackedRoute_emptiesStackedLayer() {
+    @Test func `Pop last stacked route empties stacked layer`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
 
@@ -101,7 +101,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedDetents.isEmpty)
     }
 
-    func test_pop_withoutStacked_removesTopAndRestoresPreviousInitialDetent() {
+    @Test func `Pop without stacked removes top and restores previous initial detent`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
         coordinator.currentDetent = .medium
@@ -114,7 +114,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.currentDetent == AppSheetRoute.home.detentConfiguration.initialDetent)
     }
 
-    func test_pop_atRoot_isNoOp() {
+    @Test func `Pop at root is no op`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.currentDetent = .large
 
@@ -127,7 +127,7 @@ final class SheetCoordinatorTests: XCTestCase {
 
     // MARK: - truncateStacked (OS-driven dismiss)
 
-    func test_truncateStacked_removesEverythingAtAndAboveDepth() {
+    @Test func `Truncate stacked removes everything at and above depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.recentStopsAll)
         coordinator.push(.stopDetails(stopID: "1"))
@@ -139,7 +139,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedDetents.count == 1)
     }
 
-    func test_truncateStacked_ignoresOutOfRangeDepth() {
+    @Test func `Truncate stacked ignores out of range depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
 
@@ -150,7 +150,7 @@ final class SheetCoordinatorTests: XCTestCase {
 
     // MARK: - setStackedDetent
 
-    func test_setStackedDetent_persistsAtGivenDepth() {
+    @Test func `Set stacked detent persists at given depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
         coordinator.push(.stopDetails(stopID: "1"))
@@ -161,7 +161,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedDetents == [.medium, .large])
     }
 
-    func test_setStackedDetent_ignoresOutOfRangeDepth() {
+    @Test func `Set stacked detent ignores out of range depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
         let original = coordinator.stackedDetents
@@ -173,7 +173,7 @@ final class SheetCoordinatorTests: XCTestCase {
 
     // MARK: - stackedRoute(at:) / stackedDetent(at:fallback:)
 
-    func test_stackedRoute_atDepth_returnsRouteWhenInRange() {
+    @Test func `Stacked route at depth returns route when in range`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
         coordinator.push(.stopDetails(stopID: "1"))
@@ -182,7 +182,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedRoute(at: 1) == .stopDetails(stopID: "1"))
     }
 
-    func test_stackedRoute_atDepth_returnsNilWhenOutOfRange() {
+    @Test func `Stacked route at depth returns nil when out of range`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.stackedRoute(at: 0) == nil)
 
@@ -190,7 +190,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedRoute(at: 1) == nil)
     }
 
-    func test_stackedDetent_atDepth_returnsStoredDetent() {
+    @Test func `Stacked detent at depth returns stored detent`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.tripPlanner)
         coordinator.setStackedDetent(.medium, at: 0)
@@ -198,14 +198,14 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.stackedDetent(at: 0, fallback: .large) == .medium)
     }
 
-    func test_stackedDetent_atDepth_returnsFallbackWhenOutOfRange() {
+    @Test func `Stacked detent at depth returns fallback when out of range`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.stackedDetent(at: 0, fallback: .large) == .large)
     }
 
     // MARK: - canPop / popToRoot / currentDetents
 
-    func test_canPop_isTrueWhenOnlyStackedPresented() {
+    @Test func `Can pop is true when only stacked presented`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.canPop == false)
 
@@ -213,7 +213,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.canPop == true)
     }
 
-    func test_popToRoot_clearsStackedAndUnwindsContentStack() {
+    @Test func `Pop to root clears stacked and unwinds content stack`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
         coordinator.push(.nearbyAll)        // stacked
@@ -229,7 +229,7 @@ final class SheetCoordinatorTests: XCTestCase {
         #expect(coordinator.currentDetent == AppSheetRoute.home.detentConfiguration.initialDetent)
     }
 
-    func test_currentDetents_reflectsContentStackTopRegardlessOfStacked() {
+    @Test func `Current detents reflects content stack top regardless of stacked`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.currentDetents == AppSheetRoute.home.detentConfiguration.detents)
 

--- a/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
+++ b/OBAKitTests/Stops/NearbyStopsViewModelTests.swift
@@ -7,13 +7,13 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import CoreLocation
 @testable import OBAKit
 @testable import OBAKitCore
 
-class NearbyStopsViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class NearbyStopsViewModelTests: OBATestCase {
 
     let coordinate = TestData.seattleCoordinate
     let stopsURLString = "https://www.example.com/api/where/stops-for-location.json"
@@ -38,42 +38,42 @@ class NearbyStopsViewModelTests: OBATestCase {
 
     // MARK: - Initial State
 
-    @MainActor
-    func test_init_stopsIsEmpty() {
+    @Test @MainActor
+    func `Init stops is empty`() {
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         #expect(viewModel.stops.isEmpty)
     }
 
-    @MainActor
-    func test_init_isLoadingIsFalse() {
+    @Test @MainActor
+    func `Init is loading is false`() {
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_init_operationErrorIsNil() {
+    @Test @MainActor
+    func `Init operation error is nil`() {
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         #expect(viewModel.operationError == nil)
     }
 
     // MARK: - Guard: nil apiService
 
-    @MainActor
-    func test_loadStops_nilApiService_stopsRemainsEmpty() async {
+    @Test @MainActor
+    func `Load stops nil api service stops remains empty`() async {
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         await viewModel.loadStops()
         #expect(viewModel.stops.isEmpty)
     }
 
-    @MainActor
-    func test_loadStops_nilApiService_isLoadingReturnsFalse() async {
+    @Test @MainActor
+    func `Load stops nil api service is loading returns false`() async {
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: nil)
         await viewModel.loadStops()
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_loadStops_nilApiService_setsOperationError() async {
+    @Test @MainActor
+    func `Load stops nil api service sets operation error`() async {
         // Without an API service, the screen would otherwise sit empty with no signal.
         // Surface the misconfiguration through `operationError` so the existing error
         // sink can present it.
@@ -84,8 +84,8 @@ class NearbyStopsViewModelTests: OBATestCase {
 
     // MARK: - Successful load
 
-    @MainActor
-    func test_loadStops_success_populatesStops() async {
+    @Test @MainActor
+    func `Load stops success populates stops`() async {
         let service = buildRESTService(dataLoader: makeDataLoader(stubStops: true))
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
 
@@ -95,8 +95,8 @@ class NearbyStopsViewModelTests: OBATestCase {
         #expect(viewModel.operationError == nil)
     }
 
-    @MainActor
-    func test_loadStops_success_isLoadingIsFalseAfterCompletion() async {
+    @Test @MainActor
+    func `Load stops success is loading is false after completion`() async {
         let service = buildRESTService(dataLoader: makeDataLoader(stubStops: true))
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
 
@@ -107,8 +107,8 @@ class NearbyStopsViewModelTests: OBATestCase {
 
     // MARK: - Failed load
 
-    @MainActor
-    func test_loadStops_failure_setsOperationError() async {
+    @Test @MainActor
+    func `Load stops failure sets operation error`() async {
         let service = buildRESTService(dataLoader: makeErrorLoader())
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
 
@@ -117,8 +117,8 @@ class NearbyStopsViewModelTests: OBATestCase {
         #expect(viewModel.operationError != nil)
     }
 
-    @MainActor
-    func test_loadStops_failure_stopsRemainsEmpty() async {
+    @Test @MainActor
+    func `Load stops failure stops remains empty`() async {
         let service = buildRESTService(dataLoader: makeErrorLoader())
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
 
@@ -127,8 +127,8 @@ class NearbyStopsViewModelTests: OBATestCase {
         #expect(viewModel.stops.isEmpty)
     }
 
-    @MainActor
-    func test_loadStops_failure_isLoadingIsFalseAfterCompletion() async {
+    @Test @MainActor
+    func `Load stops failure is loading is false after completion`() async {
         let service = buildRESTService(dataLoader: makeErrorLoader())
         let viewModel = NearbyStopsViewModel(coordinate: coordinate, apiService: service)
 
@@ -139,8 +139,8 @@ class NearbyStopsViewModelTests: OBATestCase {
 
     // MARK: - Guard: prevents concurrent double-load
 
-    @MainActor
-    func test_loadStops_guard_preventsDoubleLoad() async {
+    @Test @MainActor
+    func `Load stops guard prevents double load`() async {
         // CountingDataLoader yields before forwarding, giving the second concurrent
         // loadStops() a chance to run and see isLoading == true, so it returns early.
         let mockLoader = makeDataLoader(stubStops: true)

--- a/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
+++ b/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
@@ -8,11 +8,11 @@ final class AlarmLeadTimeTests {
         #expect(AlarmLeadTime.clamped(5, minutesUntilDeparture: 20) == 5)
     }
 
-    @Test func `Clamps to maximum15`() {
+    @Test func `Clamps to maximum 15`() {
         #expect(AlarmLeadTime.clamped(30, minutesUntilDeparture: 60) == 15)
     }
 
-    @Test func `Clamps to minimum1`() {
+    @Test func `Clamps to minimum 1`() {
         #expect(AlarmLeadTime.clamped(0, minutesUntilDeparture: 20) == 1)
     }
 

--- a/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
+++ b/OBAKitTests/Stops/StopPage/AlarmLeadTimeTests.swift
@@ -1,28 +1,29 @@
-import XCTest
+import Testing
 @testable import OBAKit
 
 @MainActor
-final class AlarmLeadTimeTests: XCTestCase {
-    func test_requestWithinRange_passesThrough() {
-        XCTAssertEqual(AlarmLeadTime.clamped(5, minutesUntilDeparture: 20), 5)
+@Suite(.serialized)
+final class AlarmLeadTimeTests {
+    @Test func `Request within range passes through`() {
+        #expect(AlarmLeadTime.clamped(5, minutesUntilDeparture: 20) == 5)
     }
 
-    func test_clampsToMaximum15() {
-        XCTAssertEqual(AlarmLeadTime.clamped(30, minutesUntilDeparture: 60), 15)
+    @Test func `Clamps to maximum15`() {
+        #expect(AlarmLeadTime.clamped(30, minutesUntilDeparture: 60) == 15)
     }
 
-    func test_clampsToMinimum1() {
-        XCTAssertEqual(AlarmLeadTime.clamped(0, minutesUntilDeparture: 20), 1)
+    @Test func `Clamps to minimum1`() {
+        #expect(AlarmLeadTime.clamped(0, minutesUntilDeparture: 20) == 1)
     }
 
-    func test_cappedBelowMinutesUntilDeparture() {
+    @Test func `Capped below minutes until departure`() {
         // A buzz can't be scheduled for a moment that's already passed.
-        XCTAssertEqual(AlarmLeadTime.clamped(10, minutesUntilDeparture: 4), 3)
+        #expect(AlarmLeadTime.clamped(10, minutesUntilDeparture: 4) == 3)
     }
 
-    func test_departureTooSoon_returnsNil() {
+    @Test func `Departure too soon returns nil`() {
         // Matches StopViewModel.canCreateAlarm: requires arrivalDepartureMinutes > 1.
-        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 1))
-        XCTAssertNil(AlarmLeadTime.clamped(5, minutesUntilDeparture: 0))
+        #expect(AlarmLeadTime.clamped(5, minutesUntilDeparture: 1) == nil)
+        #expect(AlarmLeadTime.clamped(5, minutesUntilDeparture: 0) == nil)
     }
 }

--- a/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
+++ b/OBAKitTests/Stops/StopPage/ApproachSliceTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Testing
 @testable import OBAKit
 import OBAKitCore
 
@@ -21,62 +21,63 @@ private func stops(_ ids: [String]) -> [StubStop] {
 }
 
 @MainActor
-final class ApproachSliceTests: XCTestCase {
+@Suite(.serialized)
+final class ApproachSliceTests {
 
-    func test_takesFourUpstreamStopsPlusUserStop() {
+    @Test func `Takes four upstream stops plus user stop`() {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "d")
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 1) // "d" within the slice
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["c", "d", "e", "f", "user"])
+        #expect(slice?.vehicleIndex == 1) // "d" within the slice
+        #expect(slice?.skippedStopCount == 0)
     }
 
-    func test_shortTrip_usesAllAvailableUpstream() {
+    @Test func `Short trip uses all available upstream`() {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "user"]), userStopID: "user", closestStopID: "a")
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 0)
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["a", "user"])
+        #expect(slice?.vehicleIndex == 0)
+        #expect(slice?.skippedStopCount == 0)
     }
 
-    func test_vehiclePastUserStop_returnsNil() {
+    @Test func `Vehicle past user stop returns nil`() {
         // Vehicle beyond the user's stop: timeline is meaningless, drop it.
         let slice = ApproachSlice.make(stopTimes: stops(["a", "user", "b"]), userStopID: "user", closestStopID: "b")
-        XCTAssertNil(slice)
+        #expect(slice == nil)
     }
 
-    func test_vehicleBeyondWindow_pinsVehicleStopAndElidesGap() {
+    @Test func `Vehicle beyond window pins vehicle stop and elides gap`() {
         // Vehicle is upstream but further back than the 4-stop window: its
         // stop pins to the top, "b"/"c" are elided, the 3 stops nearest the
         // user remain.
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "a")
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "d", "e", "f", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 0)
-        XCTAssertEqual(slice?.skippedStopCount, 2)
+        #expect(slice?.stops.map(\.stopID) == ["a", "d", "e", "f", "user"])
+        #expect(slice?.vehicleIndex == 0)
+        #expect(slice?.skippedStopCount == 2)
     }
 
-    func test_vehicleAtWindowEdge_hasNoGap() {
+    @Test func `Vehicle at window edge has no gap`() {
         // Vehicle exactly 4 stops upstream sits at the top of the contiguous
         // window; nothing is elided.
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "c")
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 0)
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["c", "d", "e", "f", "user"])
+        #expect(slice?.vehicleIndex == 0)
+        #expect(slice?.skippedStopCount == 0)
     }
 
-    func test_unknownClosestStop_hasNilVehicleIndex() {
+    @Test func `Unknown closest stop has nil vehicle index`() {
         // closestStopID not on this trip at all: show the window, no bus dot.
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "c", "d", "e", "f", "user"]), userStopID: "user", closestStopID: "zzz")
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["c", "d", "e", "f", "user"])
-        XCTAssertNil(slice?.vehicleIndex)
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["c", "d", "e", "f", "user"])
+        #expect(slice?.vehicleIndex == nil)
+        #expect(slice?.skippedStopCount == 0)
     }
 
-    func test_userStopMissing_returnsNil() {
-        XCTAssertNil(ApproachSlice.make(stopTimes: stops(["a", "b"]), userStopID: "user", closestStopID: "a"))
+    @Test func `User stop missing returns nil`() {
+        #expect(ApproachSlice.make(stopTimes: stops(["a", "b"]), userStopID: "user", closestStopID: "a") == nil)
     }
 
     // MARK: - Loop routes
 
-    func test_loopRoute_windowsAroundTheDeparturesOwnVisit() {
+    @Test func `Loop route windows around the departures own visit`() {
         // "user" is visited twice (indices 1 and 5). The departure is for the
         // second visit, and the vehicle is between the two — so the window must
         // lead up to index 5, not collapse onto the first visit.
@@ -86,12 +87,12 @@ final class ApproachSliceTests: XCTestCase {
             userStopSequence: 5,
             closestStopID: "c"
         )
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["user", "b", "c", "d", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 2) // "c"
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["user", "b", "c", "d", "user"])
+        #expect(slice?.vehicleIndex == 2) // "c"
+        #expect(slice?.skippedStopCount == 0)
     }
 
-    func test_loopRoute_vehicleStopRevisited_usesOccurrenceBeforeUserStop() {
+    @Test func `Loop route vehicle stop revisited uses occurrence before user stop`() {
         // The vehicle's closest stop ("a") also appears downstream of the user's
         // stop. The upstream occurrence is the leg the vehicle is actually on.
         let slice = ApproachSlice.make(
@@ -100,11 +101,11 @@ final class ApproachSliceTests: XCTestCase {
             userStopSequence: 2,
             closestStopID: "a"
         )
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 0)
+        #expect(slice?.stops.map(\.stopID) == ["a", "b", "user"])
+        #expect(slice?.vehicleIndex == 0)
     }
 
-    func test_loopRoute_vehiclePastTheDeparturesVisit_returnsNil() {
+    @Test func `Loop route vehicle past the departures visit returns nil`() {
         // Every occurrence of the vehicle's stop is downstream of this visit.
         let slice = ApproachSlice.make(
             stopTimes: stops(["a", "user", "b", "user", "c"]),
@@ -112,10 +113,10 @@ final class ApproachSliceTests: XCTestCase {
             userStopSequence: 1,
             closestStopID: "b"
         )
-        XCTAssertNil(slice)
+        #expect(slice == nil)
     }
 
-    func test_staleStopSequence_fallsBackToStopIDSearch() {
+    @Test func `Stale stop sequence falls back to stop ID search`() {
         // A sequence that doesn't point at the user's stop (out of range, or a
         // feed that numbers sequences differently) falls back to the first match.
         let slice = ApproachSlice.make(
@@ -124,14 +125,14 @@ final class ApproachSliceTests: XCTestCase {
             userStopSequence: 99,
             closestStopID: "a"
         )
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
-        XCTAssertEqual(slice?.vehicleIndex, 0)
+        #expect(slice?.stops.map(\.stopID) == ["a", "b", "user"])
+        #expect(slice?.vehicleIndex == 0)
     }
 
-    func test_nilClosestStop_stillShowsStops() {
+    @Test func `Nil closest stop still shows stops`() {
         let slice = ApproachSlice.make(stopTimes: stops(["a", "b", "user"]), userStopID: "user", closestStopID: nil)
-        XCTAssertEqual(slice?.stops.map(\.stopID), ["a", "b", "user"])
-        XCTAssertNil(slice?.vehicleIndex)
-        XCTAssertEqual(slice?.skippedStopCount, 0)
+        #expect(slice?.stops.map(\.stopID) == ["a", "b", "user"])
+        #expect(slice?.vehicleIndex == nil)
+        #expect(slice?.skippedStopCount == 0)
     }
 }

--- a/OBAKitTests/Stops/StopPage/DepartureStatusBridgeTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusBridgeTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Testing
 import OBAKitCore
 @testable import OBAKit
 
@@ -16,43 +16,44 @@ import OBAKitCore
 /// verify the init forwards `predicted`/`scheduleStatus` correctly and that the
 /// derived color and label stay consistent with the model's `scheduleStatus`.
 @MainActor
-final class DepartureStatusBridgeTests: XCTestCase {
+@Suite(.serialized)
+final class DepartureStatusBridgeTests {
 
     /// A live `ArrivalDeparture` (`predicted == true`) bridges to a real-time
     /// status: occupancy is shown and the color/label follow its `scheduleStatus`.
-    func test_realtimeArrivalDeparture_isRealTimeWithConsistentColorAndLabel() throws {
+    @Test func `Realtime arrival departure is real time with consistent color and label`() throws {
         let arrivalDeparture = try Fixtures.loadRESTAPIPayload(
             type: ArrivalDeparture.self,
             fileName: "arrival-and-departure-for-stop-1_11420.json"
         )
         // Guard the fixture's real-time premise so a fixture change can't silently
         // reduce this to a scheduled-only case.
-        XCTAssertTrue(arrivalDeparture.predicted)
+        #expect(arrivalDeparture.predicted)
 
         let status = DepartureStatus(arrivalDeparture: arrivalDeparture)
-        XCTAssertTrue(status.isRealTime)
-        XCTAssertTrue(status.showsOccupancy)
+        #expect(status.isRealTime)
+        #expect(status.showsOccupancy)
         assertColorAndLabelConsistent(status, with: arrivalDeparture.scheduleStatus)
     }
 
     /// A schedule-only `ArrivalDeparture` (`predicted == false`) bridges to the
     /// honesty state: no occupancy, gray, and the "schedule data" label that
     /// deliberately never claims the bus is "on time" (§4.1).
-    func test_scheduledOnlyArrivalDeparture_isNotRealTimeWithScheduleDataLabel() throws {
+    @Test func `Scheduled only arrival departure is not real time with schedule data label`() throws {
         let stopArrivals = try Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals_and_departures_for_stop_1_10020_no_realtime.json"
         )
-        let arrivalDeparture = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
         // Every entry in this fixture has `predicted == false`.
-        XCTAssertFalse(arrivalDeparture.predicted)
+        #expect(!arrivalDeparture.predicted)
 
         let status = DepartureStatus(arrivalDeparture: arrivalDeparture)
-        XCTAssertFalse(status.isRealTime)
-        XCTAssertFalse(status.showsOccupancy)
-        XCTAssertEqual(status.label, "schedule data")
-        XCTAssertNotEqual(status.label, "on time")
-        XCTAssertEqual(status.color, UIColor.secondaryLabel)
+        #expect(!status.isRealTime)
+        #expect(!status.showsOccupancy)
+        #expect(status.label == "schedule data")
+        #expect(status.label != "on time")
+        #expect(status.color == UIColor.secondaryLabel)
     }
 
     /// Asserts the real-time status' derived color and label agree with whatever
@@ -60,17 +61,17 @@ final class DepartureStatusBridgeTests: XCTestCase {
     private func assertColorAndLabelConsistent(_ status: DepartureStatus, with scheduleStatus: ScheduleStatus) {
         switch scheduleStatus {
         case .onTime:
-            XCTAssertEqual(status.color, ThemeColors.shared.departureOnTime)
-            XCTAssertEqual(status.label, "on time")
+            #expect(status.color == ThemeColors.shared.departureOnTime)
+            #expect(status.label == "on time")
         case .early:
-            XCTAssertEqual(status.color, ThemeColors.shared.departureEarly)
-            XCTAssertTrue(status.label.contains("early"))
+            #expect(status.color == ThemeColors.shared.departureEarly)
+            #expect(status.label.contains("early"))
         case .delayed:
-            XCTAssertEqual(status.color, ThemeColors.shared.departureLate)
-            XCTAssertTrue(status.label.contains("late"))
+            #expect(status.color == ThemeColors.shared.departureLate)
+            #expect(status.label.contains("late"))
         case .unknown:
-            XCTAssertEqual(status.color, UIColor.secondaryLabel)
-            XCTAssertEqual(status.label, "schedule data")
+            #expect(status.color == UIColor.secondaryLabel)
+            #expect(status.label == "schedule data")
         }
     }
 }

--- a/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
@@ -1,39 +1,40 @@
-import XCTest
+import Testing
 import OBAKitCore
 @testable import OBAKit
 
 @MainActor
-final class DepartureStatusTests: XCTestCase {
+@Suite(.serialized)
+final class DepartureStatusTests {
 
-    func test_scheduledOnly_isGrayWithScheduleDataLabel() {
+    @Test func `Scheduled only is gray with schedule data label`() {
         let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
-        XCTAssertEqual(status.color, UIColor.secondaryLabel)
-        XCTAssertEqual(status.label, "schedule data")
-        XCTAssertFalse(status.showsOccupancy)
+        #expect(status.color == UIColor.secondaryLabel)
+        #expect(status.label == "schedule data")
+        #expect(!status.showsOccupancy)
     }
 
-    func test_scheduledOnly_neverClaimsOnTime_evenWithZeroDeviation() {
+    @Test func `Scheduled only never claims on time even with zero deviation`() {
         // §4.1: a scheduled bus is NOT "on time" — we have no idea if it's on time.
         let status = DepartureStatus(isRealTime: false, scheduleStatus: .unknown, deviationMinutes: 0)
-        XCTAssertNotEqual(status.label, "on time")
+        #expect(status.label != "on time")
     }
 
-    func test_onTime_isGreen() {
+    @Test func `On time is green`() {
         let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
-        XCTAssertEqual(status.color, ThemeColors.shared.departureOnTime)
-        XCTAssertEqual(status.label, "on time")
-        XCTAssertTrue(status.showsOccupancy)
+        #expect(status.color == ThemeColors.shared.departureOnTime)
+        #expect(status.label == "on time")
+        #expect(status.showsOccupancy)
     }
 
-    func test_late_isBlue_withMinuteCount() {
+    @Test func `Late is blue with minute count`() {
         let status = DepartureStatus(isRealTime: true, scheduleStatus: .delayed, deviationMinutes: 4)
-        XCTAssertEqual(status.color, ThemeColors.shared.departureLate)
-        XCTAssertEqual(status.label, "4 min late")
+        #expect(status.color == ThemeColors.shared.departureLate)
+        #expect(status.label == "4 min late")
     }
 
-    func test_early_isRed_withMinuteCount() {
+    @Test func `Early is red with minute count`() {
         let status = DepartureStatus(isRealTime: true, scheduleStatus: .early, deviationMinutes: -3)
-        XCTAssertEqual(status.color, ThemeColors.shared.departureEarly)
-        XCTAssertEqual(status.label, "3 min early")
+        #expect(status.color == ThemeColors.shared.departureEarly)
+        #expect(status.label == "3 min early")
     }
 }

--- a/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureTimeDisplayTests.swift
@@ -4,12 +4,14 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import OBAKitCore
 @testable import OBAKit
 
 @MainActor
-final class DepartureTimeDisplayTests: XCTestCase {
+@Suite(.serialized)
+final class DepartureTimeDisplayTests {
 
     private let formatters = Formatters(
         locale: Locale(identifier: "en_US"),
@@ -37,72 +39,69 @@ final class DepartureTimeDisplayTests: XCTestCase {
 
     // MARK: - Which time is shown
 
-    func test_noRealTime_showsScheduledTimeAloneWithNoStrikethrough() {
+    @Test func `No real time shows scheduled time alone with no strikethrough`() {
         // Without a prediction there is nothing to correct, so a struck-through
         // time would imply a change that never happened.
         let display = display(expectedOffset: 0, isRealTime: false)
 
-        XCTAssertEqual(display.expectedTimeText, formatted(0))
-        XCTAssertNil(display.scheduledTimeText)
+        #expect(display.expectedTimeText == formatted(0))
+        #expect(display.scheduledTimeText == nil)
     }
 
-    func test_late_showsPredictedTimeAndStrikesTheScheduledOne() {
+    @Test func `Late shows predicted time and strikes the scheduled one`() {
         let display = display(expectedOffset: 3 * 60)
 
-        XCTAssertEqual(display.expectedTimeText, formatted(3 * 60))
-        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+        #expect(display.expectedTimeText == formatted(3 * 60))
+        #expect(display.scheduledTimeText == formatted(0))
     }
 
-    func test_early_showsPredictedTimeAndStrikesTheScheduledOne() {
+    @Test func `Early shows predicted time and strikes the scheduled one`() {
         let display = display(expectedOffset: -4 * 60)
 
-        XCTAssertEqual(display.expectedTimeText, formatted(-4 * 60))
-        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+        #expect(display.expectedTimeText == formatted(-4 * 60))
+        #expect(display.scheduledTimeText == formatted(0))
     }
 
     // MARK: - The "on time" band
 
-    func test_sameMinute_showsOneTimeOnly() {
+    @Test func `Same minute shows one time only`() {
         // A 20 second deviation formats to the same clock minute; showing
         // "10:42 AM 10:42 AM" with one struck through would be nonsense.
         let display = display(expectedOffset: 20)
 
-        XCTAssertEqual(display.expectedTimeText, formatted(0))
-        XCTAssertNil(display.scheduledTimeText)
+        #expect(display.expectedTimeText == formatted(0))
+        #expect(display.scheduledTimeText == nil)
     }
 
-    func test_differentMinuteInsideOnTimeBand_stillShowsBothTimes() {
+    @Test func `Different minute inside on time band still shows both times`() {
         // scheduleStatus calls anything inside ±1.5 min "on time", but the rider
         // still needs the corrected clock time — this is the bug in issue #1214
         // that a "strike through only when late" rule would leave unfixed.
         let display = display(expectedOffset: 80)
 
-        XCTAssertEqual(display.expectedTimeText, formatted(80))
-        XCTAssertEqual(display.scheduledTimeText, formatted(0))
+        #expect(display.expectedTimeText == formatted(80))
+        #expect(display.scheduledTimeText == formatted(0))
     }
 
     // MARK: - VoiceOver
 
-    func test_accessibility_speaksBothTimesWhenTheyDiffer() {
+    @Test func `Accessibility speaks both times when they differ`() {
         // Strikethrough is invisible to VoiceOver, so the correction has to be
         // carried by words.
         let display = display(expectedOffset: 3 * 60)
 
-        XCTAssertEqual(
-            display.accessibilityTimeDescription,
-            "scheduled \(formatted(0)), now expected \(formatted(3 * 60))"
-        )
+        #expect(display.accessibilityTimeDescription == "scheduled \(formatted(0)), now expected \(formatted(3 * 60))")
     }
 
-    func test_accessibility_speaksOneTimeWhenTheyMatch() {
+    @Test func `Accessibility speaks one time when they match`() {
         let display = display(expectedOffset: 0, isRealTime: false)
 
-        XCTAssertEqual(display.accessibilityTimeDescription, "at \(formatted(0))")
+        #expect(display.accessibilityTimeDescription == "at \(formatted(0))")
     }
 
     // MARK: - Model bridge
 
-    func test_initFromArrivalDeparture_usesPredictedTimeAsExpected() throws {
+    @Test func `Init from arrival departure uses predicted time as expected`() throws {
         let arrivalDeparture = try Fixtures.arrivalDeparture(
             predictedArrival: 1_700_000_180,
             predictedDeparture: 1_700_000_180
@@ -110,11 +109,11 @@ final class DepartureTimeDisplayTests: XCTestCase {
 
         let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
 
-        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate))
-        XCTAssertEqual(display.scheduledTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate))
+        #expect(display.scheduledTimeText == formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
     }
 
-    func test_initFromArrivalDeparture_ignoresPredictionWhenFeedSaysNotPredicted() throws {
+    @Test func `Init from arrival departure ignores prediction when feed says not predicted`() throws {
         // A payload can carry predicted times while declaring `predicted: false`.
         // `arrivalDepartureDate` hands back the prediction anyway, so the display
         // has to gate on the flag or it would strike through a time the feed
@@ -127,16 +126,16 @@ final class DepartureTimeDisplayTests: XCTestCase {
 
         let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
 
-        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
-        XCTAssertNil(display.scheduledTimeText)
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+        #expect(display.scheduledTimeText == nil)
     }
 
-    func test_initFromArrivalDeparture_withoutPrediction_showsNoStrikethrough() throws {
+    @Test func `Init from arrival departure without prediction shows no strikethrough`() throws {
         let arrivalDeparture = try Fixtures.arrivalDeparture(predicted: false)
 
         let display = DepartureTimeDisplay(arrivalDeparture: arrivalDeparture, formatters: formatters)
 
-        XCTAssertEqual(display.expectedTimeText, formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
-        XCTAssertNil(display.scheduledTimeText)
+        #expect(display.expectedTimeText == formatters.timeFormatter.string(from: arrivalDeparture.scheduledDate))
+        #expect(display.scheduledTimeText == nil)
     }
 }

--- a/OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift
+++ b/OBAKitTests/Stops/StopPage/FeatureFlagsTests.swift
@@ -6,30 +6,31 @@
 //  This source code is licensed under the Apache 2.0 license found in the
 //  LICENSE file in the root directory of this source tree.
 //
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKitCore
 
 @MainActor
-final class FeatureFlagsTests: XCTestCase {
+@Suite(.serialized)
+final class FeatureFlagsTests {
     private var defaults: UserDefaults!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
         defaults = UserDefaults(suiteName: "FeatureFlagsTests")!
         defaults.removePersistentDomain(forName: "FeatureFlagsTests")
     }
 
-    func test_newStopPage_defaultsToEnabled() {
-        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+    @Test func `New stop page defaults to enabled`() {
+        #expect(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
     }
 
-    func test_newStopPage_respectsExplicitFalse() {
+    @Test func `New stop page respects explicit false`() {
         defaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
-        XCTAssertFalse(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+        #expect(!FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
     }
 
-    func test_newStopPage_respectsExplicitTrue() {
+    @Test func `New stop page respects explicit true`() {
         defaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
-        XCTAssertTrue(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
+        #expect(FeatureFlags.isNewStopPageEnabled(userDefaults: defaults))
     }
 }

--- a/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageListBuilderTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 import OBAKitCore
 @testable import OBAKit
 
@@ -16,72 +16,73 @@ private func dep(_ id: String, route: String, mins: Int) -> StubDeparture {
 }
 
 @MainActor
-final class StopPageListBuilderTests: XCTestCase {
+@Suite(.serialized)
+final class StopPageListBuilderTests {
 
     // MARK: - Chronological partition
 
-    func test_partition_splitsAtWalkThreshold() {
+    @Test func `Partition splits at walk threshold`() {
         let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5), dep("c", route: "62", mins: 7)]
         let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
-        XCTAssertEqual(p.missed.map(\.id), ["a"])       // 1 < 4: can't reach on foot
-        XCTAssertEqual(p.reachable.map(\.id), ["b", "c"]) // 5 and 7 >= 4 (§4.5: catchable iff mins >= walk)
-        XCTAssertTrue(p.past.isEmpty)
+        #expect(p.missed.map(\.id) == ["a"])       // 1 < 4: can't reach on foot
+        #expect(p.reachable.map(\.id) == ["b", "c"]) // 5 and 7 >= 4 (§4.5: catchable iff mins >= walk)
+        #expect(p.past.isEmpty)
     }
 
-    func test_partition_boundaryIsCatchable() {
+    @Test func `Partition boundary is catchable`() {
         // minutesAway == walkMinutes is catchable (§4.5: >=)
         let p = StopPageListBuilder.chronologicalPartition([dep("x", route: "5", mins: 4)], walkMinutes: 4)
-        XCTAssertEqual(p.reachable.map(\.id), ["x"])
-        XCTAssertTrue(p.missed.isEmpty)
+        #expect(p.reachable.map(\.id) == ["x"])
+        #expect(p.missed.isEmpty)
     }
 
-    func test_partition_nilWalk_hasNoMissedBucket() {
+    @Test func `Partition nil walk has no missed bucket`() {
         let deps = [dep("a", route: "H", mins: 1), dep("b", route: "132", mins: 5)]
         let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
-        XCTAssertTrue(p.missed.isEmpty)
-        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+        #expect(p.missed.isEmpty)
+        #expect(p.reachable.map(\.id) == ["a", "b"])
     }
 
-    func test_partition_pastIsSeparateFromMissed() {
+    @Test func `Partition past is separate from missed`() {
         // §4.2: past (already departed) and missed (can't walk there in time) are distinct.
         let deps = [dep("gone", route: "24", mins: -3), dep("miss", route: "H", mins: 1), dep("ok", route: "5", mins: 9)]
         let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: 4)
-        XCTAssertEqual(p.past.map(\.id), ["gone"])
-        XCTAssertEqual(p.missed.map(\.id), ["miss"])
-        XCTAssertEqual(p.reachable.map(\.id), ["ok"])
+        #expect(p.past.map(\.id) == ["gone"])
+        #expect(p.missed.map(\.id) == ["miss"])
+        #expect(p.reachable.map(\.id) == ["ok"])
     }
 
-    func test_partition_sortsByMinutes() {
+    @Test func `Partition sorts by minutes`() {
         let deps = [dep("b", route: "1", mins: 9), dep("a", route: "2", mins: 5)]
         let p = StopPageListBuilder.chronologicalPartition(deps, walkMinutes: nil)
-        XCTAssertEqual(p.reachable.map(\.id), ["a", "b"])
+        #expect(p.reachable.map(\.id) == ["a", "b"])
     }
 
     // MARK: - Route groups
 
-    func test_groups_orderedBySoonestDeparture_notRouteName() {
+    @Test func `Groups ordered by soonest departure not route name`() {
         // §4.9: route with a bus in 1m outranks a route whose next is 5m.
         let deps = [
             dep("z5", route: "5", mins: 5), dep("h1", route: "H Line", mins: 1),
             dep("h2", route: "H Line", mins: 12), dep("z5b", route: "5", mins: 30)
         ]
         let groups = StopPageListBuilder.routeGroups(deps)
-        XCTAssertEqual(groups.map(\.routeID), ["H Line", "5"])
-        XCTAssertEqual(groups[0].departures.map(\.id), ["h1", "h2"])
-        XCTAssertEqual(groups[0].next.id, "h1")
+        #expect(groups.map(\.routeID) == ["H Line", "5"])
+        #expect(groups[0].departures.map(\.id) == ["h1", "h2"])
+        #expect(groups[0].next.id == "h1")
     }
 
-    func test_groups_excludePastDepartures() {
+    @Test func `Groups exclude past departures`() {
         let deps = [dep("gone", route: "5", mins: -2), dep("soon", route: "5", mins: 6)]
         let groups = StopPageListBuilder.routeGroups(deps)
-        XCTAssertEqual(groups.count, 1)
-        XCTAssertEqual(groups[0].departures.map(\.id), ["soon"])
+        #expect(groups.count == 1)
+        #expect(groups[0].departures.map(\.id) == ["soon"])
     }
 
-    func test_groups_chips_areAtMostThree_afterNext() {
+    @Test func `Groups chips are at most three after next`() {
         let deps = (0..<6).map { dep("d\($0)", route: "40", mins: 5 + $0 * 5) }
         let groups = StopPageListBuilder.routeGroups(deps)
-        XCTAssertEqual(groups[0].chips.map(\.id), ["d1", "d2", "d3"])
-        XCTAssertEqual(groups[0].upcoming.count, 5)
+        #expect(groups[0].chips.map(\.id) == ["d1", "d2", "d3"])
+        #expect(groups[0].upcoming.count == 5)
     }
 }

--- a/OBAKitTests/Stops/StopPage/StopPagePresentationTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPagePresentationTests.swift
@@ -36,8 +36,6 @@ final class StopPagePresentationTests: OBATestCase {
 
     isolated deinit {
         queue.cancelAllOperations()
-        queue = nil
-        application = nil
     }
 
     private func makeStop() throws -> Stop {

--- a/OBAKitTests/Stops/StopPage/StopPagePresentationTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPagePresentationTests.swift
@@ -7,9 +7,9 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 @testable import OBAKit
 @testable import OBAKitCore
+import Foundation
 import Testing
 
 /// The Stop page has two presentations: pushed onto a navigation stack (dark map header, chrome in
@@ -20,27 +20,28 @@ import Testing
 /// tests pin that down at the two seams where it could silently change — the router's default and
 /// the navigation-bar items.
 @MainActor
-class StopPagePresentationTests: OBATestCase {
+@Suite(.serialized)
+final class StopPagePresentationTests: OBATestCase {
 
     private var queue: OperationQueue!
     private var application: Application!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
         userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         queue.cancelAllOperations()
         queue = nil
         application = nil
-        try await super.tearDown()
     }
 
     private func makeStop() throws -> Stop {
-        try XCTUnwrap(Fixtures.loadSomeStops().first)
+        try #require(Fixtures.loadSomeStops().first)
     }
 
     // MARK: - Router defaults
@@ -48,7 +49,7 @@ class StopPagePresentationTests: OBATestCase {
     /// Everything that pushes — Recents, Bookmarks, the map drawer's list, transfers — calls
     /// `makeStopController` without the new argument. If the default ever flips, all of them
     /// silently acquire a bottom toolbar.
-    func test_makeStopController_defaultsToThePushedPresentation() throws {
+    @Test func `Make stop controller defaults to the pushed presentation`() throws {
         let stop = try makeStop()
 
         let byStop = application.viewRouter.makeStopController(stop: stop) as? StopPageViewController
@@ -58,7 +59,7 @@ class StopPagePresentationTests: OBATestCase {
         #expect(byID?.showsBottomToolbar == false)
     }
 
-    func test_makeStopController_optsIntoTheSheetPresentation() throws {
+    @Test func `Make stop controller opts into the sheet presentation`() throws {
         let stop = try makeStop()
 
         let byStop = application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true) as? StopPageViewController
@@ -70,7 +71,7 @@ class StopPagePresentationTests: OBATestCase {
 
     /// The legacy screen has only the pushed layout, so the flag must be inert there rather than
     /// producing a `StopViewController` that someone later assumes has a toolbar.
-    func test_legacyScreen_ignoresTheSheetFlag() throws {
+    @Test func `Legacy screen ignores the sheet flag`() throws {
         userDefaults.set(false, forKey: FeatureFlags.useNewStopPageKey)
         let stop = try makeStop()
 
@@ -83,7 +84,7 @@ class StopPagePresentationTests: OBATestCase {
 
     /// The pushed page keeps its three right-hand bar items. This is the assertion that fails if
     /// the sheet's chrome suppression ever leaks across.
-    func test_pushedPresentation_keepsItsNavigationBarItems() throws {
+    @Test func `Pushed presentation keeps its navigation bar items`() throws {
         let controller = StopPageViewController(application: application, stop: try makeStop())
         controller.loadViewIfNeeded()
 
@@ -92,7 +93,7 @@ class StopPagePresentationTests: OBATestCase {
 
     /// The sheet installs no bar items — they would duplicate the toolbar's controls inside a
     /// navigation bar that renders as a bare grabber.
-    func test_sheetPresentation_installsNoNavigationBarItems() throws {
+    @Test func `Sheet presentation installs no navigation bar items`() throws {
         let controller = StopPageViewController(application: application, stop: try makeStop(), showToolbarOnBottom: true)
         controller.loadViewIfNeeded()
 
@@ -102,7 +103,7 @@ class StopPagePresentationTests: OBATestCase {
     // MARK: - Preview mode
 
     /// A peek is a bare glance in both presentations.
-    func test_previewMode_suppressesChromeInBothPresentations() throws {
+    @Test func `Preview mode suppresses chrome in both presentations`() throws {
         let stop = try makeStop()
 
         let pushed = StopPageViewController(application: application, stop: stop)
@@ -122,7 +123,7 @@ class StopPagePresentationTests: OBATestCase {
     }
 
     /// Leaving a preview must put the pushed page's bar items back, not leave it bare.
-    func test_exitingPreviewMode_restoresPushedNavigationBarItems() throws {
+    @Test func `Exiting preview mode restores pushed navigation bar items`() throws {
         let controller = StopPageViewController(application: application, stop: try makeStop())
         controller.loadViewIfNeeded()
 

--- a/OBAKitTests/Stops/StopPage/StopPageSheetHeaderLayoutTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageSheetHeaderLayoutTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 import SwiftUI
 import UIKit
 import FloatingPanel
@@ -24,7 +25,8 @@ import FloatingPanel
 /// it. `StopPageSheetHeaderView(isCollapsed:)` exists to keep the header inside that budget, and
 /// these tests measure whether it actually does.
 @MainActor
-final class StopPageSheetHeaderLayoutTests: XCTestCase {
+@Suite(.serialized)
+final class StopPageSheetHeaderLayoutTests {
 
     /// The home-indicator inset. It is load-bearing here: it comes out of the same height the top
     /// inset region is clamped against, so a simulator window without one hides the bug.
@@ -35,8 +37,7 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
     private var parent: UIViewController!
     private var presenter: StopSheetPresenter!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() {
 
         parent = UIViewController()
         window = UIWindow(frame: CGRect(origin: .zero, size: Self.screenSize))
@@ -48,14 +49,13 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
         presenter = StopSheetPresenter()
     }
 
-    override func tearDown() async throws {
+    // `isolated deinit` because the cleanup below touches main-actor UI state.
+    // The `= nil` assignments the old `tearDown` performed are dropped: they
+    // only mattered because XCTest holds test-case instances for the whole run,
+    // and assigning nil inside `deinit` releases nothing extra regardless.
+    isolated deinit {
         presenter.dismiss(animated: false)
-        presenter = nil
         window.isHidden = true
-        window = nil
-        parent = nil
-
-        try await super.tearDown()
     }
 
     /// Stands in for `StopPageView`'s sheet presentation: the same `List` + top-inset header
@@ -97,8 +97,8 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
     }
 
     /// Presents the harness, drops it to `.tip`, and reports where the header settled.
-    private func layoutAtTip(isCollapsed: Bool) throws -> TipLayout {
-        let stop = try XCTUnwrap(Fixtures.loadSomeStops().first)
+    private func layoutAtTip(isCollapsed: Bool) async throws -> TipLayout {
+        let stop = try #require(Fixtures.loadSomeStops().first)
         var headerFrame: CGRect = .null
 
         let content = UIHostingController(rootView: Harness(
@@ -108,7 +108,7 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
         ))
         presenter.present(content, from: parent) {}
 
-        let panel = try XCTUnwrap(parent.children.compactMap { $0 as? FloatingPanelController }.first)
+        let panel = try #require(parent.children.compactMap { $0 as? FloatingPanelController }.first)
         // The real sheet's root is a `StopPageViewController`, whose navigation bar the presenter
         // hides. A bare hosting controller keeps its bar, and the bar's own height would floor the
         // content view well above the detent — masking what this test is measuring.
@@ -116,53 +116,52 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
 
         // Let the presentation animation land before moving; interrupting it mid-flight leaves
         // the surface wherever the animator had got to.
-        spin(0.6)
+        await spin(0.6)
         panel.move(to: .tip, animated: false)
         parent.view.layoutIfNeeded()
-        spin(0.4)
+        await spin(0.4)
 
-        let contentFrame = try XCTUnwrap(panel.surfaceView.contentView).convert(
-            try XCTUnwrap(panel.surfaceView.contentView).bounds,
+        let contentFrame = try #require(panel.surfaceView.contentView).convert(
+            try #require(panel.surfaceView.contentView).bounds,
             to: nil
         )
 
         return TipLayout(header: headerFrame, contentTop: contentFrame.minY)
     }
 
-    private func spin(_ seconds: TimeInterval) {
-        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    /// Lets queued main-actor work and in-flight animations run.
+    ///
+    /// This used to be `RunLoop.current.run(until:)`. Under XCTest that drained
+    /// the main queue, because the test method ran directly on the main thread's
+    /// run loop. A Swift Testing `@MainActor` test body is itself a main-queue
+    /// item, so blocking inside it cannot re-entrantly drain further main-queue
+    /// blocks — dismissal completion handlers would never fire. Suspending
+    /// instead releases the main actor, which is what actually lets the work run.
+    private func spin(_ seconds: TimeInterval) async {
+        try? await Task.sleep(for: .seconds(seconds))
     }
 
     /// The peek detent has to show the stop name and the close button, or it is a strip of route
     /// badges the rider can't identify or dismiss.
-    func test_collapsedHeader_fitsEntirelyWithinTheTipDetent() throws {
-        let layout = try layoutAtTip(isCollapsed: true)
+    @Test func `Collapsed header fits entirely within the tip detent`() async throws {
+        let layout = try await layoutAtTip(isCollapsed: true)
 
-        XCTAssertGreaterThanOrEqual(
-            layout.header.minY, layout.contentTop - 0.5,
-            "The collapsed header overflowed the top of the sheet, taking the stop name and close button with it."
-        )
-        XCTAssertLessThanOrEqual(
-            layout.header.maxY, Self.screenSize.height - Self.bottomSafeArea + 0.5,
-            "The collapsed header ran past the safe area, so its lower half sits under the home indicator."
-        )
+        #expect(layout.header.minY >= layout.contentTop - 0.5, "The collapsed header overflowed the top of the sheet, taking the stop name and close button with it.")
+        #expect(layout.header.maxY <= Self.screenSize.height - Self.bottomSafeArea + 0.5, "The collapsed header ran past the safe area, so its lower half sits under the home indicator.")
     }
 
     /// The counterpart: the full header genuinely does not fit, which is why the collapsed variant
     /// exists at all. If SwiftUI ever starts cropping a top inset from the bottom instead — or the
     /// header slims down enough to fit — this test says so, and `isCollapsed` can be revisited.
-    func test_fullHeader_doesNotFitTheTipDetent() throws {
-        let layout = try layoutAtTip(isCollapsed: false)
+    @Test func `Full header does not fit the tip detent`() async throws {
+        let layout = try await layoutAtTip(isCollapsed: false)
 
-        XCTAssertLessThan(
-            layout.header.minY, layout.contentTop,
-            "The full header now fits the tip detent; the collapsed variant may no longer be needed."
-        )
+        #expect(layout.header.minY < layout.contentTop, "The full header now fits the tip detent; the collapsed variant may no longer be needed.")
     }
 
     /// The detent is sized from the collapsed header, so a rider running a large text size gets a
     /// taller peek rather than a clipped one.
-    func test_tipDetentGrowsWithTheContentSizeCategory() {
+    @Test func `Tip detent grows with the content size category`() {
         let standard = StopSheetHeaderMetrics.collapsedHeight(
             for: UITraitCollection(preferredContentSizeCategory: .large)
         )
@@ -170,6 +169,6 @@ final class StopPageSheetHeaderLayoutTests: XCTestCase {
             for: UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
         )
 
-        XCTAssertGreaterThan(accessibility, standard)
+        #expect(accessibility > standard)
     }
 }

--- a/OBAKitTests/Stops/StopPage/StopPageSheetHeaderLayoutTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageSheetHeaderLayoutTests.swift
@@ -38,7 +38,6 @@ final class StopPageSheetHeaderLayoutTests {
     private var presenter: StopSheetPresenter!
 
     init() {
-
         parent = UIViewController()
         window = UIWindow(frame: CGRect(origin: .zero, size: Self.screenSize))
         window.rootViewController = parent
@@ -127,18 +126,6 @@ final class StopPageSheetHeaderLayoutTests {
         )
 
         return TipLayout(header: headerFrame, contentTop: contentFrame.minY)
-    }
-
-    /// Lets queued main-actor work and in-flight animations run.
-    ///
-    /// This used to be `RunLoop.current.run(until:)`. Under XCTest that drained
-    /// the main queue, because the test method ran directly on the main thread's
-    /// run loop. A Swift Testing `@MainActor` test body is itself a main-queue
-    /// item, so blocking inside it cannot re-entrantly drain further main-queue
-    /// blocks — dismissal completion handlers would never fire. Suspending
-    /// instead releases the main actor, which is what actually lets the work run.
-    private func spin(_ seconds: TimeInterval) async {
-        try? await Task.sleep(for: .seconds(seconds))
     }
 
     /// The peek detent has to show the stop name and the close button, or it is a strip of route

--- a/OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift
+++ b/OBAKitTests/Stops/StopPage/WalkTimeInfoTests.swift
@@ -1,32 +1,33 @@
-import XCTest
+import Testing
 import CoreLocation
 @testable import OBAKit
 
 @MainActor
-final class WalkTimeInfoTests: XCTestCase {
+@Suite(.serialized)
+final class WalkTimeInfoTests {
     // ~111m per 0.001 degree latitude at the equator; use real CLLocations.
     private let stopLocation = CLLocation(latitude: 47.6097, longitude: -122.3331)
 
-    func test_computesMinutesRoundedUp() {
+    @Test func `Computes minutes rounded up`() {
         // ~500m at 1.25 m/s = 400s = 6.67 min -> 7 min
         let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
         let info = WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25)
-        XCTAssertNotNil(info)
-        XCTAssertEqual(info!.walkMinutes, 7)
+        #expect(info != nil)
+        #expect(info!.walkMinutes == 7)
     }
 
-    func test_nilWhenUserLocationMissing() {
-        XCTAssertNil(WalkTimeInfo.compute(from: nil, to: stopLocation, speedMetersPerSecond: 1.25))
+    @Test func `Nil when user location missing`() {
+        #expect(WalkTimeInfo.compute(from: nil, to: stopLocation, speedMetersPerSecond: 1.25) == nil)
     }
 
-    func test_nilWhenVeryClose() {
+    @Test func `Nil when very close`() {
         // <= 40m: suppress, matching today's WalkTimeView behavior.
         let user = CLLocation(latitude: 47.60972, longitude: -122.3331)
-        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25))
+        #expect(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 1.25) == nil)
     }
 
-    func test_nilWhenSpeedInvalid() {
+    @Test func `Nil when speed invalid`() {
         let user = CLLocation(latitude: 47.6142, longitude: -122.3331)
-        XCTAssertNil(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 0))
+        #expect(WalkTimeInfo.compute(from: user, to: stopLocation, speedMetersPerSecond: 0) == nil)
     }
 }

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -7,7 +7,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -16,7 +17,8 @@ import XCTest
 /// falls back to English, and a mismatched format specifier makes `String(format:)` read
 /// past its argument list.
 @MainActor
-class LocalizationTests: XCTestCase {
+@Suite(.serialized)
+final class LocalizationTests {
 
     /// Keys whose plural forms come from `Localizable.stringsdict` rather than
     /// `Localizable.strings`. Every one of these is called with `String(format:)` and a count.
@@ -56,19 +58,20 @@ class LocalizationTests: XCTestCase {
     // MARK: - Key parity
 
     /// A key missing from a locale silently renders in English. Nothing else catches it.
-    func testEveryLocaleHasSameKeysAsEnglish() {
+    @Test func `Every locale has same keys as english`() {
         for (name, bundle) in frameworks {
             guard let english = strings(in: bundle, localization: "en") else {
-                return XCTFail("\(name): no en Localizable.strings")
+                Issue.record("\(name): no en Localizable.strings")
+                return
             }
-            XCTAssertGreaterThan(english.count, 100, "\(name): en table looks truncated")
+            #expect(english.count > 100, "\(name): en table looks truncated")
 
             for localization in bundle.localizations where localization != "en" && localization != "Base" {
                 guard let translated = strings(in: bundle, localization: localization) else { continue }
                 let missing = Set(english.keys).subtracting(translated.keys)
                 let extra = Set(translated.keys).subtracting(english.keys)
-                XCTAssertTrue(missing.isEmpty, "\(name)/\(localization) is missing \(missing.count) key(s): \(missing.sorted().prefix(5))")
-                XCTAssertTrue(extra.isEmpty, "\(name)/\(localization) has \(extra.count) key(s) not in en: \(extra.sorted().prefix(5))")
+                #expect(missing.isEmpty, "\(name)/\(localization) is missing \(missing.count) key(s): \(missing.sorted().prefix(5))")
+                #expect(extra.isEmpty, "\(name)/\(localization) has \(extra.count) key(s) not in en: \(extra.sorted().prefix(5))")
             }
         }
     }
@@ -77,7 +80,7 @@ class LocalizationTests: XCTestCase {
 
     /// A translation that drops `%@` silently renders without the app name; one that *adds*
     /// a specifier makes `String(format:)` read past the end of its arguments.
-    func testEveryLocalePreservesEnglishFormatSpecifiers() {
+    @Test func `Every locale preserves english format specifiers`() {
         for (name, bundle) in frameworks {
             guard let english = strings(in: bundle, localization: "en") else { continue }
 
@@ -85,10 +88,7 @@ class LocalizationTests: XCTestCase {
                 guard let translated = strings(in: bundle, localization: localization) else { continue }
                 for (key, translation) in translated {
                     guard let source = english[key] else { continue }
-                    XCTAssertEqual(
-                        specifiers(in: source), specifiers(in: translation),
-                        "\(name)/\(localization)/\(key): format specifiers differ from English — en=\(source) \(localization)=\(translation)"
-                    )
+                    #expect(specifiers(in: source) == specifiers(in: translation), "\(name)/\(localization)/\(key): format specifiers differ from English — en=\(source) \(localization)=\(translation)")
                 }
             }
         }
@@ -98,7 +98,7 @@ class LocalizationTests: XCTestCase {
 
     /// Every locale must carry all the plural keys, with the CLDR-mandatory `other` category.
     /// A dropped entry degrades silently to the `.strings` fallback ("1 stops").
-    func testEveryLocaleStringsdictIsWellFormed() {
+    @Test func `Every locale stringsdict is well formed`() {
         let bundle = Bundle(for: DonationCell.self)
 
         for localization in bundle.localizations where localization != "Base" {
@@ -106,22 +106,22 @@ class LocalizationTests: XCTestCase {
                                        subdirectory: nil, localization: localization),
                   let dict = NSDictionary(contentsOf: url) as? [String: Any]
             else {
-                return XCTFail("\(localization): Localizable.stringsdict is missing or unparseable")
+                Issue.record("\(localization): Localizable.stringsdict is missing or unparseable")
+                return
             }
 
             let missing = Self.pluralKeys.subtracting(dict.keys)
-            XCTAssertTrue(missing.isEmpty, "\(localization)/stringsdict is missing \(missing.sorted())")
+            #expect(missing.isEmpty, "\(localization)/stringsdict is missing \(missing.sorted())")
 
             for key in Self.pluralKeys {
                 guard let entry = dict[key] as? [String: Any],
                       let variable = entry["count"] as? [String: Any]
                 else {
-                    XCTFail("\(localization)/\(key): malformed stringsdict entry")
+                    Issue.record("\(localization)/\(key): malformed stringsdict entry")
                     continue
                 }
-                XCTAssertEqual(variable["NSStringFormatSpecTypeKey"] as? String, "NSStringPluralRuleType",
-                               "\(localization)/\(key): wrong spec type")
-                XCTAssertNotNil(variable["other"], "\(localization)/\(key): missing mandatory CLDR category 'other'")
+                #expect((variable["NSStringFormatSpecTypeKey"] as? String) == "NSStringPluralRuleType", "\(localization)/\(key): wrong spec type")
+                #expect(variable["other"] != nil, "\(localization)/\(key): missing mandatory CLDR category 'other'")
             }
         }
     }
@@ -130,7 +130,7 @@ class LocalizationTests: XCTestCase {
     /// `Localizable.stringsdict`. If the stringsdict resource ever stops being bundled, lookup
     /// silently falls back to the bare `%d` form and English renders "1 stops". Assert the
     /// singular actually resolves, which only happens when the stringsdict is present.
-    func testStringsdictIsBundledSoSingularsResolve() {
+    @Test func `Stringsdict is bundled so singulars resolve`() {
         let bundle = Bundle(for: DonationCell.self)
         let expectedSingulars = [
             "stop_page.timeline.skipped_stops_fmt": "1 stop",
@@ -140,10 +140,7 @@ class LocalizationTests: XCTestCase {
 
         for (key, expected) in expectedSingulars {
             let format = bundle.localizedString(forKey: key, value: "MISSING", table: nil)
-            XCTAssertEqual(
-                String(format: format, 1), expected,
-                "\(key) did not resolve its singular — is Localizable.stringsdict bundled?"
-            )
+            #expect(String(format: format, 1) == expected, "\(key) did not resolve its singular — is Localizable.stringsdict bundled?")
         }
     }
 }

--- a/OBAKitTests/Surveys/ExternalSurveyLauncherTests.swift
+++ b/OBAKitTests/Surveys/ExternalSurveyLauncherTests.swift
@@ -3,11 +3,12 @@
 //  OBAKitTests
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class ExternalSurveyLauncherTests: OBATestCase {
 
     nonisolated(unsafe) private var testUserDefaults: UserDefaults!
@@ -15,8 +16,9 @@ final class ExternalSurveyLauncherTests: OBATestCase {
     nonisolated(unsafe) private var context: MockSurveyURLApplicationContext!
     nonisolated(unsafe) private var service: SurveyService!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         testUserDefaults = buildUserDefaults(suiteName: "\(userDefaultsSuiteName).launcher")
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).launcher")
         store = UserDefaultsStore(userDefaults: testUserDefaults)
@@ -25,9 +27,8 @@ final class ExternalSurveyLauncherTests: OBATestCase {
         service = SurveyService(apiService: nil, userDataStore: store, application: context)
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         testUserDefaults.removePersistentDomain(forName: "\(userDefaultsSuiteName).launcher")
-        try await super.tearDown()
     }
 
     private func externalSurvey(id: Int = 1, url: String?, fields: [String] = []) -> Survey {
@@ -40,7 +41,7 @@ final class ExternalSurveyLauncherTests: OBATestCase {
         store.isSurveyCompleted(surveyId: id, userIdentifier: "u-1")
     }
 
-    func test_launch_opensExactURL_marksCompleted_callsOnSuccess() {
+    @Test func `Launch opens exact URL marks completed calls on success`() {
         let survey = externalSurvey(url: "https://oba.co/s")
         var opened: URL?
         var succeeded = false
@@ -59,7 +60,7 @@ final class ExternalSurveyLauncherTests: OBATestCase {
         #expect(self.isCompleted(1))
     }
 
-    func test_launch_appendsStopID_whenStopProvided() {
+    @Test func `Launch appends stop ID when stop provided`() {
         let survey = externalSurvey(url: "https://oba.co/s", fields: ["stop_id"])
         let stop = SurveysTestHelpers.makeStop(id: "1_99")
         var opened: URL?
@@ -72,7 +73,7 @@ final class ExternalSurveyLauncherTests: OBATestCase {
         #expect(items.first { $0.name == "stop_id" }?.value == "1_99")
     }
 
-    func test_launch_nilURL_doesNotOpen_doesNotComplete_callsOnFailure() {
+    @Test func `Launch nil URL does not open does not complete calls on failure`() {
         let survey = externalSurvey(url: nil)
         var openerCalled = false
         var failed = false
@@ -89,7 +90,7 @@ final class ExternalSurveyLauncherTests: OBATestCase {
         #expect(!self.isCompleted(1))
     }
 
-    func test_launch_openFailure_doesNotComplete_callsOnFailure() {
+    @Test func `Launch open failure does not complete calls on failure`() {
         let survey = externalSurvey(url: "https://oba.co/s")
         var succeeded = false
         var failed = false

--- a/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
+++ b/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
@@ -5,12 +5,13 @@
 //  Created by Mohamed Sliem on 19/02/2026.
 //
 
-import XCTest
+import Foundation
 import Testing
 import MapKit
 import CoreLocation
 @testable import OBAKitCore
 
+@Suite(.serialized)
 final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     var userDefaultsStore: UserDefaultsStore!
@@ -21,8 +22,9 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - Setup
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         userDefaultsStore = UserDefaultsStore(userDefaults: userDefaults)
         applicationContext = MockSurveyURLApplicationContext()
 
@@ -33,28 +35,27 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         )
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         builder = nil
         applicationContext = nil
         userDefaultsStore = nil
-        try await super.tearDown()
     }
 
     // MARK: - buildURL
 
-    func test_buildURL_returnsNil_whenSurveyHasNoQuestions() {
+    @Test func `Build URL returns nil when survey has no questions`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [])
         #expect(self.builder.buildURL(for: survey, stop: nil) == nil)
     }
 
-    func test_buildURL_returnsNil_whenBaseURLIsInvalid() {
+    @Test func `Build URL returns nil when base URLIs invalid`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [
             SurveysTestHelpers.makeSurveyQuestion(url: "not a valid url %%")
         ])
         #expect(self.builder.buildURL(for: survey, stop: nil) == nil)
     }
 
-    func test_buildURL_returnsValidURL_whenNoEmbeddedDataFields() {
+    @Test func `Build URL returns valid URL when no embedded data fields`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [
             SurveysTestHelpers.makeSurveyQuestion(url: "https://oba.co/survey")
         ])
@@ -67,7 +68,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(url?.absoluteString == "https://oba.co/survey")
     }
 
-    func test_buildURL_preservesExistingQueryItems() {
+    @Test func `Build URL preserves existing query items`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [
             SurveysTestHelpers.makeSurveyQuestion(url: "https://oba.co/survey?source=app")
         ])
@@ -79,7 +80,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - user_id
 
-    func test_buildURL_appendsUserID() {
+    @Test func `Build URL appends user ID`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["user_id"])])
 
         let url = builder.buildURL(for: survey, stop: nil)
@@ -87,7 +88,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "user_id") == testUserID)
     }
 
-    func test_buildURL_appendsEmptyUserID_whenUserIDIsEmpty() {
+    @Test func `Build URL appends empty user ID when user IDIs empty`() {
         builder = ExternalSurveyURLBuilder(
             userStore: userDefaultsStore,
             userID: "",
@@ -102,7 +103,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - region_id
 
-    func test_buildURL_appendsRegionID_whenRegionAvailable() {
+    @Test func `Build URL appends region ID when region available`() {
         applicationContext.currentRegionIdentifier = 1
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["region_id"])])
@@ -111,7 +112,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "region_id") == "1")
     }
 
-    func test_buildURL_omitsRegionID_whenNoCurrentRegion() {
+    @Test func `Build URL omits region ID when no current region`() {
         applicationContext.currentRegionIdentifier = nil
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["region_id"])])
@@ -122,7 +123,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - stop_id
 
-    func test_buildURL_appendsStopID_whenStopProvided() {
+    @Test func `Build URL appends stop ID when stop provided`() {
         let stop = SurveysTestHelpers.makeStop(id: "1_75403")
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["stop_id"])])
@@ -131,7 +132,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "stop_id") == "1_75403")
     }
 
-    func test_buildURL_omitsStopID_whenStopIsNil() {
+    @Test func `Build URL omits stop ID when stop is nil`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["stop_id"])])
 
         let url = builder.buildURL(for: survey, stop: nil)
@@ -141,7 +142,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - route_id
 
-    func test_buildURL_appendsRouteIDs_whenStopHasRoutes() {
+    @Test func `Build URL appends route IDs when stop has routes`() {
         let stop = SurveysTestHelpers.makeStop(routeIDs: ["1_40", "1_44"])
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["route_id"])])
@@ -150,7 +151,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "route_id") == "1_40,1_44")
     }
 
-    func test_buildURL_appendsSingleRouteID_whenStopHasOneRoute() {
+    @Test func `Build URL appends single route ID when stop has one route`() {
         let stop = SurveysTestHelpers.makeStop(routeIDs: ["1_40"])
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["route_id"])])
@@ -160,7 +161,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "route_id")?.contains(",") == false)
     }
 
-    func test_buildURL_omitsRouteID_whenStopHasNoRoutes() {
+    @Test func `Build URL omits route ID when stop has no routes`() {
         let stop = SurveysTestHelpers.makeStop(routeIDs: [])
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["route_id"])])
@@ -169,7 +170,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "route_id") == nil)
     }
 
-    func test_buildURL_omitsRouteID_whenStopIsNil() {
+    @Test func `Build URL omits route ID when stop is nil`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["route_id"])])
 
         let url = builder.buildURL(for: survey, stop: nil)
@@ -179,7 +180,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - recent_stop_ids
 
-    func test_buildURL_appendsRecentStopIDs_whenAvailable() {
+    @Test func `Build URL appends recent stop IDs when available`() {
         let region = makeRegion()
         userDefaultsStore.addRecentStop(SurveysTestHelpers.makeStop(id: "1_75403"), region: region)
         userDefaultsStore.addRecentStop(SurveysTestHelpers.makeStop(id: "1_29270"), region: region)
@@ -191,7 +192,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "recent_stop_ids")?.contains("1_29270") == true)
     }
 
-    func test_buildURL_appendsSingleRecentStopID_whenOneStopInStore() {
+    @Test func `Build URL appends single recent stop ID when one stop in store`() {
         let region = makeRegion()
         userDefaultsStore.addRecentStop(SurveysTestHelpers.makeStop(id: "1_75403"), region: region)
 
@@ -202,7 +203,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "recent_stop_ids")?.contains(",") == false)
     }
 
-    func test_buildURL_omitsRecentStopIDs_whenListIsEmpty() {
+    @Test func `Build URL omits recent stop IDs when list is empty`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["recent_stop_ids"])])
 
         let url = builder.buildURL(for: survey, stop: nil)
@@ -212,7 +213,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - current_location
 
-    func test_buildURL_appendsCurrentLocation_whenLocationAvailable() {
+    @Test func `Build URL appends current location when location available`() {
         applicationContext.currentCoordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["current_location"])])
@@ -221,7 +222,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "current_location") == "47.6062,-122.3321")
     }
 
-    func test_buildURL_appendsCurrentLocation_atZeroCoordinate() {
+    @Test func `Build URL appends current location at zero coordinate`() {
         applicationContext.currentCoordinate = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["current_location"])])
@@ -230,7 +231,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "current_location") == "0.0,0.0")
     }
 
-    func test_buildURL_appendsCurrentLocation_withNegativeCoordinates() {
+    @Test func `Build URL appends current location with negative coordinates`() {
         applicationContext.currentCoordinate = CLLocationCoordinate2D(latitude: -33.8688, longitude: -70.6693)
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["current_location"])])
@@ -239,7 +240,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "current_location") == "-33.8688,-70.6693")
     }
 
-    func test_buildURL_omitsCurrentLocation_whenLocationUnavailable() {
+    @Test func `Build URL omits current location when location unavailable`() {
         applicationContext.currentCoordinate = nil
 
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["current_location"])])
@@ -250,7 +251,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - Unknown Keys
 
-    func test_buildURL_ignoresUnknownEmbeddedFields() {
+    @Test func `Build URL ignores unknown embedded fields`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [makeQuestionWithFields(["unknown_key", "another_unknown"])])
 
         let url = builder.buildURL(for: survey, stop: nil)
@@ -263,7 +264,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - Multiple Fields
 
-    func test_buildURL_appendsMultipleFields() {
+    @Test func `Build URL appends multiple fields`() {
         let region = makeRegion()
         applicationContext.currentRegionIdentifier = 1
         userDefaultsStore.addRecentStop(SurveysTestHelpers.makeStop(id: "1_75403"), region: region)
@@ -281,7 +282,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "recent_stop_ids")?.contains("1_75403") == true)
     }
 
-    func test_buildURL_appendsAllSixFields_whenAllDataAvailable() {
+    @Test func `Build URL appends all six fields when all data available`() {
         let region = makeRegion()
         applicationContext.currentRegionIdentifier = 1
         applicationContext.currentCoordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
@@ -304,7 +305,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
 
     // MARK: - Lifecycle
 
-    func test_builder_doesNotRetainApplicationContext() {
+    @Test func `Builder does not retain application context`() {
         weak var weakContext: MockSurveyURLApplicationContext?
         let localBuilder: ExternalSurveyURLBuilder = {
             let ctx = MockSurveyURLApplicationContext()

--- a/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
+++ b/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
@@ -35,12 +35,6 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         )
     }
 
-    isolated deinit {
-        builder = nil
-        applicationContext = nil
-        userDefaultsStore = nil
-    }
-
     // MARK: - buildURL
 
     @Test func `Build URL returns nil when survey has no questions`() {

--- a/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
+++ b/OBAKitTests/Surveys/ExternalSurveyURLBuilderTests.swift
@@ -42,7 +42,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.builder.buildURL(for: survey, stop: nil) == nil)
     }
 
-    @Test func `Build URL returns nil when base URLIs invalid`() {
+    @Test func `Build URL returns nil when base URL is invalid`() {
         let survey = SurveysTestHelpers.makeSurvey(questions: [
             SurveysTestHelpers.makeSurveyQuestion(url: "not a valid url %%")
         ])
@@ -82,7 +82,7 @@ final class ExternalSurveyURLBuilderTests: OBATestCase {
         #expect(self.queryValue(in: url, for: "user_id") == testUserID)
     }
 
-    @Test func `Build URL appends empty user ID when user IDIs empty`() {
+    @Test func `Build URL appends empty user ID when user ID is empty`() {
         builder = ExternalSurveyURLBuilder(
             userStore: userDefaultsStore,
             userID: "",

--- a/OBAKitTests/UI/UIViewScrollViewSearchTests.swift
+++ b/OBAKitTests/UI/UIViewScrollViewSearchTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Testing
 import UIKit
 @testable import OBAKit
 
@@ -16,23 +16,24 @@ import UIKit
 /// properties the caller depends on: it finds the *shallowest* scroll view, and it reports
 /// absence rather than trapping.
 @MainActor
-final class UIViewScrollViewSearchTests: XCTestCase {
+@Suite(.serialized)
+final class UIViewScrollViewSearchTests {
 
-    func test_returnsNil_whenHierarchyHasNoScrollView() {
+    @Test func `Returns nil when hierarchy has no scroll view`() {
         let root = UIView()
         let child = UIView()
         root.addSubview(child)
         child.addSubview(UILabel())
 
-        XCTAssertNil(root.nearestDescendantScrollView())
+        #expect(root.nearestDescendantScrollView() == nil)
     }
 
-    func test_returnsReceiver_whenReceiverIsAScrollView() {
+    @Test func `Returns receiver when receiver is a scroll view`() {
         let scrollView = UIScrollView()
-        XCTAssertIdentical(scrollView.nearestDescendantScrollView(), scrollView)
+        #expect(scrollView.nearestDescendantScrollView() === scrollView)
     }
 
-    func test_findsNestedScrollView() {
+    @Test func `Finds nested scroll view`() {
         let root = UIView()
         let middle = UIView()
         let scrollView = UIScrollView()
@@ -40,13 +41,13 @@ final class UIViewScrollViewSearchTests: XCTestCase {
         root.addSubview(middle)
         middle.addSubview(scrollView)
 
-        XCTAssertIdentical(root.nearestDescendantScrollView(), scrollView)
+        #expect(root.nearestDescendantScrollView() === scrollView)
     }
 
     /// The search must be breadth-first. A SwiftUI `List`'s rows can themselves contain scroll
     /// views; tracking one of those instead of the list would make the sheet resize off a
     /// single row's scrolling.
-    func test_prefersShallowerScrollView_overOneNestedDeeperInAnEarlierBranch() {
+    @Test func `Prefers shallower scroll view over one nested deeper in an earlier branch`() {
         let root = UIView()
 
         // Earlier branch, deeper scroll view — a row's own scroll view.
@@ -62,11 +63,11 @@ final class UIViewScrollViewSearchTests: XCTestCase {
         root.addSubview(firstBranch)
         root.addSubview(shallowScrollView)
 
-        XCTAssertIdentical(root.nearestDescendantScrollView(), shallowScrollView)
+        #expect(root.nearestDescendantScrollView() === shallowScrollView)
     }
 
     /// `UITableView` and `UICollectionView` are the concrete types SwiftUI actually produces.
-    func test_findsCollectionView() {
+    @Test func `Finds collection view`() {
         let root = UIView()
         let collectionView = UICollectionView(
             frame: .zero,
@@ -74,6 +75,6 @@ final class UIViewScrollViewSearchTests: XCTestCase {
         )
         root.addSubview(collectionView)
 
-        XCTAssertIdentical(root.nearestDescendantScrollView(), collectionView)
+        #expect(root.nearestDescendantScrollView() === collectionView)
     }
 }

--- a/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
+++ b/OBAKitTests/ViewModels/AgenciesViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -15,17 +15,18 @@ import Combine
 
 /// Tests for `AgenciesViewModel`. Verifies the success path sorts by name,
 /// and that loading state resets to `false` after completion.
+@Suite(.serialized)
 final class AgenciesViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -57,8 +58,8 @@ final class AgenciesViewModelTests: OBATestCase {
         return Application(config: config)
     }
 
-    @MainActor
-    func test_init_emptyState() {
+    @Test @MainActor
+    func `Init empty state`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -67,8 +68,8 @@ final class AgenciesViewModelTests: OBATestCase {
         #expect(viewModel.agencies.isEmpty)
     }
 
-    @MainActor
-    func test_loadData_success_populatesAgenciesSortedByName() async {
+    @Test @MainActor
+    func `Load data success populates agencies sorted by name`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 

--- a/OBAKitTests/ViewModels/AgencyAlertsViewModelTests.swift
+++ b/OBAKitTests/ViewModels/AgencyAlertsViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -16,17 +16,18 @@ import Combine
 /// Tests for `AgencyAlertsViewModel`. Verifies the share-activity helper,
 /// `collapsedSections` round-trip, and the loading flag transitions on
 /// `agencyAlertsUpdated()`.
+@Suite(.serialized)
 final class AgencyAlertsViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -60,8 +61,8 @@ final class AgencyAlertsViewModelTests: OBATestCase {
 
     // MARK: - Tests
 
-    @MainActor
-    func test_init_emptyAlerts_andNotLoading() {
+    @Test @MainActor
+    func `Init empty alerts and not loading`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -72,8 +73,8 @@ final class AgencyAlertsViewModelTests: OBATestCase {
         #expect(viewModel.collapsedSections.isEmpty)
     }
 
-    @MainActor
-    func test_reloadServerData_setsIsLoadingTrue() {
+    @Test @MainActor
+    func `Reload server data sets is loading true`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -83,8 +84,8 @@ final class AgencyAlertsViewModelTests: OBATestCase {
         #expect(viewModel.isLoading)
     }
 
-    @MainActor
-    func test_agencyAlertsUpdated_clearsIsLoading() {
+    @Test @MainActor
+    func `Agency alerts updated clears is loading`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -95,8 +96,8 @@ final class AgencyAlertsViewModelTests: OBATestCase {
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_collapsedSections_survivesRefresh() {
+    @Test @MainActor
+    func `Collapsed sections survives refresh`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -110,8 +111,8 @@ final class AgencyAlertsViewModelTests: OBATestCase {
         #expect(viewModel.collapsedSections == ["agency_1", "agency_2"])
     }
 
-    @MainActor
-    func test_displayError_clearsIsLoading() {
+    @Test @MainActor
+    func `Display error clears is loading`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -17,18 +17,19 @@ import Combine
 
 /// Tests for `BookmarksViewModel`. Verifies that the `sortByGroup` preference is read
 /// from and written to UserDefaults under the documented key.
-class BookmarksViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class BookmarksViewModelTests: OBATestCase {
     private let sortByGroupKey = "OBABookmarksController_SortBookmarksByGroup"
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -66,8 +67,8 @@ class BookmarksViewModelTests: OBATestCase {
     // MARK: - Tests
 
     /// `init` defaults to `true` (set via `register(defaults:)`) on a clean UserDefaults.
-    @MainActor
-    func test_init_defaultsSortByGroupToTrue() {
+    @Test @MainActor
+    func `Init defaults sort by group to true`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -77,8 +78,8 @@ class BookmarksViewModelTests: OBATestCase {
     }
 
     /// `init` reads the persisted value back out of UserDefaults.
-    @MainActor
-    func test_init_readsSortByGroupFromUserDefaults() {
+    @Test @MainActor
+    func `Init reads sort by group from user defaults`() {
         userDefaults.set(false, forKey: sortByGroupKey)
 
         let dataLoader = MockDataLoader(testName: name)
@@ -91,8 +92,8 @@ class BookmarksViewModelTests: OBATestCase {
 
     /// `updateSortType` writes the new value to UserDefaults under the documented key
     /// and updates the published property.
-    @MainActor
-    func test_updateSortType_persistsToUserDefaults() {
+    @Test @MainActor
+    func `Update sort type persists to user defaults`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -106,8 +107,8 @@ class BookmarksViewModelTests: OBATestCase {
     // MARK: - isLoading
 
     /// `isLoading` starts `false` before any refresh.
-    @MainActor
-    func test_isLoading_defaultsToFalse() {
+    @Test @MainActor
+    func `Is loading defaults to false`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -119,8 +120,8 @@ class BookmarksViewModelTests: OBATestCase {
     /// A refresh that finds no eligible bookmarks must not leave `isLoading` stuck on `true`.
     /// `beginBatch(count: 0)` is the zero-fetch edge case in `BookmarkDataLoader` — the
     /// loader still has to report a clean `false` transition so consumer UI can recover.
-    @MainActor
-    func test_isLoading_remainsFalseWhenNoBookmarksToLoad() async {
+    @Test @MainActor
+    func `Is loading remains false when no bookmarks to load`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -141,8 +142,8 @@ class BookmarksViewModelTests: OBATestCase {
     /// string, ungrouped bookmarks land in `"unknown_group"`, and distance
     /// sorting uses `"distance_sorted_group"`. These IDs key users' persisted
     /// collapse state — renaming any of them silently orphans that state.
-    @MainActor
-    func test_rebuildSections_sectionIDsMatchLegacyVocabulary() throws {
+    @Test @MainActor
+    func `Rebuild sections section IDs match legacy vocabulary`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -150,7 +151,7 @@ class BookmarksViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
 
         let group = BookmarkGroup(name: "Work", sortOrder: 0)
         app.userDataStore.upsert(bookmarkGroup: group)
@@ -177,8 +178,8 @@ class BookmarksViewModelTests: OBATestCase {
     /// Bookmarks from other regions must not appear, and a section whose
     /// bookmarks are all filtered out is omitted entirely — with the standard
     /// empty state shown rather than a blank list.
-    @MainActor
-    func test_rebuildSections_filtersBookmarksFromOtherRegions() throws {
+    @Test @MainActor
+    func `Rebuild sections filters bookmarks from other regions`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -186,7 +187,7 @@ class BookmarksViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
 
         app.userDataStore.add(
             Bookmark(name: "Elsewhere", regionIdentifier: pugetSoundRegionIdentifier + 1, arrivalDeparture: arrivalDep),
@@ -205,8 +206,8 @@ class BookmarksViewModelTests: OBATestCase {
 
     /// A pull-to-refresh with zero eligible bookmarks must return promptly
     /// rather than suspending forever (the spinner would never dismiss).
-    @MainActor
-    func test_refreshAndWait_returnsForEmptyBatch() async {
+    @Test @MainActor
+    func `Refresh and wait returns for empty batch`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -218,8 +219,8 @@ class BookmarksViewModelTests: OBATestCase {
 
     /// `refreshAndWait` resumes only after its own batch completes, with the
     /// fetched arrival data already applied to `sections`.
-    @MainActor
-    func test_refreshAndWait_waitsForItsBatchAndAppliesData() async throws {
+    @Test @MainActor
+    func `Refresh and wait waits for its batch and applies data`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -227,7 +228,7 @@ class BookmarksViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
         app.userDataStore.add(
             Bookmark(name: "Route 49", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: arrivalDep),
             to: nil
@@ -240,7 +241,7 @@ class BookmarksViewModelTests: OBATestCase {
         await viewModel.refreshAndWait()
 
         #expect(!viewModel.isLoading)
-        let row = try XCTUnwrap(viewModel.sections.first?.rows.first)
+        let row = try #require(viewModel.sections.first?.rows.first)
         #expect(row.hasLoadedArrivalData)
         #expect(!row.arrivalDepartures.isEmpty)
     }
@@ -250,8 +251,8 @@ class BookmarksViewModelTests: OBATestCase {
     /// Collapse state persisted by the legacy `BookmarksViewController` (same
     /// key, same `Set<String>` encoding) must survive into the rewrite, and
     /// toggling must round-trip back to UserDefaults.
-    @MainActor
-    func test_collapsedSections_persistenceRoundTrip() throws {
+    @Test @MainActor
+    func `Collapsed sections persistence round trip`() throws {
         let key = "collapsedBookmarkSections"
         try userDefaults.encodeUserDefaultsObjects(Set(["unknown_group"]), key: key)
 
@@ -276,13 +277,13 @@ class BookmarksViewModelTests: OBATestCase {
     /// `BookmarkRowViewModel.==` gates the `sections` publish in
     /// `rebuildSections()` — any display-relevant field omitted from `==`
     /// means a permanently stale row on screen.
-    @MainActor
-    func test_bookmarkRowViewModel_equalityCoversDisplayFields() throws {
+    @Test @MainActor
+    func `Bookmark row view model equality covers display fields`() throws {
         let stopArrivals = try Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
         let bookmark = Bookmark(name: "Route 49", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: arrivalDep)
 
         let base = BookmarkRowViewModel(bookmark: bookmark, arrivalDepartures: [], highlightedTripIDs: [])
@@ -304,13 +305,13 @@ class BookmarksViewModelTests: OBATestCase {
 
     /// The init clamp: whole-stop bookmarks never carry arrival data, even if
     /// a caller passes some.
-    @MainActor
-    func test_bookmarkRowViewModel_clampsArrivalsForStopBookmarks() throws {
+    @Test @MainActor
+    func `Bookmark row view model clamps arrivals for stop bookmarks`() throws {
         let stopArrivals = try Fixtures.loadRESTAPIPayload(
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
         let stopBookmark = Bookmark(name: "Stop", regionIdentifier: pugetSoundRegionIdentifier, stop: arrivalDep.stop)
 
         let row = BookmarkRowViewModel(bookmark: stopBookmark, arrivalDepartures: [arrivalDep], highlightedTripIDs: [])
@@ -327,8 +328,8 @@ class BookmarksViewModelTests: OBATestCase {
     /// Regression test for the `lastBatchHadError` → `lastRefreshHadError` plumbing added in
     /// `BookmarkDataLoader` and `BookmarksViewModel`. Requires a region-eligible trip bookmark so
     /// the loader dispatches a real per-bookmark fetch that can fail.
-    @MainActor
-    func test_refresh_setsAndResetsLastRefreshHadError() async throws {
+    @Test @MainActor
+    func `Refresh sets and resets last refresh had error`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -337,7 +338,7 @@ class BookmarksViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        let arrivalDep = try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
         let bookmark = Bookmark(
             name: "Route 49",
             regionIdentifier: pugetSoundRegionIdentifier,
@@ -355,19 +356,19 @@ class BookmarksViewModelTests: OBATestCase {
         #expect(!viewModel.lastRefreshHadError)
 
         // Wait for the batch to fully complete (isLoading: false → true → false).
-        let errBatchDone = expectation(description: "error batch finishes")
+        var errBatchDone = false
         var seenLoading = false
         var cancellables = Set<AnyCancellable>()
         viewModel.$isLoading.sink { isLoading in
             if isLoading { seenLoading = true }
-            if seenLoading && !isLoading { errBatchDone.fulfill() }
+            if seenLoading && !isLoading { errBatchDone = true }
         }.store(in: &cancellables)
 
         viewModel.refresh()
         // Timeout sized for GitHub Actions runner headroom, not local speed —
         // the batch's `Task { @MainActor }` chain lands well under a second
         // locally but has flaked at 2s on CI under load.
-        await fulfillment(of: [errBatchDone], timeout: 10.0)
+        await poll(until: { errBatchDone }, timeout: .seconds(10), "error batch never finished")
         cancellables.removeAll()
 
         #expect(viewModel.lastRefreshHadError)
@@ -385,15 +386,15 @@ class BookmarksViewModelTests: OBATestCase {
             ) { $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false }
         }
 
-        let cleanBatchDone = expectation(description: "clean batch finishes")
+        var cleanBatchDone = false
         var seenLoading2 = false
         viewModel.$isLoading.sink { isLoading in
             if isLoading { seenLoading2 = true }
-            if seenLoading2 && !isLoading { cleanBatchDone.fulfill() }
+            if seenLoading2 && !isLoading { cleanBatchDone = true }
         }.store(in: &cancellables)
 
         viewModel.refresh()
-        await fulfillment(of: [cleanBatchDone], timeout: 10.0)
+        await poll(until: { cleanBatchDone }, timeout: .seconds(10), "clean batch never finished")
 
         #expect(!viewModel.lastRefreshHadError)
     }

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -16,20 +16,21 @@ import CoreLocation
 // swiftlint:disable force_cast force_try
 
 /// Tests for `CurrentTripViewModel`.
-class CurrentTripViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class CurrentTripViewModelTests: OBATestCase {
     /// Near stop 1_10020 in the fixture (NE 55th & 37th Ave NE).
     private let userLocation = CLLocation(latitude: 47.6685, longitude: -122.2883)
 
     private var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -99,14 +100,14 @@ class CurrentTripViewModelTests: OBATestCase {
 
     // MARK: - Initial State
 
-    @MainActor
-    func test_initialState_isLoading() throws {
+    @Test @MainActor
+    func `Initial state is loading`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
 
         guard case .loading = viewModel.state else {
-            XCTFail("Expected initial state .loading, got \(viewModel.state)")
+            Issue.record("Expected initial state .loading, got \(viewModel.state)")
             return
         }
         #expect(viewModel.matchResults.isEmpty)
@@ -115,8 +116,8 @@ class CurrentTripViewModelTests: OBATestCase {
 
     // MARK: - handle(results:)
 
-    @MainActor
-    func test_handleResults_empty_setsNoResults() throws {
+    @Test @MainActor
+    func `Handle results empty sets no results`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -124,15 +125,15 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.handle(results: [])
 
         guard case .noResults = viewModel.state else {
-            XCTFail("Expected .noResults, got \(viewModel.state)")
+            Issue.record("Expected .noResults, got \(viewModel.state)")
             return
         }
         #expect(viewModel.matchResults.isEmpty)
         #expect(viewModel.pendingNavigation == nil)
     }
 
-    @MainActor
-    func test_handleResults_single_setsPendingNavigation() throws {
+    @Test @MainActor
+    func `Handle results single sets pending navigation`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -148,7 +149,7 @@ class CurrentTripViewModelTests: OBATestCase {
         // consumer navigates away via `pendingNavigation`; if they dismiss the
         // modal, the list is what greets them, not a frozen loading indicator.
         guard case .multipleResults = viewModel.state else {
-            XCTFail("State should move to .multipleResults for single match, got \(viewModel.state)")
+            Issue.record("State should move to .multipleResults for single match, got \(viewModel.state)")
             return
         }
     }
@@ -158,8 +159,8 @@ class CurrentTripViewModelTests: OBATestCase {
     /// `handle(results:)`) that finds the SAME trip must not re-fire
     /// `pendingNavigation` — otherwise the user is snapped back to the modal
     /// they just dismissed every 20 seconds.
-    @MainActor
-    func test_handleResults_repeatSingleMatch_doesNotRefirePendingNavigation() throws {
+    @Test @MainActor
+    func `Handle results repeat single match does not refire pending navigation`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -182,8 +183,8 @@ class CurrentTripViewModelTests: OBATestCase {
     /// A user-initiated retry (`findVehicle()` with `resetState: true`, the
     /// default) must clear the "already presented" latch — otherwise tapping
     /// Try Again after dismissing a single-match modal would silently no-op.
-    @MainActor
-    func test_findVehicle_userInitiatedRetry_clearsPresentedLatch() async throws {
+    @Test @MainActor
+    func `Find vehicle user initiated retry clears presented latch`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, withLocation: false)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -198,7 +199,7 @@ class CurrentTripViewModelTests: OBATestCase {
         // in .noLocation before ever calling handle(results:).
         viewModel.findVehicle()
         guard case .loading = viewModel.state else {
-            XCTFail("findVehicle() should reset to .loading, got \(viewModel.state)")
+            Issue.record("findVehicle() should reset to .loading, got \(viewModel.state)")
             return
         }
 
@@ -212,8 +213,8 @@ class CurrentTripViewModelTests: OBATestCase {
     /// A background refresh (`findVehicle(resetState: false)`) must NOT reset
     /// the UI to `.loading` — the whole point of splitting the two entry points
     /// is to keep the user's screen intact between the 20-second ticks.
-    @MainActor
-    func test_findVehicle_backgroundRefresh_preservesState() async throws {
+    @Test @MainActor
+    func `Find vehicle background refresh preserves state`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, withLocation: false)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -224,7 +225,7 @@ class CurrentTripViewModelTests: OBATestCase {
         let second = makeMatchResult()
         viewModel.handle(results: [first, second])
         guard case .multipleResults = viewModel.state else {
-            XCTFail("Precondition: expected .multipleResults, got \(viewModel.state)")
+            Issue.record("Precondition: expected .multipleResults, got \(viewModel.state)")
             return
         }
 
@@ -234,7 +235,7 @@ class CurrentTripViewModelTests: OBATestCase {
         // must NOT have flipped to `.loading` before the task runs.
         viewModel.findVehicle(resetState: false)
         guard case .multipleResults = viewModel.state else {
-            XCTFail("Background refresh must preserve .multipleResults, got \(viewModel.state)")
+            Issue.record("Background refresh must preserve .multipleResults, got \(viewModel.state)")
             return
         }
 
@@ -246,8 +247,8 @@ class CurrentTripViewModelTests: OBATestCase {
     /// Two `.error` cases compare equal iff their `localizedDescription`s match
     /// — SwiftUI's `.onChange(of: state)` depends on this to decide when to
     /// fire failure haptics, so a typo here would silently break the trigger.
-    @MainActor
-    func test_stateEquality_error_comparesByLocalizedDescription() throws {
+    @Test @MainActor
+    func `State equality error compares by localized description`() throws {
         let errorA1 = NSError(domain: "A", code: 1, userInfo: [NSLocalizedDescriptionKey: "boom"])
         let errorA2 = NSError(domain: "B", code: 2, userInfo: [NSLocalizedDescriptionKey: "boom"])
         let errorB = NSError(domain: "C", code: 3, userInfo: [NSLocalizedDescriptionKey: "different"])
@@ -259,8 +260,8 @@ class CurrentTripViewModelTests: OBATestCase {
         #expect(CurrentTripViewModel.State.error(errorA1) != CurrentTripViewModel.State.multipleResults)
     }
 
-    @MainActor
-    func test_handleResults_multiple_setsMultipleResults() throws {
+    @Test @MainActor
+    func `Handle results multiple sets multiple results`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -270,7 +271,7 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.handle(results: [first, second])
 
         guard case .multipleResults = viewModel.state else {
-            XCTFail("Expected .multipleResults, got \(viewModel.state)")
+            Issue.record("Expected .multipleResults, got \(viewModel.state)")
             return
         }
         #expect(viewModel.matchResults.count == 2)
@@ -279,8 +280,8 @@ class CurrentTripViewModelTests: OBATestCase {
 
     // MARK: - handle(error:)
 
-    @MainActor
-    func test_handleError_noRealtimeData_setsNoRealtime() throws {
+    @Test @MainActor
+    func `Handle error no realtime data sets no realtime`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -288,13 +289,13 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.handle(error: NearbyTripMatcher.MatchError.noRealtimeData)
 
         guard case .noRealtime = viewModel.state else {
-            XCTFail("Expected .noRealtime, got \(viewModel.state)")
+            Issue.record("Expected .noRealtime, got \(viewModel.state)")
             return
         }
     }
 
-    @MainActor
-    func test_handleError_genericError_setsErrorState() throws {
+    @Test @MainActor
+    func `Handle error generic error sets error state`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -303,7 +304,7 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.handle(error: underlying)
 
         guard case .error(let surfaced) = viewModel.state else {
-            XCTFail("Expected .error, got \(viewModel.state)")
+            Issue.record("Expected .error, got \(viewModel.state)")
             return
         }
         #expect((surfaced as NSError).code == 42)
@@ -311,8 +312,8 @@ class CurrentTripViewModelTests: OBATestCase {
 
     /// `noStopsNearby` is a `MatchError` but not `noRealtimeData` — it must fall through
     /// to the generic `.error` branch, not be silently mapped to `.noRealtime`.
-    @MainActor
-    func test_handleError_noStopsNearby_fallsThroughToError() throws {
+    @Test @MainActor
+    func `Handle error no stops nearby falls through to error`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -320,7 +321,7 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.handle(error: NearbyTripMatcher.MatchError.noStopsNearby)
 
         guard case .error = viewModel.state else {
-            XCTFail("Expected .error for .noStopsNearby, got \(viewModel.state)")
+            Issue.record("Expected .error for .noStopsNearby, got \(viewModel.state)")
             return
         }
     }
@@ -330,8 +331,8 @@ class CurrentTripViewModelTests: OBATestCase {
     /// When the UIKit consumer cannot perform single-match navigation (no embedded
     /// `UINavigationController`), the VM falls back to the disambiguation list so
     /// the user can still tap through. `matchResults` is preserved from `handle(results:)`.
-    @MainActor
-    func test_pendingNavigationUnavailable_fallsBackToMultipleResults() throws {
+    @Test @MainActor
+    func `Pending navigation unavailable falls back to multiple results`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -344,7 +345,7 @@ class CurrentTripViewModelTests: OBATestCase {
         viewModel.pendingNavigationUnavailable()
 
         guard case .multipleResults = viewModel.state else {
-            XCTFail("Expected .multipleResults, got \(viewModel.state)")
+            Issue.record("Expected .multipleResults, got \(viewModel.state)")
             return
         }
         #expect(viewModel.pendingNavigation == nil)
@@ -356,8 +357,8 @@ class CurrentTripViewModelTests: OBATestCase {
 
     /// `start()` must kick off `findVehicle()` — guards against a future refactor
     /// accidentally turning it into a no-op (e.g. only starting the timer).
-    @MainActor
-    func test_start_invokesFindVehicle() async throws {
+    @Test @MainActor
+    func `Start invokes find vehicle`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, withLocation: false)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -366,7 +367,7 @@ class CurrentTripViewModelTests: OBATestCase {
         for _ in 0..<5 { await Task.yield() }
 
         guard case .noLocation = viewModel.state else {
-            XCTFail("Expected start() to kick findVehicle() into the no-location branch, got \(viewModel.state)")
+            Issue.record("Expected start() to kick findVehicle() into the no-location branch, got \(viewModel.state)")
             return
         }
 
@@ -375,8 +376,8 @@ class CurrentTripViewModelTests: OBATestCase {
 
     // MARK: - findVehicle()
 
-    @MainActor
-    func test_findVehicle_noLocation_setsNoLocationState() async throws {
+    @Test @MainActor
+    func `Find vehicle no location sets no location state`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, withLocation: false)
         let viewModel = CurrentTripViewModel(application: app, route: route30())
@@ -385,7 +386,7 @@ class CurrentTripViewModelTests: OBATestCase {
         for _ in 0..<5 { await Task.yield() }
 
         guard case .noLocation = viewModel.state else {
-            XCTFail("Expected .noLocation, got \(viewModel.state)")
+            Issue.record("Expected .noLocation, got \(viewModel.state)")
             return
         }
     }

--- a/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
+++ b/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
@@ -386,7 +386,7 @@ final class EditBookmarkViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Persist saves to group when group IDIs provided`() throws {
+    func `Persist saves to group when group ID is provided`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
+++ b/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
@@ -7,24 +7,25 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 /// Tests for `EditBookmarkViewModel`. Covers initial state derivation, save outcome
 /// routing (add vs edit, duplicate detection), persistence, and analytics emission.
-class EditBookmarkViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class EditBookmarkViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -96,13 +97,13 @@ class EditBookmarkViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        return try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
     }
 
     // MARK: - Initial State (Add Mode)
 
-    @MainActor
-    func test_addMode_initialName_usesStopFormattedTitle() throws {
+    @Test @MainActor
+    func `Add mode initial name uses stop formatted title`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -115,8 +116,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(vm.initialIsFavorite)
     }
 
-    @MainActor
-    func test_addMode_initialName_usesRouteAndHeadsignForTripBookmark() throws {
+    @Test @MainActor
+    func `Add mode initial name uses route and headsign for trip bookmark`() throws {
         let arrivalDep = try makeArrivalDeparture()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -129,8 +130,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - Initial State (Edit Mode)
 
-    @MainActor
-    func test_editMode_initialName_usesBookmarkName() throws {
+    @Test @MainActor
+    func `Edit mode initial name uses bookmark name`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -142,8 +143,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(vm.initialName == "My Custom Name")
     }
 
-    @MainActor
-    func test_editMode_initialGroupID_usesBookmarkGroupID() throws {
+    @Test @MainActor
+    func `Edit mode initial group ID uses bookmark group ID`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -160,8 +161,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - bookmarkGroups
 
-    @MainActor
-    func test_bookmarkGroups_reflectsDataStore() throws {
+    @Test @MainActor
+    func `Bookmark groups reflects data store`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -178,8 +179,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - currentGroupID
 
-    @MainActor
-    func test_currentGroupID_returnsNilInAddMode() throws {
+    @Test @MainActor
+    func `Current group ID returns nil in add mode`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -189,8 +190,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(vm.currentGroupID() == nil)
     }
 
-    @MainActor
-    func test_currentGroupID_returnsGroupIDForExistingBookmark() throws {
+    @Test @MainActor
+    func `Current group ID returns group ID for existing bookmark`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -206,8 +207,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(vm.currentGroupID() == group.id)
     }
 
-    @MainActor
-    func test_currentGroupID_reflectsLiveMove_divergingFromInitialGroupID() throws {
+    @Test @MainActor
+    func `Current group ID reflects live move diverging from initial group ID`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -232,8 +233,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - prepareToSave (add mode)
 
-    @MainActor
-    func test_prepareToSave_returnsRegionUnavailable_whenCurrentRegionIsUnavailable() throws {
+    @Test @MainActor
+    func `Prepare to save returns region unavailable when current region is unavailable`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithoutRegion(dataLoader: dataLoader)
@@ -242,13 +243,13 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "My Stop", isFavorite: true)
 
         guard case .regionUnavailable = outcome else {
-            XCTFail("Expected .regionUnavailable, got \(outcome)")
+            Issue.record("Expected .regionUnavailable, got \(outcome)")
             return
         }
     }
 
-    @MainActor
-    func test_prepareToSave_returnsReady_forNewStopBookmark() throws {
+    @Test @MainActor
+    func `Prepare to save returns ready for new stop bookmark`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -257,15 +258,15 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "My Stop", isFavorite: true)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave, got \(outcome)")
+            Issue.record("Expected .readyToSave, got \(outcome)")
             return
         }
         #expect(bookmark.name == "My Stop")
         #expect(isNew)
     }
 
-    @MainActor
-    func test_prepareToSave_restoresDataObjectName_whenNameIsEmpty() throws {
+    @Test @MainActor
+    func `Prepare to save restores data object name when name is empty`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -274,13 +275,13 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "   ", isFavorite: true)
 
         guard case .readyToSave(let bookmark, _) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
         #expect(bookmark.name == Formatters.formattedTitle(stop: stop))
     }
 
-    @MainActor
-    func test_prepareToSave_returnsDuplicate_whenBookmarkAlreadyExists() throws {
+    @Test @MainActor
+    func `Prepare to save returns duplicate when bookmark already exists`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -292,7 +293,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
 
         guard case .duplicateRequiresConfirmation(let dup) = outcome else {
-            XCTFail("Expected .duplicateRequiresConfirmation, got \(outcome)")
+            Issue.record("Expected .duplicateRequiresConfirmation, got \(outcome)")
             return
         }
         #expect(dup.name == "Stop")
@@ -300,8 +301,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - prepareToSave (edit mode)
 
-    @MainActor
-    func test_prepareToSave_editMode_doesNotMutateBookmarkUntilPersist() throws {
+    @Test @MainActor
+    func `Prepare to save edit mode does not mutate bookmark until persist`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -314,7 +315,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Updated Name", isFavorite: false)
 
         guard case .readyToSave(let saved, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave, got \(outcome)")
+            Issue.record("Expected .readyToSave, got \(outcome)")
             return
         }
         #expect(saved.name == "Original")
@@ -326,8 +327,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(!saved.isFavorite)
     }
 
-    @MainActor
-    func test_persist_editMode_restoresDataObjectName_whenNameIsEmpty() throws {
+    @Test @MainActor
+    func `Persist edit mode restores data object name when name is empty`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -339,14 +340,14 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "   ", isFavorite: true)
 
         guard case .readyToSave(let saved, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
         vm.persist(saved, name: "   ", isFavorite: true, to: nil, isNewBookmark: isNew)
         #expect(saved.name == Formatters.formattedTitle(stop: stop))
     }
 
-    @MainActor
-    func test_prepareToSave_editMode_doesNotCheckForDuplicates() throws {
+    @Test @MainActor
+    func `Prepare to save edit mode does not check for duplicates`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -358,7 +359,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
 
         guard case .readyToSave(_, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave, got \(outcome)")
+            Issue.record("Expected .readyToSave, got \(outcome)")
             return
         }
         #expect(!isNew)
@@ -366,8 +367,8 @@ class EditBookmarkViewModelTests: OBATestCase {
 
     // MARK: - persist
 
-    @MainActor
-    func test_persist_savesBookmarkToDataStore() throws {
+    @Test @MainActor
+    func `Persist saves bookmark to data store`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -376,7 +377,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Home", isFavorite: false)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(bookmark, name: "Home", isFavorite: false, to: nil, isNewBookmark: isNew)
@@ -384,8 +385,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(app.userDataStore.findBookmark(id: bookmark.id) != nil)
     }
 
-    @MainActor
-    func test_persist_savesToGroup_whenGroupIDIsProvided() throws {
+    @Test @MainActor
+    func `Persist saves to group when group IDIs provided`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -397,7 +398,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(bookmark, name: "Stop", isFavorite: true, to: group.id, isNewBookmark: isNew)
@@ -406,8 +407,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(inGroup.contains { $0.id == bookmark.id })
     }
 
-    @MainActor
-    func test_persist_editMode_movesToNewGroup() throws {
+    @Test @MainActor
+    func `Persist edit mode moves to new group`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -424,7 +425,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
 
         guard case .readyToSave(let saved, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(saved, name: "Stop", isFavorite: true, to: groupB.id, isNewBookmark: isNew)
@@ -432,8 +433,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(app.userDataStore.bookmarksInGroup(groupB).contains { $0.id == bookmark.id })
     }
 
-    @MainActor
-    func test_persist_reportsAnalyticsForNewTripBookmark() throws {
+    @Test @MainActor
+    func `Persist reports analytics for new trip bookmark`() throws {
         let arrivalDep = try makeArrivalDeparture()
         let analyticsMock = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
@@ -443,7 +444,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Route", isFavorite: true)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(bookmark, name: "Route", isFavorite: true, to: nil, isNewBookmark: isNew)
@@ -458,8 +459,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect((addBookmarkEvents.first?.value as? String) == expectedValue)
     }
 
-    @MainActor
-    func test_persist_doesNotReportAnalyticsWhenEditingExistingTripBookmark() throws {
+    @Test @MainActor
+    func `Persist does not report analytics when editing existing trip bookmark`() throws {
         let arrivalDep = try makeArrivalDeparture()
         let analyticsMock = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
@@ -472,7 +473,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Updated Route", isFavorite: true)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(bookmark, name: "Updated Route", isFavorite: true, to: nil, isNewBookmark: isNew)
@@ -480,8 +481,8 @@ class EditBookmarkViewModelTests: OBATestCase {
         #expect(analyticsMock.reportedEvents.filter { $0.label == AnalyticsLabels.addBookmark }.isEmpty)
     }
 
-    @MainActor
-    func test_persist_doesNotReportAnalyticsForStopBookmark() throws {
+    @Test @MainActor
+    func `Persist does not report analytics for stop bookmark`() throws {
         let stop = try makeStop()
         let analyticsMock = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
@@ -491,7 +492,7 @@ class EditBookmarkViewModelTests: OBATestCase {
         let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
 
         guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            XCTFail("Expected .readyToSave"); return
+            Issue.record("Expected .readyToSave"); return
         }
 
         vm.persist(bookmark, name: "Stop", isFavorite: true, to: nil, isNewBookmark: isNew)

--- a/OBAKitTests/ViewModels/ManageBookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/ManageBookmarksViewModelTests.swift
@@ -7,24 +7,25 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 /// Tests for `ManageBookmarksViewModel`. Covers data access delegation, bookmark deletion
 /// (with analytics), name persistence, transit-name restoration, and reorder logic.
-class ManageBookmarksViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class ManageBookmarksViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -68,13 +69,13 @@ class ManageBookmarksViewModelTests: OBATestCase {
             type: StopArrivals.self,
             fileName: "arrivals-and-departures-for-stop-1_10914.json"
         )
-        return try XCTUnwrap(stopArrivals.arrivalsAndDepartures.first)
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
     }
 
     // MARK: - Data Access
 
-    @MainActor
-    func test_bookmarkGroups_reflectsDataStore() {
+    @Test @MainActor
+    func `Bookmark groups reflects data store`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageBookmarksViewModel(application: app)
@@ -87,8 +88,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(vm.bookmarkGroups.count == 1)
     }
 
-    @MainActor
-    func test_bookmarksInGroup_returnsCorrectSubset() throws {
+    @Test @MainActor
+    func `Bookmarks in group returns correct subset`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -107,8 +108,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(vm.bookmarksInGroup(nil).count == 1)
     }
 
-    @MainActor
-    func test_findGroup_returnsGroupByID() {
+    @Test @MainActor
+    func `Find group returns group by ID`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageBookmarksViewModel(application: app)
@@ -120,8 +121,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(vm.findGroup(id: UUID()) == nil)
     }
 
-    @MainActor
-    func test_findBookmark_returnsByID() throws {
+    @Test @MainActor
+    func `Find bookmark returns by ID`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -136,8 +137,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
 
     // MARK: - deleteBookmark
 
-    @MainActor
-    func test_deleteBookmark_removesFromDataStore() throws {
+    @Test @MainActor
+    func `Delete bookmark removes from data store`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -151,8 +152,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(app.userDataStore.findBookmark(id: bookmark.id) == nil)
     }
 
-    @MainActor
-    func test_deleteBookmark_reportsAnalyticsForTripBookmark() throws {
+    @Test @MainActor
+    func `Delete bookmark reports analytics for trip bookmark`() throws {
         let arrivalDep = try makeArrivalDeparture()
         let analyticsMock = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
@@ -174,8 +175,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect((removeEvents.first?.value as? String) == expectedValue)
     }
 
-    @MainActor
-    func test_deleteBookmark_noAnalyticsForStopBookmark() throws {
+    @Test @MainActor
+    func `Delete bookmark no analytics for stop bookmark`() throws {
         let stop = try makeStop()
         let analyticsMock = AnalyticsMock()
         let dataLoader = MockDataLoader(testName: name)
@@ -192,8 +193,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
 
     // MARK: - saveNameChange
 
-    @MainActor
-    func test_saveNameChange_persistsNonEmptyName() throws {
+    @Test @MainActor
+    func `Save name change persists non empty name`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -207,8 +208,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(app.userDataStore.findBookmark(id: bookmark.id)?.name == "New Name")
     }
 
-    @MainActor
-    func test_saveNameChange_ignoresEmptyName() throws {
+    @Test @MainActor
+    func `Save name change ignores empty name`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -224,8 +225,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
 
     // MARK: - restoreTransitName
 
-    @MainActor
-    func test_restoreTransitName_restoresStopFormattedTitleForStopBookmark() throws {
+    @Test @MainActor
+    func `Restore transit name restores stop formatted title for stop bookmark`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -240,8 +241,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(app.userDataStore.findBookmark(id: bookmark.id)?.name == expected)
     }
 
-    @MainActor
-    func test_restoreTransitName_restoresTripNameForTripBookmark() throws {
+    @Test @MainActor
+    func `Restore transit name restores trip name for trip bookmark`() throws {
         let arrivalDep = try makeArrivalDeparture()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -258,8 +259,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
 
     // MARK: - moveBookmark
 
-    @MainActor
-    func test_moveBookmark_movesBookmarkToDestinationGroup() throws {
+    @Test @MainActor
+    func `Move bookmark moves bookmark to destination group`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
@@ -277,8 +278,8 @@ class ManageBookmarksViewModelTests: OBATestCase {
         #expect(vm.bookmarksInGroup(nil).isEmpty)
     }
 
-    @MainActor
-    func test_moveBookmark_respectsIndexParameter() throws {
+    @Test @MainActor
+    func `Move bookmark respects index parameter`() throws {
         let stop = try makeStop()
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)

--- a/OBAKitTests/ViewModels/ManageGroupsViewModelTests.swift
+++ b/OBAKitTests/ViewModels/ManageGroupsViewModelTests.swift
@@ -7,23 +7,24 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
 /// Tests for `ManageGroupsViewModel`. Covers group list access and the replace-all mutation.
-class ManageGroupsViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class ManageGroupsViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -60,8 +61,8 @@ class ManageGroupsViewModelTests: OBATestCase {
 
     // MARK: - bookmarkGroups
 
-    @MainActor
-    func test_bookmarkGroups_startsEmpty() {
+    @Test @MainActor
+    func `Bookmark groups starts empty`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -69,8 +70,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(vm.bookmarkGroups.isEmpty)
     }
 
-    @MainActor
-    func test_bookmarkGroups_reflectsDataStore() {
+    @Test @MainActor
+    func `Bookmark groups reflects data store`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -84,8 +85,8 @@ class ManageGroupsViewModelTests: OBATestCase {
 
     // MARK: - replaceGroups
 
-    @MainActor
-    func test_replaceGroups_updatesDataStore() {
+    @Test @MainActor
+    func `Replace groups updates data store`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -103,8 +104,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(groupNames.contains("Beta"))
     }
 
-    @MainActor
-    func test_replaceGroups_withEmpty_clearsAllGroups() {
+    @Test @MainActor
+    func `Replace groups with empty clears all groups`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -117,8 +118,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(vm.bookmarkGroups.isEmpty)
     }
 
-    @MainActor
-    func test_replaceGroups_preservesExistingGroupIDs() {
+    @Test @MainActor
+    func `Replace groups preserves existing group IDs`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -136,8 +137,8 @@ class ManageGroupsViewModelTests: OBATestCase {
 
     // MARK: - groups(from:)
 
-    @MainActor
-    func test_groupsFrom_convertsRowsToBookmarkGroups() {
+    @Test @MainActor
+    func `Groups from converts rows to bookmark groups`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -155,8 +156,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(groups[1].sortOrder == 1)
     }
 
-    @MainActor
-    func test_groupsFrom_skipsEmptyAndWhitespaceOnlyNames() {
+    @Test @MainActor
+    func `Groups from skips empty and whitespace only names`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -173,8 +174,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(groups[0].name == "Valid")
     }
 
-    @MainActor
-    func test_groupsFrom_preservesExistingUUIDTags() {
+    @Test @MainActor
+    func `Groups from preserves existing UUID tags`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)
@@ -189,8 +190,8 @@ class ManageGroupsViewModelTests: OBATestCase {
         #expect(groups.first?.name == "Renamed Group")
     }
 
-    @MainActor
-    func test_groupsFrom_assignsFreshIDWhenTagIsNilOrInvalid() {
+    @Test @MainActor
+    func `Groups from assigns fresh ID when tag is nil or invalid`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = ManageGroupsViewModel(application: app)

--- a/OBAKitTests/ViewModels/MapPanelViewModelTests.swift
+++ b/OBAKitTests/ViewModels/MapPanelViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -15,17 +15,18 @@ import Combine
 
 /// Tests for `MapPanelViewModel`: nearby-stops publishing, alert reads from the store,
 /// and the search-mode transitions that drive `requestedPanelDetent`.
-class MapPanelViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class MapPanelViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -68,8 +69,8 @@ class MapPanelViewModelTests: OBATestCase {
     // MARK: - Nearby Stops
 
     /// `updateNearbyStops(_:)` publishes the new list on `$nearbyStops`.
-    @MainActor
-    func test_updateNearbyStops_publishes() throws {
+    @Test @MainActor
+    func `Update nearby stops publishes`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -95,8 +96,8 @@ class MapPanelViewModelTests: OBATestCase {
     /// `refreshAlerts()` mirrors the alerts store's `recentHighSeverityAlerts`.
     /// With a fresh, unpopulated store both are empty — the assertion proves the VM reads
     /// through to the store rather than holding stale local state.
-    @MainActor
-    func test_refreshAlerts_readsFromStore() {
+    @Test @MainActor
+    func `Refresh alerts reads from store`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -110,15 +111,15 @@ class MapPanelViewModelTests: OBATestCase {
     /// `refreshAlerts()` reflects non-empty store state and maps every qualifying alert.
     /// Injects a recent high-severity alert directly, bypassing the network fetch so
     /// the test is not sensitive to fixture timestamp decay.
-    @MainActor
-    func test_refreshAlerts_nonEmptyStore() throws {
+    @Test @MainActor
+    func `Refresh alerts non empty store`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
         // Build a high-severity alert with a start time of "now" so it passes the
         // 8-hour recency filter in `recentHighSeverityAlerts`.
         let agencies = try Fixtures.loadRESTAPIPayload(type: [AgencyWithCoverage].self, fileName: "agencies_with_coverage.json")
-        let agency = try XCTUnwrap(agencies.first)
+        let agency = try #require(agencies.first)
 
         var period = TransitRealtime_TimeRange()
         period.start = UInt64(Date().timeIntervalSince1970)
@@ -148,8 +149,8 @@ class MapPanelViewModelTests: OBATestCase {
     // MARK: - Search Mode → Panel Detent
 
     /// `enterSearchMode()` requests the full detent; `exitSearchMode()` returns to the tip.
-    @MainActor
-    func test_searchMode_drivesRequestedPanelDetent() {
+    @Test @MainActor
+    func `Search mode drives requested panel detent`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 

--- a/OBAKitTests/ViewModels/MapViewModelTests.swift
+++ b/OBAKitTests/ViewModels/MapViewModelTests.swift
@@ -507,7 +507,7 @@ final class MapViewModelTests: OBATestCase {
     /// backs off to a coarser zoom (11) so the ~1km fuzz cell fits in view.
     /// Mirrors the branch in `MapViewController.centerMapOnUserLocation`.
     @Test @MainActor
-    func `Zoom level for current location full accuracy returns17`() {
+    func `Zoom level for current location full accuracy returns 17`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -520,7 +520,7 @@ final class MapViewModelTests: OBATestCase {
     /// on screen. Companion to `_fullAccuracyReturns17` — both branches must
     /// stay covered or a future refactor could silently change one.
     @Test @MainActor
-    func `Zoom level for current location reduced accuracy returns11`() {
+    func `Zoom level for current location reduced accuracy returns 11`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, accuracyAuthorization: .reducedAccuracy)
         let viewModel = MapViewModel(application: app)

--- a/OBAKitTests/ViewModels/MapViewModelTests.swift
+++ b/OBAKitTests/ViewModels/MapViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 import CoreLocation
@@ -16,17 +16,18 @@ import CoreLocation
 
 /// Tests for `MapViewModel`: weather loading (success + error), map-type toggle
 /// persistence + publishing, and the location-authorization delegate callback.
-class MapViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class MapViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -94,8 +95,8 @@ class MapViewModelTests: OBATestCase {
     // MARK: - Weather
 
     /// A successful weather fetch publishes a non-nil display.
-    @MainActor
-    func test_loadWeather_successPublishesDisplay() async {
+    @Test @MainActor
+    func `Load weather success publishes display`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         stubWeatherSuccess(dataLoader: dataLoader)
@@ -113,8 +114,8 @@ class MapViewModelTests: OBATestCase {
     /// the floating button would otherwise vanish on every network blip even
     /// when a perfectly good last-known forecast exists. First loads
     /// successfully, then errors, then asserts the last forecast survives.
-    @MainActor
-    func test_loadWeather_errorKeepsLastForecast() async {
+    @Test @MainActor
+    func `Load weather error keeps last forecast`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         stubWeatherSuccess(dataLoader: dataLoader)
@@ -147,8 +148,8 @@ class MapViewModelTests: OBATestCase {
     /// `loadWeather()` leaves `weatherDisplay` nil. This is the configuration-shaped
     /// inversion of `test_loadWeather_errorKeepsLastForecast` — out-of-region SHOULD
     /// drop the button, transient failures SHOULD NOT.
-    @MainActor
-    func test_loadWeather_clearsDisplayWhenObacoUnavailable() async {
+    @Test @MainActor
+    func `Load weather clears display when obaco unavailable`() async {
         // `RegionsService` prefers disk-stored regions over the bundled file,
         // and prior runs in the same simulator can leave a stored copy with a
         // sidecar URL. Wipe the shared on-disk default-regions file so the
@@ -192,8 +193,8 @@ class MapViewModelTests: OBATestCase {
     /// `toggleMapType()` flips the published `mapType` between `.standard` and `.hybrid`
     /// and persists the selection through `MapRegionManager` so a later launch
     /// (or the UIKit path) reads the same value.
-    @MainActor
-    func test_toggleMapType_flipsAndPublishesAndPersists() {
+    @Test @MainActor
+    func `Toggle map type flips and publishes and persists`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -220,8 +221,8 @@ class MapViewModelTests: OBATestCase {
     /// propagates back into `MapViewModel.mapType`. Covers the case where the
     /// UIKit path (or a future consumer) changes the persisted value while
     /// the SwiftUI root is mounted.
-    @MainActor
-    func test_mapType_syncsFromExternalMapRegionManagerChange() async {
+    @Test @MainActor
+    func `Map type syncs from external map region manager change`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -242,8 +243,8 @@ class MapViewModelTests: OBATestCase {
     // MARK: - Location Authorization
 
     /// The `LocationServiceDelegate` callback updates the published `locationAuthStatus`.
-    @MainActor
-    func test_locationAuthStatus_updatesViaDelegateCallback() async {
+    @Test @MainActor
+    func `Location auth status updates via delegate callback`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 
@@ -309,8 +310,8 @@ class MapViewModelTests: OBATestCase {
     }
 
     /// When the gate is closed, `checkForSurveyPrompt` neither fetches nor emits.
-    @MainActor
-    func test_checkForSurveyPrompt_doesNothingWhenIneligible() async {
+    @Test @MainActor
+    func `Check for survey prompt does nothing when ineligible`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubEmptySurveys(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -328,8 +329,8 @@ class MapViewModelTests: OBATestCase {
 
     /// When eligible but no survey matches the map, `surveyToPresent` does not emit
     /// and the reminder is not advanced.
-    @MainActor
-    func test_checkForSurveyPrompt_doesNotEmitWhenNoMapSurvey() async {
+    @Test @MainActor
+    func `Check for survey prompt does not emit when no map survey`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubEmptySurveys(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -351,8 +352,8 @@ class MapViewModelTests: OBATestCase {
     /// reminder. Verifies the intent contract directly rather than going through the
     /// `findSurveyForMap` integration path (orchestrator-level happy paths cover
     /// the find + submit sequence).
-    @MainActor
-    func test_didPresentSurveyPrompt_advancesReminderOnPresented() async {
+    @Test @MainActor
+    func `Did present survey prompt advances reminder on presented`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubEmptySurveys(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -377,8 +378,8 @@ class MapViewModelTests: OBATestCase {
     /// After `presented == false`, the session flag rolls back so a second
     /// `checkForSurveyPrompt()` can re-emit on `surveyToPresent`. Without the
     /// rollback the prompt would be lost for the rest of the session.
-    @MainActor
-    func test_checkForSurveyPrompt_reEmitsAfterPresentedFalseRollback() async {
+    @Test @MainActor
+    func `Check for survey prompt re emits after presented false rollback`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubMapSurvey(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -405,8 +406,8 @@ class MapViewModelTests: OBATestCase {
     /// `didPresentSurveyPrompt(_:presented:)` with `presented == false` does not
     /// advance the reminder — that path is the rollback for "presenter went away
     /// between emission and present."
-    @MainActor
-    func test_didPresentSurveyPrompt_doesNotAdvanceReminderWhenNotPresented() async {
+    @Test @MainActor
+    func `Did present survey prompt does not advance reminder when not presented`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubEmptySurveys(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -445,8 +446,8 @@ class MapViewModelTests: OBATestCase {
     /// `hasShownSurveyThisSession = true` synchronously before `send` (after the awaited
     /// refresh) so a second call racing through the post-await re-check sees the flag set
     /// and bails. This is the direct analogue of the StopViewModel re-entrancy test.
-    @MainActor
-    func test_checkForSurveyPrompt_concurrentCallsEmitOnce() async {
+    @Test @MainActor
+    func `Check for survey prompt concurrent calls emit once`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubMapSurvey(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -469,8 +470,8 @@ class MapViewModelTests: OBATestCase {
     /// cached survey list would otherwise resolve `findSurveyForMap()`.
     /// Prevents prompting off a stale cached survey after a transient network
     /// failure.
-    @MainActor
-    func test_checkForSurveyPrompt_doesNotEmitWhenRefreshFailed() async {
+    @Test @MainActor
+    func `Check for survey prompt does not emit when refresh failed`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubSurveysError(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -497,16 +498,16 @@ class MapViewModelTests: OBATestCase {
     /// The zoom-in-for-stops span is a fixed constant shared with `MapStatusPill`
     /// / `MapViewController.didTapZoomInForStops` so both surfaces zoom to the
     /// same target when the user taps "Zoom in for stops."
-    @MainActor
-    func test_zoomInForStopsSpan_isSharedConstant() {
+    @Test @MainActor
+    func `Zoom in for stops span is shared constant`() {
         #expect(MapViewModel.zoomInForStopsSpan == 0.01)
     }
 
     /// Full-accuracy authorization returns a tight zoom (17); reduced-accuracy
     /// backs off to a coarser zoom (11) so the ~1km fuzz cell fits in view.
     /// Mirrors the branch in `MapViewController.centerMapOnUserLocation`.
-    @MainActor
-    func test_zoomLevelForCurrentLocation_fullAccuracyReturns17() {
+    @Test @MainActor
+    func `Zoom level for current location full accuracy returns17`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -518,8 +519,8 @@ class MapViewModelTests: OBATestCase {
     /// Reduced accuracy backs off to 11 so the ~1km fuzz cell fits comfortably
     /// on screen. Companion to `_fullAccuracyReturns17` — both branches must
     /// stay covered or a future refactor could silently change one.
-    @MainActor
-    func test_zoomLevelForCurrentLocation_reducedAccuracyReturns11() {
+    @Test @MainActor
+    func `Zoom level for current location reduced accuracy returns11`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, accuracyAuthorization: .reducedAccuracy)
         let viewModel = MapViewModel(application: app)
@@ -534,8 +535,8 @@ class MapViewModelTests: OBATestCase {
     /// to the zoom-in action even if the user is also on reduced accuracy.
     /// Mirrors `MapStatusView.configure(for:zoomInStatus:)` where `zoomInStatus`
     /// overwrites the base state.
-    @MainActor
-    func test_topPillState_zoomWarningWinsOverPermission() {
+    @Test @MainActor
+    func `Top pill state zoom warning wins over permission`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -545,8 +546,8 @@ class MapViewModelTests: OBATestCase {
     }
 
     /// With no zoom warning and full permission, the pill is hidden.
-    @MainActor
-    func test_topPillState_hiddenWhenAuthorizedAndZoomed() {
+    @Test @MainActor
+    func `Top pill state hidden when authorized and zoomed`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -556,8 +557,8 @@ class MapViewModelTests: OBATestCase {
     }
 
     /// A `.denied` auth status maps to `.locationServicesOff` when no zoom warning is active.
-    @MainActor
-    func test_topPillState_deniedMapsToLocationServicesOff() async {
+    @Test @MainActor
+    func `Top pill state denied maps to location services off`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -572,8 +573,8 @@ class MapViewModelTests: OBATestCase {
     /// visible-but-non-actionable pill. A restricted (MDM/parental) user can't
     /// lift the restriction in Settings, so folding it into `.locationServicesOff`
     /// — which offers a "Turn On in Settings" prompt — would be a dead end.
-    @MainActor
-    func test_topPillState_restrictedMapsToLocationServicesUnavailable() async {
+    @Test @MainActor
+    func `Top pill state restricted maps to location services unavailable`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -585,8 +586,8 @@ class MapViewModelTests: OBATestCase {
     }
 
     /// A `.notDetermined` auth status maps to `.notDetermined` when no zoom warning is active.
-    @MainActor
-    func test_topPillState_notDeterminedMapsToPill() async {
+    @Test @MainActor
+    func `Top pill state not determined maps to pill`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let viewModel = MapViewModel(application: app)
@@ -600,8 +601,8 @@ class MapViewModelTests: OBATestCase {
     /// `.authorizedWhenInUse` + `.reducedAccuracy` surfaces the imprecise-location
     /// pill so the user can raise accuracy without leaving the map. Mirrors the
     /// branch in `MapStatusView.state(for:)`.
-    @MainActor
-    func test_topPillState_authorizedReducedAccuracyMapsToImpreciseLocation() async {
+    @Test @MainActor
+    func `Top pill state authorized reduced accuracy maps to imprecise location`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, accuracyAuthorization: .reducedAccuracy)
         let viewModel = MapViewModel(application: app)
@@ -616,8 +617,8 @@ class MapViewModelTests: OBATestCase {
     /// (the "Allow Once" path) clears the imprecise-location pill. Guards the
     /// regression where `topPillState` read accuracy live from `locationService`
     /// and never re-evaluated on an accuracy-only change, leaving the pill stuck.
-    @MainActor
-    func test_topPillState_accuracyElevationClearsImprecisePill() async {
+    @Test @MainActor
+    func `Top pill state accuracy elevation clears imprecise pill`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, accuracyAuthorization: .reducedAccuracy)
         let viewModel = MapViewModel(application: app)

--- a/OBAKitTests/ViewModels/RoutePickerViewModelTests.swift
+++ b/OBAKitTests/ViewModels/RoutePickerViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -18,18 +18,19 @@ import Combine
 /// Tests for `RoutePickerViewModel`. Covers initial state, the API-fallback load
 /// path, missing-location error path, API failure surfacing, search filtering
 /// (case-insensitivity, short vs long name match, empty-query reset), and sort order.
-class RoutePickerViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class RoutePickerViewModelTests: OBATestCase {
 
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -104,8 +105,8 @@ class RoutePickerViewModelTests: OBATestCase {
     // MARK: - Initial State
 
     /// Before `loadRoutes()` runs, the VM exposes empty lists and a `false` finished flag.
-    @MainActor
-    func test_initialState_isEmptyAndNotLoaded() {
+    @Test @MainActor
+    func `Initial state is empty and not loaded`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let vm = RoutePickerViewModel(application: app)
@@ -120,8 +121,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// With no cached stops, the VM fetches via the API service, deduplicates and sorts
     /// routes, and flips `didFinishLoading` to `true`.
-    @MainActor
-    func test_loadRoutes_apiFallback_populatesFilteredRoutes() async {
+    @Test @MainActor
+    func `Load routes api fallback populates filtered routes`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -141,8 +142,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// Routes are sorted alphabetically (case-insensitive) — matches the existing VC behavior
     /// via `localizedCaseInsensitiveSort()`.
-    @MainActor
-    func test_loadRoutes_sortsRoutesCaseInsensitively() async {
+    @Test @MainActor
+    func `Load routes sorts routes case insensitively`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -158,8 +159,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// Calling `loadRoutes()` twice with a cache miss both times produces a stable, identical
     /// result — no duplication, no error, same route set.
-    @MainActor
-    func test_loadRoutes_canBeCalledRepeatedly() async {
+    @Test @MainActor
+    func `Load routes can be called repeatedly`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -182,8 +183,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// With no current location, `loadRoutes()` surfaces a localized error message and
     /// flips `didFinishLoading` so the UI can render the error state.
-    @MainActor
-    func test_loadRoutes_noLocation_setsLoadError() async {
+    @Test @MainActor
+    func `Load routes no location sets load error`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplicationWithoutLocation(dataLoader: dataLoader)
@@ -199,8 +200,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// An API failure (invalid response payload) is surfaced as a `loadError` rather than
     /// crashing or leaving the UI stuck in a loading state.
-    @MainActor
-    func test_loadRoutes_apiError_setsLoadError() async {
+    @Test @MainActor
+    func `Load routes api error sets load error`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocationWithError(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -217,8 +218,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// Empty query restores all routes; a non-matching query yields zero results;
     /// a matching prefix narrows the list and stays case-insensitive across upper/lower forms.
-    @MainActor
-    func test_updateSearch_filtersCaseInsensitively() async {
+    @Test @MainActor
+    func `Update search filters case insensitively`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -247,8 +248,8 @@ class RoutePickerViewModelTests: OBATestCase {
     }
 
     /// A query that matches only a route's long name (not its short name) still hits.
-    @MainActor
-    func test_updateSearch_matchesLongName() async {
+    @Test @MainActor
+    func `Update search matches long name`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -277,8 +278,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// `updateSearch` called BEFORE `loadRoutes()` is a no-op (filteredRoutes stays empty),
     /// but stores the query so a later load honors it.
-    @MainActor
-    func test_updateSearch_beforeLoad_isHonoredAfterLoad() async {
+    @Test @MainActor
+    func `Update search before load is honored after load`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -297,8 +298,8 @@ class RoutePickerViewModelTests: OBATestCase {
     // MARK: - Publisher contracts
 
     /// `$filteredRoutes` emits whenever the search query changes the result set.
-    @MainActor
-    func test_filteredRoutesPublisher_emitsOnSearchChange() async {
+    @Test @MainActor
+    func `Filtered routes publisher emits on search change`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -322,8 +323,8 @@ class RoutePickerViewModelTests: OBATestCase {
     }
 
     /// `$didFinishLoading` emits `true` after a successful load.
-    @MainActor
-    func test_didFinishLoadingPublisher_flipsAfterLoad() async {
+    @Test @MainActor
+    func `Did finish loading publisher flips after load`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         let app = createApplication(dataLoader: dataLoader)
@@ -349,8 +350,8 @@ class RoutePickerViewModelTests: OBATestCase {
     /// no location (error path) and then receives one (success path). This is the
     /// shape that actually exercises the clear-on-retry contract — a fresh VM would
     /// pass regardless of whether the clear line existed.
-    @MainActor
-    func test_loadRoutes_retryClearsPriorLoadError() async {
+    @Test @MainActor
+    func `Load routes retry clears prior load error`() async {
         let dataLoader = MockDataLoader(testName: name)
         stubStopsForLocation(dataLoader: dataLoader)
         stubRegions(dataLoader: dataLoader)
@@ -388,8 +389,8 @@ class RoutePickerViewModelTests: OBATestCase {
 
     /// When `mapRegionManager.stops` is already populated, `loadRoutes()` takes the
     /// cache path and does not hit the stops API.
-    @MainActor
-    func test_loadRoutes_cacheFirst_doesNotHitAPI() async {
+    @Test @MainActor
+    func `Load routes cache first does not hit API`() async {
         let dataLoader = MockDataLoader(testName: name)
 
         // Counter wrapping the stops-for-location matcher.
@@ -434,8 +435,8 @@ class RoutePickerViewModelTests: OBATestCase {
     /// A cancelled `loadRoutes()` finalizes without setting `loadError`. The VM
     /// matches both `CancellationError` and `URLError(.cancelled)` so a re-observed
     /// VM doesn't get stuck on "Loading routes…".
-    @MainActor
-    func test_loadRoutes_cancellation_finalizesWithoutError() async {
+    @Test @MainActor
+    func `Load routes cancellation finalizes without error`() async {
         let dataLoader = MockDataLoader(testName: name)
         // Stub the stops endpoint to throw URLError(.cancelled) — the shape
         // URLSession surfaces when a data task is cancelled.

--- a/OBAKitTests/ViewModels/ServiceAlertViewModelTests.swift
+++ b/OBAKitTests/ViewModels/ServiceAlertViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 @testable import OBAKit
@@ -17,17 +17,18 @@ import Combine
 
 /// Tests for `ServiceAlertViewModel`. Verifies HTML build, idempotent
 /// `viewDidAppear()`, and mark-as-read side effect.
+@Suite(.serialized)
 final class ServiceAlertViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -64,7 +65,7 @@ final class ServiceAlertViewModelTests: OBATestCase {
     private func loadServiceAlert() throws -> ServiceAlert {
         let data = Fixtures.loadData(file: "arrival-and-departure-for-stop-MTS_11589.json")
         let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<ArrivalDeparture>.self, from: data)
-        return try XCTUnwrap(response.references?.serviceAlerts.first)
+        return try #require(response.references?.serviceAlerts.first)
     }
 
     @MainActor
@@ -78,8 +79,8 @@ final class ServiceAlertViewModelTests: OBATestCase {
 
     // MARK: - Tests
 
-    @MainActor
-    func test_renderedHTML_isNil_beforeViewDidAppear() throws {
+    @Test @MainActor
+    func `Rendered HTML is nil before view did appear`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alert = try loadServiceAlert()
@@ -88,8 +89,8 @@ final class ServiceAlertViewModelTests: OBATestCase {
         #expect(viewModel.renderedHTML == nil)
     }
 
-    @MainActor
-    func test_viewDidAppear_buildsHTML_andContainsCoreSections() async throws {
+    @Test @MainActor
+    func `View did appear builds HTML and contains core sections`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alert = try loadServiceAlert()
@@ -98,7 +99,7 @@ final class ServiceAlertViewModelTests: OBATestCase {
         viewModel.viewDidAppear()
 
         let html = await waitForRender(viewModel: viewModel)
-        let rendered = try XCTUnwrap(html)
+        let rendered = try #require(html)
         #expect(rendered.contains("<html>"))
         #expect(rendered.contains("</html>"))
         #expect(rendered.contains("<h1>"))
@@ -106,8 +107,8 @@ final class ServiceAlertViewModelTests: OBATestCase {
         #expect(rendered.contains("In Effect"))
     }
 
-    @MainActor
-    func test_viewDidAppear_marksAlertAsRead() async throws {
+    @Test @MainActor
+    func `View did appear marks alert as read`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alert = try loadServiceAlert()
@@ -120,8 +121,8 @@ final class ServiceAlertViewModelTests: OBATestCase {
         #expect(!app.userDataStore.isUnread(serviceAlert: alert))
     }
 
-    @MainActor
-    func test_viewDidAppear_isIdempotent() async throws {
+    @Test @MainActor
+    func `View did appear is idempotent`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
         let alert = try loadServiceAlert()

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 import CoreLocation
@@ -17,18 +17,19 @@ import CoreLocation
 // swiftlint:disable force_cast force_try
 
 /// Tests for `StopViewModel`. Regression tests for review issues #1, #2, and #8.
-class StopViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class StopViewModelTests: OBATestCase {
     let testStopID = "1_TEST"
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -186,8 +187,8 @@ class StopViewModelTests: OBATestCase {
 
     /// Empty results should drive the auto-extend recursion all the way to the 720-minute cap,
     /// monotonically increase `minutesAfter`, and flip `isLoadMoreExhausted` to true.
-    @MainActor
-    func test_autoExtend_walksToCapAndFlipsExhausted() async {
+    @Test @MainActor
+    func `Auto extend walks to cap and flips exhausted`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
@@ -215,8 +216,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `reportStopViewed` must fire exactly once per VM lifetime, even when refresh() is
     /// invoked many times by the auto-extend chain or by the user.
-    @MainActor
-    func test_analyticsFiresExactlyOnceAcrossRefreshes() async {
+    @Test @MainActor
+    func `Analytics fires exactly once across refreshes`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
@@ -239,8 +240,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `addRecentStop` is one-shot per VM lifetime — multiple successful refreshes must not
     /// re-touch the recents list.
-    @MainActor
-    func test_recentStop_recordedExactlyOnce() async {
+    @Test @MainActor
+    func `Recent stop recorded exactly once`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
@@ -260,8 +261,8 @@ class StopViewModelTests: OBATestCase {
     /// auto-refresh — so the `/surveys.json` endpoint must be hit exactly once across
     /// multiple refreshes. The fetch runs in `surveyRefreshTask`; awaiting it gives an
     /// exact count rather than a polled one.
-    @MainActor
-    func test_surveys_refreshedExactlyOnceAcrossRefreshes() async {
+    @Test @MainActor
+    func `Surveys refreshed exactly once across refreshes`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let counter = SurveyHitCounter()
@@ -285,13 +286,13 @@ class StopViewModelTests: OBATestCase {
     /// If the persisted preferences for this stop hide every route the stop serves,
     /// the first successful fetch must flip `isListFiltered` to `false` so the user
     /// doesn't land on an empty list.
-    @MainActor
-    func test_disableFilter_runsOnInitialLoadWhenAllRoutesHidden() async throws {
+    @Test @MainActor
+    func `Disable filter runs on initial load when all routes hidden`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
 
-        let region = try XCTUnwrap(app.currentRegion)
+        let region = try #require(app.currentRegion)
 
         // The fixture's stop serves a single route, "1_R1". Pre-hide it.
         // We need a `Stop` object to call the data-store setter; build a minimal one from JSON.
@@ -314,8 +315,8 @@ class StopViewModelTests: OBATestCase {
     /// `$stop` must not re-emit across refreshes when the underlying value is unchanged.
     /// Re-emission would re-run the VC's `applyData` + `configureTabBarButtons` + title
     /// assignment for no reason on every 30 s refresh cycle.
-    @MainActor
-    func test_stop_doesNotReEmitWhenUnchangedAcrossRefreshes() async {
+    @Test @MainActor
+    func `Stop does not re emit when unchanged across refreshes`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
@@ -343,8 +344,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `shouldRefresh` returns `true` when no successful fetch has happened yet, and `false`
     /// immediately after a successful refresh.
-    @MainActor
-    func test_shouldRefresh_nilLastUpdatedIsTrue_recentLastUpdatedIsFalse() async {
+    @Test @MainActor
+    func `Should refresh nil last updated is true recent last updated is false`() async {
         let dataLoader = MockDataLoader(testName: name)
         let analytics = AnalyticsMock()
         let app = createApplication(dataLoader: dataLoader, analytics: analytics)
@@ -362,8 +363,8 @@ class StopViewModelTests: OBATestCase {
     // MARK: - Inline Hero Survey
 
     /// On a fresh VM (before any fetch), `currentSurvey` is `nil`.
-    @MainActor
-    func test_currentSurvey_isNilBeforeFetch() {
+    @Test @MainActor
+    func `Current survey is nil before fetch`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -374,8 +375,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `submitHeroAnswer` with no current survey is a no-op (no error emission, no
     /// presentFullSurvey emission).
-    @MainActor
-    func test_submitHeroAnswer_isNoOpWhenNoCurrentSurvey() async {
+    @Test @MainActor
+    func `Submit hero answer is no op when no current survey`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -394,8 +395,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `dismissCurrentSurvey()` with no current survey is a no-op and does not set
     /// the reminder date.
-    @MainActor
-    func test_dismissCurrentSurvey_isNoOpWhenNoCurrentSurvey() {
+    @Test @MainActor
+    func `Dismiss current survey is no op when no current survey`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -409,8 +410,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `launchExternalSurvey()` with no explicit target and no `currentSurvey`
     /// must be a no-op: neither callback fires, and no survey is touched.
-    @MainActor
-    func test_launchExternalSurvey_noCurrentSurveyAndNoTarget_isNoOp() {
+    @Test @MainActor
+    func `Launch external survey no current survey and no target is no op`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -431,8 +432,8 @@ class StopViewModelTests: OBATestCase {
     /// When an explicit target is passed but the URL cannot be built, the
     /// launcher's failure path runs: `onFailure` fires, `onSuccess` does not,
     /// and the survey stays uncompleted.
-    @MainActor
-    func test_launchExternalSurvey_explicitTargetWithNoURL_callsFailure() {
+    @Test @MainActor
+    func `Launch external survey explicit target with no URL calls failure`() {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
         let viewModel = StopViewModel(application: app, stopID: testStopID)
@@ -562,8 +563,8 @@ class StopViewModelTests: OBATestCase {
 
     /// After a refresh, `currentSurvey` becomes non-nil when the survey list is
     /// populated, eligibility is open, and a matching survey exists.
-    @MainActor
-    func test_currentSurvey_populatedAfterRefreshWhenEligible() async {
+    @Test @MainActor
+    func `Current survey populated after refresh when eligible`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithHeroSurvey(
             dataLoader: dataLoader,
@@ -587,8 +588,8 @@ class StopViewModelTests: OBATestCase {
     /// card too, even though `surveyOrchestrator.isEligible()` alone would
     /// still say yes — the coordinator's session-scoped `canShowInlineCards()`
     /// gate must apply to both inline surfaces, not just donations.
-    @MainActor
-    func test_currentSurvey_suppressedAfterReviewPromptShownThisSession() async {
+    @Test @MainActor
+    func `Current survey suppressed after review prompt shown this session`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithHeroSurvey(
             dataLoader: dataLoader,
@@ -608,8 +609,8 @@ class StopViewModelTests: OBATestCase {
 
     /// Hero-only success: submit clears `currentSurvey`, marks the survey
     /// completed, and emits no error / no presentFullSurvey.
-    @MainActor
-    func test_submitHeroAnswer_completedOutcome_clearsCard() async {
+    @Test @MainActor
+    func `Submit hero answer completed outcome clears card`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithHeroSurvey(
             dataLoader: dataLoader,
@@ -641,8 +642,8 @@ class StopViewModelTests: OBATestCase {
 
     /// Needs-remaining outcome: card clears AND `presentFullSurvey` emits with the
     /// hero response id (from the canned fixture) and stop location forwarded.
-    @MainActor
-    func test_submitHeroAnswer_needsRemainingOutcome_clearsCardAndEmitsPresent() async {
+    @Test @MainActor
+    func `Submit hero answer needs remaining outcome clears card and emits present`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithHeroSurvey(
             dataLoader: dataLoader,
@@ -679,8 +680,8 @@ class StopViewModelTests: OBATestCase {
 
     /// Submission failure path: `currentSurvey` is preserved and the error
     /// publisher emits exactly once.
-    @MainActor
-    func test_submitHeroAnswer_errorPath_emitsErrorAndKeepsCard() async {
+    @Test @MainActor
+    func `Submit hero answer error path emits error and keeps card`() async {
         let dataLoader = MockDataLoader(testName: name)
         // Stub the surveys list, but NOT the submit endpoint — submission throws.
         let app = createApplicationWithHeroSurvey(
@@ -722,8 +723,8 @@ class StopViewModelTests: OBATestCase {
     /// Re-entrancy guard: a second concurrent `submitHeroAnswer` is dropped while
     /// the first is in flight, so the survey is only marked completed once and
     /// `presentFullSurvey` does not double-fire on the needs-remaining path.
-    @MainActor
-    func test_submitHeroAnswer_reEntrancyGuard_blocksConcurrentSubmit() async {
+    @Test @MainActor
+    func `Submit hero answer re entrancy guard blocks concurrent submit`() async {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplicationWithHeroSurvey(
             dataLoader: dataLoader,
@@ -757,15 +758,15 @@ class StopViewModelTests: OBATestCase {
     /// `StopViewController`, even with the new-stop-page flag ON (its default),
     /// because the transfer UX isn't built on the new page yet. A plain open with
     /// the flag ON resolves to the new `StopPageViewController`.
-    @MainActor
-    func test_makeStopController_transferContext_fallsBackToLegacyScreen() throws {
+    @Test @MainActor
+    func `Make stop controller transfer context falls back to legacy screen`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
         // The new-stop-page flag defaults to ON when unset.
         #expect(FeatureFlags.isNewStopPageEnabled(userDefaults: app.userDefaults))
 
-        let stop = try XCTUnwrap(try Fixtures.loadSomeStops().first)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
 
         let transfer = TransferContext(arrivalTime: Date(), fromRouteShortName: "1", fromTripHeadsign: "Downtown")
         let transferController = app.viewRouter.makeStopController(stop: stop, transferContext: transfer)
@@ -779,8 +780,8 @@ class StopViewModelTests: OBATestCase {
 
     /// `alarmLeadTimeMinutes` derives the displayed lead time from the alarm's
     /// `tripDate`/`alarmDate` spread, not from any stored minutes field.
-    @MainActor
-    func test_alarmLeadTimeMinutes_derivesFromDates() throws {
+    @Test @MainActor
+    func `Alarm lead time minutes derives from dates`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
         let viewModel = StopViewModel(application: app, stopID: testStopID)
@@ -793,8 +794,8 @@ class StopViewModelTests: OBATestCase {
 
     /// With no `tripDate`/`alarmDate` to measure, the lead time falls back to the
     /// default rather than surfacing a bogus value.
-    @MainActor
-    func test_alarmLeadTimeMinutes_fallsBackToDefaultOnNilDates() throws {
+    @Test @MainActor
+    func `Alarm lead time minutes falls back to default on nil dates`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
         let viewModel = StopViewModel(application: app, stopID: testStopID)
@@ -813,8 +814,8 @@ class StopViewModelTests: OBATestCase {
     /// size on insert" behavior: nil before the async fetch has populated the
     /// cache, identical to the fetched details afterwards, and nil again after
     /// a refresh invalidates the cache.
-    @MainActor
-    func test_cachedApproachTripDetails_warmAfterFetch_invalidatedByRefresh() async throws {
+    @Test @MainActor
+    func `Cached approach trip details warm after fetch invalidated by refresh`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(
             dataLoader: dataLoader,
@@ -831,7 +832,7 @@ class StopViewModelTests: OBATestCase {
         let viewModel = StopViewModel(application: app, stopID: testStopID)
         await viewModel.refresh()
 
-        let departure = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures.first)
+        let departure = try #require(viewModel.stopArrivals?.arrivalsAndDepartures.first)
         #expect(departure.predicted)
 
         // Cold: nothing cached until the async path has run.
@@ -852,8 +853,8 @@ class StopViewModelTests: OBATestCase {
     /// vehicleID and serviceDate — so the cache has to key on all three. Keyed on
     /// tripID alone, the same trip running on two service days shares one entry and
     /// the panel renders the other day's timeline.
-    @MainActor
-    func test_approachCache_sameTripDifferentServiceDate_doesNotCollide() async throws {
+    @Test @MainActor
+    func `Approach cache same trip different service date does not collide`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(
             dataLoader: dataLoader,
@@ -869,9 +870,9 @@ class StopViewModelTests: OBATestCase {
         let viewModel = StopViewModel(application: app, stopID: testStopID)
         await viewModel.refresh()
 
-        let departures = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures)
-        let today = try XCTUnwrap(departures.first { $0.vehicleID == "1_7028" })
-        let tomorrow = try XCTUnwrap(departures.first { $0.vehicleID == "1_9999" })
+        let departures = try #require(viewModel.stopArrivals?.arrivalsAndDepartures)
+        let today = try #require(departures.first { $0.vehicleID == "1_7028" })
+        let tomorrow = try #require(departures.first { $0.vehicleID == "1_9999" })
 
         // Same trip, different instance: only the service date and vehicle differ.
         #expect(today.tripID == tomorrow.tripID)
@@ -891,13 +892,13 @@ class StopViewModelTests: OBATestCase {
     /// approach cache key has to account for.
     private func arrivalsWithSameTripOnTwoServiceDays() throws -> Data {
         let raw = Fixtures.loadData(file: "arrivals_and_departures_for_stop_1_10020.json")
-        var payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
-        var data = try XCTUnwrap(payload["data"] as? [String: Any])
-        var entry = try XCTUnwrap(data["entry"] as? [String: Any])
-        var arrDeps = try XCTUnwrap(entry["arrivalsAndDepartures"] as? [[String: Any]])
+        var payload = try #require(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        var data = try #require(payload["data"] as? [String: Any])
+        var entry = try #require(data["entry"] as? [String: Any])
+        var arrDeps = try #require(entry["arrivalsAndDepartures"] as? [[String: Any]])
 
-        var nextDay = try XCTUnwrap(arrDeps.first)
-        let serviceDate = try XCTUnwrap(nextDay["serviceDate"] as? Int)
+        var nextDay = try #require(arrDeps.first)
+        let serviceDate = try #require(nextDay["serviceDate"] as? Int)
         nextDay["serviceDate"] = serviceDate + 86_400_000 // ms
         nextDay["vehicleId"] = "1_9999"
         arrDeps.append(nextDay)
@@ -913,8 +914,8 @@ class StopViewModelTests: OBATestCase {
     /// Cancelling with no Obaco service must not report success: the server alarm is
     /// still armed and will still fire, so dropping the local copy would leave the
     /// rider with a buzzing alarm they can no longer see or cancel.
-    @MainActor
-    func test_cancelAlarm_withoutObacoService_keepsAlarmAndSurfacesError() async throws {
+    @Test @MainActor
+    func `Cancel alarm without obaco service keeps alarm and surfaces error`() async throws {
         removeStoredRegionsFile()
 
         let dataLoader = MockDataLoader(testName: name)
@@ -931,8 +932,8 @@ class StopViewModelTests: OBATestCase {
         let viewModel = StopViewModel(application: app, stopID: testStopID)
         await viewModel.refresh()
 
-        let departure = try XCTUnwrap(viewModel.stopArrivals?.arrivalsAndDepartures.first)
-        let region = try XCTUnwrap(app.currentRegion)
+        let departure = try #require(viewModel.stopArrivals?.arrivalsAndDepartures.first)
+        let region = try #require(app.currentRegion)
 
         let alarm = try Fixtures.loadAlarm()
         alarm.deepLink = ArrivalDepartureDeepLink(arrivalDeparture: departure, regionID: region.regionIdentifier)
@@ -953,15 +954,15 @@ class StopViewModelTests: OBATestCase {
 
     // MARK: - Review prompt success recording
 
-    @MainActor
-    func test_successfulFetchWithPredictedArrival_recordsOneSuccess() async {
+    @Test @MainActor
+    func `Successful fetch with predicted arrival records one success`() async {
         let (viewModel, application) = buildViewModel(arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json")
         await viewModel.refresh()
         #expect(application.reviewPromptPolicy.successCount == 1)
     }
 
-    @MainActor
-    func test_repeatedRefreshes_recordOnlyOneSuccess() async {
+    @Test @MainActor
+    func `Repeated refreshes record only one success`() async {
         let (viewModel, application) = buildViewModel(arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json")
         await viewModel.refresh()
         await viewModel.refresh()
@@ -969,8 +970,8 @@ class StopViewModelTests: OBATestCase {
         #expect(application.reviewPromptPolicy.successCount == 1)
     }
 
-    @MainActor
-    func test_scheduledOnlyArrivals_recordNoSuccess() async {
+    @Test @MainActor
+    func `Scheduled only arrivals record no success`() async {
         let (viewModel, application) = buildViewModel(arrivalsFixture: "arrivals_and_departures_for_stop_1_10020_no_realtime.json")
         await viewModel.refresh()
         #expect(application.reviewPromptPolicy.successCount == 0)
@@ -978,16 +979,16 @@ class StopViewModelTests: OBATestCase {
 
     /// Hide every route the fixture's predicted arrivals belong to, so the rider
     /// never saw a real-time row.
-    @MainActor
-    func test_predictedArrivalOnHiddenRoute_recordsNoSuccess() async {
+    @Test @MainActor
+    func `Predicted arrival on hidden route records no success`() async {
         let (viewModel, application) = buildViewModel(arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json")
         hideAllRoutes(in: viewModel)
         await viewModel.refresh()
         #expect(application.reviewPromptPolicy.successCount == 0)
     }
 
-    @MainActor
-    func test_failedFetch_recordsNoSuccessAndFlagsError() async {
+    @Test @MainActor
+    func `Failed fetch records no success and flags error`() async {
         let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 500)
         await viewModel.refresh()
         #expect(application.reviewPromptPolicy.successCount == 0)
@@ -996,9 +997,9 @@ class StopViewModelTests: OBATestCase {
 
     /// A broken bookmark is not a failure the rider watched happen: the page says so
     /// and offers a way out.
-    @MainActor
-    func test_requestNotFound_withBookmarkContext_doesNotFlagError() async throws {
-        let stop = try XCTUnwrap(try Fixtures.loadSomeStops().first)
+    @Test @MainActor
+    func `Request not found with bookmark context does not flag error`() async throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
         let bookmark = Bookmark(name: "Broken", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
         let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 404, bookmarkContext: bookmark)
         await viewModel.refresh()
@@ -1007,8 +1008,8 @@ class StopViewModelTests: OBATestCase {
 
     /// Without a bookmark behind it — a deep link, a search result, a map pin — the same
     /// 404 strands the rider on a page with no arrivals and no error, which counts.
-    @MainActor
-    func test_requestNotFound_withoutBookmarkContext_flagsError() async {
+    @Test @MainActor
+    func `Request not found without bookmark context flags error`() async {
         let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 404)
         await viewModel.refresh()
         #expect(application.promptCoordinator.sawErrorThisSession)

--- a/OBAKitTests/ViewModels/SurveyOrchestratorTests.swift
+++ b/OBAKitTests/ViewModels/SurveyOrchestratorTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -21,14 +21,16 @@ import CoreLocation
 /// Network paths are exercised against `SurveyService(apiService: nil)` — any
 /// call that reaches the network throws, which lets us positively assert that
 /// the caller's guards executed before the network branch.
-class SurveyOrchestratorTests: OBATestCase {
+@Suite(.serialized)
+final class SurveyOrchestratorTests: OBATestCase {
 
     private var surveyService: SurveyService!
     private var dataStore: UserDefaultsStore!
     private var orchestrator: SurveyOrchestrator!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         dataStore = UserDefaultsStore(userDefaults: userDefaults)
         surveyService = SurveyService(apiService: nil, userDataStore: dataStore)
         let service = surveyService!
@@ -41,11 +43,10 @@ class SurveyOrchestratorTests: OBATestCase {
         }
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         orchestrator = nil
         surveyService = nil
         dataStore = nil
-        try await super.tearDown()
     }
 
     // MARK: - Fixtures
@@ -86,15 +87,15 @@ class SurveyOrchestratorTests: OBATestCase {
     // MARK: - isEligible
 
     /// When the global toggle is off, the gate is closed.
-    @MainActor
-    func test_isEligible_isFalseWhenSurveysDisabled() {
+    @Test @MainActor
+    func `Is eligible is false when surveys disabled`() {
         dataStore.isSurveyEnabled = false
         #expect(!self.orchestrator.isEligible())
     }
 
     /// `alwaysShowSurveysOnStops` opens the gate regardless of launch count / reminder.
-    @MainActor
-    func test_isEligible_isTrueWithAlwaysShowFlag() {
+    @Test @MainActor
+    func `Is eligible is true with always show flag`() {
         dataStore.isSurveyEnabled = true
         dataStore.alwaysShowSurveysOnStops = true
         #expect(self.orchestrator.isEligible())
@@ -108,8 +109,8 @@ class SurveyOrchestratorTests: OBATestCase {
     /// Also pins that a thrown submission does NOT record survey engagement —
     /// `noteSurveyEngaged()` sits after the network call succeeds, so a throw
     /// here must leave the coordinator's review-prompt gate untouched.
-    @MainActor
-    func test_submitHero_throwsWithoutAPIService() async {
+    @Test @MainActor
+    func `Submit hero throws without API service`() async {
         let hero = Self.makeQuestion(id: 1)
         let survey = Self.makeSurvey(questions: [hero])
         let coordinator = PromptCoordinator(userDefaults: userDefaults)
@@ -126,7 +127,7 @@ class SurveyOrchestratorTests: OBATestCase {
 
         #expect(!self.dataStore.isSurveyCompleted(surveyId: survey.id, userIdentifier: self.dataStore.surveyUserIdentifier))
         #expect(self.dataStore.nextSurveyReminderDate == nil)
-        XCTAssertTrue(coordinator.canShowReviewPrompt(), "a failed submission must not start the engagement cooldown")
+        #expect(coordinator.canShowReviewPrompt(), "a failed submission must not start the engagement cooldown")
     }
 
     /// Hero submit with no remaining questions returns `.completed`, marks the
@@ -134,15 +135,15 @@ class SurveyOrchestratorTests: OBATestCase {
     ///
     /// Also pins that a successful submission is a survey engagement: it must
     /// start the coordinator's 14-day cooldown that gates the review prompt.
-    @MainActor
-    func test_submitHero_returnsCompletedWhenNoRemainingQuestions() async throws {
+    @Test @MainActor
+    func `Submit hero returns completed when no remaining questions`() async throws {
         let hero = Self.makeQuestion(id: 1, position: 1)
         let survey = Self.makeSurvey(questions: [hero])
         let (service, _) = Self.buildLiveSurveyService(testName: name, userDataStore: dataStore)
         let coordinator = PromptCoordinator(userDefaults: userDefaults)
         let liveOrchestrator = SurveyOrchestrator(surveyService: service, promptCoordinator: coordinator)
 
-        XCTAssertTrue(coordinator.canShowReviewPrompt())
+        #expect(coordinator.canShowReviewPrompt())
 
         let outcome = try await liveOrchestrator.submitHero(
             survey: survey, answer: "yes", stopID: "1_TEST", stopLocation: nil
@@ -155,7 +156,7 @@ class SurveyOrchestratorTests: OBATestCase {
         let userID = dataStore.surveyUserIdentifier
         #expect(self.dataStore.isSurveyCompleted(surveyId: survey.id, userIdentifier: userID))
         #expect(self.dataStore.nextSurveyReminderDate != nil)
-        XCTAssertFalse(coordinator.canShowReviewPrompt(), "a successful submission is an engagement and starts the 14-day cooldown")
+        #expect(!coordinator.canShowReviewPrompt(), "a successful submission is an engagement and starts the 14-day cooldown")
     }
 
     /// Hero submit on a survey with remaining questions returns
@@ -164,8 +165,8 @@ class SurveyOrchestratorTests: OBATestCase {
     ///
     /// Also pins that this outcome is still a survey engagement — it must
     /// start the coordinator's 14-day cooldown just like `.completed` does.
-    @MainActor
-    func test_submitHero_returnsNeedsRemainingWhenFollowupsExist() async throws {
+    @Test @MainActor
+    func `Submit hero returns needs remaining when followups exist`() async throws {
         let hero = Self.makeQuestion(id: 1, position: 1)
         let follow = Self.makeQuestion(id: 2, position: 2, required: false)
         let survey = Self.makeSurvey(questions: [hero, follow])
@@ -173,7 +174,7 @@ class SurveyOrchestratorTests: OBATestCase {
         let coordinator = PromptCoordinator(userDefaults: userDefaults)
         let liveOrchestrator = SurveyOrchestrator(surveyService: service, promptCoordinator: coordinator)
 
-        XCTAssertTrue(coordinator.canShowReviewPrompt())
+        #expect(coordinator.canShowReviewPrompt())
 
         let outcome = try await liveOrchestrator.submitHero(
             survey: survey, answer: "yes", stopID: "1_TEST", stopLocation: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
@@ -188,15 +189,15 @@ class SurveyOrchestratorTests: OBATestCase {
         let userID = dataStore.surveyUserIdentifier
         #expect(!self.dataStore.isSurveyCompleted(surveyId: survey.id, userIdentifier: userID))
         #expect(self.dataStore.nextSurveyReminderDate != nil)
-        XCTAssertFalse(coordinator.canShowReviewPrompt(), "a successful submission is an engagement and starts the 14-day cooldown")
+        #expect(!coordinator.canShowReviewPrompt(), "a successful submission is an engagement and starts the 14-day cooldown")
     }
 
     /// A survey whose only question isn't at `position == 1` has `heroQuestion == nil`.
     /// `submitHero` must throw `.missingHeroQuestion` rather than crash on the force-unwrap
     /// of optional hero data. `Survey` is decoded from the network, so this shape is
     /// defensible.
-    @MainActor
-    func test_submitHero_throwsMissingHeroQuestionWhenNoPositionOneQuestion() async {
+    @Test @MainActor
+    func `Submit hero throws missing hero question when no position one question`() async {
         let follow = Self.makeQuestion(id: 2, position: 2, type: .text)
         let survey = Self.makeSurvey(questions: [follow])
         // Sanity check the fixture: this survey genuinely has no hero.
@@ -219,7 +220,7 @@ class SurveyOrchestratorTests: OBATestCase {
         let userID = dataStore.surveyUserIdentifier
         #expect(!self.dataStore.isSurveyCompleted(surveyId: survey.id, userIdentifier: userID))
         #expect(self.dataStore.nextSurveyReminderDate == nil)
-        XCTAssertTrue(coordinator.canShowReviewPrompt(), "a guard-clause throw must not start the engagement cooldown")
+        #expect(coordinator.canShowReviewPrompt(), "a guard-clause throw must not start the engagement cooldown")
     }
 
     // MARK: - Live SurveyService builder (for happy-path network)
@@ -252,8 +253,8 @@ class SurveyOrchestratorTests: OBATestCase {
 
     /// `dismiss(_:)` sets the reminder date. The dismissal is recorded via
     /// `markSurveyCompleted` (which `SurveyService.dismissSurvey` calls).
-    @MainActor
-    func test_dismiss_setsReminderAndMarksCompleted() {
+    @Test @MainActor
+    func `Dismiss sets reminder and marks completed`() {
         let survey = Self.makeSurvey(questions: [Self.makeQuestion(id: 1)])
         let userID = dataStore.surveyUserIdentifier
         #expect(self.dataStore.nextSurveyReminderDate == nil)
@@ -268,17 +269,17 @@ class SurveyOrchestratorTests: OBATestCase {
     /// 14-day cooldown that gates the review prompt — otherwise a rider who
     /// just interacted with a survey card could be asked for a review in the
     /// same sitting.
-    @MainActor
-    func test_dismiss_recordsSurveyEngagement() {
+    @Test @MainActor
+    func `Dismiss records survey engagement`() {
         let coordinator = PromptCoordinator(userDefaults: userDefaults)
         let orchestrator = SurveyOrchestrator(
             surveyService: surveyService,
             promptCoordinator: coordinator
         )
 
-        XCTAssertTrue(coordinator.canShowReviewPrompt())
+        #expect(coordinator.canShowReviewPrompt())
         orchestrator.dismiss(Self.makeSurvey(questions: [Self.makeQuestion(id: 1)]))
-        XCTAssertFalse(coordinator.canShowReviewPrompt(), "engagement starts the 14-day cooldown")
+        #expect(!coordinator.canShowReviewPrompt(), "engagement starts the 14-day cooldown")
     }
 
     // MARK: - lastError accessor
@@ -286,8 +287,8 @@ class SurveyOrchestratorTests: OBATestCase {
     /// `lastError` is `nil` before any refresh runs. The gate in
     /// `MapViewModel.checkForSurveyPrompt` relies on this so the very first
     /// session check doesn't get short-circuited by a stale value.
-    @MainActor
-    func test_lastError_isNilBeforeRefresh() {
+    @Test @MainActor
+    func `Last error is nil before refresh`() {
         #expect(self.orchestrator.lastError == nil)
     }
 
@@ -295,8 +296,8 @@ class SurveyOrchestratorTests: OBATestCase {
     /// `apiService: nil`, `fetchSurveys` records `APIError.surveyServiceNotConfigured`
     /// rather than throwing — this verifies the orchestrator surfaces it so
     /// `MapViewModel.checkForSurveyPrompt` can gate on it.
-    @MainActor
-    func test_lastError_reflectsUnderlyingService_afterFetchFailure() async {
+    @Test @MainActor
+    func `Last error reflects underlying service after fetch failure`() async {
         #expect(self.orchestrator.lastError == nil)
 
         await orchestrator.refreshSurveys()
@@ -316,8 +317,8 @@ class SurveyOrchestratorTests: OBATestCase {
     // MARK: - noteReminderAndAdvanceSession
 
     /// `noteReminderAndAdvanceSession()` advances the reminder by ~3 days.
-    @MainActor
-    func test_noteReminderAndAdvanceSession_setsReminderAboutThreeDaysOut() {
+    @Test @MainActor
+    func `Note reminder and advance session sets reminder about three days out`() {
         let before = Date()
         orchestrator.noteReminderAndAdvanceSession()
         let after = Date()

--- a/OBAKitTests/ViewModels/SurveyOrchestratorTests.swift
+++ b/OBAKitTests/ViewModels/SurveyOrchestratorTests.swift
@@ -43,12 +43,6 @@ final class SurveyOrchestratorTests: OBATestCase {
         }
     }
 
-    isolated deinit {
-        orchestrator = nil
-        surveyService = nil
-        dataStore = nil
-    }
-
     // MARK: - Fixtures
 
     private static func makeQuestion(

--- a/OBAKitTests/ViewModels/SurveyViewModelTests.swift
+++ b/OBAKitTests/ViewModels/SurveyViewModelTests.swift
@@ -39,12 +39,6 @@ final class SurveyViewModelTests: OBATestCase {
         cancellables = []
     }
 
-    isolated deinit {
-        cancellables = nil
-        surveyService = nil
-        dataStore = nil
-    }
-
     // MARK: - Fixtures
 
     private static func makeQuestion(

--- a/OBAKitTests/ViewModels/SurveyViewModelTests.swift
+++ b/OBAKitTests/ViewModels/SurveyViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import Combine
 import CoreLocation
@@ -24,24 +24,25 @@ import CoreLocation
 /// we use a real `SurveyService(apiService: nil)`. Any code path that reaches
 /// the network throws — which lets us positively assert that validation
 /// *passed* (we observe `.network`, not `.validationFailed`).
-class SurveyViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class SurveyViewModelTests: OBATestCase {
 
     private var surveyService: SurveyService!
     private var dataStore: UserDefaultsStore!
     private var cancellables: Set<AnyCancellable>!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         dataStore = UserDefaultsStore(userDefaults: userDefaults)
         surveyService = SurveyService(apiService: nil, userDataStore: dataStore)
         cancellables = []
     }
 
-    override func tearDown() async throws {
+    isolated deinit {
         cancellables = nil
         surveyService = nil
         dataStore = nil
-        try await super.tearDown()
     }
 
     // MARK: - Fixtures
@@ -103,8 +104,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// A fresh VM exposes the survey it was constructed with, retains `heroResponseID`,
     /// and shows every question when no hero has been submitted.
-    @MainActor
-    func test_init_preservesSurveyAndHeroResponseID() {
+    @Test @MainActor
+    func `Init preserves survey and hero response ID`() {
         let q1 = Self.makeQuestion(id: 1, position: 1)
         let q2 = Self.makeQuestion(id: 2, position: 2)
         let vm = makeViewModel(questions: [q1, q2], heroResponseID: "hero-42")
@@ -118,8 +119,8 @@ class SurveyViewModelTests: OBATestCase {
     // MARK: - questionsToShow
 
     /// Without a hero response, every question is shown. With one preset, the hero is skipped.
-    @MainActor
-    func test_questionsToShow_respectsHeroResponseID() {
+    @Test @MainActor
+    func `Questions to show respects hero response ID`() {
         let hero = Self.makeQuestion(id: 1, position: 1)
         let follow = Self.makeQuestion(id: 2, position: 2)
 
@@ -134,8 +135,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Submitting answers for distinct questions accumulates them; validation passes when all
     /// required questions are covered.
-    @MainActor
-    func test_updateAnswer_accumulatesAnswersAcrossQuestions() async {
+    @Test @MainActor
+    func `Update answer accumulates answers across questions`() async {
         let q1 = Self.makeQuestion(id: 1, position: 1, type: .text)
         let q2 = Self.makeQuestion(id: 2, position: 2, type: .text)
         let vm = makeViewModel(questions: [q1, q2])
@@ -149,8 +150,8 @@ class SurveyViewModelTests: OBATestCase {
     }
 
     /// A second answer for the same question replaces the first.
-    @MainActor
-    func test_updateAnswer_replacesPriorAnswerForSameQuestion() async {
+    @Test @MainActor
+    func `Update answer replaces prior answer for same question`() async {
         let q = Self.makeQuestion(id: 7, type: .text)
         let vm = makeViewModel(questions: [q])
 
@@ -166,8 +167,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Toggling on accumulates selections; toggling off removes them. The resulting answer
     /// is JSON-encoded by `SurveyService.formatCheckboxAnswer`.
-    @MainActor
-    func test_toggleCheckbox_accumulatesAndRemoves() async {
+    @Test @MainActor
+    func `Toggle checkbox accumulates and removes`() async {
         let q = Self.makeQuestion(id: 9, type: .checkbox, options: ["a", "b", "c"])
         let vm = makeViewModel(questions: [q])
 
@@ -182,8 +183,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Toggling all options off leaves a stored answer (an empty JSON array `"[]"`), which is
     /// still considered an answer for validation purposes — matching the existing VC behavior.
-    @MainActor
-    func test_toggleCheckbox_offlyAllStillCountsAsAnswer() async {
+    @Test @MainActor
+    func `Toggle checkbox offly all still counts as answer`() async {
         let q = Self.makeQuestion(id: 9, type: .checkbox, options: ["a", "b"])
         let vm = makeViewModel(questions: [q])
 
@@ -197,8 +198,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Toggling a checkbox on a question that was never touched succeeds — the
     /// `default: []` subscript handles a missing entry without crashing.
-    @MainActor
-    func test_toggleCheckbox_doesNotCrashOnFirstToggle() {
+    @Test @MainActor
+    func `Toggle checkbox does not crash on first toggle`() {
         let q = Self.makeQuestion(id: 9, type: .checkbox, options: ["x"])
         let vm = makeViewModel(questions: [q])
 
@@ -211,8 +212,8 @@ class SurveyViewModelTests: OBATestCase {
     // MARK: - submit validation
 
     /// `submit()` with no responses on a survey with required questions emits `.validationFailed`.
-    @MainActor
-    func test_submit_validationFailed_whenRequiredAnswersMissing() async {
+    @Test @MainActor
+    func `Submit validation failed when required answers missing`() async {
         let q = Self.makeQuestion(id: 1, required: true, type: .text)
         let vm = makeViewModel(questions: [q])
 
@@ -225,8 +226,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Non-required follow-up questions can be left unanswered without blocking submission,
     /// as long as the hero question has an answer.
-    @MainActor
-    func test_submit_nonRequiredQuestionsDoNotBlockValidation() async {
+    @Test @MainActor
+    func `Submit non required questions do not block validation`() async {
         let hero = Self.makeQuestion(id: 1, position: 1, required: true, type: .text)
         let optional = Self.makeQuestion(id: 2, position: 2, required: false, type: .text)
         let vm = makeViewModel(questions: [hero, optional])
@@ -242,8 +243,8 @@ class SurveyViewModelTests: OBATestCase {
     /// submitted on the fresh path — the hero-answer lookup fails. Because the
     /// hero question exists (a label *is* a question at position 1) but has no
     /// captured answer, the VM surfaces `.malformedSurveyData`.
-    @MainActor
-    func test_submit_labelOnlySurvey_emitsMalformedSurveyData() async {
+    @Test @MainActor
+    func `Submit label only survey emits malformed survey data`() async {
         let label = Self.makeQuestion(id: 1, position: 1, required: false, type: .label)
         let vm = makeViewModel(questions: [label])
 
@@ -255,8 +256,8 @@ class SurveyViewModelTests: OBATestCase {
     }
 
     /// On the retry path (`heroResponseID` preset), only the remaining questions are validated.
-    @MainActor
-    func test_submit_retryPath_validatesRemainingOnly() async {
+    @Test @MainActor
+    func `Submit retry path validates remaining only`() async {
         let hero = Self.makeQuestion(id: 1, position: 1, required: true)
         let follow = Self.makeQuestion(id: 2, position: 2, required: false)
         let vm = makeViewModel(questions: [hero, follow], heroResponseID: "hero-id")
@@ -267,8 +268,8 @@ class SurveyViewModelTests: OBATestCase {
     }
 
     /// Validation failure does NOT mark the survey completed or set a reminder.
-    @MainActor
-    func test_submit_validationFailure_doesNotMarkSurveyCompleted() async {
+    @Test @MainActor
+    func `Submit validation failure does not mark survey completed`() async {
         let q = Self.makeQuestion(id: 1, required: true, type: .text)
         let vm = makeViewModel(questions: [q])
 
@@ -282,8 +283,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Network failure does NOT mark the survey completed either — only a successful
     /// `submit()` should flip that bit.
-    @MainActor
-    func test_submit_networkFailure_doesNotMarkSurveyCompleted() async {
+    @Test @MainActor
+    func `Submit network failure does not mark survey completed`() async {
         let q = Self.makeQuestion(id: 1, required: true, type: .text)
         let vm = makeViewModel(questions: [q])
         vm.updateAnswer(for: q, answer: "yes")
@@ -296,8 +297,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// On the fresh path, if the survey has no hero question at all, submission
     /// surfaces `.malformedSurveyData` (an invariant violation, not user error).
-    @MainActor
-    func test_submit_freshPath_emitsMalformedSurveyDataWhenNoHeroQuestion() async {
+    @Test @MainActor
+    func `Submit fresh path emits malformed survey data when no hero question`() async {
         // No question has position == 1, so `survey.heroQuestion` is nil.
         let q = Self.makeQuestion(id: 1, position: 2, required: false, type: .text)
         let vm = makeViewModel(questions: [q])
@@ -314,8 +315,8 @@ class SurveyViewModelTests: OBATestCase {
     // MARK: - submissionResult publisher
 
     /// `submissionResult` emits one event per `submit()` invocation. Two submits → two events.
-    @MainActor
-    func test_submissionResult_emitsOnEverySubmit() async {
+    @Test @MainActor
+    func `Submission result emits on every submit`() async {
         let q = Self.makeQuestion(id: 1, required: true, type: .text)
         let vm = makeViewModel(questions: [q])
 
@@ -335,8 +336,8 @@ class SurveyViewModelTests: OBATestCase {
     // MARK: - cancel
 
     /// `cancel()` calls `markSurveyForLater` and sets the reminder date.
-    @MainActor
-    func test_cancel_marksForLaterAndSetsReminder() {
+    @Test @MainActor
+    func `Cancel marks for later and sets reminder`() {
         let q = Self.makeQuestion(id: 1)
         let vm = makeViewModel(questions: [q])
 
@@ -353,8 +354,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// The reminder date set by `cancel()` is roughly 3 days in the future (matches
     /// `SurveyService.setNextReminderDate()`'s contract).
-    @MainActor
-    func test_cancel_remindersDateIsAboutThreeDaysOut() {
+    @Test @MainActor
+    func `Cancel reminders date is about three days out`() {
         let vm = makeViewModel(questions: [Self.makeQuestion(id: 1)])
 
         let before = Date()
@@ -402,8 +403,8 @@ class SurveyViewModelTests: OBATestCase {
     /// "Open Survey" button) so it can never be satisfied in-form. Validation
     /// must skip required external-survey questions, otherwise `submit()`
     /// could never proceed for a hero-external-survey configuration.
-    @MainActor
-    func test_validation_requiredExternalSurveyQuestion_isExcluded() async {
+    @Test @MainActor
+    func `Validation required external survey question is excluded`() async {
         let hero = Self.makeQuestion(id: 1, position: 1, required: true, type: .text)
         let external = Self.makeQuestion(id: 2, position: 2, required: true, type: .externalSurvey)
         let vm = makeViewModel(questions: [hero, external])
@@ -420,8 +421,8 @@ class SurveyViewModelTests: OBATestCase {
     /// Excluding external-survey questions must not bypass *other* unanswered
     /// required questions — validation should still fail if a required text
     /// question is missing.
-    @MainActor
-    func test_validation_externalSurveyExclusion_doesNotBypassOtherRequired() async {
+    @Test @MainActor
+    func `Validation external survey exclusion does not bypass other required`() async {
         let hero = Self.makeQuestion(id: 1, position: 1, required: true, type: .text)
         let followUp = Self.makeQuestion(id: 2, position: 2, required: true, type: .text)
         let external = Self.makeQuestion(id: 3, position: 3, required: true, type: .externalSurvey)
@@ -443,8 +444,8 @@ class SurveyViewModelTests: OBATestCase {
     /// `onFailure` fires, `onSuccess` does not, and the survey is NOT marked
     /// completed. Exercises the integration with the real `ExternalSurveyLauncher`
     /// owned by the VM.
-    @MainActor
-    func test_launchExternalSurvey_noURL_callsFailureAndDoesNotMarkCompleted() {
+    @Test @MainActor
+    func `Launch external survey no URL calls failure and does not mark completed`() {
         // No `url:` on the question → `externalSurveyURL(for:stop:)` returns nil.
         let external = Self.makeQuestion(id: 1, position: 1, required: true, type: .externalSurvey)
         let vm = makeViewModel(questions: [external])
@@ -532,8 +533,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Fresh path with hero only: one POST, zero PUTs, success, survey marked completed,
     /// and `heroResponseID` populated from the canned submission ID.
-    @MainActor
-    func test_submit_freshPath_heroOnly_succeedsAndMarksCompleted() async {
+    @Test @MainActor
+    func `Submit fresh path hero only succeeds and marks completed`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
@@ -554,8 +555,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Fresh path with hero + follow-up: hero POST first, then a single PUT for the
     /// remaining responses. Both legs fire; survey is marked completed.
-    @MainActor
-    func test_submit_freshPath_heroPlusFollowup_runsBothLegs() async {
+    @Test @MainActor
+    func `Submit fresh path hero plus followup runs both legs`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
@@ -578,8 +579,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Retry path (`heroResponseID` preset): the hero POST is skipped entirely;
     /// only the PUT fires; survey is marked completed.
-    @MainActor
-    func test_submit_retryPath_skipsHeroSubmit() async {
+    @Test @MainActor
+    func `Submit retry path skips hero submit`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
@@ -604,8 +605,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Fresh path with hero only and no follow-up: the `remainingResponses.isEmpty`
     /// branch is taken, so zero PUTs fire and submission still succeeds.
-    @MainActor
-    func test_submit_freshPath_remainingResponsesEmpty_skipsAdditionalLeg() async {
+    @Test @MainActor
+    func `Submit fresh path remaining responses empty skips additional leg`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, required: false, type: .text)
@@ -628,8 +629,8 @@ class SurveyViewModelTests: OBATestCase {
     /// (so `heroResponseID` is set and the hero answer is still in `responses`) but the
     /// additional-questions PUT failed. When the user retries, the PUT body must not
     /// include the hero answer — otherwise the hero is duplicated server-side.
-    @MainActor
-    func test_submit_retryPath_filtersHeroFromAdditionalResponses() async throws {
+    @Test @MainActor
+    func `Submit retry path filters hero from additional responses`() async throws {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
@@ -652,11 +653,11 @@ class SurveyViewModelTests: OBATestCase {
         #expect(counter.puts == 1)
 
         // PUT body is `{"responses": "<stringified JSON array>"}`. Decode both layers.
-        let body = try XCTUnwrap(counter.lastPutBody)
-        let outer = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
-        let inner = try XCTUnwrap(outer["responses"] as? String)
-        let innerData = try XCTUnwrap(inner.data(using: .utf8))
-        let responses = try XCTUnwrap(try JSONSerialization.jsonObject(with: innerData) as? [[String: Any]])
+        let body = try #require(counter.lastPutBody)
+        let outer = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let inner = try #require(outer["responses"] as? String)
+        let innerData = try #require(inner.data(using: .utf8))
+        let responses = try #require(try JSONSerialization.jsonObject(with: innerData) as? [[String: Any]])
         let questionIDs = responses.compactMap { $0["question_id"] as? Int }
         #expect(!questionIDs.contains(hero.id))
         #expect(questionIDs == [follow.id])
@@ -665,8 +666,8 @@ class SurveyViewModelTests: OBATestCase {
     /// `isSubmitting` toggles around a submit: false before, true while in-flight,
     /// false again after. Snapshot the published values via a sink so we capture the
     /// transient `true` rather than only observing the post-completion state.
-    @MainActor
-    func test_isSubmitting_togglesAroundSubmit() async {
+    @Test @MainActor
+    func `Is submitting toggles around submit`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
@@ -686,8 +687,8 @@ class SurveyViewModelTests: OBATestCase {
 
     /// Concurrent `submit()` calls: the in-flight guard prevents the second from
     /// firing a second hero POST.
-    @MainActor
-    func test_submit_inFlightGuard_blocksConcurrentSubmit() async {
+    @Test @MainActor
+    func `Submit in flight guard blocks concurrent submit`() async {
         let counter = HitCounter()
         let liveService = buildLiveSurveyService(counter: counter)
         let hero = Self.makeQuestion(id: 1, position: 1, type: .text)

--- a/OBAKitTests/ViewModels/TripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/TripViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -16,17 +16,18 @@ import Testing
 
 /// Tests for `TripViewModel`. Regression coverage for the `catch is CancellationError`
 /// branch added in the VM refactor.
-class TripViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class TripViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -101,8 +102,8 @@ class TripViewModelTests: OBATestCase {
     /// A cancelled `loadData()` task must not surface a user-facing error. The `catch is
     /// CancellationError { return }` branch in `loadData()` handles this; if it's removed,
     /// the cancellation would fall through to the generic `catch { operationError = error }`.
-    @MainActor
-    func test_loadData_doesNotSurfaceCancellationError() async throws {
+    @Test @MainActor
+    func `Load data does not surface cancellation error`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader)
 

--- a/OBAKitTests/ViewModels/VehiclesViewModelTests.swift
+++ b/OBAKitTests/ViewModels/VehiclesViewModelTests.swift
@@ -7,7 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 import CoreLocation
 @testable import OBAKit
@@ -21,17 +21,18 @@ import CoreLocation
 /// the fixture. That exercises the full pipeline — stubbed agencies-with-coverage
 /// request, task group, skipped-status generation, published state transitions —
 /// without any live network traffic.
-class VehiclesViewModelTests: OBATestCase {
+@Suite(.serialized)
+final class VehiclesViewModelTests: OBATestCase {
     var queue: OperationQueue!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override init() async throws {
+        try await super.init()
+
         queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
+    isolated deinit {
         queue.cancelAllOperations()
     }
 
@@ -75,7 +76,7 @@ class VehiclesViewModelTests: OBATestCase {
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let dataDict = json?["data"] as? [String: Any]
         let list = dataDict?["list"] as? [[String: Any]]
-        return try XCTUnwrap(list?.compactMap { $0["agencyId"] as? String })
+        return try #require(list?.compactMap { $0["agencyId"] as? String })
     }
 
     /// Disables every agency in the fixture so `fetchVehicles()` makes no live network calls.
@@ -87,8 +88,8 @@ class VehiclesViewModelTests: OBATestCase {
 
     // MARK: - Initial State
 
-    @MainActor
-    func test_init_hasEmptyState() {
+    @Test @MainActor
+    func `Init has empty state`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         let viewModel = VehiclesViewModel(application: app)
 
@@ -101,8 +102,8 @@ class VehiclesViewModelTests: OBATestCase {
 
     // MARK: - Fetch Guards
 
-    @MainActor
-    func test_fetchVehicles_withoutCurrentRegion_isANoOp() async {
+    @Test @MainActor
+    func `Fetch vehicles without current region is a no op`() async {
         let app = createApplication(dataLoader: MockDataLoader(testName: name), withRegion: false)
         let viewModel = VehiclesViewModel(application: app)
 
@@ -116,8 +117,8 @@ class VehiclesViewModelTests: OBATestCase {
 
     // MARK: - Fetch
 
-    @MainActor
-    func test_fetchVehicles_allAgenciesDisabled_producesSkippedStatusesWithoutNetworkCalls() async throws {
+    @Test @MainActor
+    func `Fetch vehicles all agencies disabled produces skipped statuses without network calls`() async throws {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         try disableAllAgencies(in: app)
         let viewModel = VehiclesViewModel(application: app)
@@ -137,8 +138,8 @@ class VehiclesViewModelTests: OBATestCase {
         #expect(!viewModel.isLoading)
     }
 
-    @MainActor
-    func test_fetchVehicles_sortsFeedStatusesByAgencyName() async throws {
+    @Test @MainActor
+    func `Fetch vehicles sorts feed statuses by agency name`() async throws {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         try disableAllAgencies(in: app)
         let viewModel = VehiclesViewModel(application: app)
@@ -149,8 +150,8 @@ class VehiclesViewModelTests: OBATestCase {
         #expect(names == names.sorted())
     }
 
-    @MainActor
-    func test_agencyCounts_reflectDisabledAgencies() async throws {
+    @Test @MainActor
+    func `Agency counts reflect disabled agencies`() async throws {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         try disableAllAgencies(in: app)
         let viewModel = VehiclesViewModel(application: app)
@@ -164,8 +165,8 @@ class VehiclesViewModelTests: OBATestCase {
 
     // MARK: - Agency Filtering
 
-    @MainActor
-    func test_agencyEnabled_defaultsToTrueAndPersistsChanges() {
+    @Test @MainActor
+    func `Agency enabled defaults to true and persists changes`() {
         // No-region app: the fetch spawned by setAgencyEnabled() no-ops safely.
         let app = createApplication(dataLoader: MockDataLoader(testName: name), withRegion: false)
         let viewModel = VehiclesViewModel(application: app)
@@ -188,8 +189,8 @@ class VehiclesViewModelTests: OBATestCase {
 
     // MARK: - Auto-Refresh Lifecycle
 
-    @MainActor
-    func test_startAutoRefresh_triggersAFetch_andStopCancels() async throws {
+    @Test @MainActor
+    func `Start auto refresh triggers a fetch and stop cancels`() async throws {
         let app = createApplication(dataLoader: MockDataLoader(testName: name))
         try disableAllAgencies(in: app)
         let viewModel = VehiclesViewModel(application: app)
@@ -206,8 +207,8 @@ class VehiclesViewModelTests: OBATestCase {
         viewModel.stopAutoRefresh()
     }
 
-    @MainActor
-    func test_stopAutoRefresh_withoutStart_isSafe() {
+    @Test @MainActor
+    func `Stop auto refresh without start is safe`() {
         let app = createApplication(dataLoader: MockDataLoader(testName: name), withRegion: false)
         let viewModel = VehiclesViewModel(application: app)
 

--- a/OBAKitTests/Weather/WeatherDisplayTests.swift
+++ b/OBAKitTests/Weather/WeatherDisplayTests.swift
@@ -7,7 +7,6 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import Testing
 import Foundation
 @testable import OBAKit
@@ -17,7 +16,8 @@ import Foundation
 /// review pinned down: past-hour filtering, "Now" labelling, the 24-entry cap,
 /// Date-based identity, and the empty-input edge case.
 @MainActor
-final class WeatherDisplayTests: XCTestCase {
+@Suite(.serialized)
+final class WeatherDisplayTests {
 
     // MARK: - Fixtures
 
@@ -71,7 +71,7 @@ final class WeatherDisplayTests: XCTestCase {
     /// The Obaco API sometimes ships the previous full hour at index 0.
     /// `upcomingHourly` must drop it so the "Now" cell aligns with the actual
     /// current hour, not an hour ago.
-    func test_upcomingHourly_dropsHoursBeforeCurrentHourBucket() {
+    @Test func `Upcoming hourly drops hours before current hour bucket`() {
         let oneHourAgo = now.addingTimeInterval(-3600)
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let nextHour = currentHour.addingTimeInterval(3600)
@@ -86,7 +86,7 @@ final class WeatherDisplayTests: XCTestCase {
     }
 
     /// Even when the API ships 48 hours, the window is capped at 24.
-    func test_upcomingHourly_cappedAt24Entries() {
+    @Test func `Upcoming hourly capped at24 entries`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let hourly = makeHourly(epochs: (0..<48).map { currentHour.addingTimeInterval(Double($0) * 3600).timeIntervalSince1970 })
 
@@ -97,7 +97,7 @@ final class WeatherDisplayTests: XCTestCase {
 
     /// Even if the API delivers hourly entries out of chronological order, the
     /// window must still start at the current hour (sort before slicing).
-    func test_upcomingHourly_sortsOutOfOrderInput() {
+    @Test func `Upcoming hourly sorts out of order input`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let inOrder = (0..<3).map { currentHour.addingTimeInterval(Double($0) * 3600).timeIntervalSince1970 }
         let shuffled = [inOrder[2], inOrder[0], inOrder[1]]
@@ -111,7 +111,7 @@ final class WeatherDisplayTests: XCTestCase {
     }
 
     /// If every entry is in the past, none survive the filter.
-    func test_upcomingHourly_allPastEntriesReturnsEmpty() {
+    @Test func `Upcoming hourly all past entries returns empty`() {
         let past = (1...3).map { now.addingTimeInterval(-Double($0) * 3600).timeIntervalSince1970 }
         let hourly = makeHourly(epochs: past)
 
@@ -122,7 +122,7 @@ final class WeatherDisplayTests: XCTestCase {
 
     /// A glitch that ships the same hour twice would otherwise give `ForEach`
     /// duplicate `id`s and mark both cells `isNow`. The window de-dupes.
-    func test_upcomingHourly_dedupesRepeatedTimestamps() {
+    @Test func `Upcoming hourly dedupes repeated timestamps`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let nextHour = currentHour.addingTimeInterval(3600)
         let hourly = makeHourly(epochs: [currentHour.timeIntervalSince1970,
@@ -139,7 +139,7 @@ final class WeatherDisplayTests: XCTestCase {
 
     /// First entry of a pre-windowed slice should be labelled "Now" and
     /// flagged `isNow`.
-    func test_list_firstEntryIsNow() {
+    @Test func `List first entry is now`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let upcoming = makeHourly(epochs: (0..<3).map { currentHour.addingTimeInterval(Double($0) * 3600).timeIntervalSince1970 })
 
@@ -153,7 +153,7 @@ final class WeatherDisplayTests: XCTestCase {
     /// Identity is the hour timestamp, not the array index. This is what keeps
     /// `ForEach`/`LazyHStack` from reusing the same cell view for a different
     /// hour across refreshes.
-    func test_list_identityIsHourTimestamp() {
+    @Test func `List identity is hour timestamp`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let upcoming = makeHourly(epochs: (0..<3).map { currentHour.addingTimeInterval(Double($0) * 3600).timeIntervalSince1970 })
 
@@ -163,7 +163,7 @@ final class WeatherDisplayTests: XCTestCase {
         #expect(entries.map(\.id) == expectedIds)
     }
 
-    func test_list_emptyUpcomingReturnsEmpty() {
+    @Test func `List empty upcoming returns empty`() {
         let entries = HourlyEntry.list(from: [], locale: usLocale)
         #expect(entries.isEmpty)
     }
@@ -174,13 +174,13 @@ final class WeatherDisplayTests: XCTestCase {
     /// `day == night` never pinned an actual mapping — a regression that
     /// returned the unknown-key fallback for every key would still satisfy
     /// it. Lock down at least one concrete mapping.
-    func test_conditionText_mapsKnownIconKeys() {
+    @Test func `Condition text maps known icon keys`() {
         #expect(WeatherFormatter.conditionText(for: "snow") == "Snow")
         #expect(WeatherFormatter.conditionText(for: "clear-day") == "Clear")
         #expect(WeatherFormatter.conditionText(for: "rain") == "Rain")
     }
 
-    func test_isKnownIconKey_distinguishesMappedFromUnmapped() {
+    @Test func `Is known icon key distinguishes mapped from unmapped`() {
         #expect(WeatherFormatter.isKnownIconKey("clear-day") == true)
         #expect(WeatherFormatter.isKnownIconKey("partly-cloudy-night") == true)
         #expect(WeatherFormatter.isKnownIconKey("thunderstorm") == false)
@@ -191,7 +191,7 @@ final class WeatherDisplayTests: XCTestCase {
     /// key the formatter models, so adding a new condition to the metadata
     /// without a matching palette entry fails here instead of silently
     /// rendering as gray.
-    func test_weatherIconPalette_coversAllKnownIconKeys() {
+    @Test func `Weather icon palette covers all known icon keys`() {
         let paletteKeys = Set(WeatherIconPalette.colors.keys)
         let missing = WeatherFormatter.knownIconKeys.subtracting(paletteKeys)
         #expect(missing == [])
@@ -214,7 +214,7 @@ final class WeatherDisplayTests: XCTestCase {
     /// both consume the same Header/Stats/HourlyEntry slices. Pinning the
     /// derived strings from a fixture locks the contract so a formatter tweak
     /// that only updates one surface would fail here.
-    func test_init_populatesHeaderStatsAndHourlyFromFixture() throws {
+    @Test func `Init populates header stats and hourly from fixture`() throws {
         let forecast = try loadPugetSoundForecast()
         let display = WeatherDisplay(forecast: forecast, locale: usLocale, now: pugetSoundNow, calendar: utcCalendar)
 
@@ -237,7 +237,7 @@ final class WeatherDisplayTests: XCTestCase {
         // Hourly strip — non-empty, first cell labelled "Now" and flagged as
         // the current hour, later cells fall through to formatted times.
         #expect(!display.hourly.isEmpty)
-        let firstHour = try XCTUnwrap(display.hourly.first)
+        let firstHour = try #require(display.hourly.first)
         #expect(firstHour.timeLabel == "Now")
         #expect(firstHour.isNow == true)
         if display.hourly.count > 1 {
@@ -251,7 +251,7 @@ final class WeatherDisplayTests: XCTestCase {
     /// The Puget Sound fixture happens to have `precip_probability == 0`, so
     /// truncation never bites in the fixture test. Cover the typical case so
     /// a regression that flips truncation to rounding (or vice-versa) trips.
-    func test_stats_precipTextTruncatesToInteger() throws {
+    @Test func `Stats precip text truncates to integer`() throws {
         let json: [String: Any] = [
             "icon": "rain",
             "precip_per_hour": 1.2,
@@ -274,10 +274,10 @@ final class WeatherDisplayTests: XCTestCase {
     /// Header owns the `"H:%@  L:%@"` join (the only formatting it does on
     /// hi/lo). The fixture test only asserts non-nil, so an upstream tweak
     /// that swapped the order or dropped the prefix would slip through.
-    func test_header_highLowTextJoinsWithLocalisedFormat() throws {
+    @Test func `Header high low text joins with localised format`() throws {
         let forecast = try loadPugetSoundForecast()
         let display = WeatherDisplay(forecast: forecast, locale: usLocale, now: pugetSoundNow, calendar: utcCalendar)
-        let highLowText = try XCTUnwrap(display.header.highLowText)
+        let highLowText = try #require(display.header.highLowText)
 
         #expect(highLowText.hasPrefix("H:"))
         #expect(highLowText.contains("  L:"))

--- a/OBAKitTests/Weather/WeatherDisplayTests.swift
+++ b/OBAKitTests/Weather/WeatherDisplayTests.swift
@@ -86,7 +86,7 @@ final class WeatherDisplayTests {
     }
 
     /// Even when the API ships 48 hours, the window is capped at 24.
-    @Test func `Upcoming hourly capped at24 entries`() {
+    @Test func `Upcoming hourly capped at 24 entries`() {
         let currentHour = utcCalendar.dateInterval(of: .hour, for: now)!.start
         let hourly = makeHourly(epochs: (0..<48).map { currentHour.addingTimeInterval(Double($0) * 3600).timeIntervalSince1970 })
 

--- a/OBAKitTests/Weather/WeatherFormatterTests.swift
+++ b/OBAKitTests/Weather/WeatherFormatterTests.swift
@@ -131,7 +131,7 @@ final class WeatherFormatterTests {
     /// the cap test belongs there. This test pins the cap end-to-end: feed
     /// 25 raw entries with an outlier 25th, send them through `upcomingHourly`
     /// → `highLow`, and confirm the outlier is dropped.
-    @Test func `High low through upcoming hourly capped at24 entries`() {
+    @Test func `High low through upcoming hourly capped at 24 entries`() {
         // Anchor "now" at epoch 0 (UTC) so the upcomingHourly past-hour filter
         // sees the synthesised entries as upcoming.
         let now = Date(timeIntervalSince1970: 0)

--- a/OBAKitTests/Weather/WeatherFormatterTests.swift
+++ b/OBAKitTests/Weather/WeatherFormatterTests.swift
@@ -7,18 +7,19 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import OBAKitCore
 
 /// Tests for `WeatherFormatter`: pure-function helpers feeding both the UIKit
 /// weather button and the SwiftUI weather card.
 @MainActor
-final class WeatherFormatterTests: XCTestCase {
+@Suite(.serialized)
+final class WeatherFormatterTests {
 
     // MARK: - systemImageName
 
-    func test_systemImageName_knownKeys() {
+    @Test func `System image name known keys`() {
         let cases: [(key: String, symbol: String)] = [
             ("clear-day", "sun.max.fill"),
             ("clear-night", "moon.stars.fill"),
@@ -36,19 +37,19 @@ final class WeatherFormatterTests: XCTestCase {
         }
     }
 
-    func test_systemImageName_unknownKeyFallsBackToCloud() {
+    @Test func `System image name unknown key falls back to cloud`() {
         #expect(WeatherFormatter.systemImageName(for: "tornado") == "cloud.fill")
         #expect(WeatherFormatter.systemImageName(for: "") == "cloud.fill")
     }
 
     // MARK: - conditionText
 
-    func test_conditionText_groupsDayAndNightVariants() {
+    @Test func `Condition text groups day and night variants`() {
         #expect(WeatherFormatter.conditionText(for: "clear-day") == WeatherFormatter.conditionText(for: "clear-night"))
         #expect(WeatherFormatter.conditionText(for: "partly-cloudy-day") == WeatherFormatter.conditionText(for: "partly-cloudy-night"))
     }
 
-    func test_conditionText_unknownKeyReturnsPlaceholder() {
+    @Test func `Condition text unknown key returns placeholder`() {
         #expect(WeatherFormatter.conditionText(for: "tornado") == "—")
     }
 
@@ -58,7 +59,7 @@ final class WeatherFormatterTests: XCTestCase {
     /// warning gate accepts must also produce a real condition string, not
     /// the "—" fallback. If a future key is added to the metadata table
     /// without a matching `ConditionKey` case, this fails.
-    func test_isKnownIconKey_impliesConditionText() {
+    @Test func `Is known icon key implies condition text`() {
         let placeholder = OBALoc(
             "weather.condition.unknown",
             value: "—",
@@ -72,12 +73,12 @@ final class WeatherFormatterTests: XCTestCase {
 
     // MARK: - formatTemp (locale-dependent)
 
-    func test_formatTemp_usLocaleKeepsFahrenheit() {
+    @Test func `Format temp us locale keeps fahrenheit`() {
         let result = WeatherFormatter.formatTemp(50, locale: Locale(identifier: "en_US"))
         #expect(result.contains("50"))
     }
 
-    func test_formatTemp_metricLocaleConvertsToCelsius() {
+    @Test func `Format temp metric locale converts to celsius`() {
         // 50°F == 10°C
         let result = WeatherFormatter.formatTemp(50, locale: Locale(identifier: "fr_FR"))
         #expect(result.contains("10"))
@@ -85,24 +86,24 @@ final class WeatherFormatterTests: XCTestCase {
 
     // MARK: - formatWindSpeed
 
-    func test_formatWindSpeed_usLocaleUsesMph() {
+    @Test func `Format wind speed us locale uses mph`() {
         let result = WeatherFormatter.formatWindSpeed(16.0934, locale: Locale(identifier: "en_US"))
         #expect(result == "10 mph")
     }
 
-    func test_formatWindSpeed_ukLocaleUsesMph() {
+    @Test func `Format wind speed uk locale uses mph`() {
         let result = WeatherFormatter.formatWindSpeed(16.0934, locale: Locale(identifier: "en_GB"))
         #expect(result == "10 mph")
     }
 
-    func test_formatWindSpeed_metricLocaleUsesKmh() {
+    @Test func `Format wind speed metric locale uses kmh`() {
         let result = WeatherFormatter.formatWindSpeed(10, locale: Locale(identifier: "fr_FR"))
         #expect(result == "10 km/h")
     }
 
     // MARK: - formatTime
 
-    func test_formatTime_usLocaleHasAmPmMarker() {
+    @Test func `Format time us locale has am pm marker`() {
         // Don't pin to a specific hour — the formatter renders in the host
         // timezone, which varies across CI runners. The contract for en_US is
         // "12-hour clock with an AM/PM marker", which we can check regardless
@@ -112,7 +113,7 @@ final class WeatherFormatterTests: XCTestCase {
         #expect((result.contains("AM") || result.contains("PM")) == true)
     }
 
-    func test_formatTime_24HourLocaleHasNoAmPm() {
+    @Test func `Format time 24 hour locale has no am pm`() {
         let date = Date(timeIntervalSince1970: 1782525600)
         let result = WeatherFormatter.formatTime(date, locale: Locale(identifier: "fr_FR")).uppercased()
         #expect(!result.contains("AM"))
@@ -121,7 +122,7 @@ final class WeatherFormatterTests: XCTestCase {
 
     // MARK: - highLow
 
-    func test_highLow_returnsNilForEmptyForecasts() {
+    @Test func `High low returns nil for empty forecasts`() {
         #expect(WeatherFormatter.highLow(from: [], locale: Locale(identifier: "en_US")) == nil)
     }
 
@@ -130,7 +131,7 @@ final class WeatherFormatterTests: XCTestCase {
     /// the cap test belongs there. This test pins the cap end-to-end: feed
     /// 25 raw entries with an outlier 25th, send them through `upcomingHourly`
     /// → `highLow`, and confirm the outlier is dropped.
-    func test_highLow_throughUpcomingHourly_cappedAt24Entries() {
+    @Test func `High low through upcoming hourly capped at24 entries`() {
         // Anchor "now" at epoch 0 (UTC) so the upcomingHourly past-hour filter
         // sees the synthesised entries as upcoming.
         let now = Date(timeIntervalSince1970: 0)

--- a/OBAKitTests/Weather/WeatherFormatterTests.swift
+++ b/OBAKitTests/Weather/WeatherFormatterTests.swift
@@ -104,8 +104,9 @@ final class WeatherFormatterTests {
     // MARK: - formatTime
 
     @Test func `Format time us locale has am pm marker`() {
-        // Don't pin to a specific hour — the formatter renders in the host
-        // timezone, which varies across CI runners. The contract for en_US is
+        // Don't pin to a specific hour — the formatter renders in whatever
+        // `NSTimeZone.default` is, which OBATestCase pins to GMT for the bundle
+        // but this suite does not inherit. The contract for en_US is
         // "12-hour clock with an AM/PM marker", which we can check regardless
         // of which hour the date lands on.
         let date = Date(timeIntervalSince1970: 1782525600)

--- a/OBAKitTests/project.yml
+++ b/OBAKitTests/project.yml
@@ -11,10 +11,13 @@ targets:
     # It used to pin SWIFT_VERSION to 5.0, because Swift 6 mode rejects a
     # @MainActor XCTestCase subclass: XCTestCase's designated initializers are
     # nonisolated, and the synthesized override of init(invocation:) then has
-    # mismatched isolation. There was no source-level fix — NSInvocation is
-    # unavailable in Swift, so the override cannot be written by hand. The
-    # suites are Swift Testing now, which has no such initializer to inherit,
-    # so the pin is gone. See docs/swift6-migration-plan.md, "Phase 4".
+    # mismatched isolation. There is no way to keep such a class @MainActor —
+    # init(invocation:) takes NSInvocation, which is unavailable in Swift, so
+    # the override cannot be written by hand. (A class that does not need main
+    # actor isolation can opt out with `nonisolated`; PolylinePerformanceTests
+    # does exactly that. Test suites did need it.) The suites are Swift Testing
+    # now, which has no such initializer to inherit, so the pin is gone.
+    # See docs/swift6-migration-plan.md, "Phase 4".
     dependencies:
       - target: App
     info:

--- a/OBAKitTests/project.yml
+++ b/OBAKitTests/project.yml
@@ -3,22 +3,18 @@ targets:
     type: bundle.unit-test
     platform: iOS
     sources: ["."]
-    settings:
-      base:
-        # Swift 6 migration Phase 4: pinned to the Swift 5 language mode
-        # because Xcode 27 beta 3's XCTest rejects @MainActor test classes in
-        # Swift 6 mode — full analysis in docs/swift6-migration-plan.md,
-        # "Phase 4 status". All three settings below are part of the same
-        # freeze (the measured, ratcheted status quo); when the flip succeeds
-        # on a future Xcode, remove all three together.
-        SWIFT_VERSION: "5.0"
-        SWIFT_DEFAULT_ACTOR_ISOLATION: nonisolated
-        SWIFT_APPROACHABLE_CONCURRENCY: NO
-        # No SWIFT_WARNINGS_AS_ERRORS_GROUPS override here: this target reached
-        # zero concurrency warnings on 2026-07-28, so it now inherits the
-        # project-wide escalation from Apps/Shared/app_shared.yml and is locked
-        # against regressions like every other target. The Swift 5 pin above is
-        # unrelated and still required (see the XCTest note).
+    # No settings overrides: this target inherits the Swift 6 language mode,
+    # main-actor default isolation, approachable concurrency, and the
+    # concurrency-groups-as-errors lock from Apps/Shared/app_shared.yml, like
+    # every other target.
+    #
+    # It used to pin SWIFT_VERSION to 5.0, because Swift 6 mode rejects a
+    # @MainActor XCTestCase subclass: XCTestCase's designated initializers are
+    # nonisolated, and the synthesized override of init(invocation:) then has
+    # mismatched isolation. There was no source-level fix — NSInvocation is
+    # unavailable in Swift, so the override cannot be written by hand. The
+    # suites are Swift Testing now, which has no such initializer to inherit,
+    # so the pin is gone. See docs/swift6-migration-plan.md, "Phase 4".
     dependencies:
       - target: App
     info:

--- a/docs/swift6-migration-plan.md
+++ b/docs/swift6-migration-plan.md
@@ -338,6 +338,52 @@ alongside each phase (the ratchet counts tests too, via
 tooling can piggyback Swift Testing migration on files that get touched
 anyway, but don't couple the two efforts.
 
+### Phase 4 is done: the tests are Swift Testing, and the target is Swift 6 (2026-07-28)
+
+The blocker below was real and outlived Xcode 27 beta 4 — re-measured, it
+reproduced exactly. It was never going to be fixed by waiting, because it is a
+property of `XCTestCase`, not a beta-toolchain bug. **Migrating the suite to
+Swift Testing removed the inherited initializers the diagnostic was about**, and
+`OBAKitTests/project.yml` now carries no settings overrides at all: the target
+inherits Swift 6, main-actor default isolation, approachable concurrency, and
+the concurrency-groups-as-errors lock from `Apps/Shared/app_shared.yml` like
+every other target.
+
+The suite went from 1,517 XCTest tests + 11 Swift Testing tests to 1,527 Swift
+Testing tests + 1 XCTest test — 1,528 either way, which is how we know nothing
+was silently dropped. That check matters more than it sounds: Swift Testing
+discovers tests from runtime metadata, so a suite that fails to register does
+not fail, it simply disappears.
+
+Notes worth keeping:
+
+- **A suite may inherit from a plain base class.** `OBATestCase` stopped being
+  an `XCTestCase` and became an ordinary `@MainActor` class; its 109 subclasses
+  kept their declaration lines, and Swift Testing instantiates the subclass per
+  test function exactly as `setUp` used to. Verified by running it, not by
+  reading about it.
+- **One test could not move.** `measure` has no Swift Testing equivalent, so
+  `PolylinePerformanceTests` stays an `XCTestCase` — marked `nonisolated`,
+  which is load-bearing. Omitting `@MainActor` is *not* enough under
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`; the class has to opt out
+  explicitly or it re-creates the blocker single-handedly.
+- **`RunLoop.current.run(until:)` stops working inside a test.** Under XCTest it
+  drained the main queue, because the test method ran directly on the main
+  thread's run loop. A Swift Testing `@MainActor` test body is itself a
+  main-queue item, so blocking inside it cannot re-entrantly drain further
+  main-queue blocks. Suspend (`Task.sleep`) instead of blocking.
+- **The flip found two real data races the old settings hid.** The test target
+  used to build with `SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated` and no
+  approachable concurrency, so `MockDataLoader` matcher closures could touch
+  main-actor state unchecked. Under Swift 6 the runtime isolation assertion
+  fires and *kills the test process* — the suite crash-looped until
+  `DeleteRecorder` and `UnsafeTaskBox` in `LiveActivityRegistryTests` were made
+  `nonisolated`. `MockDataLoaderMatcher` is now `@Sendable` so the next one is a
+  build error rather than a crash; that change immediately surfaced five more
+  latent captures across the suite.
+
+The historical account of the blocker follows.
+
 ### Phase 4 status: blocked on the toolchain (2026-07-16)
 
 Every test class is `@MainActor` and the warning count is down to 39 (38 after
@@ -597,16 +643,19 @@ build failure, not a ratcheted warning (verified by reintroducing one).
 | 1 | OBAKitCore (+ approachable concurrency) | 119 → 0 | Core in Swift 6 mode | ✅ done |
 | 2 | OBAKit (+ MainActor default) | 467 → 0 | OBAKit in Swift 6 mode | ✅ done |
 | 3 | App, OBAWidget, KiedyBus | 14 → 0 | whole project `SWIFT_VERSION = 6.0` | ✅ done |
-| 4 | OBAKitTests | 0* | tests in Swift 6 mode | ⛔ blocked on Xcode 27 b3 XCTest (see Phase 4 status) |
+| 4 | OBAKitTests | 0* | tests in Swift 6 mode | ✅ done (2026-07-28, via the Swift Testing migration) |
+
+**The migration is complete: every target in the project builds in the Swift 6
+language mode.**
 
 *\* The test count spiked to 596 after Phase 1 (`OBATestCase` going
 `@MainActor` surfaced autoclosure warnings), then collapsed once every
 remaining plain-`XCTestCase` class was annotated `@MainActor`.
 Ratchet baseline: 999 → 733 (Phase 1) → 57 (Phase 2) → 39 (Phase 3) → 38 →
 8 (2026-07-28, Nimble → `#expect(throws:)`) → 5 (polling sites) → **0**
-(test-local fixtures; the target is now locked with the project-wide
-`SWIFT_WARNINGS_AS_ERRORS_GROUPS`, though the Swift 6 *language mode* flip is
-still blocked on XCTest).*
+(test-local fixtures). The target is locked with the project-wide
+`SWIFT_WARNINGS_AS_ERRORS_GROUPS`, and as of 2026-07-28 it also builds in the
+Swift 6 language mode — see "Phase 4 is done".*
 
 ### Phase 1 implementation notes (2026-07-16)
 

--- a/docs/swift6-migration-plan.md
+++ b/docs/swift6-migration-plan.md
@@ -378,7 +378,8 @@ Notes worth keeping:
   main-actor state unchecked. Under Swift 6 the runtime isolation assertion
   fires and *kills the test process* — the suite crash-looped until
   `DeleteRecorder` and `UnsafeTaskBox` in `LiveActivityRegistryTests` were made
-  `nonisolated`. `MockDataLoaderMatcher` is now `@Sendable` so the next one is a
+  `nonisolated` (`UnsafeTaskBox` has since been replaced by the shared
+  `SendableBox` helper). `MockDataLoaderMatcher` is now `@Sendable` so the next one is a
   build error rather than a crash; that change immediately surfaced five more
   latent captures across the suite.
 
@@ -574,17 +575,26 @@ reproduces on both iOS 18.5 and iOS 26.2 simulators, so it's codegen, not
 the runtime. Xcode 27 beta 3 (Swift 6.4) does not emit implicit isolated
 deinits and is unaffected — and as of 2026-07-25 CI builds with it too, on the
 `xcode-27` runner image (previously pinned to Xcode 26.6, the newest
-same-generation compiler on the GA images). Watch the 11 explicit
+same-generation compiler on the GA images). Watch the explicit
 `isolated deinit` sites on iOS 18 devices regardless: they use the
 back-deploy shim compiled by whatever Xcode builds the release.
 
-Consequence of the pin worth remembering: the test target compiles in the
-Swift 5 language mode, so it does not get *full* Swift 6 enforcement. It is no
-longer unguarded, though — as of 2026-07-28 it reached zero concurrency
-warnings and dropped its `SWIFT_WARNINGS_AS_ERRORS_GROUPS` opt-out, so the five
+**That count grew from 11 to 49 on 2026-07-28**, when the Swift Testing
+migration turned every test `tearDown` that touches main-actor state into an
+`isolated deinit`. It is deliberate, and it is worth being clear-eyed about:
+the bug described above is specific to Xcode 26.2's codegen for
+main-actor-default classes, and OBAKitTests is now exactly that configuration.
+It is not a new exposure in practice — the front matter already requires
+Xcode 26.4+/27, and CI runs 27 — but the blast radius if anyone builds this
+target with 26.2 is now four times what it was.
+
+The test target used to be pinned to the Swift 5 language mode, which meant it
+never got *full* Swift 6 enforcement. **That pin is gone as of 2026-07-28**
+(see "Phase 4 is done"): the target compiles in Swift 6 like every other, and
+had already dropped its `SWIFT_WARNINGS_AS_ERRORS_GROUPS` opt-out, so the five
 concurrency diagnostic groups are escalated to errors here exactly as they are
-on every other target. A regression in a test-only helper or mock is now a
-build failure, not a ratcheted warning (verified by reintroducing one).
+elsewhere. A regression in a test-only helper or mock is a build failure, not a
+ratcheted warning (verified by reintroducing one).
 
 ## Dependency notes
 


### PR DESCRIPTION
## Summary

- Migrates OBAKitTests from XCTest to Swift Testing — 172 suites, ~1,010 `XCTAssert*`/`XCTUnwrap` call sites, 64 `XCTFail`. `OBATestCase` stops being an `XCTestCase` and becomes a plain `@MainActor` base class, so its 109 subclasses keep their declaration lines and only their `setUp`/`tearDown` change shape.
- Flips the test target to the **Swift 6 language mode**. `OBAKitTests/project.yml` now has no settings block at all and inherits from `Apps/Shared/app_shared.yml` like every other target, which completes `docs/swift6-migration-plan.md`: **every target in the project is on Swift 6.**
- Fixes a CI regression the migration caused and a batch of documentation the migration outdated.

**Test count is unchanged: 1,517 XCTest + 11 Swift Testing before, 1,527 Swift Testing + 1 XCTest after.** That check is the point rather than a formality — Swift Testing discovers tests from runtime metadata, so a suite that fails to register disappears instead of failing.

## Why this was the way to unblock Swift 6

Swift 6 rejects a `@MainActor` XCTestCase subclass: `XCTestCase`'s designated initializers are nonisolated, so the synthesized override of `init(invocation:)` has mismatched isolation, and `NSInvocation` being unavailable in Swift means it can't be written by hand. I re-measured on Xcode 27 beta 4 before starting and it still reproduced — it's a property of `XCTestCase`, not a beta bug, so waiting for a newer Xcode was never going to clear it. Migrating removes the inherited initializers, and with them the diagnostic.

## Things worth a reviewer's attention

- **A Swift Testing suite can inherit a plain base class.** I verified this by *running* it before committing to the shape, not just compiling it. This is what made a 172-class migration tractable.
- **The flip found two real data races the old settings hid**, and they don't warn — the runtime isolation assertion kills the test process, so the suite crash-looped. `DeleteRecorder` and `UnsafeTaskBox` were lock-guarded and documented as thread-safe, but under main-actor-by-default their methods became main-actor, and `reconcile()` calls them from a detached task. `MockDataLoaderMatcher` is `@Sendable` now so the next one is a build error; that change alone surfaced five more latent captures.
- **`RunLoop.current.run(until:)` silently stops working inside a test.** Under XCTest it drained the main queue; a Swift Testing `@MainActor` test body is itself a main-queue item and can't re-entrantly drain. Six sheet-dismissal tests failed on completion handlers that never fired. It's `Task.sleep` now, which releases the main actor.
- **`PolylinePerformanceTests` stays on XCTest** because `measure` has no Swift Testing equivalent — marked `nonisolated`, which is load-bearing. Under a main-actor default, merely omitting `@MainActor` would re-create the blocker.
- **The CI "Report slowest tests" step was silently broken by this change.** It parsed the XCTest log format; measured against a real run, the old pattern matched 1 line of 1,528. It now parses both formats.

## Test plan

- [x] Full suite green under Swift 6: 1,527 Swift Testing + 1 XCTest, 173 suites, 0 failures, 0 crash-restarts, `xcodebuild` exit 0
- [x] **Suites can still fail** — deliberately broke one test in an inherited-base suite and one in a standalone suite; both reported with exact file:line and the failing expression. Reverted.
- [x] Concurrency ratchet re-measured cold via `scripts/measure_concurrency` (isolated DerivedData *and* compilation cache): still **0**
- [x] App builds, installs, launches and renders in the simulator — confirms the project regeneration didn't disturb the app target
- [x] SwiftLint clean
- [x] New CI timing parser validated against a real 1,528-test log (1,527 parsed vs 1 before)

## Review notes

Non-blocking, deliberately left alone:

- **`.serialized` is on all 171 suites**, including pure-value ones that don't need it. That was a deliberate call to preserve XCTest's ordering semantics while changing one variable at a time. Relaxing it where there's no shared state is a reasonable follow-up; note it only orders tests *within* a suite, so it isn't what makes cross-suite global state safe.
- **~300 `@Test @MainActor` annotations are now redundant** since the target defaults to main-actor. They're behaviour-neutral but they do drown out the 17 `nonisolated` annotations that carry real meaning. Left as a separate mechanical sweep.
- **`tearDown` → `deinit` is not an exact substitution.** `deinit` fires when the last reference drops, so cleanup can land later than `tearDown` did. Nothing in the suite depends on that ordering today; a `TestScoping` fixture trait would be the principled fix if it ever does.
- **The `measure` test asserts nothing** — there's no `.xcbaseline` in the repo, so it records a timing and can't fail. Worth deciding whether it earns the one remaining `import XCTest` and the `nonisolated` special case.
- **Duplication left in place**: the `queue`/`cancelAllOperations` fixture appears in ~25 suites and a scoped-defaults fixture in 5. Both would hoist cleanly onto `OBATestCase` but felt like scope creep at the end of an already-large migration.
- **Merge-conflict warning**: PR #1209 is open and rewrites `LocationServiceTests.swift` plus adds `LocationServiceMocks.swift` in XCTest style. Whichever lands second needs re-migrating.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-ios/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787900832&installation_model_id=429412&pr_number=1240&repository=OneBusAway%2Fonebusaway-ios&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-ios%2Fpull%2F1240&signature=e69160781dbb0bcd8efddf900436b7caf0bfc31e7a0f71c37bb361610bd9d303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->