### PR TITLE
fix: switch Dynamic Island to the newest tracked trip

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -238,13 +238,28 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
         }
 
         let attributes = TripAttributes(staticData: staticData)
+        // Prominence so the Dynamic Island switches to this Track when another
+        // trip is already live (#1189 Problem 2). Default score is 0 and equal
+        // scores keep the first-started activity.
+        let prominence = TripLiveActivityRelevance.prominenceScore()
         do {
             let activity = try Activity.request(
                 attributes: attributes,
-                content: .init(state: contentState, staleDate: nil),
+                content: TripLiveActivityRelevance.content(
+                    state: contentState,
+                    staleDate: nil,
+                    relevanceScore: prominence
+                ),
                 pushType: .token
             )
             trackLiveActivity(activity, arrivalDepartures: arrivalDepartures)
+            let activityID = activity.id
+            Task {
+                await Activity<TripAttributes>.demoteLivePeers(
+                    exceptActivityID: activityID,
+                    relativeTo: prominence
+                )
+            }
             Logger.info("Started Live Activity with ID: \(activity.id)")
             showLiveActivityStartedToast()
         } catch {
@@ -298,6 +313,10 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 // `update`. Re-fetch by ID inside a detached task instead — that copy
                 // never crosses an isolation boundary.
                 let activityID = activity.id
+                // Preserve prominence — rebuilding with the default score of 0
+                // would hand the Dynamic Island back to the first-started trip
+                // after every arrivals refresh (#1189 Problem 2).
+                let relevanceScore = activity.content.relevanceScore
                 Task.detached {
                     guard let activity = Activity<TripAttributes>.activities.first(where: { $0.id == activityID }) else {
                         // The activity ended between the loop and this task; dropping
@@ -307,7 +326,11 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                         return
                     }
                     await activity.update(
-                        .init(state: contentState, staleDate: nil)
+                        TripLiveActivityRelevance.content(
+                            state: contentState,
+                            staleDate: nil,
+                            relevanceScore: relevanceScore
+                        )
                     )
                     Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")
                 }

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -221,9 +221,15 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
         // Tapping Track again on a bookmark that is already tracked — or tracking
         // the same trip from the stop page — would otherwise mint a second
         // activity for one stop, leaving the user with duplicate Lock Screen
-        // cards and duplicate OBACloud push registrations.
-        if Activity<TripAttributes>.running(matching: staticData) != nil {
-            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); not starting a duplicate.")
+        // cards and duplicate OBACloud push registrations. Re-Track still needs
+        // to promote the existing activity: after A→B the Island is on B with A
+        // demoted to 0, so tapping Track on A again must bump A (not just toast).
+        if let existing = Activity<TripAttributes>.running(matching: staticData) {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
+            let existingID = existing.id
+            Task {
+                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
+            }
             showLiveActivityStartedToast()
             return
         }
@@ -313,10 +319,10 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 // `update`. Re-fetch by ID inside a detached task instead — that copy
                 // never crosses an isolation boundary.
                 let activityID = activity.id
-                // Preserve prominence — rebuilding with the default score of 0
-                // would hand the Dynamic Island back to the first-started trip
-                // after every arrivals refresh (#1189 Problem 2).
-                let relevanceScore = activity.content.relevanceScore
+                // Preserve prominence via the shared helper — rebuilding with the
+                // default score of 0 would hand the Island back to the first-
+                // started trip after every arrivals refresh (#1189 Problem 2).
+                let existingContent = activity.content
                 Task.detached {
                     guard let activity = Activity<TripAttributes>.activities.first(where: { $0.id == activityID }) else {
                         // The activity ended between the loop and this task; dropping
@@ -326,10 +332,10 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                         return
                     }
                     await activity.update(
-                        TripLiveActivityRelevance.content(
+                        TripLiveActivityRelevance.contentPreservingRelevance(
                             state: contentState,
                             staleDate: nil,
-                            relevanceScore: relevanceScore
+                            existing: existingContent
                         )
                     )
                     Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -472,13 +472,28 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         }
 
         let attributes = TripAttributes(staticData: staticData)
+        // Prominence so the Dynamic Island switches to this Track when another
+        // trip is already live (#1189 Problem 2). Default score is 0 and equal
+        // scores keep the first-started activity.
+        let prominence = TripLiveActivityRelevance.prominenceScore()
         do {
             let activity = try Activity.request(
                 attributes: attributes,
-                content: .init(state: contentState, staleDate: nil),
+                content: TripLiveActivityRelevance.content(
+                    state: contentState,
+                    staleDate: nil,
+                    relevanceScore: prominence
+                ),
                 pushType: .token
             )
             application.liveActivityTracker.track(activity: activity, metadata: .init(departure))
+            let activityID = activity.id
+            Task {
+                await Activity<TripAttributes>.demoteLivePeers(
+                    exceptActivityID: activityID,
+                    relativeTo: prominence
+                )
+            }
             Logger.info("Started Live Activity with ID: \(activity.id)")
             viewModel.signalLiveActivityStarted()
         } catch {

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -458,9 +458,15 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
 
         // The same trip can be started from here and from the bookmarks list, so
         // this guard has to live on both start paths — otherwise one stop ends up
-        // with two Lock Screen cards and two OBACloud push registrations.
-        if Activity<TripAttributes>.running(matching: staticData) != nil {
-            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); not starting a duplicate.")
+        // with two Lock Screen cards and two OBACloud push registrations. Re-Track
+        // still needs to promote the existing activity: after A→B the Island is
+        // on B with A demoted to 0, so tapping Track on A again must bump A.
+        if let existing = Activity<TripAttributes>.running(matching: staticData) {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
+            let existingID = existing.id
+            Task {
+                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
+            }
             // Re-show the confirmation rather than appearing to do nothing.
             viewModel.signalLiveActivityStarted()
             return

--- a/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
+++ b/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
@@ -1,0 +1,78 @@
+//
+//  TripLiveActivityRelevance.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import ActivityKit
+import Foundation
+
+/// Dynamic Island / Lock Screen ordering for trip Live Activities (#1189 Problem 2).
+///
+/// ActivityKit shows the Live Activity with the highest `relevanceScore` in the
+/// Dynamic Island. When scores are equal (or unset — default `0`), it keeps the
+/// first activity that was started. Both start paths previously built
+/// `ActivityContent` without a score, so tracking bookmark B after A left the
+/// Island on A.
+///
+/// Scores are relative. A newly user-started activity gets a monotonic
+/// prominence score; peers are demoted to ``demotedScore``. Local content
+/// refreshes must pass the activity's existing score through
+/// ``content(state:staleDate:relevanceScore:)`` — rebuilding with the default
+/// of `0` undoes prominence after the next arrivals poll.
+public enum TripLiveActivityRelevance {
+
+    /// Score assigned to activities that should yield the Dynamic Island.
+    public static let demotedScore: Double = 0
+
+    /// Monotonic score for a trip the rider just chose to Track.
+    public static func prominenceScore(now: Date = Date()) -> Double {
+        now.timeIntervalSince1970
+    }
+
+    public static func content(
+        state: TripAttributes.ContentState,
+        staleDate: Date? = nil,
+        relevanceScore: Double
+    ) -> ActivityContent<TripAttributes.ContentState> {
+        ActivityContent(state: state, staleDate: staleDate, relevanceScore: relevanceScore)
+    }
+}
+
+extension Activity where Attributes == TripAttributes {
+
+    /// Lowers every *other* live trip's `relevanceScore` so `exceptActivityID`
+    /// (the activity just started) keeps the Dynamic Island (#1189 Problem 2).
+    ///
+    /// No-ops for the excluded id and for dismissed/ended activities that
+    /// ActivityKit still lists in `activities`.
+    ///
+    /// - Parameter prominence: The score assigned to the newly started activity.
+    ///   Peers are demoted strictly below it (`demotedScore`, which must remain
+    ///   lower than any prominence this app issues).
+    public static func demoteLivePeers(
+        exceptActivityID: String,
+        relativeTo prominence: Double
+    ) async {
+        let demoted = TripLiveActivityRelevance.demotedScore
+        assert(
+            demoted < prominence,
+            "demotedScore must stay below prominence so the new Track wins the Island"
+        )
+
+        for activity in activities {
+            guard activity.id != exceptActivityID else { continue }
+            guard LiveActivityRegistry.isLive(activity.activityState) else { continue }
+
+            let content = TripLiveActivityRelevance.content(
+                state: activity.content.state,
+                staleDate: activity.content.staleDate,
+                relevanceScore: demoted
+            )
+            await activity.update(content)
+        }
+    }
+}

--- a/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
+++ b/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
@@ -18,11 +18,10 @@ import Foundation
 /// `ActivityContent` without a score, so tracking bookmark B after A left the
 /// Island on A.
 ///
-/// Scores are relative. A newly user-started activity gets a monotonic
-/// prominence score; peers are demoted to ``demotedScore``. Local content
-/// refreshes must pass the activity's existing score through
-/// ``content(state:staleDate:relevanceScore:)`` — rebuilding with the default
-/// of `0` undoes prominence after the next arrivals poll.
+/// Scores are relative. A newly user-started (or re-tracked) activity gets a
+/// monotonic prominence score; peers are demoted to ``demotedScore``. Local
+/// content refreshes must go through ``contentPreservingRelevance`` — rebuilding
+/// with the default of `0` undoes prominence after the next arrivals poll.
 public enum TripLiveActivityRelevance {
 
     /// Score assigned to activities that should yield the Dynamic Island.
@@ -40,19 +39,54 @@ public enum TripLiveActivityRelevance {
     ) -> ActivityContent<TripAttributes.ContentState> {
         ActivityContent(state: state, staleDate: staleDate, relevanceScore: relevanceScore)
     }
+
+    /// Rebuilds content for a local arrivals refresh while keeping the activity's
+    /// current Dynamic Island ranking. Passing anything other than
+    /// `existing.relevanceScore` here is how the Island used to snap back to the
+    /// first-started trip after every poll.
+    public static func contentPreservingRelevance(
+        state: TripAttributes.ContentState,
+        staleDate: Date? = nil,
+        existing: ActivityContent<TripAttributes.ContentState>
+    ) -> ActivityContent<TripAttributes.ContentState> {
+        content(state: state, staleDate: staleDate, relevanceScore: existing.relevanceScore)
+    }
 }
 
 extension Activity where Attributes == TripAttributes {
 
+    /// Bumps the live activity identified by `activityID` to a fresh prominence
+    /// score and demotes every other live peer so the Dynamic Island follows a
+    /// re-Track of an already-running trip (#1189 Problem 2 review).
+    ///
+    /// Takes an id (not `Activity`) so callers can hop into a `Task` without
+    /// sending a non-`Sendable` ActivityKit value across isolation.
+    public static func promoteToDynamicIsland(activityID: String) async {
+        guard let activity = activities.first(where: { $0.id == activityID }),
+              LiveActivityRegistry.isLive(activity.activityState) else {
+            return
+        }
+        let prominence = TripLiveActivityRelevance.prominenceScore()
+        await activity.update(
+            TripLiveActivityRelevance.content(
+                state: activity.content.state,
+                staleDate: nil,
+                relevanceScore: prominence
+            )
+        )
+        await demoteLivePeers(exceptActivityID: activityID, relativeTo: prominence)
+    }
+
     /// Lowers every *other* live trip's `relevanceScore` so `exceptActivityID`
-    /// (the activity just started) keeps the Dynamic Island (#1189 Problem 2).
+    /// (the activity just started or promoted) keeps the Dynamic Island
+    /// (#1189 Problem 2).
     ///
     /// No-ops for the excluded id and for dismissed/ended activities that
     /// ActivityKit still lists in `activities`.
     ///
-    /// - Parameter prominence: The score assigned to the newly started activity.
-    ///   Peers are demoted strictly below it (`demotedScore`, which must remain
-    ///   lower than any prominence this app issues).
+    /// - Parameter prominence: The score assigned to the newly started / promoted
+    ///   activity. Peers are demoted strictly below it (`demotedScore`, which must
+    ///   remain lower than any prominence this app issues).
     public static func demoteLivePeers(
         exceptActivityID: String,
         relativeTo prominence: Double

--- a/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
+++ b/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
@@ -50,16 +50,41 @@ final class TripLiveActivityRelevanceTests {
         #expect(content.staleDate == nil)
     }
 
-    /// Local refreshes must not wipe prominence — rebuilding with the default
-    /// score of 0 is what kept the first-started activity in the Dynamic Island
-    /// after a later Track (#1189 Problem 2).
-    @Test func `Preserved score helper keeps existing prominence on refresh`() {
-        let state = TripAttributes.ContentState(arrivals: [])
-        let refreshed = TripLiveActivityRelevance.content(
-            state: state,
+    /// Pins the refresh path used by `updateRunningLiveActivities`: the new
+    /// content state may change, but the score must come from the *existing*
+    /// content — not a literal, and not the ActivityContent default of `0`.
+    /// Building with a bare `.init(state:staleDate:)` would score `0` and fail
+    /// the second expectation, which is the regression this guards.
+    @Test func `Content preserving relevance keeps existing score across state refresh`() {
+        let previousState = TripAttributes.ContentState(arrivals: [])
+        let existing = TripLiveActivityRelevance.content(
+            state: previousState,
             staleDate: nil,
             relevanceScore: 1_700_000_050
         )
+        let refreshedState = TripAttributes.ContentState(arrivals: [
+            .init(
+                departureTime: 1_700_000_100,
+                scheduleStatus: .onTime,
+                scheduleDeviation: 0,
+                isArrival: false
+            )
+        ])
+
+        let refreshed = TripLiveActivityRelevance.contentPreservingRelevance(
+            state: refreshedState,
+            staleDate: nil,
+            existing: existing
+        )
+
+        #expect(refreshed.state == refreshedState)
+        #expect(refreshed.relevanceScore == existing.relevanceScore)
         #expect(refreshed.relevanceScore == 1_700_000_050)
+
+        // Contrast: the default ActivityContent score is 0. If the call site
+        // ever drops back to `.init(state:staleDate:)`, this is what Island gets.
+        let wiped = ActivityContent(state: refreshedState, staleDate: nil)
+        #expect(wiped.relevanceScore == 0)
+        #expect(wiped.relevanceScore != existing.relevanceScore)
     }
 }

--- a/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
+++ b/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
@@ -1,0 +1,65 @@
+//
+//  TripLiveActivityRelevanceTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import ActivityKit
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+/// Pins the Dynamic Island prominence policy for #1189 Problem 2.
+///
+/// ActivityKit itself isn't injectable, so these tests lock the score math and
+/// `ActivityContent` construction that the bookmark/stop start paths share —
+/// the same seam pattern as `TripAttributesIdentityTests` for Problem 1.
+@MainActor
+@Suite(.serialized)
+final class TripLiveActivityRelevanceTests {
+
+    @Test func `Prominence score is strictly above demoted score`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let prominence = TripLiveActivityRelevance.prominenceScore(now: now)
+        #expect(prominence > TripLiveActivityRelevance.demotedScore)
+        #expect(prominence == now.timeIntervalSince1970)
+    }
+
+    @Test func `Later track outranks earlier track`() {
+        let earlier = TripLiveActivityRelevance.prominenceScore(
+            now: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let later = TripLiveActivityRelevance.prominenceScore(
+            now: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        #expect(later > earlier)
+    }
+
+    @Test func `Content carries the supplied relevance score`() {
+        let state = TripAttributes.ContentState(arrivals: [])
+        let content = TripLiveActivityRelevance.content(
+            state: state,
+            staleDate: nil,
+            relevanceScore: 42
+        )
+        #expect(content.state == state)
+        #expect(content.relevanceScore == 42)
+        #expect(content.staleDate == nil)
+    }
+
+    /// Local refreshes must not wipe prominence — rebuilding with the default
+    /// score of 0 is what kept the first-started activity in the Dynamic Island
+    /// after a later Track (#1189 Problem 2).
+    @Test func `Preserved score helper keeps existing prominence on refresh`() {
+        let state = TripAttributes.ContentState(arrivals: [])
+        let refreshed = TripLiveActivityRelevance.content(
+            state: state,
+            staleDate: nil,
+            relevanceScore: 1_700_000_050
+        )
+        #expect(refreshed.relevanceScore == 1_700_000_050)
+    }
+}


### PR DESCRIPTION
## Summary
- Assign a monotonic `relevanceScore` when starting a Live Activity from bookmarks or the stop page, so ActivityKit promotes the trip the rider just tracked into the Dynamic Island.
- Demote other live peers after start.
- **Re-Track of an already-live trip** promotes it in place (bump score + demote peers) instead of only showing the success toast.
- Preserve `relevanceScore` on local content refreshes via `contentPreservingRelevance` (rebuilding with the default score of `0` previously handed the Island back to the first-started activity).

Addresses Problem 2 of #1189 (app side). Does **not** close #1189 — OBACloud push `relevance-score` still needs a follow-up so production pushes don't re-tie scores.

### Follow-up
https://github.com/OneBusAway/onebusaway-ios/issues/1252

## Test plan
- [x] `xcodebuild build-for-testing -scheme App` (iOS Simulator)
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/TripLiveActivityRelevanceTests`
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/TripAttributesIdentityTests`
- [ ] On device: Track A → Track B (Island shows B) → Track A again (Island returns to A)
- [ ] CI `OBAKitTests` green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting a trip now promotes its Live Activity to the Dynamic Island.
  * Newly created trip activities receive relevance ranking so the most important trip is highlighted.
  * Other active trip activities are automatically de-emphasized.

* **Bug Fixes**
  * Refreshing trip information now preserves the activity’s existing prominence instead of resetting it.
  * Matching existing activities are promoted rather than producing duplicate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->