### PR TITLE
fix: stabilize survey checkbox JSON and lock fresh-path hero filter

### DIFF
--- a/OBAKit/Surveys/SurveyViewController.swift
+++ b/OBAKit/Surveys/SurveyViewController.swift
@@ -88,7 +88,10 @@ class SurveyViewController: FormViewController {
     /// submit is in flight, so a second tap can't silently be dropped by the VM's in-flight
     /// guard. Cancel button is intentionally left enabled — letting the user back out of a
     /// hung submit matches the rest of the app's modal sheets.
-    private func updateSubmitRow(isSubmitting: Bool) {
+    ///
+    /// Internal (not `private`) so `SurveyViewControllerTests` can drive the Eureka
+    /// affordance directly without standing up a live submit (#1169).
+    func updateSubmitRow(isSubmitting: Bool) {
         guard let row = form.rowBy(tag: "submit") as? ButtonRow else { return }
         row.disabled = Condition(booleanLiteral: isSubmitting)
         row.evaluateDisabled()

--- a/OBAKit/ViewModels/SurveyViewModel.swift
+++ b/OBAKit/ViewModels/SurveyViewModel.swift
@@ -112,10 +112,19 @@ final class SurveyViewModel: ObservableObject {
             checkboxSelections[question.id, default: []].remove(option)
         }
 
-        let selections = Array(checkboxSelections[question.id, default: []])
+        // Sort so identical selections always encode the same JSON (#1169).
+        let selections = checkboxSelections[question.id, default: []].sorted()
         // swiftlint:disable:next force_try
         let jsonAnswer = try! SurveyService.formatCheckboxAnswer(selections)
         updateAnswer(for: question, answer: jsonAnswer)
+    }
+
+    /// The currently stored answer string for `question`, if any.
+    ///
+    /// Exposed for unit tests that need to assert encoding (e.g. checkbox
+    /// JSON order) without going through a submit round-trip.
+    func storedAnswer(for question: SurveyQuestion) -> String? {
+        responses.first { $0.questionId == question.id }?.answer
     }
 
     /// User cancelled — reschedule the survey for later.

--- a/OBAKitTests/Surveys/SurveyViewControllerTests.swift
+++ b/OBAKitTests/Surveys/SurveyViewControllerTests.swift
@@ -1,0 +1,87 @@
+//
+//  SurveyViewControllerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Eureka
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Covers the Eureka submit-row affordance driven by `$isSubmitting` (#1169 item 3):
+/// disable + "Submitting…" title while in flight, restore on idle, Cancel stays enabled.
+@Suite(.serialized)
+@MainActor
+final class SurveyViewControllerTests: OBATestCase {
+
+    private var surveyService: SurveyService!
+    private var dataStore: UserDefaultsStore!
+
+    override init() async throws {
+        try await super.init()
+        dataStore = UserDefaultsStore(userDefaults: userDefaults)
+        surveyService = SurveyService(apiService: nil, userDataStore: dataStore)
+    }
+
+    private func makeLoadedController() -> SurveyViewController {
+        let survey = SurveysTestHelpers.makeSurvey(
+            questions: [SurveysTestHelpers.makeSurveyQuestion(id: 1, type: .text)]
+        )
+        let controller = SurveyViewController(
+            viewModel: SurveyViewModel(survey: survey, surveyService: surveyService)
+        )
+        controller.loadViewIfNeeded()
+        return controller
+    }
+
+    private func submitRow(_ controller: SurveyViewController) throws -> ButtonRow {
+        try #require(controller.form.rowBy(tag: "submit") as? ButtonRow)
+    }
+
+    // Titles use the English `value:` fallbacks from SurveyViewController — OBALoc is
+    // defined in both OBAKit and OBAKitCore, so calling it from a dual-import test
+    // target is ambiguous under `@testable`.
+    private let submitTitle = "Submit Survey"
+    private let submittingTitle = "Submitting…"
+
+    /// After load, the sink fires with `isSubmitting == false`: idle title, enabled submit,
+    /// Cancel (nav close) still enabled.
+    @Test func `Submit row starts idle with Cancel enabled`() throws {
+        let controller = makeLoadedController()
+        let row = try submitRow(controller)
+
+        #expect(row.title == submitTitle)
+        #expect(!row.isDisabled)
+        #expect(controller.navigationItem.leftBarButtonItem?.isEnabled == true)
+    }
+
+    /// In-flight: submit disables and swaps to "Submitting…"; Cancel must stay tappable so
+    /// a hung submit can still be dismissed (matches modal-sheet convention in the comment).
+    @Test func `Update submit row disables and retitles while submitting`() throws {
+        let controller = makeLoadedController()
+        controller.updateSubmitRow(isSubmitting: true)
+
+        let row = try submitRow(controller)
+        #expect(row.title == submittingTitle)
+        #expect(row.isDisabled)
+        #expect(controller.navigationItem.leftBarButtonItem?.isEnabled == true)
+    }
+
+    /// Leaving the in-flight state restores the idle title and re-enables submit without
+    /// touching Cancel.
+    @Test func `Update submit row restores idle state after submitting`() throws {
+        let controller = makeLoadedController()
+        controller.updateSubmitRow(isSubmitting: true)
+        controller.updateSubmitRow(isSubmitting: false)
+
+        let row = try submitRow(controller)
+        #expect(row.title == submitTitle)
+        #expect(!row.isDisabled)
+        #expect(controller.navigationItem.leftBarButtonItem?.isEnabled == true)
+    }
+}

--- a/OBAKitTests/ViewModels/SurveyViewModelTests.swift
+++ b/OBAKitTests/ViewModels/SurveyViewModelTests.swift
@@ -203,6 +203,23 @@ final class SurveyViewModelTests: OBATestCase {
         _ = vm
     }
 
+    /// Checkbox answers must encode in sorted order so logically identical
+    /// selections produce a stable JSON payload (#1169).
+    @Test @MainActor
+    func `Toggle checkbox encodes selections in sorted order`() throws {
+        let q = Self.makeQuestion(id: 9, type: .checkbox, options: ["a", "b", "c"])
+        let vm = makeViewModel(questions: [q])
+
+        // Select out of order — without `.sorted()` the JSON order follows Set
+        // iteration and is not stable across runs / platforms.
+        vm.toggleCheckbox(option: "c", selected: true, for: q)
+        vm.toggleCheckbox(option: "a", selected: true, for: q)
+        vm.toggleCheckbox(option: "b", selected: true, for: q)
+
+        let expected = try SurveyService.formatCheckboxAnswer(["a", "b", "c"])
+        #expect(vm.storedAnswer(for: q) == expected)
+    }
+
     // MARK: - submit validation
 
     /// `submit()` with no responses on a survey with required questions emits `.validationFailed`.
@@ -647,6 +664,40 @@ final class SurveyViewModelTests: OBATestCase {
         #expect(counter.puts == 1)
 
         // PUT body is `{"responses": "<stringified JSON array>"}`. Decode both layers.
+        let body = try #require(counter.lastPutBody)
+        let outer = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let inner = try #require(outer["responses"] as? String)
+        let innerData = try #require(inner.data(using: .utf8))
+        let responses = try #require(try JSONSerialization.jsonObject(with: innerData) as? [[String: Any]])
+        let questionIDs = responses.compactMap { $0["question_id"] as? Int }
+        #expect(!questionIDs.contains(hero.id))
+        #expect(questionIDs == [follow.id])
+    }
+
+    /// Fresh path with hero + follow-up: the PUT for additional questions must
+    /// exclude the hero answer — wire-level parity with the retry-path filter
+    /// test (#1169).
+    @Test @MainActor
+    func `Submit fresh path filters hero from additional responses`() async throws {
+        let counter = HitCounter()
+        let liveService = buildLiveSurveyService(counter: counter)
+        let hero = Self.makeQuestion(id: 1, position: 1, type: .text)
+        let follow = Self.makeQuestion(id: 2, position: 2, type: .text)
+        let vm = SurveyViewModel(
+            survey: Self.makeSurvey(questions: [hero, follow]),
+            surveyService: liveService
+        )
+        vm.updateAnswer(for: hero, answer: "yes")
+        vm.updateAnswer(for: follow, answer: "additional")
+
+        let result = await firstSubmissionResult(vm: vm)
+
+        guard case .success = result else {
+            Issue.record("Expected .success; got \(result)"); return
+        }
+        #expect(counter.posts == 1)
+        #expect(counter.puts == 1)
+
         let body = try #require(counter.lastPutBody)
         let outer = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
         let inner = try #require(outer["responses"] as? String)


### PR DESCRIPTION
## Summary
- Sort checkbox selections before `formatCheckboxAnswer` so logically identical answers encode to stable JSON (no Set-iteration order noise).
- Add a wire-level assertion that the fresh hero+follow-up submit path excludes the hero `question_id` from the additional PUT body — parity with the existing retry-path test.
- Expose a small `storedAnswer(for:)` seam so the checkbox ordering test can inspect encoding without a submit round-trip.
- Cover Eureka `updateSubmitRow`: in-flight disables submit + "Submitting…" title; idle restores; Cancel (nav close) stays enabled.

Closes #1169

### Out of scope
Issue item 4 deferred:
- `RoutePickerViewModel.loadState` / typed `surveySubmissionError` redesign — future SwiftUI consumer work.

## Test plan
- [x] `xcodebuild build-for-testing -scheme App` (iOS Simulator)
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/SurveyViewModelTests` — **29 tests, 0 failures**
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/SurveyViewControllerTests` — **3 tests, 0 failures**
- [ ] CI `OBAKitTests` green on this PR