### PR TITLE
Rental range filter and fuel labels on the map

### DIFF
--- a/OBAKit/Analytics/Analytics.swift
+++ b/OBAKit/Analytics/Analytics.swift
@@ -65,6 +65,10 @@ public class AnalyticsLabels: NSObject {
     /// layer's conversion into trip planning.
     @objc public static let rentalPlanTripTapped = "Rental Plan Trip Tapped"
 
+    /// Label used when the rental minimum-range filter changes. Value: the
+    /// threshold in meters, or "0" for no minimum.
+    @objc public static let rentalRangeFilterChanged = "Rental Range Filter Changed"
+
     /// Label used when 'Learn More About Donations' screen is displayed
     @objc public static let donationLearnMoreShown = "Donation Learn More Shown"
 

--- a/OBAKit/Mapping/Layers/MapLayer.swift
+++ b/OBAKit/Mapping/Layers/MapLayer.swift
@@ -133,4 +133,9 @@ extension Notification.Name {
     /// Posted (object: the layer's `id`) when a layer is toggled on or off —
     /// drives the basemap button's active-layer count badge.
     public static let mapLayerEnabledStateDidChange = Notification.Name("OBAMapLayerEnabledStateDidChange")
+
+    /// Posted when the shared rental minimum-range filter changes. Lets
+    /// `MapViewController` push the new value into the rental coordinator without
+    /// `MapRegionManager` needing to know the coordinator exists.
+    public static let rentalRangeFilterDidChange = Notification.Name("OBARentalRangeFilterDidChange")
 }

--- a/OBAKit/Mapping/Layers/MapSheetView.swift
+++ b/OBAKit/Mapping/Layers/MapSheetView.swift
@@ -39,6 +39,16 @@ import UIKit
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+
+        // Settings may mirror this same UserDefaults key while the sheet stays its
+        // owner, so an external writer must not leave an open sheet showing a stale
+        // rung.
+        NotificationCenter.default.publisher(for: .rentalRangeFilterDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Basemap

--- a/OBAKit/Mapping/Layers/MapSheetView.swift
+++ b/OBAKit/Mapping/Layers/MapSheetView.swift
@@ -73,6 +73,27 @@ import UIKit
         objectWillChange.send()
         mapRegionManager.resetMapLayersToDefaults()
     }
+
+    // MARK: - Rental Range Filter
+
+    /// Computed once per sheet presentation: the ladder involves a
+    /// MeasurementFormatter and a localized string, neither worth redoing per render.
+    let rangeFilterPresets = RentalRangePreset.presets()
+
+    /// The rung to highlight. A stored value that isn't on the current ladder — the
+    /// rider's locale changed since they chose it — highlights the closest rung
+    /// without the stored preference being rewritten.
+    var selectedRangePresetID: Int {
+        RentalRangePreset.nearest(
+            toMeters: mapRegionManager.rentalRangeFilter.minimumRangeMeters,
+            in: rangeFilterPresets
+        )?.id ?? 0
+    }
+
+    func selectRangePreset(id: Int) {
+        objectWillChange.send()
+        mapRegionManager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: id)
+    }
 }
 
 struct MapSheetView: View {
@@ -89,10 +110,7 @@ struct MapSheetView: View {
                     group: .transit
                 )
 
-                layerSection(
-                    title: OBALoc("map_sheet.other_modes_group", value: "Other ways to get around", comment: "Map sheet group header for non-transit mobility layers"),
-                    group: .otherModes
-                )
+                otherModesSection
             }
             .navigationTitle(OBALoc("map_sheet.title", value: "Map", comment: "Title of the Map sheet"))
             .navigationBarTitleDisplayMode(.inline)
@@ -180,6 +198,45 @@ struct MapSheetView: View {
                 }
             }
         }
+    }
+
+    /// The non-transit section, which carries the range-filter row beneath its
+    /// layer toggles. The row shows whenever a rental layer row is visible — not
+    /// only when one is enabled — so it doesn't jump in and out of the sheet as the
+    /// rider toggles them, and so the filter can be set before turning a layer on.
+    @ViewBuilder
+    private var otherModesSection: some View {
+        let layers = model.visibleLayers(in: .otherModes)
+        if !layers.isEmpty {
+            Section(OBALoc("map_sheet.other_modes_group", value: "Other ways to get around", comment: "Map sheet group header for non-transit mobility layers")) {
+                ForEach(layers, id: \.id) { layer in
+                    layerRow(layer)
+                }
+                rangeFilterRow
+            }
+        }
+    }
+
+    /// `.menu` is stated explicitly rather than left to `.automatic`, which Apple
+    /// documents as "based on the picker's context" — in a List that has resolved
+    /// to a navigation link in some OS versions and a menu in others.
+    private var rangeFilterRow: some View {
+        Picker(selection: Binding(
+            get: { model.selectedRangePresetID },
+            set: { model.selectRangePreset(id: $0) }
+        )) {
+            ForEach(model.rangeFilterPresets) { preset in
+                Text(preset.title).tag(preset.meters)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "bolt")
+                    .foregroundStyle(Color(uiColor: .rentalPurple))
+                    .frame(width: 28)
+                Text(OBALoc("map_sheet.minimum_range", value: "Minimum range", comment: "Map sheet row label for the rental minimum-range filter"))
+            }
+        }
+        .pickerStyle(.menu)
     }
 
     @ViewBuilder

--- a/OBAKit/Mapping/Layers/MapSheetView.swift
+++ b/OBAKit/Mapping/Layers/MapSheetView.swift
@@ -233,6 +233,7 @@ struct MapSheetView: View {
                 Image(systemName: "bolt")
                     .foregroundStyle(Color(uiColor: .rentalPurple))
                     .frame(width: 28)
+                    .accessibilityHidden(true)
                 Text(OBALoc("map_sheet.minimum_range", value: "Minimum range", comment: "Map sheet row label for the rental minimum-range filter"))
             }
         }
@@ -253,6 +254,7 @@ struct MapSheetView: View {
             Image(systemName: layer.iconName)
                 .foregroundStyle(Color(uiColor: layer.tintColor))
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(layer.title)

--- a/OBAKit/Mapping/Layers/RentalAnnotation.swift
+++ b/OBAKit/Mapping/Layers/RentalAnnotation.swift
@@ -34,6 +34,13 @@ public final class RentalAnnotation: NSObject, MKAnnotation {
                                      comment: "Number of rental vehicles available at a station"), available)
     }
 
+    /// Whether the view should render its fuel label.
+    ///
+    /// Set by `RentalLayerCoordinator` from the current zoom. It lives on the
+    /// annotation rather than the view because `RentalMapLayer.annotationView(for:)`
+    /// only dequeues a view and has no access to viewport state.
+    public var showsFuelLabel: Bool = false
+
     public init(rental: VehicleRental) {
         self.rental = rental
         self.coordinate = rental.coordinate

--- a/OBAKit/Mapping/Layers/RentalAnnotationView.swift
+++ b/OBAKit/Mapping/Layers/RentalAnnotationView.swift
@@ -112,8 +112,10 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
         fuelLabel.isHidden = fuelText == nil || !rentalAnnotation.showsFuelLabel
 
         // VoiceOver ignores the zoom gate: a visual-density rule must not cost a
-        // VoiceOver user the fuel figure.
-        accessibilityLabel = [rental.displayLabel, fuelText]
+        // VoiceOver user information. The station occupancy line is carried across
+        // explicitly because assigning accessibilityLabel replaces MapKit's
+        // title/subtitle default — anything omitted here is silently lost.
+        accessibilityLabel = [rental.displayLabel, rentalAnnotation.subtitle, fuelText]
             .compactMap { $0 }
             .joined(separator: ", ")
     }

--- a/OBAKit/Mapping/Layers/RentalAnnotationView.swift
+++ b/OBAKit/Mapping/Layers/RentalAnnotationView.swift
@@ -127,6 +127,14 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
             .joined(separator: ", ")
     }
 
+    /// Applies just the zoom gate's decision, without re-running `configure()`.
+    /// The gate flips on every crossing of the fuel-label zoom threshold, and a
+    /// full reconfigure per visible annotation would re-resolve SF Symbols and
+    /// re-run a distance formatter to change one Bool.
+    func setShowsFuelLabel(_ shows: Bool) {
+        fuelLabel.isHidden = !shows || fuelLabel.text == nil
+    }
+
     private static func glyphName(for formFactor: VehicleFormFactor?) -> String {
         guard let formFactor else { return "bicycle" }
         if formFactor.isScooter { return "scooter" }

--- a/OBAKit/Mapping/Layers/RentalAnnotationView.swift
+++ b/OBAKit/Mapping/Layers/RentalAnnotationView.swift
@@ -66,6 +66,13 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
         addSubview(fuelLabel)
         NSLayoutConstraint.activate([
             fuelLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            // MKMarkerAnnotationView documents neither its bounds nor its default
+            // centerOffset. Measured on iPhone 17 Pro / iOS 26.3: bounds
+            // (0, 0, 31.33, 34.94), centerOffset (0, -17.47) — i.e.
+            // centerOffset.y == -bounds.height/2, so MapKit places bounds.maxY at
+            // the annotation's coordinate and the balloon tip sits there. Pinning
+            // to bottomAnchor therefore tracks the tip even as the view's height
+            // changes; the `1` below is a fixed gap, not a derived offset.
             fuelLabel.topAnchor.constraint(equalTo: bottomAnchor, constant: 1)
         ])
 

--- a/OBAKit/Mapping/Layers/RentalAnnotationView.swift
+++ b/OBAKit/Mapping/Layers/RentalAnnotationView.swift
@@ -21,6 +21,35 @@ extension UIColor {
 /// Non-operative entities render gray.
 public class RentalAnnotationView: MKMarkerAnnotationView {
 
+    /// The fuel figure rendered beneath the balloon. A plain subview, so it does
+    /// not participate in MapKit's marker collision logic — `collisionMode`
+    /// interprets a frame derived from this view's own bounds, and the label is
+    /// drawn outside them. Some overlap in an unusually dense block is accepted.
+    let fuelLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.isHidden = true
+
+        // Start from a preferred font so Dynamic Type applies, then add weight.
+        let base = UIFont.preferredFont(forTextStyle: .caption1)
+        let descriptor = base.fontDescriptor.withSymbolicTraits(.traitBold) ?? base.fontDescriptor
+        label.font = UIFont(descriptor: descriptor, size: 0)
+        label.adjustsFontForContentSizeCategory = true
+
+        // A white halo keeps the text legible over satellite basemaps.
+        label.layer.shadowColor = UIColor.white.cgColor
+        label.layer.shadowRadius = 2
+        label.layer.shadowOpacity = 1
+        label.layer.shadowOffset = .zero
+
+        // The view composes its own accessibility label; a second element here
+        // would make VoiceOver announce the figure twice.
+        label.isAccessibilityElement = false
+
+        return label
+    }()
+
     public override var annotation: MKAnnotation? {
         didSet { configure() }
     }
@@ -31,6 +60,15 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
         // Rentals yield to transit stops when MapKit has to choose.
         displayPriority = .defaultLow
         titleVisibility = .hidden
+
+        // The label sits outside bounds, so it must not be clipped.
+        clipsToBounds = false
+        addSubview(fuelLabel)
+        NSLayoutConstraint.activate([
+            fuelLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            fuelLabel.topAnchor.constraint(equalTo: bottomAnchor, constant: 1)
+        ])
+
         configure()
     }
 
@@ -42,10 +80,15 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
         super.prepareForReuse()
         clusteringIdentifier = "rentals"
         displayPriority = .defaultLow
+        // MKAnnotationView's default implementation does nothing, so subclass
+        // state that isn't reset here leaks into the next annotation.
+        fuelLabel.text = nil
+        fuelLabel.isHidden = true
     }
 
     private func configure() {
-        guard let rental = (annotation as? RentalAnnotation)?.rental else { return }
+        guard let rentalAnnotation = annotation as? RentalAnnotation else { return }
+        let rental = rentalAnnotation.rental
 
         markerTintColor = rental.isOperative ? .rentalPurple : .systemGray
 
@@ -62,6 +105,17 @@ public class RentalAnnotationView: MKMarkerAnnotationView {
             glyphText = nil
             glyphImage = UIImage(systemName: Self.glyphName(for: vehicle.vehicleType?.formFactor))
         }
+
+        let fuelText = RentalFormat.fuelLabelText(for: rental)
+        fuelLabel.text = fuelText
+        fuelLabel.textColor = rental.isOperative ? .rentalPurple : .systemGray
+        fuelLabel.isHidden = fuelText == nil || !rentalAnnotation.showsFuelLabel
+
+        // VoiceOver ignores the zoom gate: a visual-density rule must not cost a
+        // VoiceOver user the fuel figure.
+        accessibilityLabel = [rental.displayLabel, fuelText]
+            .compactMap { $0 }
+            .joined(separator: ", ")
     }
 
     private static func glyphName(for formFactor: VehicleFormFactor?) -> String {

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -26,31 +26,6 @@ import UIKit
     func rentalLayer(open url: URL, webFallback: URL?)
 }
 
-// MARK: - Shared Formatting
-
-/// Formatting shared by the rental detail and cluster-list surfaces, so the
-/// walk estimate, battery string, and distance formatter exist exactly once.
-enum RentalFormat {
-    /// Cached: a fresh MKDistanceFormatter per row per render is waste.
-    static let distanceFormatter = MKDistanceFormatter()
-
-    /// Straight-line walk estimate at the app's default walking speed.
-    /// Nil beyond 10 km — a "119 min walk" line is noise, not information.
-    static func walkTimeText(from userLocation: CLLocation?, to coordinate: CLLocationCoordinate2D) -> String? {
-        guard let userLocation else { return nil }
-        let target = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-        let meters = userLocation.distance(from: target)
-        guard meters.isFinite, meters < 10_000 else { return nil }
-
-        let minutes = max(1, Int((meters / WalkingSpeed.defaultMetersPerSecond / 60).rounded()))
-        return String(format: OBALoc("rental_detail.walk_time_fmt", value: "%d min walk", comment: "Estimated walking time to a rental vehicle"), minutes)
-    }
-
-    static func batteryText(_ percent: Double) -> String {
-        "\(Int((percent * 100).rounded()))%"
-    }
-}
-
 // MARK: - Detail Sheet
 
 /// Bottom sheet for a single rental vehicle or station — same visual family as

--- a/OBAKit/Mapping/Layers/RentalFormat.swift
+++ b/OBAKit/Mapping/Layers/RentalFormat.swift
@@ -15,7 +15,6 @@ import OTPKit
 /// Shared rider-facing formatting for rental entities, used by the detail sheet,
 /// the cluster list, and the map annotation's fuel label.
 enum RentalFormat {
-
     /// Cached: a fresh MKDistanceFormatter per row per render is waste.
     static let distanceFormatter = MKDistanceFormatter()
 

--- a/OBAKit/Mapping/Layers/RentalFormat.swift
+++ b/OBAKit/Mapping/Layers/RentalFormat.swift
@@ -1,0 +1,69 @@
+//
+//  RentalFormat.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import OBAKitCore
+import OTPKit
+
+/// Shared rider-facing formatting for rental entities, used by the detail sheet,
+/// the cluster list, and the map annotation's fuel label.
+enum RentalFormat {
+
+    /// Cached: a fresh MKDistanceFormatter per row per render is waste.
+    static let distanceFormatter = MKDistanceFormatter()
+
+    /// A second formatter for space-constrained surfaces. The default style spells
+    /// the unit out — 5,470 m renders as "3.4 miles" under en_US, where this one
+    /// gives "3.4 mi". Only the abbreviated form fits under a map pin. The detail
+    /// sheet's spelled-out rendering is deliberate, so the two coexist rather than
+    /// one being mutated in place.
+    static let abbreviatedDistanceFormatter: MKDistanceFormatter = {
+        let formatter = MKDistanceFormatter()
+        formatter.unitStyle = .abbreviated
+        return formatter
+    }()
+
+    /// Straight-line walk estimate at the app's default walking speed.
+    /// Nil beyond 10 km — a "119 min walk" line is noise, not information.
+    static func walkTimeText(from userLocation: CLLocation?, to coordinate: CLLocationCoordinate2D) -> String? {
+        guard let userLocation else { return nil }
+        let target = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        let meters = userLocation.distance(from: target)
+        guard meters.isFinite, meters < 10_000 else { return nil }
+
+        let minutes = max(1, Int((meters / WalkingSpeed.defaultMetersPerSecond / 60).rounded()))
+        return String(format: OBALoc("rental_detail.walk_time_fmt", value: "%d min walk", comment: "Estimated walking time to a rental vehicle"), minutes)
+    }
+
+    static func batteryText(_ percent: Double) -> String {
+        "\(Int((percent * 100).rounded()))%"
+    }
+
+    /// The text rendered beneath a rental map pin: battery percent when the feed
+    /// provides it, else remaining range, else nothing.
+    ///
+    /// The percent-first ordering matches the mockup, but the range fallback is the
+    /// common path in practice: on the launch feed `percent` is null across the
+    /// whole fleet while `range` is populated.
+    static func fuelLabelText(for rental: VehicleRental) -> String? {
+        guard case .vehicle(let vehicle) = rental, let fuel = vehicle.fuel else { return nil }
+
+        if let percent = fuel.percent {
+            // Feeds do send values outside 0...1; clamp rather than render "120%".
+            return batteryText(min(max(percent, 0), 1))
+        }
+
+        if let range = fuel.range {
+            return abbreviatedDistanceFormatter.string(fromDistance: CLLocationDistance(range))
+        }
+
+        return nil
+    }
+}

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -15,9 +15,11 @@ import OTPKit
 ///
 /// Both layers are backed by one `VehicleRentalSource`: enabling both fetches once
 /// with the union of their form factors, and the snapshot is partitioned at
-/// annotation-creation time. All debounce, cancellation, and diffing live in the
-/// framework — this class only converts viewports, applies diffed snapshots to the
-/// map, and tracks runtime availability from fetch outcomes.
+/// annotation-creation time. Fetch debounce and cancellation live in OTPKit's
+/// `VehicleRentalSource`; this class runs delivered snapshots through a second,
+/// client-side visibility pass — `RentalVisibility`, gating on form factors and the
+/// range threshold — before converting viewports and applying the resulting diffs
+/// to the map, and it tracks runtime availability from fetch outcomes.
 @MainActor final class RentalLayerCoordinator {
 
     private let source: VehicleRentalSource

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -154,7 +154,10 @@ import OTPKit
 
     // MARK: - Snapshot Application
 
-    private func apply(_ snapshot: VehicleRentalSnapshot) {
+    // Exposed (not `private`) so RentalLayerCoordinatorTests can feed snapshots
+    // directly and drive the synchronous filter path without going through the
+    // async `AsyncStream`/debounce plumbing.
+    func apply(_ snapshot: VehicleRentalSnapshot) {
         lastSnapshotAt = snapshot.fetchedAt
         setAvailability(.available)
 

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -26,7 +26,21 @@ import OTPKit
     /// Form factors per enabled layer id. The source fetches the union.
     private var enabledLayerFactors: [String: Set<VehicleFormFactor>] = [:]
 
+    /// Decides which delivered rentals belong on the map. All the caching and
+    /// diffing lives here; this class only applies the result to the map view.
+    private var visibility = RentalVisibility()
+
+    /// The annotations currently on the map, by entity id.
     private var annotations: [VehicleRental.ID: RentalAnnotation] = [:]
+
+    /// Visible-map-rect height (in map points) at or below which fuel labels
+    /// render. Tighter than the layer's own 20,000-point zoom window because the
+    /// labels are subviews and don't participate in MapKit's collision logic, so
+    /// they need more room than the markers do. At latitude 47.6 there are 9.9464
+    /// map points per metre, making this an 804 m-tall viewport — a few blocks.
+    private static let fuelLabelMaxVisibleHeight = 8_000.0
+
+    private var showsFuelLabels = false
 
     /// When the last successful snapshot arrived; drives freshness lines.
     private(set) var lastSnapshotAt: Date?
@@ -84,7 +98,7 @@ import OTPKit
         }
 
         let factors = combinedFormFactors
-        pruneAnnotations(notMatching: factors)
+        apply(visibility.setFormFactors(factors))
 
         let mapRect = lastMapRect
         Task {
@@ -102,9 +116,16 @@ import OTPKit
         }
     }
 
+    /// Applies a new minimum-range threshold. Purely client-side: the entities are
+    /// already cached, so relaxing the threshold restores vehicles with no refetch.
+    func setRangeFilter(_ filter: RentalRangeFilter) {
+        apply(visibility.setFilter(filter))
+    }
+
     /// `mapRect` is nil when the zoom gate is closed — everything is removed.
     func viewportDidChange(_ mapRect: MKMapRect?) {
         lastMapRect = mapRect
+        updateFuelLabelVisibility(for: mapRect)
         guard hasEnabledLayers else { return }
 
         // The layer might have been dimmed by an earlier failure; a region change
@@ -112,6 +133,22 @@ import OTPKit
         let boundingBox = mapRect.map(Self.boundingBox(for:))
         Task {
             await source.setViewport(boundingBox)
+        }
+    }
+
+    /// Pushes the current zoom's label decision onto every annotation. Cheap: it
+    /// no-ops unless the gate actually flipped.
+    private func updateFuelLabelVisibility(for mapRect: MKMapRect?) {
+        let shows = mapRect.map { $0.height <= Self.fuelLabelMaxVisibleHeight } ?? false
+        guard shows != showsFuelLabels else { return }
+        showsFuelLabels = shows
+
+        guard let mapView else { return }
+        for annotation in annotations.values {
+            annotation.showsFuelLabel = shows
+            if let view = mapView.view(for: annotation) as? RentalAnnotationView {
+                view.annotation = annotation
+            }
         }
     }
 
@@ -125,31 +162,37 @@ import OTPKit
             Logger.info("Rental fetch partial errors: \(snapshot.partialErrors.joined(separator: "; "))")
         }
 
-        guard let mapView else { return }
+        apply(visibility.apply(snapshot))
+    }
 
-        for id in snapshot.removed {
+    /// Translates a visibility diff into map view operations. The only place this
+    /// class touches annotations.
+    private func apply(_ changes: RentalVisibility.Changes) {
+        guard let mapView, !changes.isEmpty else { return }
+
+        var removed: [RentalAnnotation] = []
+        for id in changes.removed {
             if let annotation = annotations.removeValue(forKey: id) {
-                mapView.removeAnnotation(annotation)
+                removed.append(annotation)
             }
         }
+        mapView.removeAnnotations(removed)
 
-        for rental in snapshot.updated {
+        for rental in changes.updated {
             guard let annotation = annotations[rental.id] else { continue }
             annotation.update(with: rental)
             // Re-assigning the annotation re-runs the view's configure() so glyphs
-            // (availability counts) and tint (operative state) track the data;
-            // identity is unchanged, so selection survives.
+            // (availability counts), tint (operative state), and the fuel label
+            // track the data; identity is unchanged, so selection survives.
             if let view = mapView.view(for: annotation) as? RentalAnnotationView {
                 view.annotation = annotation
             }
         }
 
-        let factors = combinedFormFactors
-        guard !factors.isEmpty else { return }
-
         var added: [RentalAnnotation] = []
-        for rental in snapshot.added where annotations[rental.id] == nil && rental.matches(formFactors: factors) {
+        for rental in changes.added where annotations[rental.id] == nil {
             let annotation = RentalAnnotation(rental: rental)
+            annotation.showsFuelLabel = showsFuelLabels
             annotations[rental.id] = annotation
             added.append(annotation)
         }
@@ -176,20 +219,6 @@ import OTPKit
     func reattachAnnotations() {
         guard let mapView, !annotations.isEmpty else { return }
         mapView.addAnnotations(Array(annotations.values))
-    }
-
-    private func pruneAnnotations(notMatching factors: Set<VehicleFormFactor>) {
-        guard let mapView else { return }
-
-        var removed: [RentalAnnotation] = []
-        for (id, annotation) in annotations {
-            let stillVisible = !factors.isEmpty && annotation.rental.matches(formFactors: factors)
-            if !stillVisible {
-                annotations.removeValue(forKey: id)
-                removed.append(annotation)
-            }
-        }
-        mapView.removeAnnotations(removed)
     }
 
     private func setAvailability(_ newValue: MapLayerAvailability) {

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -33,12 +33,13 @@ import OTPKit
     /// The annotations currently on the map, by entity id.
     private var annotations: [VehicleRental.ID: RentalAnnotation] = [:]
 
-    /// Visible-map-rect height (in map points) at or below which fuel labels
-    /// render. Tighter than the layer's own 20,000-point zoom window because the
-    /// labels are subviews and don't participate in MapKit's collision logic, so
-    /// they need more room than the markers do. At latitude 47.6 there are 9.9464
-    /// map points per metre, making this an 804 m-tall viewport — a few blocks.
-    private static let fuelLabelMaxVisibleHeight = 8_000.0
+    /// Fuel labels need more room than the markers do, so they gate on a tighter
+    /// window than the layer's own `zoomWindow` (20,000-point) — the labels are
+    /// subviews and don't participate in MapKit's collision logic. Same type, so
+    /// the two spellings of "is this viewport small enough" stay in sync. At
+    /// latitude 47.6 there are 9.9464 map points per metre, making 8,000 map
+    /// points (`MKMapRect` units, not metres) an 804 m-tall viewport — a few blocks.
+    private static let fuelLabelZoomWindow = MapLayerZoomWindow(maxVisibleHeight: 8_000)
 
     private var showsFuelLabels = false
 
@@ -98,7 +99,7 @@ import OTPKit
         }
 
         let factors = combinedFormFactors
-        apply(visibility.setFormFactors(factors))
+        syncMapView(with: visibility.setFormFactors(factors))
 
         let mapRect = lastMapRect
         Task {
@@ -119,7 +120,7 @@ import OTPKit
     /// Applies a new minimum-range threshold. Purely client-side: the entities are
     /// already cached, so relaxing the threshold restores vehicles with no refetch.
     func setRangeFilter(_ filter: RentalRangeFilter) {
-        apply(visibility.setFilter(filter))
+        syncMapView(with: visibility.setFilter(filter))
     }
 
     /// `mapRect` is nil when the zoom gate is closed — everything is removed.
@@ -139,16 +140,14 @@ import OTPKit
     /// Pushes the current zoom's label decision onto every annotation. Cheap: it
     /// no-ops unless the gate actually flipped.
     private func updateFuelLabelVisibility(for mapRect: MKMapRect?) {
-        let shows = mapRect.map { $0.height <= Self.fuelLabelMaxVisibleHeight } ?? false
+        let shows = mapRect.map { Self.fuelLabelZoomWindow.contains(visibleHeight: $0.height) } ?? false
         guard shows != showsFuelLabels else { return }
         showsFuelLabels = shows
 
         guard let mapView else { return }
         for annotation in annotations.values {
             annotation.showsFuelLabel = shows
-            if let view = mapView.view(for: annotation) as? RentalAnnotationView {
-                view.annotation = annotation
-            }
+            (mapView.view(for: annotation) as? RentalAnnotationView)?.setShowsFuelLabel(shows)
         }
     }
 
@@ -165,7 +164,7 @@ import OTPKit
             Logger.info("Rental fetch partial errors: \(snapshot.partialErrors.joined(separator: "; "))")
         }
 
-        apply(visibility.apply(snapshot))
+        syncMapView(with: visibility.apply(snapshot))
     }
 
     /// Translates a visibility diff into map view operations. The only place this
@@ -173,7 +172,7 @@ import OTPKit
     /// equal to `RentalVisibility`'s visible-id set. Do not add an early return here:
     /// one that skips a branch (e.g. on an empty `added`/`removed`/`updated` array)
     /// would silently break that invariant and, with it, cache restore.
-    private func apply(_ changes: RentalVisibility.Changes) {
+    private func syncMapView(with changes: RentalVisibility.Changes) {
         guard let mapView, !changes.isEmpty else { return }
 
         var removed: [RentalAnnotation] = []

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -166,7 +166,10 @@ import OTPKit
     }
 
     /// Translates a visibility diff into map view operations. The only place this
-    /// class touches annotations.
+    /// class mutates the `annotations` dictionary — it must keep `Set(annotations.keys)`
+    /// equal to `RentalVisibility`'s visible-id set. Do not add an early return here:
+    /// one that skips a branch (e.g. on an empty `added`/`removed`/`updated` array)
+    /// would silently break that invariant and, with it, cache restore.
     private func apply(_ changes: RentalVisibility.Changes) {
         guard let mapView, !changes.isEmpty else { return }
 

--- a/OBAKit/Mapping/Layers/RentalRangeFilter.swift
+++ b/OBAKit/Mapping/Layers/RentalRangeFilter.swift
@@ -1,0 +1,36 @@
+//
+//  RentalRangeFilter.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OTPKit
+
+/// The rider's "don't show me nearly-dead vehicles" filter.
+///
+/// Fail-open by design: only a vehicle that *reports* a range below the threshold
+/// is hidden. Docked stations, pedal bikes, and vehicles whose feed omits `range`
+/// all leave through the same early return — a feed that never publishes range
+/// must not be filterable into an empty map. This mirrors the convention already
+/// set by `VehicleRental.matches(formFactors:)`.
+struct RentalRangeFilter: Equatable {
+
+    /// Threshold in meters. Zero means "Any" — no filtering at all.
+    let minimumRangeMeters: Int
+
+    static let any = RentalRangeFilter(minimumRangeMeters: 0)
+
+    var isActive: Bool { minimumRangeMeters > 0 }
+
+    func allows(_ rental: VehicleRental) -> Bool {
+        guard isActive,
+              case .vehicle(let vehicle) = rental,
+              let range = vehicle.fuel?.range else {
+            return true
+        }
+        return range >= minimumRangeMeters
+    }
+}

--- a/OBAKit/Mapping/Layers/RentalRangeFilter.swift
+++ b/OBAKit/Mapping/Layers/RentalRangeFilter.swift
@@ -16,7 +16,7 @@ import OTPKit
 /// all leave through the same early return — a feed that never publishes range
 /// must not be filterable into an empty map. This mirrors the convention already
 /// set by `VehicleRental.matches(formFactors:)`.
-struct RentalRangeFilter: Equatable {
+public struct RentalRangeFilter: Equatable {
 
     /// Threshold in meters. Zero means "Any" — no filtering at all.
     let minimumRangeMeters: Int

--- a/OBAKit/Mapping/Layers/RentalRangeFilter.swift
+++ b/OBAKit/Mapping/Layers/RentalRangeFilter.swift
@@ -16,7 +16,7 @@ import OTPKit
 /// all leave through the same early return — a feed that never publishes range
 /// must not be filterable into an empty map. This mirrors the convention already
 /// set by `VehicleRental.matches(formFactors:)`.
-public struct RentalRangeFilter: Equatable {
+struct RentalRangeFilter: Equatable {
 
     /// Threshold in meters. Zero means "Any" — no filtering at all.
     let minimumRangeMeters: Int

--- a/OBAKit/Mapping/Layers/RentalRangePreset.swift
+++ b/OBAKit/Mapping/Layers/RentalRangePreset.swift
@@ -34,7 +34,8 @@ struct RentalRangePreset: Equatable, Identifiable {
     /// miles), and anything unrecognized lands on metric, which is right for most
     /// of the world.
     static func presets(
-        measurementSystem: Locale.MeasurementSystem = Locale.current.measurementSystem
+        measurementSystem: Locale.MeasurementSystem = Locale.current.measurementSystem,
+        locale: Locale = .current
     ) -> [RentalRangePreset] {
         let usesMiles = measurementSystem == .us || measurementSystem == .uk
         let unit: UnitLength = usesMiles ? .miles : .kilometers
@@ -44,6 +45,8 @@ struct RentalRangePreset: Equatable, Identifiable {
             meters: 0,
             title: OBALoc("map_sheet.minimum_range_any", value: "Any", comment: "Range filter menu option imposing no minimum range")
         )
+
+        let formatter = Self.formatter(for: locale)
 
         return [anyRung] + values.map { value in
             let measurement = Measurement(value: value, unit: unit)
@@ -63,11 +66,12 @@ struct RentalRangePreset: Equatable, Identifiable {
 
     /// `.providedUnit` suppresses both conversion and locale substitution, so the
     /// displayed number matches the rung exactly ("5 mi", not "8 km").
-    private static let formatter: MeasurementFormatter = {
+    private static func formatter(for locale: Locale) -> MeasurementFormatter {
         let formatter = MeasurementFormatter()
+        formatter.locale = locale
         formatter.unitOptions = .providedUnit
         formatter.unitStyle = .medium
         formatter.numberFormatter.maximumFractionDigits = 0
         return formatter
-    }()
+    }
 }

--- a/OBAKit/Mapping/Layers/RentalRangePreset.swift
+++ b/OBAKit/Mapping/Layers/RentalRangePreset.swift
@@ -1,0 +1,73 @@
+//
+//  RentalRangePreset.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// One rung of the Map sheet's minimum-range menu.
+///
+/// The stored preference is always metres; these rungs are the rider-facing
+/// choices. Rung values are whole numbers in the rider's own units rather than a
+/// metric ladder converted from miles, because "8 km" reads as a bug.
+struct RentalRangePreset: Equatable, Identifiable {
+
+    /// The threshold this rung selects. Zero is the "Any" rung.
+    let meters: Int
+
+    /// Rider-facing label: "Any", "5 mi", "10 km".
+    let title: String
+
+    var id: Int { meters }
+
+    /// The ladder for a measurement system.
+    ///
+    /// `Locale.MeasurementSystem` is a struct, not an enum — it carries `.metric`,
+    /// `.us`, and `.uk` but can be built from any BCP-47 identifier, so it can
+    /// never be switched exhaustively. Miles are therefore the *explicit* case and
+    /// metric the fallback: `.uk` genuinely wants miles (UK road distances are in
+    /// miles), and anything unrecognized lands on metric, which is right for most
+    /// of the world.
+    static func presets(
+        measurementSystem: Locale.MeasurementSystem = Locale.current.measurementSystem
+    ) -> [RentalRangePreset] {
+        let usesMiles = measurementSystem == .us || measurementSystem == .uk
+        let unit: UnitLength = usesMiles ? .miles : .kilometers
+        let values: [Double] = usesMiles ? [1, 2, 5, 10, 15] : [2, 5, 10, 15, 25]
+
+        let anyRung = RentalRangePreset(
+            meters: 0,
+            title: OBALoc("map_sheet.minimum_range_any", value: "Any", comment: "Range filter menu option imposing no minimum range")
+        )
+
+        return [anyRung] + values.map { value in
+            let measurement = Measurement(value: value, unit: unit)
+            return RentalRangePreset(
+                meters: Int(measurement.converted(to: .meters).value.rounded()),
+                title: formatter.string(from: measurement)
+            )
+        }
+    }
+
+    /// The rung closest to a stored metre value. Used only to highlight the menu
+    /// selection — filtering keeps using the stored value, so a preference set in
+    /// another locale is never silently rewritten.
+    static func nearest(toMeters meters: Int, in presets: [RentalRangePreset]) -> RentalRangePreset? {
+        presets.min { abs($0.meters - meters) < abs($1.meters - meters) }
+    }
+
+    /// `.providedUnit` suppresses both conversion and locale substitution, so the
+    /// displayed number matches the rung exactly ("5 mi", not "8 km").
+    private static let formatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.unitStyle = .medium
+        formatter.numberFormatter.maximumFractionDigits = 0
+        return formatter
+    }()
+}

--- a/OBAKit/Mapping/Layers/RentalVisibility.swift
+++ b/OBAKit/Mapping/Layers/RentalVisibility.swift
@@ -1,0 +1,125 @@
+//
+//  RentalVisibility.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OTPKit
+
+/// Which delivered rentals belong on the map.
+///
+/// Holds every entity `VehicleRentalSource` has delivered for the current viewport
+/// — not just the visible ones — so relaxing a filter restores vehicles from cache
+/// instead of waiting for a refetch. The source emits only diffs, so an entity
+/// dropped for being under threshold would otherwise never come back.
+///
+/// Memory stays bounded without extra work: the source replaces its delivered set
+/// wholesale on each fetch and reports everything absent as removed, so this cache
+/// tracks the padded viewport rather than growing across a session.
+///
+/// No MapKit and no async: every mutation returns the exact changes to apply.
+struct RentalVisibility {
+
+    /// What the map must do to catch up with a mutation.
+    struct Changes: Equatable {
+        var added: [VehicleRental] = []
+        var removed: [VehicleRental.ID] = []
+        var updated: [VehicleRental] = []
+
+        var isEmpty: Bool { added.isEmpty && removed.isEmpty && updated.isEmpty }
+    }
+
+    private var cache: [VehicleRental.ID: VehicleRental] = [:]
+    private var visibleIDs: Set<VehicleRental.ID> = []
+
+    private(set) var formFactors: Set<VehicleFormFactor> = []
+    private(set) var filter: RentalRangeFilter = .any
+
+    /// With no form factors selected, every layer is off and nothing is visible.
+    private func isVisible(_ rental: VehicleRental) -> Bool {
+        !formFactors.isEmpty && rental.matches(formFactors: formFactors) && filter.allows(rental)
+    }
+
+    // MARK: - Snapshot application
+
+    mutating func apply(_ snapshot: VehicleRentalSnapshot) -> Changes {
+        var changes = Changes()
+
+        for id in snapshot.removed {
+            cache.removeValue(forKey: id)
+            if visibleIDs.remove(id) != nil {
+                changes.removed.append(id)
+            }
+        }
+
+        for rental in snapshot.added where cache[rental.id] == nil {
+            cache[rental.id] = rental
+            if isVisible(rental) {
+                visibleIDs.insert(rental.id)
+                changes.added.append(rental)
+            }
+        }
+
+        for rental in snapshot.updated {
+            cache[rental.id] = rental
+            // An update that crosses the visibility boundary is an add or a
+            // removal — never an update. Emitting it as an update would leave the
+            // map showing a vehicle the rider has filtered out.
+            switch (visibleIDs.contains(rental.id), isVisible(rental)) {
+            case (true, true):
+                changes.updated.append(rental)
+            case (true, false):
+                visibleIDs.remove(rental.id)
+                changes.removed.append(rental.id)
+            case (false, true):
+                visibleIDs.insert(rental.id)
+                changes.added.append(rental)
+            case (false, false):
+                break
+            }
+        }
+
+        return changes
+    }
+
+    // MARK: - Selection changes
+
+    mutating func setFormFactors(_ formFactors: Set<VehicleFormFactor>) -> Changes {
+        guard formFactors != self.formFactors else { return Changes() }
+        self.formFactors = formFactors
+        return reconcile()
+    }
+
+    mutating func setFilter(_ filter: RentalRangeFilter) -> Changes {
+        guard filter != self.filter else { return Changes() }
+        self.filter = filter
+        return reconcile()
+    }
+
+    /// Recomputes visibility across the whole cache. Sorted by id so the emitted
+    /// changes are deterministic, mirroring `VehicleRentalSource`'s own convention
+    /// of sorting its removed array.
+    private mutating func reconcile() -> Changes {
+        var changes = Changes()
+
+        for id in cache.keys.sorted() {
+            guard let rental = cache[id] else { continue }
+
+            switch (visibleIDs.contains(id), isVisible(rental)) {
+            case (true, false):
+                visibleIDs.remove(id)
+                changes.removed.append(id)
+            case (false, true):
+                visibleIDs.insert(id)
+                changes.added.append(rental)
+            case (true, true), (false, false):
+                break
+            }
+        }
+
+        return changes
+    }
+}

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -354,9 +354,12 @@ public class MapRegionManager: NSObject,
     }
 
     /// True when any layer's on/off state differs from its default, or the rental
-    /// range filter is active — drives the Map sheet's Reset affordance.
+    /// range filter is active *and visible* — drives the Map sheet's Reset
+    /// affordance. The filter row only renders when a `.otherModes` layer is
+    /// registered (rental layers are region-gated), so a non-zero filter left over
+    /// from another region must not offer a Reset that changes nothing on screen.
     public var mapLayersDifferFromDefaults: Bool {
-        if rentalRangeFilter != .any { return true }
+        if rentalRangeFilter != .any, mapLayers.contains(where: { $0.group == .otherModes }) { return true }
         return mapLayers.contains { isMapLayerEnabled(id: $0.id) != $0.isEnabledByDefault }
     }
 

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -320,7 +320,7 @@ public class MapRegionManager: NSObject,
     }
 
     /// The UserDefaults key persisting the shared rental minimum-range threshold.
-    public static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
+    static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
 
     /// The minimum-range filter shared by the Bikes and Scooters layers — one
     /// threshold, not one per layer.
@@ -329,7 +329,7 @@ public class MapRegionManager: NSObject,
     /// and `resetMapLayersToDefaults()` cover it, which is what makes the Map
     /// sheet's Reset button honest. No `register(defaults:)` is needed: an unset
     /// key reads as 0, which is exactly `.any`.
-    public var rentalRangeFilter: RentalRangeFilter {
+    var rentalRangeFilter: RentalRangeFilter {
         get {
             RentalRangeFilter(
                 minimumRangeMeters: application.userDefaults.integer(forKey: Self.rentalMinimumRangeDefaultsKey)

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -319,22 +319,54 @@ public class MapRegionManager: NSObject,
         )
     }
 
+    /// The UserDefaults key persisting the shared rental minimum-range threshold.
+    public static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
+
+    /// The minimum-range filter shared by the Bikes and Scooters layers — one
+    /// threshold, not one per layer.
+    ///
+    /// It lives here beside the per-layer enablement so `mapLayersDifferFromDefaults`
+    /// and `resetMapLayersToDefaults()` cover it, which is what makes the Map
+    /// sheet's Reset button honest. No `register(defaults:)` is needed: an unset
+    /// key reads as 0, which is exactly `.any`.
+    public var rentalRangeFilter: RentalRangeFilter {
+        get {
+            RentalRangeFilter(
+                minimumRangeMeters: application.userDefaults.integer(forKey: Self.rentalMinimumRangeDefaultsKey)
+            )
+        }
+        set {
+            guard rentalRangeFilter != newValue else { return }
+            application.userDefaults.set(newValue.minimumRangeMeters, forKey: Self.rentalMinimumRangeDefaultsKey)
+
+            NotificationCenter.default.post(name: .rentalRangeFilterDidChange, object: nil)
+            application.analytics?.reportEvent(
+                pageURL: "app://localhost/map",
+                label: AnalyticsLabels.rentalRangeFilterChanged,
+                value: String(newValue.minimumRangeMeters)
+            )
+        }
+    }
+
     /// The number of enabled, non-hidden layers — the basemap button's badge.
     public var enabledMapLayerCount: Int {
         mapLayers.filter { $0.availability != .unsupported && isMapLayerEnabled(id: $0.id) }.count
     }
 
-    /// True when any layer's on/off state differs from its default — drives the
-    /// Map sheet's Reset affordance.
+    /// True when any layer's on/off state differs from its default, or the rental
+    /// range filter is active — drives the Map sheet's Reset affordance.
     public var mapLayersDifferFromDefaults: Bool {
-        mapLayers.contains { isMapLayerEnabled(id: $0.id) != $0.isEnabledByDefault }
+        if rentalRangeFilter != .any { return true }
+        return mapLayers.contains { isMapLayerEnabled(id: $0.id) != $0.isEnabledByDefault }
     }
 
-    /// Restores every registered layer to its default on/off state.
+    /// Restores every registered layer to its default on/off state, and clears the
+    /// rental range filter.
     public func resetMapLayersToDefaults() {
         for layer in mapLayers {
             setMapLayerEnabled(layer.isEnabledByDefault, id: layer.id)
         }
+        rentalRangeFilter = .any
     }
 
     /// Whether stop annotations should render. True when no stops layer is

--- a/OBAKit/Mapping/MapViewController+MapLayers.swift
+++ b/OBAKit/Mapping/MapViewController+MapLayers.swift
@@ -48,6 +48,10 @@ extension MapViewController {
         let coordinator = RentalLayerCoordinator(service: service, mapView: mapRegionManager.mapView)
         rentalLayerCoordinator = coordinator
 
+        // Apply a filter chosen in a previous session before the first fetch,
+        // rather than one notification late.
+        coordinator.setRangeFilter(mapRegionManager.rentalRangeFilter)
+
         let bikes = RentalMapLayer.bikesLayer(coordinator: coordinator)
         bikes.actionsDelegate = self
         mapRegionManager.registerMapLayer(bikes)
@@ -81,6 +85,13 @@ extension MapViewController {
 
     @objc func mapLayerStateDidChange(_ note: NSNotification) {
         updateMapLayerBadge()
+    }
+
+    /// `MapViewController` is the composition root for the rental layers, so it
+    /// carries the threshold from the Map sheet's write to the coordinator that
+    /// acts on it. `MapRegionManager` stays unaware the coordinator exists.
+    @objc func rentalRangeFilterDidChange(_ note: NSNotification) {
+        rentalLayerCoordinator?.setRangeFilter(mapRegionManager.rentalRangeFilter)
     }
 
     func updateMapLayerBadge() {

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -165,6 +165,7 @@ class MapViewController: UIViewController,
         configureMapLayers()
         NotificationCenter.default.addObserver(self, selector: #selector(mapLayerStateDidChange(_:)), name: .mapLayerEnabledStateDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(mapLayerStateDidChange(_:)), name: .mapLayerAvailabilityDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(rentalRangeFilterDidChange(_:)), name: .rentalRangeFilterDidChange, object: nil)
 
         bindViewModel()
     }

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1547,3 +1547,6 @@
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Wind speed";
 
+
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Any";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1546,7 +1546,3 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Wind speed";
-
-
-/* Range filter menu option imposing no minimum range */
-"map_sheet.minimum_range_any" = "Any";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1546,3 +1546,4 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Wind speed";
+

--- a/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
+++ b/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
@@ -8,9 +8,38 @@
 //
 
 import Foundation
+import MapKit
 import Testing
+import UIKit
 @testable import OBAKit
 @testable import OBAKitCore
+
+/// A minimal `.otherModes` layer stand-in. `RentalMapLayer`'s initializer is
+/// private to its file, and these tests only need something that makes
+/// `mapLayers.contains(where: { $0.group == .otherModes })` true — not a
+/// working rental pipeline.
+@MainActor
+private final class FakeOtherModesMapLayer: NSObject, MapLayer {
+    let id = "fake.other-modes"
+    let title = "Fake"
+    let iconName = "bicycle"
+    let tintColor: UIColor = .systemPurple
+    let group: MapLayerGroup = .otherModes
+    let isEnabledByDefault = true
+    let availability: MapLayerAvailability = .available
+    let zoomWindow = MapLayerZoomWindow(maxVisibleHeight: .greatestFiniteMagnitude)
+    let densityBudget = 100
+    let isClusterable = false
+    let refreshPolicy: MapLayerRefreshPolicy = .static
+    let staleAfter: Duration? = nil
+
+    func annotationView(for annotation: MKAnnotation, in mapView: MKMapView) -> MKAnnotationView? { nil }
+    func detailViewController(for annotation: MKAnnotation) -> UIViewController? { nil }
+    func activate() {}
+    func deactivate() {}
+    func viewportDidChange(_ mapRect: MKMapRect?) {}
+    func mapAnnotationsWereCleared() {}
+}
 
 /// Persistence for the shared rental minimum-range threshold. It lives on
 /// `MapRegionManager` beside the per-layer enablement so the Map sheet's Reset
@@ -79,11 +108,22 @@ final class MapRegionManagerRentalFilterTests: OBATestCase {
     }
 
     /// An active filter is a difference from defaults, so Reset must be offered
-    /// even when every layer toggle is untouched.
+    /// even when every layer toggle is untouched — but only where the filter row
+    /// is actually visible, i.e. a `.otherModes` layer is registered.
     @Test func activeFilterCountsAsDifferingFromDefaults() {
+        manager.registerMapLayer(FakeOtherModesMapLayer())
+
         #expect(manager.mapLayersDifferFromDefaults == false)
         manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
         #expect(manager.mapLayersDifferFromDefaults)
+    }
+
+    /// The inverse of the above: in a region with no rental layer registered, the
+    /// filter row never renders, so a leftover non-default filter value must not
+    /// make Reset appear — that would be a button that changes nothing visible.
+    @Test func activeFilterWithoutARentalLayerDoesNotCountAsDiffering() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(manager.mapLayersDifferFromDefaults == false)
     }
 
     @Test func resetClearsTheFilter() {

--- a/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
+++ b/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
@@ -54,28 +54,28 @@ final class MapRegionManagerRentalFilterTests: OBATestCase {
     }
 
     @Test func postsOnChange() async {
-        var posted = false
-        let token = NotificationCenter.default.addObserver(
-            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
-        ) { _ in posted = true }
-        defer { NotificationCenter.default.removeObserver(token) }
+        await confirmation("filter change posts a notification") { posted in
+            let token = NotificationCenter.default.addObserver(
+                forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+            ) { _ in posted() }
+            defer { NotificationCenter.default.removeObserver(token) }
 
-        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
-        #expect(posted)
+            manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        }
     }
 
     /// A redundant write must not post — the coordinator would refilter for nothing.
-    @Test func doesNotPostWhenUnchanged() {
+    @Test func doesNotPostWhenUnchanged() async {
         manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
 
-        var posted = false
-        let token = NotificationCenter.default.addObserver(
-            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
-        ) { _ in posted = true }
-        defer { NotificationCenter.default.removeObserver(token) }
+        await confirmation("redundant write posts nothing", expectedCount: 0) { posted in
+            let token = NotificationCenter.default.addObserver(
+                forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+            ) { _ in posted() }
+            defer { NotificationCenter.default.removeObserver(token) }
 
-        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
-        #expect(posted == false)
+            manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        }
     }
 
     /// An active filter is a difference from defaults, so Reset must be offered

--- a/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
+++ b/OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
@@ -1,0 +1,94 @@
+//
+//  MapRegionManagerRentalFilterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Persistence for the shared rental minimum-range threshold. It lives on
+/// `MapRegionManager` beside the per-layer enablement so the Map sheet's Reset
+/// affordance covers it without new machinery.
+///
+/// Inherits `OBATestCase` for its per-instance `UserDefaults` domain: Swift Testing
+/// runs suites concurrently within one process, so isolation has to come from the
+/// fixture rather than from the schedule.
+@MainActor
+@Suite(.serialized)
+final class MapRegionManagerRentalFilterTests: OBATestCase {
+
+    private var manager: MapRegionManager!
+
+    override init() async throws {
+        try await super.init()
+        let queue = OperationQueue()
+        let dataLoader = MockDataLoader(testName: name)
+        manager = MapRegionManager(application: buildApplication(queue: queue, dataLoader: dataLoader))
+    }
+
+    @Test func defaultsToAny() {
+        #expect(manager.rentalRangeFilter == .any)
+        #expect(manager.rentalRangeFilter.isActive == false)
+    }
+
+    @Test func persistsTheThreshold() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(manager.rentalRangeFilter.minimumRangeMeters == 8047)
+    }
+
+    /// Asserts the write lands in the suite's scratch domain. This depends on
+    /// `buildApplication` configuring the app with `OBATestCase.userDefaults` —
+    /// check `OBATestCase.buildApplication(queue:dataLoader:)` if it fails, and
+    /// read through `manager.rentalRangeFilter` instead if the app owns a
+    /// different domain.
+    @Test func writesThroughToUserDefaults() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        let stored = userDefaults.integer(forKey: MapRegionManager.rentalMinimumRangeDefaultsKey)
+        #expect(stored == 8047)
+    }
+
+    @Test func postsOnChange() async {
+        var posted = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+        ) { _ in posted = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(posted)
+    }
+
+    /// A redundant write must not post — the coordinator would refilter for nothing.
+    @Test func doesNotPostWhenUnchanged() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+
+        var posted = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+        ) { _ in posted = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(posted == false)
+    }
+
+    /// An active filter is a difference from defaults, so Reset must be offered
+    /// even when every layer toggle is untouched.
+    @Test func activeFilterCountsAsDifferingFromDefaults() {
+        #expect(manager.mapLayersDifferFromDefaults == false)
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(manager.mapLayersDifferFromDefaults)
+    }
+
+    @Test func resetClearsTheFilter() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        manager.resetMapLayersToDefaults()
+        #expect(manager.rentalRangeFilter == .any)
+    }
+}

--- a/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
+++ b/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
@@ -121,4 +121,28 @@ final class RentalAnnotationViewTests {
 
         #expect(subject.fuelLabel.isHidden == false)
     }
+
+    /// A station's glyph is its availability count, not a form-factor symbol.
+    @Test func stationWithAvailabilityShowsCountGlyph() throws {
+        let subject = view(for: try RentalFixtures.station(vehiclesAvailable: 4), showsFuelLabel: false)
+        #expect(subject.glyphText == "4")
+    }
+
+    /// When a station's feed omits an availability count, the count glyph falls
+    /// back to a form-factor image rather than rendering blank.
+    @Test func stationWithoutAvailabilityFallsBackToImageGlyph() throws {
+        let subject = view(for: try RentalFixtures.station(vehiclesAvailable: nil), showsFuelLabel: false)
+        #expect(subject.glyphText == nil)
+        #expect(subject.glyphImage != nil)
+    }
+
+    @Test func operativeVehicleTintsPurple() throws {
+        let subject = view(for: try RentalFixtures.vehicle(operative: true), showsFuelLabel: false)
+        #expect(subject.markerTintColor == .rentalPurple)
+    }
+
+    @Test func nonOperativeVehicleTintsGray() throws {
+        let subject = view(for: try RentalFixtures.vehicle(operative: false), showsFuelLabel: false)
+        #expect(subject.markerTintColor == .systemGray)
+    }
 }

--- a/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
+++ b/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
@@ -1,0 +1,111 @@
+//
+//  RentalAnnotationViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+import UIKit
+import OTPKit
+@testable import OBAKit
+
+/// The fuel figure rendered beneath a rental marker. Its visibility is driven by
+/// `RentalAnnotation.showsFuelLabel` rather than by the view reading the viewport,
+/// because the layer's dequeue path has no access to map state.
+@MainActor
+@Suite(.serialized)
+final class RentalAnnotationViewTests {
+
+    private func view(for rental: VehicleRental, showsFuelLabel: Bool) -> RentalAnnotationView {
+        let annotation = RentalAnnotation(rental: rental)
+        annotation.showsFuelLabel = showsFuelLabel
+        return RentalAnnotationView(annotation: annotation, reuseIdentifier: nil)
+    }
+
+    @Test func showsPercentWhenGatedOn() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+
+        #expect(subject.fuelLabel.text == "62%")
+        #expect(subject.fuelLabel.isHidden == false)
+    }
+
+    /// The zoom gate hides the label, but the text stays correct so re-showing it
+    /// costs nothing.
+    @Test func hidesLabelWhenGatedOff() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func hidesLabelWhenThereIsNoFuelData() throws {
+        let subject = view(for: try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: nil), showsFuelLabel: true)
+
+        #expect(subject.fuelLabel.text == nil)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func hidesLabelForStations() throws {
+        let subject = view(for: try RentalFixtures.station(), showsFuelLabel: true)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func labelIsPurpleWhenOperative() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62, operative: true), showsFuelLabel: true)
+        #expect(subject.fuelLabel.textColor == .rentalPurple)
+    }
+
+    @Test func labelIsGrayWhenNotOperative() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62, operative: false), showsFuelLabel: true)
+        #expect(subject.fuelLabel.textColor == .systemGray)
+    }
+
+    /// A visual-clutter rule must not cost a VoiceOver user information: the fuel
+    /// figure is announced even when the label is hidden by zoom.
+    @Test func accessibilityLabelCarriesFuelEvenWhenHidden() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+
+        let label = try #require(subject.accessibilityLabel)
+        #expect(label.contains("62%"))
+    }
+
+    @Test func accessibilityLabelIncludesTheDisplayLabel() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 0.62)
+        let subject = view(for: rental, showsFuelLabel: true)
+
+        let label = try #require(subject.accessibilityLabel)
+        #expect(label.contains(rental.displayLabel))
+    }
+
+    /// The child label must not be its own element, or VoiceOver announces the
+    /// figure twice.
+    @Test func childLabelIsNotAnAccessibilityElement() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+        #expect(subject.fuelLabel.isAccessibilityElement == false)
+    }
+
+    /// `MKAnnotationView.prepareForReuse()` does nothing by default, so subclass
+    /// state that isn't reset by hand leaks into the next annotation.
+    @Test func reuseClearsTheLabel() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+        subject.prepareForReuse()
+
+        #expect(subject.fuelLabel.text == nil)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    /// Re-assigning the annotation is how the coordinator pushes a new gate value.
+    @Test func reassigningAnnotationRefreshesTheLabel() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+        #expect(subject.fuelLabel.isHidden)
+
+        let annotation = try #require(subject.annotation as? RentalAnnotation)
+        annotation.showsFuelLabel = true
+        subject.annotation = annotation
+
+        #expect(subject.fuelLabel.isHidden == false)
+    }
+}

--- a/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
+++ b/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
@@ -80,6 +80,19 @@ final class RentalAnnotationViewTests {
         #expect(label.contains(rental.displayLabel))
     }
 
+    /// Assigning `accessibilityLabel` replaces MapKit's title/subtitle default, so
+    /// a station's occupancy line has to be carried across explicitly or VoiceOver
+    /// users lose it on every browse pass.
+    @Test func accessibilityLabelIncludesStationAvailability() throws {
+        let annotation = RentalAnnotation(rental: try RentalFixtures.station(vehiclesAvailable: 4))
+        annotation.showsFuelLabel = true
+        let subtitle = try #require(annotation.subtitle)
+        let subject = RentalAnnotationView(annotation: annotation, reuseIdentifier: nil)
+
+        let label = try #require(subject.accessibilityLabel)
+        #expect(label.contains(subtitle))
+    }
+
     /// The child label must not be its own element, or VoiceOver announces the
     /// figure twice.
     @Test func childLabelIsNotAnAccessibilityElement() throws {

--- a/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
+++ b/OBAKitTests/Mapping/RentalAnnotationViewTests.swift
@@ -145,4 +145,30 @@ final class RentalAnnotationViewTests {
         let subject = view(for: try RentalFixtures.vehicle(operative: false), showsFuelLabel: false)
         #expect(subject.markerTintColor == .systemGray)
     }
+
+    // MARK: - setShowsFuelLabel (the narrow zoom-gate setter)
+
+    /// The coordinator calls this instead of reassigning `.annotation` to avoid a
+    /// full `configure()` on every zoom-threshold crossing; it must still show and
+    /// hide the label correctly on its own.
+    @Test func setShowsFuelLabelTogglesTheLabel() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+        #expect(subject.fuelLabel.isHidden)
+
+        subject.setShowsFuelLabel(true)
+        #expect(subject.fuelLabel.isHidden == false)
+
+        subject.setShowsFuelLabel(false)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    /// Mirrors `configure()`'s own rule: a label with no text stays hidden
+    /// regardless of the gate.
+    @Test func setShowsFuelLabelKeepsHiddenWhenThereIsNoFuelText() throws {
+        let subject = view(for: try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: nil), showsFuelLabel: false)
+        #expect(subject.fuelLabel.text == nil)
+
+        subject.setShowsFuelLabel(true)
+        #expect(subject.fuelLabel.isHidden)
+    }
 }

--- a/OBAKitTests/Mapping/RentalFixtures.swift
+++ b/OBAKitTests/Mapping/RentalFixtures.swift
@@ -12,11 +12,14 @@ import OTPKit
 
 /// Builds `VehicleRental` values for tests.
 ///
-/// These are decoded from JSON rather than constructed directly: OTPKit's
-/// `RentalVehicle`, `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose
-/// only internal memberwise initializers, so the sole cross-module entry point is
-/// `VehicleRental.init(from:)`. Decoding has the side benefit of exercising the
-/// same path real payloads take, including `__typename` discrimination.
+/// These are decoded rather than constructed directly: OTPKit's `RentalVehicle`,
+/// `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose only internal
+/// memberwise initializers, so the sole cross-module entry point is
+/// `VehicleRental.init(from:)`. Dictionaries are built and handed to
+/// `Fixtures.dictionaryToModel`, which round-trips them through
+/// `JSONSerialization` + `JSONDecoder` — the same convention `Fixtures.swift`
+/// uses elsewhere. Decoding has the side benefit of exercising the same path
+/// real payloads take, including `__typename` discrimination.
 enum RentalFixtures {
 
     /// A free-floating rental vehicle. Pass `rangeMeters: nil, batteryPercent: nil`
@@ -31,32 +34,32 @@ enum RentalFixtures {
         lat: Double = 47.6,
         lon: Double = -122.3
     ) throws -> VehicleRental {
-        var fuelFields: [String] = []
-        if let batteryPercent {
-            fuelFields.append("\"percent\": \(batteryPercent)")
-        }
-        if let rangeMeters {
-            fuelFields.append("\"range\": \(rangeMeters)")
-        }
-        let fuelJSON = fuelFields.isEmpty ? "null" : "{ \(fuelFields.joined(separator: ", ")) }"
-        let propulsionJSON = propulsion.map { "\"\($0)\"" } ?? "null"
+        var fuel: [String: Any] = [:]
+        if let batteryPercent { fuel["percent"] = batteryPercent }
+        if let rangeMeters { fuel["range"] = rangeMeters }
+        let fuelValue: Any = fuel.isEmpty ? NSNull() : fuel
 
-        let json = """
-        {
-          "__typename": "RentalVehicle",
-          "vehicleId": "\(id)",
-          "name": "Default vehicle type",
-          "lat": \(lat),
-          "lon": \(lon),
-          "allowPickupNow": true,
-          "operative": \(operative),
-          "rentalNetwork": { "networkId": "lime_seattle", "url": null },
-          "rentalUris": null,
-          "vehicleType": { "formFactor": "\(formFactor)", "propulsionType": \(propulsionJSON) },
-          "fuel": \(fuelJSON)
+        var vehicleType: [String: Any] = ["formFactor": formFactor]
+        if let propulsion {
+            vehicleType["propulsionType"] = propulsion
+        } else {
+            vehicleType["propulsionType"] = NSNull()
         }
-        """
-        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+
+        let dictionary: [String: Any] = [
+            "__typename": "RentalVehicle",
+            "vehicleId": id,
+            "name": "Default vehicle type",
+            "lat": lat,
+            "lon": lon,
+            "allowPickupNow": true,
+            "operative": operative,
+            "rentalNetwork": ["networkId": "lime_seattle", "url": NSNull()] as [String: Any],
+            "rentalUris": NSNull(),
+            "vehicleType": vehicleType,
+            "fuel": fuelValue
+        ]
+        return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
     }
 
     /// A non-powered vehicle: a pedal bike, with no `fuel` object at all.
@@ -72,17 +75,29 @@ enum RentalFixtures {
         lat: Double = 47.6,
         lon: Double = -122.3
     ) throws -> VehicleRental {
-        let json = """
-        {
-          "__typename": "VehicleRentalStation",
-          "stationId": "\(id)",
-          "name": "Pine St Station",
-          "lat": \(lat),
-          "lon": \(lon),
-          "vehiclesAvailable": \(vehiclesAvailable.map(String.init) ?? "null"),
-          "operative": \(operative)
+        var dictionary: [String: Any] = [
+            "__typename": "VehicleRentalStation",
+            "stationId": id,
+            "name": "Pine St Station",
+            "lat": lat,
+            "lon": lon,
+            "operative": operative
+        ]
+        if let vehiclesAvailable {
+            dictionary["vehiclesAvailable"] = vehiclesAvailable
+        } else {
+            dictionary["vehiclesAvailable"] = NSNull()
         }
-        """
-        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+        return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
+    }
+
+    /// A snapshot with the fixed `fetchedAt` every rental test depends on for
+    /// determinism — `Date()` is avoided deliberately.
+    static func snapshot(
+        added: [VehicleRental] = [],
+        removed: [VehicleRental.ID] = [],
+        updated: [VehicleRental] = []
+    ) -> VehicleRentalSnapshot {
+        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
     }
 }

--- a/OBAKitTests/Mapping/RentalFixtures.swift
+++ b/OBAKitTests/Mapping/RentalFixtures.swift
@@ -1,0 +1,88 @@
+//
+//  RentalFixtures.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OTPKit
+
+/// Builds `VehicleRental` values for tests.
+///
+/// These are decoded from JSON rather than constructed directly: OTPKit's
+/// `RentalVehicle`, `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose
+/// only internal memberwise initializers, so the sole cross-module entry point is
+/// `VehicleRental.init(from:)`. Decoding has the side benefit of exercising the
+/// same path real payloads take, including `__typename` discrimination.
+enum RentalFixtures {
+
+    /// A free-floating rental vehicle. Pass `rangeMeters: nil, batteryPercent: nil`
+    /// for a vehicle whose feed publishes no fuel data at all.
+    static func vehicle(
+        id: String = "v1",
+        formFactor: String = "SCOOTER",
+        propulsion: String? = "ELECTRIC",
+        rangeMeters: Int? = nil,
+        batteryPercent: Double? = nil,
+        operative: Bool = true,
+        lat: Double = 47.6,
+        lon: Double = -122.3
+    ) throws -> VehicleRental {
+        var fuelFields: [String] = []
+        if let batteryPercent {
+            fuelFields.append("\"percent\": \(batteryPercent)")
+        }
+        if let rangeMeters {
+            fuelFields.append("\"range\": \(rangeMeters)")
+        }
+        let fuelJSON = fuelFields.isEmpty ? "null" : "{ \(fuelFields.joined(separator: ", ")) }"
+        let propulsionJSON = propulsion.map { "\"\($0)\"" } ?? "null"
+
+        let json = """
+        {
+          "__typename": "RentalVehicle",
+          "vehicleId": "\(id)",
+          "name": "Default vehicle type",
+          "lat": \(lat),
+          "lon": \(lon),
+          "allowPickupNow": true,
+          "operative": \(operative),
+          "rentalNetwork": { "networkId": "lime_seattle", "url": null },
+          "rentalUris": null,
+          "vehicleType": { "formFactor": "\(formFactor)", "propulsionType": \(propulsionJSON) },
+          "fuel": \(fuelJSON)
+        }
+        """
+        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+    }
+
+    /// A non-powered vehicle: a pedal bike, with no `fuel` object at all.
+    static func pedalBike(id: String = "b1") throws -> VehicleRental {
+        try vehicle(id: id, formFactor: "BICYCLE", propulsion: "HUMAN", rangeMeters: nil, batteryPercent: nil)
+    }
+
+    /// A docked station. Stations never carry fuel data.
+    static func station(
+        id: String = "s1",
+        vehiclesAvailable: Int? = 4,
+        operative: Bool = true,
+        lat: Double = 47.6,
+        lon: Double = -122.3
+    ) throws -> VehicleRental {
+        let json = """
+        {
+          "__typename": "VehicleRentalStation",
+          "stationId": "\(id)",
+          "name": "Pine St Station",
+          "lat": \(lat),
+          "lon": \(lon),
+          "vehiclesAvailable": \(vehiclesAvailable.map(String.init) ?? "null"),
+          "operative": \(operative)
+        }
+        """
+        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+    }
+}

--- a/OBAKitTests/Mapping/RentalFormatTests.swift
+++ b/OBAKitTests/Mapping/RentalFormatTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import MapKit
 import Testing
 import OTPKit
 @testable import OBAKit
@@ -50,11 +51,23 @@ final class RentalFormatTests {
     /// The default `MKDistanceFormatter` style spells the unit out ("3.4 miles"),
     /// which is far too long to sit under a map pin. The abbreviated style is the
     /// whole reason this formatter is separate from the detail sheet's.
+    ///
+    /// Comparing string contents against hardcoded English words ("miles") passes
+    /// vacuously under a non-English host locale, where the spelled-out and
+    /// abbreviated forms both differ from those words. Instead, build both styles
+    /// from the same (ambient) locale and require the pin label to match the
+    /// abbreviated one and differ from the spelled-out one — the second assertion
+    /// is the one that actually catches a regression to the shared formatter.
     @Test func rangeFallbackUsesAbbreviatedUnits() throws {
         let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: nil)
         let text = try #require(RentalFormat.fuelLabelText(for: rental))
-        #expect(text.contains("miles") == false)
-        #expect(text.contains("Kilometer") == false)
+
+        let abbreviated = MKDistanceFormatter()
+        abbreviated.unitStyle = .abbreviated
+        let spelledOut = MKDistanceFormatter()
+
+        #expect(text == abbreviated.string(fromDistance: 5470))
+        #expect(text != spelledOut.string(fromDistance: 5470))
     }
 
     @Test func noFuelDataYieldsNoLabel() throws {

--- a/OBAKitTests/Mapping/RentalFormatTests.swift
+++ b/OBAKitTests/Mapping/RentalFormatTests.swift
@@ -1,0 +1,80 @@
+//
+//  RentalFormatTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// The text that sits under a rental pin: battery percent when the feed provides
+/// it, remaining range otherwise. On the launch feed `percent` is null fleet-wide
+/// while `range` is populated, so the fallback is the common path, not the edge.
+@MainActor
+@Suite(.serialized)
+final class RentalFormatTests {
+
+    @Test func percentIsPreferredOverRange() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: 0.62)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "62%")
+    }
+
+    @Test func percentRoundsToWholeNumber() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 0.626)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "63%")
+    }
+
+    /// Feeds do send out-of-range values; clamp rather than render "120%".
+    @Test func percentAboveOneClampsToHundred() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 1.2)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "100%")
+    }
+
+    @Test func negativePercentClampsToZero() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: -0.1)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "0%")
+    }
+
+    @Test func fallsBackToRangeWhenPercentMissing() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: nil)
+        let text = RentalFormat.fuelLabelText(for: rental)
+        #expect(text != nil)
+        #expect(text?.contains("%") == false)
+    }
+
+    /// The default `MKDistanceFormatter` style spells the unit out ("3.4 miles"),
+    /// which is far too long to sit under a map pin. The abbreviated style is the
+    /// whole reason this formatter is separate from the detail sheet's.
+    @Test func rangeFallbackUsesAbbreviatedUnits() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: nil)
+        let text = try #require(RentalFormat.fuelLabelText(for: rental))
+        #expect(text.contains("miles") == false)
+        #expect(text.contains("Kilometer") == false)
+    }
+
+    @Test func noFuelDataYieldsNoLabel() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: nil)
+        #expect(RentalFormat.fuelLabelText(for: rental) == nil)
+    }
+
+    @Test func pedalBikeYieldsNoLabel() throws {
+        #expect(RentalFormat.fuelLabelText(for: try RentalFixtures.pedalBike()) == nil)
+    }
+
+    /// Stations have no fuel of their own; the docked vehicles do.
+    @Test func stationYieldsNoLabel() throws {
+        #expect(RentalFormat.fuelLabelText(for: try RentalFixtures.station()) == nil)
+    }
+
+    /// The detail sheet's formatter must keep its spelled-out style — this task
+    /// adds a formatter rather than mutating the shared one.
+    @Test func detailSheetFormatterIsUnchanged() {
+        #expect(RentalFormat.distanceFormatter.unitStyle == .default)
+        #expect(RentalFormat.abbreviatedDistanceFormatter.unitStyle == .abbreviated)
+    }
+}

--- a/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
+++ b/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
@@ -1,0 +1,168 @@
+//
+//  RentalLayerCoordinatorTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// `RentalLayerCoordinator` is the seam between `RentalVisibility`'s pure diffing
+/// (covered by `RentalVisibilityTests`) and the actual `MKMapView`. These tests drive
+/// that seam directly through `apply(_:)`, which is exposed (not `private`) for this
+/// purpose, and never `await` anything: `setLayer`/`viewportDidChange` each fire off
+/// a detached `Task` that talks to `VehicleRentalSource`, but a synchronous,
+/// `@MainActor` test body can't yield, so those tasks never get a chance to run
+/// before the assertions do. That isolates the filter and zoom-gate logic from the
+/// async fetch/debounce pipeline entirely.
+@MainActor
+@Suite(.serialized)
+final class RentalLayerCoordinatorTests {
+
+    /// Never actually called in these tests (no `await` reaches it), but the
+    /// coordinator's initializer requires a `VehicleRentalService` to construct its
+    /// `VehicleRentalSource`.
+    private struct StubVehicleRentalService: VehicleRentalService {
+        func fetchVehicleRentals(
+            in boundingBox: VehicleRentalBoundingBox,
+            formFactors: Set<VehicleFormFactor>?
+        ) async throws -> VehicleRentalFetchResult {
+            VehicleRentalFetchResult(rentals: [])
+        }
+    }
+
+    private let scooters: Set<VehicleFormFactor> = [.scooter, .scooterSeated, .scooterStanding]
+
+    private func makeCoordinator() -> (coordinator: RentalLayerCoordinator, mapView: MKMapView) {
+        let mapView = MKMapView()
+        let coordinator = RentalLayerCoordinator(service: StubVehicleRentalService(), mapView: mapView)
+        return (coordinator, mapView)
+    }
+
+    private func snapshot(
+        added: [VehicleRental] = [],
+        removed: [VehicleRental.ID] = [],
+        updated: [VehicleRental] = []
+    ) -> VehicleRentalSnapshot {
+        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    /// `MKMapView.annotations` may include a user-location annotation, so tests must
+    /// never assert on the raw count — only on rental annotations specifically.
+    private func rentalAnnotations(_ mapView: MKMapView) -> [RentalAnnotation] {
+        mapView.annotations.compactMap { $0 as? RentalAnnotation }
+    }
+
+    // MARK: - Filter behavior (the diagnostic core)
+
+    @Test func addingVehiclesRendersBothAnnotations() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+
+        coordinator.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+
+        #expect(rentalAnnotations(mapView).count == 2)
+    }
+
+    @Test func raisingTheThresholdHidesTheShortRangeVehicle() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+
+        coordinator.setRangeFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        let remaining = rentalAnnotations(mapView)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.rental.id == "far")
+    }
+
+    /// The whole point of `RentalVisibility`'s cache: relaxing the filter restores
+    /// the previously-hidden vehicle from cache, with no refetch involved.
+    @Test func loweringTheThresholdRestoresTheHiddenVehicle() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+        coordinator.setRangeFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        coordinator.setRangeFilter(.any)
+
+        let restored = rentalAnnotations(mapView)
+        #expect(restored.count == 2)
+        #expect(Set(restored.map(\.rental.id)) == ["near", "far"])
+    }
+
+    /// Fail-open: a vehicle whose feed omits `range` is never filterable into
+    /// invisibility, matching `RentalRangeFilter.allows(_:)`'s documented contract.
+    @Test func vehicleWithNoRangeDataSurvivesAnActiveFilter() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.setRangeFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        coordinator.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "no-range-data", rangeMeters: nil)
+        ]))
+
+        #expect(rentalAnnotations(mapView).map(\.rental.id) == ["no-range-data"])
+    }
+
+    // MARK: - Fuel-label zoom gate
+
+    @Test func smallViewportShowsFuelLabels() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+
+        // Well under the 8,000-map-point gate.
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+
+        let annotations = rentalAnnotations(mapView)
+        #expect(!annotations.isEmpty)
+        #expect(annotations.allSatisfy { $0.showsFuelLabel })
+    }
+
+    @Test func largeViewportHidesFuelLabels() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+
+        var largeRect = TestData.seattleMapRect
+        largeRect.size.height = 10_000 // above the 8,000-map-point gate
+        coordinator.viewportDidChange(largeRect)
+
+        let annotations = rentalAnnotations(mapView)
+        #expect(!annotations.isEmpty)
+        #expect(annotations.allSatisfy { !$0.showsFuelLabel })
+    }
+
+    @Test func closedZoomGateHidesFuelLabels() throws {
+        let (coordinator, mapView) = makeCoordinator()
+        coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
+        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+
+        // Establish the "on" state first, so a passing test here can't be an
+        // artifact of `showsFuelLabels` simply defaulting to false.
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        #expect(rentalAnnotations(mapView).allSatisfy { $0.showsFuelLabel })
+
+        coordinator.viewportDidChange(nil)
+
+        let annotations = rentalAnnotations(mapView)
+        #expect(!annotations.isEmpty)
+        #expect(annotations.allSatisfy { !$0.showsFuelLabel })
+    }
+}

--- a/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
+++ b/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
@@ -45,14 +45,6 @@ final class RentalLayerCoordinatorTests {
         return (coordinator, mapView)
     }
 
-    private func snapshot(
-        added: [VehicleRental] = [],
-        removed: [VehicleRental.ID] = [],
-        updated: [VehicleRental] = []
-    ) -> VehicleRentalSnapshot {
-        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
-    }
-
     /// `MKMapView.annotations` may include a user-location annotation, so tests must
     /// never assert on the raw count — only on rental annotations specifically.
     private func rentalAnnotations(_ mapView: MKMapView) -> [RentalAnnotation] {
@@ -65,7 +57,7 @@ final class RentalLayerCoordinatorTests {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
 
-        coordinator.apply(snapshot(added: [
+        coordinator.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
             try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
         ]))
@@ -76,7 +68,7 @@ final class RentalLayerCoordinatorTests {
     @Test func raisingTheThresholdHidesTheShortRangeVehicle() throws {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
-        coordinator.apply(snapshot(added: [
+        coordinator.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
             try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
         ]))
@@ -93,7 +85,7 @@ final class RentalLayerCoordinatorTests {
     @Test func loweringTheThresholdRestoresTheHiddenVehicle() throws {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
-        coordinator.apply(snapshot(added: [
+        coordinator.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
             try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
         ]))
@@ -113,7 +105,7 @@ final class RentalLayerCoordinatorTests {
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
         coordinator.setRangeFilter(RentalRangeFilter(minimumRangeMeters: 8047))
 
-        coordinator.apply(snapshot(added: [
+        coordinator.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "no-range-data", rangeMeters: nil)
         ]))
 
@@ -125,7 +117,7 @@ final class RentalLayerCoordinatorTests {
     @Test func smallViewportShowsFuelLabels() throws {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
-        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+        coordinator.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
 
         // Well under the 8,000-map-point gate.
         coordinator.viewportDidChange(TestData.seattleMapRect)
@@ -138,7 +130,7 @@ final class RentalLayerCoordinatorTests {
     @Test func largeViewportHidesFuelLabels() throws {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
-        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+        coordinator.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
 
         var largeRect = TestData.seattleMapRect
         largeRect.size.height = 10_000 // above the 8,000-map-point gate
@@ -152,7 +144,7 @@ final class RentalLayerCoordinatorTests {
     @Test func closedZoomGateHidesFuelLabels() throws {
         let (coordinator, mapView) = makeCoordinator()
         coordinator.setLayer(id: "scooters", enabled: true, formFactors: scooters)
-        coordinator.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+        coordinator.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
 
         // Establish the "on" state first, so a passing test here can't be an
         // artifact of `showsFuelLabels` simply defaulting to false.

--- a/OBAKitTests/Mapping/RentalRangeFilterTests.swift
+++ b/OBAKitTests/Mapping/RentalRangeFilterTests.swift
@@ -1,0 +1,68 @@
+//
+//  RentalRangeFilterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// The rental minimum-range filter is deliberately fail-open: it hides only a
+/// vehicle that *reports* a range below the threshold. Everything else — stations,
+/// pedal bikes, vehicles whose feed omits range — stays on the map, so a feed that
+/// never publishes range can't be filtered into an empty map.
+@MainActor
+@Suite(.serialized)
+final class RentalRangeFilterTests {
+
+    @Test func inactiveFilterAllowsEverything() throws {
+        let filter = RentalRangeFilter.any
+
+        #expect(filter.isActive == false)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 100)))
+        #expect(filter.allows(try RentalFixtures.station()))
+        #expect(filter.allows(try RentalFixtures.pedalBike()))
+    }
+
+    @Test func hidesVehicleBelowThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 3200)) == false)
+    }
+
+    @Test func keepsVehicleAtExactlyThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 8047)))
+    }
+
+    @Test func keepsVehicleAboveThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 13000)))
+    }
+
+    @Test func keepsVehicleWithUnknownRange() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: nil)))
+    }
+
+    /// A battery percent is not a range; it must not be mistaken for one.
+    @Test func keepsVehicleWithPercentButNoRange() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: 0.05)))
+    }
+
+    /// A pedal bike's range is the rider's legs. Filtering it out would be wrong.
+    @Test func keepsPedalBike() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.pedalBike()))
+    }
+
+    @Test func keepsStation() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.station()))
+    }
+}

--- a/OBAKitTests/Mapping/RentalRangePresetTests.swift
+++ b/OBAKitTests/Mapping/RentalRangePresetTests.swift
@@ -1,0 +1,84 @@
+//
+//  RentalRangePresetTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+
+/// The range-filter menu ladder. Rungs are whole numbers in the rider's own units
+/// rather than a metric ladder converted from miles, because "8 km" reads as a bug.
+@MainActor
+@Suite(.serialized)
+final class RentalRangePresetTests {
+
+    @Test func imperialLadderUsesWholeMiles() {
+        let titles = RentalRangePreset.presets(measurementSystem: .us).map(\.title)
+        #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
+    }
+
+    @Test func metricLadderUsesWholeKilometres() {
+        let titles = RentalRangePreset.presets(measurementSystem: .metric).map(\.title)
+        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
+    }
+
+    /// UK road distances are in miles even though the UK is otherwise metric.
+    @Test func unitedKingdomGetsMiles() {
+        let titles = RentalRangePreset.presets(measurementSystem: .uk).map(\.title)
+        #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
+    }
+
+    /// `Locale.MeasurementSystem` is a struct constructible from any BCP-47
+    /// identifier, so it can never be switched exhaustively. Anything unrecognized
+    /// must land on metric — that's right for most of the world.
+    @Test func unknownSystemFallsBackToMetric() {
+        let titles = RentalRangePreset.presets(measurementSystem: Locale.MeasurementSystem("nonsense")).map(\.title)
+        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
+    }
+
+    @Test func anyRungIsZeroMetres() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(presets.first?.meters == 0)
+    }
+
+    @Test func imperialRungsConvertToMetres() {
+        let meters = RentalRangePreset.presets(measurementSystem: .us).map(\.meters)
+        #expect(meters == [0, 1609, 3219, 8047, 16093, 24140])
+    }
+
+    @Test func metricRungsConvertToMetres() {
+        let meters = RentalRangePreset.presets(measurementSystem: .metric).map(\.meters)
+        #expect(meters == [0, 2000, 5000, 10000, 15000, 25000])
+    }
+
+    @Test func identifierIsTheMetreValue() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(presets.map(\.id) == presets.map(\.meters))
+    }
+
+    @Test func nearestRungMatchesExactly() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 8047, in: presets)?.meters == 8047)
+    }
+
+    /// A stored value from another locale's ladder highlights the closest rung,
+    /// without the stored preference being rewritten.
+    @Test func nearestRungSnapsAnOffLadderValue() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 10_000, in: presets)?.meters == 8047)
+    }
+
+    @Test func nearestRungHandlesZero() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 0, in: presets)?.meters == 0)
+    }
+
+    @Test func nearestRungOnEmptyLadderIsNil() {
+        #expect(RentalRangePreset.nearest(toMeters: 5000, in: []) == nil)
+    }
+}

--- a/OBAKitTests/Mapping/RentalRangePresetTests.swift
+++ b/OBAKitTests/Mapping/RentalRangePresetTests.swift
@@ -18,18 +18,18 @@ import Testing
 final class RentalRangePresetTests {
 
     @Test func imperialLadderUsesWholeMiles() {
-        let titles = RentalRangePreset.presets(measurementSystem: .us).map(\.title)
+        let titles = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US")).map(\.title)
         #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
     }
 
     @Test func metricLadderUsesWholeKilometres() {
-        let titles = RentalRangePreset.presets(measurementSystem: .metric).map(\.title)
+        let titles = RentalRangePreset.presets(measurementSystem: .metric, locale: Locale(identifier: "en_US")).map(\.title)
         #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
     }
 
     /// UK road distances are in miles even though the UK is otherwise metric.
     @Test func unitedKingdomGetsMiles() {
-        let titles = RentalRangePreset.presets(measurementSystem: .uk).map(\.title)
+        let titles = RentalRangePreset.presets(measurementSystem: .uk, locale: Locale(identifier: "en_US")).map(\.title)
         #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
     }
 
@@ -37,48 +37,60 @@ final class RentalRangePresetTests {
     /// identifier, so it can never be switched exhaustively. Anything unrecognized
     /// must land on metric — that's right for most of the world.
     @Test func unknownSystemFallsBackToMetric() {
-        let titles = RentalRangePreset.presets(measurementSystem: Locale.MeasurementSystem("nonsense")).map(\.title)
+        let titles = RentalRangePreset.presets(measurementSystem: Locale.MeasurementSystem("nonsense"), locale: Locale(identifier: "en_US")).map(\.title)
         #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
     }
 
     @Test func anyRungIsZeroMetres() {
-        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        let presets = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US"))
         #expect(presets.first?.meters == 0)
     }
 
     @Test func imperialRungsConvertToMetres() {
-        let meters = RentalRangePreset.presets(measurementSystem: .us).map(\.meters)
+        let meters = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US")).map(\.meters)
         #expect(meters == [0, 1609, 3219, 8047, 16093, 24140])
     }
 
     @Test func metricRungsConvertToMetres() {
-        let meters = RentalRangePreset.presets(measurementSystem: .metric).map(\.meters)
+        let meters = RentalRangePreset.presets(measurementSystem: .metric, locale: Locale(identifier: "en_US")).map(\.meters)
         #expect(meters == [0, 2000, 5000, 10000, 15000, 25000])
     }
 
     @Test func identifierIsTheMetreValue() {
-        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        let presets = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US"))
         #expect(presets.map(\.id) == presets.map(\.meters))
     }
 
     @Test func nearestRungMatchesExactly() {
-        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        let presets = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US"))
         #expect(RentalRangePreset.nearest(toMeters: 8047, in: presets)?.meters == 8047)
     }
 
     /// A stored value from another locale's ladder highlights the closest rung,
     /// without the stored preference being rewritten.
     @Test func nearestRungSnapsAnOffLadderValue() {
-        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        let presets = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US"))
         #expect(RentalRangePreset.nearest(toMeters: 10_000, in: presets)?.meters == 8047)
     }
 
     @Test func nearestRungHandlesZero() {
-        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        let presets = RentalRangePreset.presets(measurementSystem: .us, locale: Locale(identifier: "en_US"))
         #expect(RentalRangePreset.nearest(toMeters: 0, in: presets)?.meters == 0)
     }
 
     @Test func nearestRungOnEmptyLadderIsNil() {
         #expect(RentalRangePreset.nearest(toMeters: 5000, in: []) == nil)
+    }
+
+    /// Titles are rendered in the caller's locale, not the process's ambient one.
+    /// Without an injected locale this assertion would silently depend on the test
+    /// host's system settings — the same ambient-global trap the GMT pin in
+    /// OBATestCase exists to close.
+    @Test func titlesFollowTheProvidedLocale() {
+        let titles = RentalRangePreset.presets(
+            measurementSystem: .metric,
+            locale: Locale(identifier: "de_DE")
+        ).map(\.title)
+        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
     }
 }

--- a/OBAKitTests/Mapping/RentalRangePresetTests.swift
+++ b/OBAKitTests/Mapping/RentalRangePresetTests.swift
@@ -85,12 +85,21 @@ final class RentalRangePresetTests {
     /// Titles are rendered in the caller's locale, not the process's ambient one.
     /// Without an injected locale this assertion would silently depend on the test
     /// host's system settings — the same ambient-global trap the GMT pin in
-    /// OBATestCase exists to close.
+    /// OBATestCase exists to close. `de_DE` doesn't prove this: its "km" is
+    /// byte-identical to `en_US`'s, so the assertion would still pass even if
+    /// `formatter.locale = locale` were deleted from production code. `ar` was
+    /// chosen to actually differ — measured on iPhone 17 Pro / iOS 26.3, it
+    /// keeps Western digits here (Arabic-Indic numerals turn out to be a
+    /// region-specific default, e.g. `ar_SA`, not part of the bare `ar` locale
+    /// data) but does localize the unit abbreviation ("كم"), which is enough to
+    /// make the assertion fail if the injected locale is ever dropped. "Any"
+    /// stays English because it comes from `OBALoc`, which reads the app
+    /// bundle's language, not the formatter's locale.
     @Test func titlesFollowTheProvidedLocale() {
         let titles = RentalRangePreset.presets(
             measurementSystem: .metric,
-            locale: Locale(identifier: "de_DE")
+            locale: Locale(identifier: "ar")
         ).map(\.title)
-        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
+        #expect(titles == ["Any", "2 كم", "5 كم", "10 كم", "15 كم", "25 كم"])
     }
 }

--- a/OBAKitTests/Mapping/RentalVisibilityTests.swift
+++ b/OBAKitTests/Mapping/RentalVisibilityTests.swift
@@ -23,14 +23,6 @@ final class RentalVisibilityTests {
     private let scooters: Set<VehicleFormFactor> = [.scooter, .scooterSeated, .scooterStanding]
     private let bikes: Set<VehicleFormFactor> = [.bicycle, .cargoBicycle]
 
-    private func snapshot(
-        added: [VehicleRental] = [],
-        removed: [VehicleRental.ID] = [],
-        updated: [VehicleRental] = []
-    ) -> VehicleRentalSnapshot {
-        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
-    }
-
     // MARK: - Snapshot application
 
     @Test func addsMatchingEntities() throws {
@@ -38,7 +30,7 @@ final class RentalVisibilityTests {
         _ = visibility.setFormFactors(scooters)
 
         let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
-        let changes = visibility.apply(snapshot(added: [scooter]))
+        let changes = visibility.apply(RentalFixtures.snapshot(added: [scooter]))
 
         #expect(changes.added.map(\.id) == ["v1"])
         #expect(changes.removed.isEmpty)
@@ -49,7 +41,7 @@ final class RentalVisibilityTests {
         _ = visibility.setFormFactors(scooters)
 
         let bike = try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
-        let changes = visibility.apply(snapshot(added: [bike]))
+        let changes = visibility.apply(RentalFixtures.snapshot(added: [bike]))
 
         #expect(changes.isEmpty)
     }
@@ -58,41 +50,41 @@ final class RentalVisibilityTests {
         var visibility = RentalVisibility()
         let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
 
-        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+        #expect(visibility.apply(RentalFixtures.snapshot(added: [scooter])).isEmpty)
     }
 
     @Test func removesEntities() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
 
-        let changes = visibility.apply(snapshot(removed: ["v1"]))
+        let changes = visibility.apply(RentalFixtures.snapshot(removed: ["v1"]))
         #expect(changes.removed == ["v1"])
     }
 
     @Test func removingAnInvisibleEntityChangesNothing() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")]))
 
-        #expect(visibility.apply(snapshot(removed: ["b1"])).isEmpty)
+        #expect(visibility.apply(RentalFixtures.snapshot(removed: ["b1"])).isEmpty)
     }
 
     @Test func duplicateAddIsIgnored() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
         let scooter = try RentalFixtures.vehicle(id: "v1")
-        _ = visibility.apply(snapshot(added: [scooter]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [scooter]))
 
-        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+        #expect(visibility.apply(RentalFixtures.snapshot(added: [scooter])).isEmpty)
     }
 
     @Test func updatesVisibleEntityInPlace() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
 
-        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 9_000)]))
+        let changes = visibility.apply(RentalFixtures.snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 9_000)]))
         #expect(changes.updated.map(\.id) == ["v1"])
         #expect(changes.added.isEmpty)
         #expect(changes.removed.isEmpty)
@@ -105,10 +97,10 @@ final class RentalVisibilityTests {
     @Test func updateCrossingBelowThresholdBecomesARemoval() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
         _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
 
-        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        let changes = visibility.apply(RentalFixtures.snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
         #expect(changes.removed == ["v1"])
         #expect(changes.updated.isEmpty)
     }
@@ -118,9 +110,9 @@ final class RentalVisibilityTests {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
         _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
 
-        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 12_000)]))
+        let changes = visibility.apply(RentalFixtures.snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 12_000)]))
         #expect(changes.added.map(\.id) == ["v1"])
         #expect(changes.updated.isEmpty)
     }
@@ -129,9 +121,9 @@ final class RentalVisibilityTests {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
         _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 1_000)]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 1_000)]))
 
-        #expect(visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 2_000)])).isEmpty)
+        #expect(visibility.apply(RentalFixtures.snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 2_000)])).isEmpty)
     }
 
     // MARK: - Filter changes
@@ -139,7 +131,7 @@ final class RentalVisibilityTests {
     @Test func raisingTheThresholdHidesShortRangeVehicles() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
             try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
         ]))
@@ -154,7 +146,7 @@ final class RentalVisibilityTests {
     @Test func loweringTheThresholdRestoresFromCache() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
             try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
         ]))
@@ -168,7 +160,7 @@ final class RentalVisibilityTests {
     @Test func settingTheSameFilterChangesNothing() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        _ = visibility.apply(RentalFixtures.snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
         _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
 
         #expect(visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047)).isEmpty)
@@ -178,7 +170,7 @@ final class RentalVisibilityTests {
     @Test func raisingTheThresholdKeepsStationsAndPedalBikes() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(bikes)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.station(id: "s1"),
             try RentalFixtures.pedalBike(id: "b1")
         ]))
@@ -191,7 +183,7 @@ final class RentalVisibilityTests {
     @Test func narrowingFormFactorsPrunes() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters.union(bikes))
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
             try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
         ]))
@@ -203,7 +195,7 @@ final class RentalVisibilityTests {
     @Test func wideningFormFactorsRestoresFromCache() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
             try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
         ]))
@@ -215,7 +207,7 @@ final class RentalVisibilityTests {
     @Test func clearingFormFactorsRemovesEverything() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "v1"),
             try RentalFixtures.vehicle(id: "v2")
         ]))
@@ -229,7 +221,7 @@ final class RentalVisibilityTests {
     @Test func wholesaleChangesAreSortedByIdentifier() throws {
         var visibility = RentalVisibility()
         _ = visibility.setFormFactors(scooters)
-        _ = visibility.apply(snapshot(added: [
+        _ = visibility.apply(RentalFixtures.snapshot(added: [
             try RentalFixtures.vehicle(id: "zebra", rangeMeters: 1_000),
             try RentalFixtures.vehicle(id: "alpha", rangeMeters: 1_000),
             try RentalFixtures.vehicle(id: "middle", rangeMeters: 1_000)

--- a/OBAKitTests/Mapping/RentalVisibilityTests.swift
+++ b/OBAKitTests/Mapping/RentalVisibilityTests.swift
@@ -1,0 +1,250 @@
+//
+//  RentalVisibilityTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// `RentalVisibility` holds every entity the source has delivered — not just the
+/// visible ones — and answers "what should change on the map?" for each mutation.
+/// The cache is what makes the range filter reversible: `VehicleRentalSource` emits
+/// only diffs, so a dropped entity is not in a later `added` list.
+@MainActor
+@Suite(.serialized)
+final class RentalVisibilityTests {
+
+    private let scooters: Set<VehicleFormFactor> = [.scooter, .scooterSeated, .scooterStanding]
+    private let bikes: Set<VehicleFormFactor> = [.bicycle, .cargoBicycle]
+
+    private func snapshot(
+        added: [VehicleRental] = [],
+        removed: [VehicleRental.ID] = [],
+        updated: [VehicleRental] = []
+    ) -> VehicleRentalSnapshot {
+        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    // MARK: - Snapshot application
+
+    @Test func addsMatchingEntities() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+
+        let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
+        let changes = visibility.apply(snapshot(added: [scooter]))
+
+        #expect(changes.added.map(\.id) == ["v1"])
+        #expect(changes.removed.isEmpty)
+    }
+
+    @Test func ignoresEntitiesOfOtherFormFactors() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+
+        let bike = try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        let changes = visibility.apply(snapshot(added: [bike]))
+
+        #expect(changes.isEmpty)
+    }
+
+    @Test func withNoFormFactorsNothingIsVisible() throws {
+        var visibility = RentalVisibility()
+        let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
+
+        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+    }
+
+    @Test func removesEntities() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+
+        let changes = visibility.apply(snapshot(removed: ["v1"]))
+        #expect(changes.removed == ["v1"])
+    }
+
+    @Test func removingAnInvisibleEntityChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")]))
+
+        #expect(visibility.apply(snapshot(removed: ["b1"])).isEmpty)
+    }
+
+    @Test func duplicateAddIsIgnored() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        let scooter = try RentalFixtures.vehicle(id: "v1")
+        _ = visibility.apply(snapshot(added: [scooter]))
+
+        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+    }
+
+    @Test func updatesVisibleEntityInPlace() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 9_000)]))
+        #expect(changes.updated.map(\.id) == ["v1"])
+        #expect(changes.added.isEmpty)
+        #expect(changes.removed.isEmpty)
+    }
+
+    // MARK: - Threshold crossing
+
+    /// A scooter that drains below the threshold has to leave the map, and an
+    /// update is not a way to leave — it must be emitted as a removal.
+    @Test func updateCrossingBelowThresholdBecomesARemoval() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        #expect(changes.removed == ["v1"])
+        #expect(changes.updated.isEmpty)
+    }
+
+    /// The mirror image: fresh data lifting a vehicle above the threshold is an add.
+    @Test func updateCrossingAboveThresholdBecomesAnAdd() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 12_000)]))
+        #expect(changes.added.map(\.id) == ["v1"])
+        #expect(changes.updated.isEmpty)
+    }
+
+    @Test func updateStayingInvisibleChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 1_000)]))
+
+        #expect(visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 2_000)])).isEmpty)
+    }
+
+    // MARK: - Filter changes
+
+    @Test func raisingTheThresholdHidesShortRangeVehicles() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+
+        let changes = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        #expect(changes.removed == ["near"])
+        #expect(changes.added.isEmpty)
+    }
+
+    /// The whole point of the cache: lowering the threshold restores vehicles
+    /// without waiting for a refetch, because the source will not re-add them.
+    @Test func loweringTheThresholdRestoresFromCache() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        let changes = visibility.setFilter(.any)
+        #expect(changes.added.map(\.id) == ["near"])
+        #expect(changes.removed.isEmpty)
+    }
+
+    @Test func settingTheSameFilterChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        #expect(visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047)).isEmpty)
+    }
+
+    /// Fail-open under a filter change too: stations and pedal bikes never leave.
+    @Test func raisingTheThresholdKeepsStationsAndPedalBikes() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(bikes)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.station(id: "s1"),
+            try RentalFixtures.pedalBike(id: "b1")
+        ]))
+
+        #expect(visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 24_140)).isEmpty)
+    }
+
+    // MARK: - Form factor changes
+
+    @Test func narrowingFormFactorsPrunes() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters.union(bikes))
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
+            try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        ]))
+
+        let changes = visibility.setFormFactors(scooters)
+        #expect(changes.removed == ["b1"])
+    }
+
+    @Test func wideningFormFactorsRestoresFromCache() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
+            try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        ]))
+
+        let changes = visibility.setFormFactors(scooters.union(bikes))
+        #expect(changes.added.map(\.id) == ["b1"])
+    }
+
+    @Test func clearingFormFactorsRemovesEverything() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1"),
+            try RentalFixtures.vehicle(id: "v2")
+        ]))
+
+        let changes = visibility.setFormFactors([])
+        #expect(changes.removed == ["v1", "v2"])
+    }
+
+    /// Wholesale recomputations sort by id, matching `VehicleRentalSource`'s own
+    /// convention, so the emitted changes are reproducible.
+    @Test func wholesaleChangesAreSortedByIdentifier() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "zebra", rangeMeters: 1_000),
+            try RentalFixtures.vehicle(id: "alpha", rangeMeters: 1_000),
+            try RentalFixtures.vehicle(id: "middle", rangeMeters: 1_000)
+        ]))
+
+        let changes = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        #expect(changes.removed == ["alpha", "middle", "zebra"])
+    }
+
+    @Test func exposesCurrentFormFactorsAndFilter() {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 5_000))
+
+        #expect(visibility.formFactors == scooters)
+        #expect(visibility.filter == RentalRangeFilter(minimumRangeMeters: 5_000))
+    }
+}

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -1715,7 +1715,7 @@ Replace the body of `configure()` with:
 
         // VoiceOver ignores the zoom gate: a visual-density rule must not cost a
         // VoiceOver user the fuel figure.
-        accessibilityLabel = [rental.displayLabel, fuelText]
+        accessibilityLabel = [rental.displayLabel, rentalAnnotation.subtitle, fuelText]
             .compactMap { $0 }
             .joined(separator: ", ")
     }
@@ -1747,7 +1747,7 @@ xcodebuild test-without-building -only-testing:OBAKitTests/RentalAnnotationViewT
   -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
-Expected: PASS, **11 tests executed**.
+Expected: PASS, **12 tests executed**.
 
 - [ ] **Step 6: Lint and commit**
 

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -1401,7 +1401,7 @@ In `OBAKit/Mapping/MapRegionManager.swift`, insert immediately after `setMapLaye
 
 ```swift
     /// The UserDefaults key persisting the shared rental minimum-range threshold.
-    public static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
+    static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
 
     /// The minimum-range filter shared by the Bikes and Scooters layers — one
     /// threshold, not one per layer.
@@ -1410,7 +1410,7 @@ In `OBAKit/Mapping/MapRegionManager.swift`, insert immediately after `setMapLaye
     /// and `resetMapLayersToDefaults()` cover it, which is what makes the Map
     /// sheet's Reset button honest. No `register(defaults:)` is needed: an unset
     /// key reads as 0, which is exactly `.any`.
-    public var rentalRangeFilter: RentalRangeFilter {
+    var rentalRangeFilter: RentalRangeFilter {
         get {
             RentalRangeFilter(
                 minimumRangeMeters: application.userDefaults.integer(forKey: Self.rentalMinimumRangeDefaultsKey)

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -1,0 +1,2156 @@
+# Rental Range Filter and Fuel Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared minimum-range filter for the Bikes and Scooters map layers, and render each rental pin's battery percent (falling back to remaining range) beneath its marker.
+
+**Architecture:** Three new pure value types carry all the logic — `RentalRangeFilter` (the predicate), `RentalRangePreset` (the menu ladder), and `RentalVisibility` (a cache of every delivered entity plus the diff between what is cached and what belongs on the map). `RentalLayerCoordinator` shrinks to translating `RentalVisibility.Changes` into `MKMapView` calls. The threshold persists on `MapRegionManager` beside the existing per-layer enablement, so the Map sheet's Reset affordance covers it; `MapViewController` wires a change notification through to the coordinator.
+
+**Tech Stack:** Swift 6, UIKit + MapKit, SwiftUI (Map sheet), OTPKit (`VehicleRental` models), Swift Testing, XcodeGen.
+
+Full design rationale: `docs/superpowers/specs/2026-07-29-rental-range-filter-design.md`.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Simulator is `iPhone 17 Pro`.** iPhone 16 is not installed on this machine; `CLAUDE.md`'s destination string is stale.
+- **Run `scripts/generate_project OneBusAway` after creating ANY new source or test file.** XcodeGen discovers files from disk. A test file the project doesn't know about does not fail — it silently runs zero tests, which reads as passing.
+- **Always `set -o pipefail` before piping `xcodebuild` to `tail`.** Without it a failed build exits 0 and the failure is invisible.
+- **A failing test run stalls for ~10 minutes in `simctl diagnose`.** Once failures have printed, kill `xcodebuild` rather than waiting. Do not run two failing suites concurrently.
+- **Swift 6 language mode, main-actor default isolation** in OBAKit (OBAKitCore pins back to `nonisolated`). The five concurrency diagnostic groups are escalated to **errors** — a data-race warning fails the build.
+- **Consequence of the above:** every new type in this plan is implicitly main-actor isolated, so every test suite touching them must be annotated `@MainActor`.
+- **Tests are Swift Testing** (`@Suite` / `@Test` / `#expect`), never XCTest. Suites are `final class`, annotated `@MainActor @Suite(.serialized)`.
+- **Test isolation comes from fixtures, not scheduling.** Swift Testing runs suites in parallel via task groups in one process. Never touch `UserDefaults.standard`; use `OBATestCase`'s per-instance `userDefaultsSuiteName`.
+- **OTPKit's rental models have no public memberwise initializer.** `RentalVehicle`, `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose only internal memberwise inits. Test fixtures must be built by decoding JSON through `VehicleRental.init(from:)`, which *is* public. Task 1 builds that helper.
+- **New user-facing strings** go in `OBAKit/Strings/en.lproj/Localizable.strings` via `OBALoc(...)` with a `value:` and a `comment:`. Do not hand-edit other locales.
+- **Lint before each commit:** `scripts/swiftlint.sh`.
+
+### Standard commands
+
+Build for testing (run once up front, and again after any `generate_project`):
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Run one suite:
+
+```bash
+set -o pipefail
+xcodebuild test-without-building -only-testing:OBAKitTests/<SuiteName> \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+---
+
+## File Structure
+
+**Create — production (`OBAKit/Mapping/Layers/`)**
+
+| File | Responsibility |
+| --- | --- |
+| `RentalRangeFilter.swift` | The fail-open minimum-range predicate. Nothing else. |
+| `RentalRangePreset.swift` | The locale-appropriate menu ladder and nearest-rung lookup. |
+| `RentalVisibility.swift` | Cache of delivered entities + the add/remove/update diff. No MapKit, no async. |
+| `RentalFormat.swift` | Shared rental formatting, moved out of `RentalDetailViewController.swift`, plus the new fuel-label text. |
+
+**Create — tests (`OBAKitTests/Mapping/`)**
+
+| File | Responsibility |
+| --- | --- |
+| `RentalFixtures.swift` | JSON-decoded `VehicleRental` builders. Not a suite. |
+| `RentalRangeFilterTests.swift` | The allow matrix. |
+| `RentalRangePresetTests.swift` | Both ladders, metres, titles, nearest rung. |
+| `RentalVisibilityTests.swift` | Diffs, threshold changes, cache restore, ordering. |
+| `RentalFormatTests.swift` | Percent rounding/clamping, range fallback, nil cases. |
+| `RentalAnnotationViewTests.swift` | Label text, hidden state, tint, accessibility. |
+| `MapRegionManagerRentalFilterTests.swift` | Persistence, reset, differs-from-defaults. |
+
+**Modify**
+
+| File | Change |
+| --- | --- |
+| `OBAKit/Mapping/Layers/RentalDetailViewController.swift` | Remove the `RentalFormat` enum (moved to its own file). |
+| `OBAKit/Mapping/Layers/MapLayer.swift` | Add the `.rentalRangeFilterDidChange` notification name. |
+| `OBAKit/Mapping/MapRegionManager.swift` | Add `rentalRangeFilter`; fold it into reset and differs-from-defaults. |
+| `OBAKit/Mapping/Layers/RentalAnnotation.swift` | Add `showsFuelLabel`. |
+| `OBAKit/Mapping/Layers/RentalAnnotationView.swift` | Add the fuel label subview and accessibility label. |
+| `OBAKit/Mapping/Layers/RentalLayerCoordinator.swift` | Adopt `RentalVisibility`; add `setRangeFilter`; add the label zoom gate; delete `pruneAnnotations`. |
+| `OBAKit/Mapping/Layers/MapSheetView.swift` | Add the picker row to the "Other ways to get around" section. |
+| `OBAKit/Mapping/MapViewController+MapLayers.swift` | Seed the coordinator's filter; observe the change notification. |
+| `OBAKit/Mapping/MapViewController.swift:166-167` | Register the new notification observer. |
+| `OBAKit/Analytics/Analytics.swift` | Add the `rentalRangeFilterChanged` label. |
+| `OBAKit/Strings/en.lproj/Localizable.strings` | Two new strings. |
+
+---
+
+## Task 1: Range filter predicate and test fixtures
+
+The predicate is the smallest piece and the first consumer of the fixture helper, so they land together.
+
+**Files:**
+- Create: `OBAKit/Mapping/Layers/RentalRangeFilter.swift`
+- Create: `OBAKitTests/Mapping/RentalFixtures.swift`
+- Test: `OBAKitTests/Mapping/RentalRangeFilterTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `struct RentalRangeFilter: Equatable` with `let minimumRangeMeters: Int`, `static let any`, `var isActive: Bool`, `func allows(_ rental: VehicleRental) -> Bool`
+  - `enum RentalFixtures` with
+    `static func vehicle(id: String, formFactor: String, propulsion: String?, rangeMeters: Int?, batteryPercent: Double?, operative: Bool, lat: Double, lon: Double) throws -> VehicleRental`
+    and `static func station(id: String, vehiclesAvailable: Int?, operative: Bool, lat: Double, lon: Double) throws -> VehicleRental`
+
+- [ ] **Step 1: Write the fixture helper**
+
+Create `OBAKitTests/Mapping/RentalFixtures.swift`. This decodes rather than constructs, because OTPKit's rental models expose no public memberwise init — only `VehicleRental.init(from:)` is public.
+
+```swift
+//
+//  RentalFixtures.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OTPKit
+
+/// Builds `VehicleRental` values for tests.
+///
+/// These are decoded from JSON rather than constructed directly: OTPKit's
+/// `RentalVehicle`, `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose
+/// only internal memberwise initializers, so the sole cross-module entry point is
+/// `VehicleRental.init(from:)`. Decoding has the side benefit of exercising the
+/// same path real payloads take, including `__typename` discrimination.
+enum RentalFixtures {
+
+    /// A free-floating rental vehicle. Pass `rangeMeters: nil, batteryPercent: nil`
+    /// for a vehicle whose feed publishes no fuel data at all.
+    static func vehicle(
+        id: String = "v1",
+        formFactor: String = "SCOOTER",
+        propulsion: String? = "ELECTRIC",
+        rangeMeters: Int? = nil,
+        batteryPercent: Double? = nil,
+        operative: Bool = true,
+        lat: Double = 47.6,
+        lon: Double = -122.3
+    ) throws -> VehicleRental {
+        var fuelFields: [String] = []
+        if let batteryPercent {
+            fuelFields.append("\"percent\": \(batteryPercent)")
+        }
+        if let rangeMeters {
+            fuelFields.append("\"range\": \(rangeMeters)")
+        }
+        let fuelJSON = fuelFields.isEmpty ? "null" : "{ \(fuelFields.joined(separator: ", ")) }"
+        let propulsionJSON = propulsion.map { "\"\($0)\"" } ?? "null"
+
+        let json = """
+        {
+          "__typename": "RentalVehicle",
+          "vehicleId": "\(id)",
+          "name": "Default vehicle type",
+          "lat": \(lat),
+          "lon": \(lon),
+          "allowPickupNow": true,
+          "operative": \(operative),
+          "rentalNetwork": { "networkId": "lime_seattle", "url": null },
+          "rentalUris": null,
+          "vehicleType": { "formFactor": "\(formFactor)", "propulsionType": \(propulsionJSON) },
+          "fuel": \(fuelJSON)
+        }
+        """
+        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+    }
+
+    /// A non-powered vehicle: a pedal bike, with no `fuel` object at all.
+    static func pedalBike(id: String = "b1") throws -> VehicleRental {
+        try vehicle(id: id, formFactor: "BICYCLE", propulsion: "HUMAN", rangeMeters: nil, batteryPercent: nil)
+    }
+
+    /// A docked station. Stations never carry fuel data.
+    static func station(
+        id: String = "s1",
+        vehiclesAvailable: Int? = 4,
+        operative: Bool = true,
+        lat: Double = 47.6,
+        lon: Double = -122.3
+    ) throws -> VehicleRental {
+        let json = """
+        {
+          "__typename": "VehicleRentalStation",
+          "stationId": "\(id)",
+          "name": "Pine St Station",
+          "lat": \(lat),
+          "lon": \(lon),
+          "vehiclesAvailable": \(vehiclesAvailable.map(String.init) ?? "null"),
+          "operative": \(operative)
+        }
+        """
+        return try JSONDecoder().decode(VehicleRental.self, from: Data(json.utf8))
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `OBAKitTests/Mapping/RentalRangeFilterTests.swift`:
+
+```swift
+//
+//  RentalRangeFilterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// The rental minimum-range filter is deliberately fail-open: it hides only a
+/// vehicle that *reports* a range below the threshold. Everything else — stations,
+/// pedal bikes, vehicles whose feed omits range — stays on the map, so a feed that
+/// never publishes range can't be filtered into an empty map.
+@MainActor
+@Suite(.serialized)
+final class RentalRangeFilterTests {
+
+    @Test func inactiveFilterAllowsEverything() throws {
+        let filter = RentalRangeFilter.any
+
+        #expect(filter.isActive == false)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 100)))
+        #expect(filter.allows(try RentalFixtures.station()))
+        #expect(filter.allows(try RentalFixtures.pedalBike()))
+    }
+
+    @Test func hidesVehicleBelowThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 3200)) == false)
+    }
+
+    @Test func keepsVehicleAtExactlyThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 8047)))
+    }
+
+    @Test func keepsVehicleAboveThreshold() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: 13000)))
+    }
+
+    @Test func keepsVehicleWithUnknownRange() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: nil)))
+    }
+
+    /// A battery percent is not a range; it must not be mistaken for one.
+    @Test func keepsVehicleWithPercentButNoRange() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: 0.05)))
+    }
+
+    /// A pedal bike's range is the rider's legs. Filtering it out would be wrong.
+    @Test func keepsPedalBike() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.pedalBike()))
+    }
+
+    @Test func keepsStation() throws {
+        let filter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(filter.allows(try RentalFixtures.station()))
+    }
+}
+```
+
+- [ ] **Step 3: Regenerate the project and run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "cannot find 'RentalRangeFilter' in scope". This is the red state — the type doesn't exist yet.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Create `OBAKit/Mapping/Layers/RentalRangeFilter.swift`:
+
+```swift
+//
+//  RentalRangeFilter.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OTPKit
+
+/// The rider's "don't show me nearly-dead vehicles" filter.
+///
+/// Fail-open by design: only a vehicle that *reports* a range below the threshold
+/// is hidden. Docked stations, pedal bikes, and vehicles whose feed omits `range`
+/// all leave through the same early return — a feed that never publishes range
+/// must not be filterable into an empty map. This mirrors the convention already
+/// set by `VehicleRental.matches(formFactors:)`.
+struct RentalRangeFilter: Equatable {
+
+    /// Threshold in meters. Zero means "Any" — no filtering at all.
+    let minimumRangeMeters: Int
+
+    static let any = RentalRangeFilter(minimumRangeMeters: 0)
+
+    var isActive: Bool { minimumRangeMeters > 0 }
+
+    func allows(_ rental: VehicleRental) -> Bool {
+        guard isActive,
+              case .vehicle(let vehicle) = rental,
+              let range = vehicle.fuel?.range else {
+            return true
+        }
+        return range >= minimumRangeMeters
+    }
+}
+```
+
+- [ ] **Step 5: Regenerate, build, and run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalRangeFilterTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **8 tests executed**. If it reports 0 tests, `generate_project` did not pick up the new files — re-run it and rebuild.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalRangeFilter.swift \
+        OBAKitTests/Mapping/RentalFixtures.swift \
+        OBAKitTests/Mapping/RentalRangeFilterTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Add the fail-open rental range filter predicate"
+```
+
+---
+
+## Task 2: Preset ladder
+
+**Files:**
+- Create: `OBAKit/Mapping/Layers/RentalRangePreset.swift`
+- Modify: `OBAKit/Strings/en.lproj/Localizable.strings`
+- Test: `OBAKitTests/Mapping/RentalRangePresetTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `struct RentalRangePreset: Equatable, Identifiable` with `let meters: Int`, `let title: String`, `var id: Int { meters }`,
+  `static func presets(measurementSystem: Locale.MeasurementSystem = Locale.current.measurementSystem) -> [RentalRangePreset]`,
+  `static func nearest(toMeters: Int, in: [RentalRangePreset]) -> RentalRangePreset?`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Mapping/RentalRangePresetTests.swift`. Note the exact metre values: 1 mi = 1609.344 → 1609; 2 mi → 3219; 5 mi = 8046.72 → 8047; 10 mi → 16093; 15 mi → 24140.
+
+```swift
+//
+//  RentalRangePresetTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+
+/// The range-filter menu ladder. Rungs are whole numbers in the rider's own units
+/// rather than a metric ladder converted from miles, because "8 km" reads as a bug.
+@MainActor
+@Suite(.serialized)
+final class RentalRangePresetTests {
+
+    @Test func imperialLadderUsesWholeMiles() {
+        let titles = RentalRangePreset.presets(measurementSystem: .us).map(\.title)
+        #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
+    }
+
+    @Test func metricLadderUsesWholeKilometres() {
+        let titles = RentalRangePreset.presets(measurementSystem: .metric).map(\.title)
+        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
+    }
+
+    /// UK road distances are in miles even though the UK is otherwise metric.
+    @Test func unitedKingdomGetsMiles() {
+        let titles = RentalRangePreset.presets(measurementSystem: .uk).map(\.title)
+        #expect(titles == ["Any", "1 mi", "2 mi", "5 mi", "10 mi", "15 mi"])
+    }
+
+    /// `Locale.MeasurementSystem` is a struct constructible from any BCP-47
+    /// identifier, so it can never be switched exhaustively. Anything unrecognized
+    /// must land on metric — that's right for most of the world.
+    @Test func unknownSystemFallsBackToMetric() {
+        let titles = RentalRangePreset.presets(measurementSystem: Locale.MeasurementSystem("nonsense")).map(\.title)
+        #expect(titles == ["Any", "2 km", "5 km", "10 km", "15 km", "25 km"])
+    }
+
+    @Test func anyRungIsZeroMetres() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(presets.first?.meters == 0)
+    }
+
+    @Test func imperialRungsConvertToMetres() {
+        let meters = RentalRangePreset.presets(measurementSystem: .us).map(\.meters)
+        #expect(meters == [0, 1609, 3219, 8047, 16093, 24140])
+    }
+
+    @Test func metricRungsConvertToMetres() {
+        let meters = RentalRangePreset.presets(measurementSystem: .metric).map(\.meters)
+        #expect(meters == [0, 2000, 5000, 10000, 15000, 25000])
+    }
+
+    @Test func identifierIsTheMetreValue() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(presets.map(\.id) == presets.map(\.meters))
+    }
+
+    @Test func nearestRungMatchesExactly() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 8047, in: presets)?.meters == 8047)
+    }
+
+    /// A stored value from another locale's ladder highlights the closest rung,
+    /// without the stored preference being rewritten.
+    @Test func nearestRungSnapsAnOffLadderValue() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 10_000, in: presets)?.meters == 8047)
+    }
+
+    @Test func nearestRungHandlesZero() {
+        let presets = RentalRangePreset.presets(measurementSystem: .us)
+        #expect(RentalRangePreset.nearest(toMeters: 0, in: presets)?.meters == 0)
+    }
+
+    @Test func nearestRungOnEmptyLadderIsNil() {
+        #expect(RentalRangePreset.nearest(toMeters: 5000, in: []) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "cannot find 'RentalRangePreset' in scope".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `OBAKit/Mapping/Layers/RentalRangePreset.swift`:
+
+```swift
+//
+//  RentalRangePreset.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// One rung of the Map sheet's minimum-range menu.
+///
+/// The stored preference is always metres; these rungs are the rider-facing
+/// choices. Rung values are whole numbers in the rider's own units rather than a
+/// metric ladder converted from miles, because "8 km" reads as a bug.
+struct RentalRangePreset: Equatable, Identifiable {
+
+    /// The threshold this rung selects. Zero is the "Any" rung.
+    let meters: Int
+
+    /// Rider-facing label: "Any", "5 mi", "10 km".
+    let title: String
+
+    var id: Int { meters }
+
+    /// The ladder for a measurement system.
+    ///
+    /// `Locale.MeasurementSystem` is a struct, not an enum — it carries `.metric`,
+    /// `.us`, and `.uk` but can be built from any BCP-47 identifier, so it can
+    /// never be switched exhaustively. Miles are therefore the *explicit* case and
+    /// metric the fallback: `.uk` genuinely wants miles (UK road distances are in
+    /// miles), and anything unrecognized lands on metric, which is right for most
+    /// of the world.
+    static func presets(
+        measurementSystem: Locale.MeasurementSystem = Locale.current.measurementSystem
+    ) -> [RentalRangePreset] {
+        let usesMiles = measurementSystem == .us || measurementSystem == .uk
+        let unit: UnitLength = usesMiles ? .miles : .kilometers
+        let values: [Double] = usesMiles ? [1, 2, 5, 10, 15] : [2, 5, 10, 15, 25]
+
+        let anyRung = RentalRangePreset(
+            meters: 0,
+            title: OBALoc("map_sheet.minimum_range_any", value: "Any", comment: "Range filter menu option imposing no minimum range")
+        )
+
+        return [anyRung] + values.map { value in
+            let measurement = Measurement(value: value, unit: unit)
+            return RentalRangePreset(
+                meters: Int(measurement.converted(to: .meters).value.rounded()),
+                title: formatter.string(from: measurement)
+            )
+        }
+    }
+
+    /// The rung closest to a stored metre value. Used only to highlight the menu
+    /// selection — filtering keeps using the stored value, so a preference set in
+    /// another locale is never silently rewritten.
+    static func nearest(toMeters meters: Int, in presets: [RentalRangePreset]) -> RentalRangePreset? {
+        presets.min { abs($0.meters - meters) < abs($1.meters - meters) }
+    }
+
+    /// `.providedUnit` suppresses both conversion and locale substitution, so the
+    /// displayed number matches the rung exactly ("5 mi", not "8 km").
+    private static let formatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.unitStyle = .medium
+        formatter.numberFormatter.maximumFractionDigits = 0
+        return formatter
+    }()
+}
+```
+
+- [ ] **Step 4: Add the localized string**
+
+Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
+
+```
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Any";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalRangePresetTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **12 tests executed**.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalRangePreset.swift \
+        OBAKit/Strings/en.lproj/Localizable.strings \
+        OBAKitTests/Mapping/RentalRangePresetTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Add the locale-appropriate rental range preset ladder"
+```
+
+---
+
+## Task 3: Extract RentalFormat and add fuel-label text
+
+`RentalFormat` currently lives inside `RentalDetailViewController.swift`, which was already the wrong home; this task adds a third consumer, so it moves out.
+
+**Files:**
+- Create: `OBAKit/Mapping/Layers/RentalFormat.swift`
+- Modify: `OBAKit/Mapping/Layers/RentalDetailViewController.swift` (delete the `RentalFormat` enum, lines ~33-52)
+- Test: `OBAKitTests/Mapping/RentalFormatTests.swift`
+
+**Interfaces:**
+- Consumes: `RentalFixtures` from Task 1.
+- Produces: `enum RentalFormat` with the existing `static let distanceFormatter: MKDistanceFormatter`, `static func walkTimeText(from: CLLocation?, to: CLLocationCoordinate2D) -> String?`, `static func batteryText(_ percent: Double) -> String`, plus new `static let abbreviatedDistanceFormatter: MKDistanceFormatter` and `static func fuelLabelText(for rental: VehicleRental) -> String?`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Mapping/RentalFormatTests.swift`. The range assertions avoid hard-coding a locale-specific string; they assert the *abbreviated* property, which is what actually matters for a pin label.
+
+```swift
+//
+//  RentalFormatTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// The text that sits under a rental pin: battery percent when the feed provides
+/// it, remaining range otherwise. On the launch feed `percent` is null fleet-wide
+/// while `range` is populated, so the fallback is the common path, not the edge.
+@MainActor
+@Suite(.serialized)
+final class RentalFormatTests {
+
+    @Test func percentIsPreferredOverRange() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: 0.62)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "62%")
+    }
+
+    @Test func percentRoundsToWholeNumber() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 0.626)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "63%")
+    }
+
+    /// Feeds do send out-of-range values; clamp rather than render "120%".
+    @Test func percentAboveOneClampsToHundred() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 1.2)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "100%")
+    }
+
+    @Test func negativePercentClampsToZero() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: -0.1)
+        #expect(RentalFormat.fuelLabelText(for: rental) == "0%")
+    }
+
+    @Test func fallsBackToRangeWhenPercentMissing() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: nil)
+        let text = RentalFormat.fuelLabelText(for: rental)
+        #expect(text != nil)
+        #expect(text?.contains("%") == false)
+    }
+
+    /// The default `MKDistanceFormatter` style spells the unit out ("3.4 miles"),
+    /// which is far too long to sit under a map pin. The abbreviated style is the
+    /// whole reason this formatter is separate from the detail sheet's.
+    @Test func rangeFallbackUsesAbbreviatedUnits() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: 5470, batteryPercent: nil)
+        let text = try #require(RentalFormat.fuelLabelText(for: rental))
+        #expect(text.contains("miles") == false)
+        #expect(text.contains("Kilometer") == false)
+    }
+
+    @Test func noFuelDataYieldsNoLabel() throws {
+        let rental = try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: nil)
+        #expect(RentalFormat.fuelLabelText(for: rental) == nil)
+    }
+
+    @Test func pedalBikeYieldsNoLabel() throws {
+        #expect(RentalFormat.fuelLabelText(for: try RentalFixtures.pedalBike()) == nil)
+    }
+
+    /// Stations have no fuel of their own; the docked vehicles do.
+    @Test func stationYieldsNoLabel() throws {
+        #expect(RentalFormat.fuelLabelText(for: try RentalFixtures.station()) == nil)
+    }
+
+    /// The detail sheet's formatter must keep its spelled-out style — this task
+    /// adds a formatter rather than mutating the shared one.
+    @Test func detailSheetFormatterIsUnchanged() {
+        #expect(RentalFormat.distanceFormatter.unitStyle == .default)
+        #expect(RentalFormat.abbreviatedDistanceFormatter.unitStyle == .abbreviated)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "type 'RentalFormat' has no member 'fuelLabelText'" and "...no member 'abbreviatedDistanceFormatter'".
+
+- [ ] **Step 3: Create the new file with the moved and new code**
+
+Create `OBAKit/Mapping/Layers/RentalFormat.swift`:
+
+```swift
+//
+//  RentalFormat.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import OBAKitCore
+import OTPKit
+
+/// Shared rider-facing formatting for rental entities, used by the detail sheet,
+/// the cluster list, and the map annotation's fuel label.
+enum RentalFormat {
+
+    /// Cached: a fresh MKDistanceFormatter per row per render is waste.
+    static let distanceFormatter = MKDistanceFormatter()
+
+    /// A second formatter for space-constrained surfaces. The default style spells
+    /// the unit out — 5,470 m renders as "3.4 miles" under en_US, where this one
+    /// gives "3.4 mi". Only the abbreviated form fits under a map pin. The detail
+    /// sheet's spelled-out rendering is deliberate, so the two coexist rather than
+    /// one being mutated in place.
+    static let abbreviatedDistanceFormatter: MKDistanceFormatter = {
+        let formatter = MKDistanceFormatter()
+        formatter.unitStyle = .abbreviated
+        return formatter
+    }()
+
+    /// Straight-line walk estimate at the app's default walking speed.
+    /// Nil beyond 10 km — a "119 min walk" line is noise, not information.
+    static func walkTimeText(from userLocation: CLLocation?, to coordinate: CLLocationCoordinate2D) -> String? {
+        guard let userLocation else { return nil }
+        let target = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        let meters = userLocation.distance(from: target)
+        guard meters.isFinite, meters < 10_000 else { return nil }
+
+        let minutes = max(1, Int((meters / WalkingSpeed.defaultMetersPerSecond / 60).rounded()))
+        return String(format: OBALoc("rental_detail.walk_time_fmt", value: "%d min walk", comment: "Estimated walking time to a rental vehicle"), minutes)
+    }
+
+    static func batteryText(_ percent: Double) -> String {
+        "\(Int((percent * 100).rounded()))%"
+    }
+
+    /// The text rendered beneath a rental map pin: battery percent when the feed
+    /// provides it, else remaining range, else nothing.
+    ///
+    /// The percent-first ordering matches the mockup, but the range fallback is the
+    /// common path in practice: on the launch feed `percent` is null across the
+    /// whole fleet while `range` is populated.
+    static func fuelLabelText(for rental: VehicleRental) -> String? {
+        guard case .vehicle(let vehicle) = rental, let fuel = vehicle.fuel else { return nil }
+
+        if let percent = fuel.percent {
+            // Feeds do send values outside 0...1; clamp rather than render "120%".
+            return batteryText(min(max(percent, 0), 1))
+        }
+
+        if let range = fuel.range {
+            return abbreviatedDistanceFormatter.string(fromDistance: CLLocationDistance(range))
+        }
+
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Delete the old enum from the detail view controller**
+
+In `OBAKit/Mapping/Layers/RentalDetailViewController.swift`, delete the entire `enum RentalFormat { ... }` block (it begins at the line `enum RentalFormat {` and ends with the closing brace before the `// MARK: - Detail Sheet` comment). Leave everything else in that file untouched — the `RentalFormat.` call sites still resolve, now to the new file.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalFormatTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **10 tests executed**.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalFormat.swift \
+        OBAKit/Mapping/Layers/RentalDetailViewController.swift \
+        OBAKitTests/Mapping/RentalFormatTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Extract RentalFormat and add abbreviated fuel-label text"
+```
+
+---
+
+## Task 4: Visibility cache and diff
+
+The core of the feature. `VehicleRentalSource` emits only diffs against what it has previously delivered, so without a local cache a vehicle dropped for being under threshold would never reappear when the threshold is lowered.
+
+**Files:**
+- Create: `OBAKit/Mapping/Layers/RentalVisibility.swift`
+- Test: `OBAKitTests/Mapping/RentalVisibilityTests.swift`
+
+**Interfaces:**
+- Consumes: `RentalRangeFilter` (Task 1), `RentalFixtures` (Task 1).
+- Produces: `struct RentalVisibility` with
+  - nested `struct Changes: Equatable` having `var added: [VehicleRental]`, `var removed: [VehicleRental.ID]`, `var updated: [VehicleRental]`, `var isEmpty: Bool`
+  - `private(set) var formFactors: Set<VehicleFormFactor>`, `private(set) var filter: RentalRangeFilter`
+  - `mutating func apply(_ snapshot: VehicleRentalSnapshot) -> Changes`
+  - `mutating func setFormFactors(_ formFactors: Set<VehicleFormFactor>) -> Changes`
+  - `mutating func setFilter(_ filter: RentalRangeFilter) -> Changes`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Mapping/RentalVisibilityTests.swift`:
+
+```swift
+//
+//  RentalVisibilityTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// `RentalVisibility` holds every entity the source has delivered — not just the
+/// visible ones — and answers "what should change on the map?" for each mutation.
+/// The cache is what makes the range filter reversible: `VehicleRentalSource` emits
+/// only diffs, so a dropped entity is not in a later `added` list.
+@MainActor
+@Suite(.serialized)
+final class RentalVisibilityTests {
+
+    private let scooters: Set<VehicleFormFactor> = [.scooter, .scooterSeated, .scooterStanding]
+    private let bikes: Set<VehicleFormFactor> = [.bicycle, .cargoBicycle]
+
+    private func snapshot(
+        added: [VehicleRental] = [],
+        removed: [VehicleRental.ID] = [],
+        updated: [VehicleRental] = []
+    ) -> VehicleRentalSnapshot {
+        VehicleRentalSnapshot(added: added, removed: removed, updated: updated, fetchedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    // MARK: - Snapshot application
+
+    @Test func addsMatchingEntities() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+
+        let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
+        let changes = visibility.apply(snapshot(added: [scooter]))
+
+        #expect(changes.added.map(\.id) == ["v1"])
+        #expect(changes.removed.isEmpty)
+    }
+
+    @Test func ignoresEntitiesOfOtherFormFactors() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+
+        let bike = try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        let changes = visibility.apply(snapshot(added: [bike]))
+
+        #expect(changes.isEmpty)
+    }
+
+    @Test func withNoFormFactorsNothingIsVisible() throws {
+        var visibility = RentalVisibility()
+        let scooter = try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER")
+
+        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+    }
+
+    @Test func removesEntities() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1")]))
+
+        let changes = visibility.apply(snapshot(removed: ["v1"]))
+        #expect(changes.removed == ["v1"])
+    }
+
+    @Test func removingAnInvisibleEntityChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")]))
+
+        #expect(visibility.apply(snapshot(removed: ["b1"])).isEmpty)
+    }
+
+    @Test func duplicateAddIsIgnored() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        let scooter = try RentalFixtures.vehicle(id: "v1")
+        _ = visibility.apply(snapshot(added: [scooter]))
+
+        #expect(visibility.apply(snapshot(added: [scooter])).isEmpty)
+    }
+
+    @Test func updatesVisibleEntityInPlace() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 9_000)]))
+        #expect(changes.updated.map(\.id) == ["v1"])
+        #expect(changes.added.isEmpty)
+        #expect(changes.removed.isEmpty)
+    }
+
+    // MARK: - Threshold crossing
+
+    /// A scooter that drains below the threshold has to leave the map, and an
+    /// update is not a way to leave — it must be emitted as a removal.
+    @Test func updateCrossingBelowThresholdBecomesARemoval() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 10_000)]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        #expect(changes.removed == ["v1"])
+        #expect(changes.updated.isEmpty)
+    }
+
+    /// The mirror image: fresh data lifting a vehicle above the threshold is an add.
+    @Test func updateCrossingAboveThresholdBecomesAnAdd() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+
+        let changes = visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 12_000)]))
+        #expect(changes.added.map(\.id) == ["v1"])
+        #expect(changes.updated.isEmpty)
+    }
+
+    @Test func updateStayingInvisibleChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 1_000)]))
+
+        #expect(visibility.apply(snapshot(updated: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 2_000)])).isEmpty)
+    }
+
+    // MARK: - Filter changes
+
+    @Test func raisingTheThresholdHidesShortRangeVehicles() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+
+        let changes = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        #expect(changes.removed == ["near"])
+        #expect(changes.added.isEmpty)
+    }
+
+    /// The whole point of the cache: lowering the threshold restores vehicles
+    /// without waiting for a refetch, because the source will not re-add them.
+    @Test func loweringTheThresholdRestoresFromCache() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "near", rangeMeters: 3_000),
+            try RentalFixtures.vehicle(id: "far", rangeMeters: 12_000)
+        ]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        let changes = visibility.setFilter(.any)
+        #expect(changes.added.map(\.id) == ["near"])
+        #expect(changes.removed.isEmpty)
+    }
+
+    @Test func settingTheSameFilterChangesNothing() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [try RentalFixtures.vehicle(id: "v1", rangeMeters: 3_000)]))
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+
+        #expect(visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047)).isEmpty)
+    }
+
+    /// Fail-open under a filter change too: stations and pedal bikes never leave.
+    @Test func raisingTheThresholdKeepsStationsAndPedalBikes() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(bikes)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.station(id: "s1"),
+            try RentalFixtures.pedalBike(id: "b1")
+        ]))
+
+        #expect(visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 24_140)).isEmpty)
+    }
+
+    // MARK: - Form factor changes
+
+    @Test func narrowingFormFactorsPrunes() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters.union(bikes))
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
+            try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        ]))
+
+        let changes = visibility.setFormFactors(scooters)
+        #expect(changes.removed == ["b1"])
+    }
+
+    @Test func wideningFormFactorsRestoresFromCache() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1", formFactor: "SCOOTER"),
+            try RentalFixtures.vehicle(id: "b1", formFactor: "BICYCLE")
+        ]))
+
+        let changes = visibility.setFormFactors(scooters.union(bikes))
+        #expect(changes.added.map(\.id) == ["b1"])
+    }
+
+    @Test func clearingFormFactorsRemovesEverything() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "v1"),
+            try RentalFixtures.vehicle(id: "v2")
+        ]))
+
+        let changes = visibility.setFormFactors([])
+        #expect(changes.removed == ["v1", "v2"])
+    }
+
+    /// Wholesale recomputations sort by id, matching `VehicleRentalSource`'s own
+    /// convention, so the emitted changes are reproducible.
+    @Test func wholesaleChangesAreSortedByIdentifier() throws {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.apply(snapshot(added: [
+            try RentalFixtures.vehicle(id: "zebra", rangeMeters: 1_000),
+            try RentalFixtures.vehicle(id: "alpha", rangeMeters: 1_000),
+            try RentalFixtures.vehicle(id: "middle", rangeMeters: 1_000)
+        ]))
+
+        let changes = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 8047))
+        #expect(changes.removed == ["alpha", "middle", "zebra"])
+    }
+
+    @Test func exposesCurrentFormFactorsAndFilter() {
+        var visibility = RentalVisibility()
+        _ = visibility.setFormFactors(scooters)
+        _ = visibility.setFilter(RentalRangeFilter(minimumRangeMeters: 5_000))
+
+        #expect(visibility.formFactors == scooters)
+        #expect(visibility.filter == RentalRangeFilter(minimumRangeMeters: 5_000))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "cannot find 'RentalVisibility' in scope".
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `OBAKit/Mapping/Layers/RentalVisibility.swift`:
+
+```swift
+//
+//  RentalVisibility.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OTPKit
+
+/// Which delivered rentals belong on the map.
+///
+/// Holds every entity `VehicleRentalSource` has delivered for the current viewport
+/// — not just the visible ones — so relaxing a filter restores vehicles from cache
+/// instead of waiting for a refetch. The source emits only diffs, so an entity
+/// dropped for being under threshold would otherwise never come back.
+///
+/// Memory stays bounded without extra work: the source replaces its delivered set
+/// wholesale on each fetch and reports everything absent as removed, so this cache
+/// tracks the padded viewport rather than growing across a session.
+///
+/// No MapKit and no async: every mutation returns the exact changes to apply.
+struct RentalVisibility {
+
+    /// What the map must do to catch up with a mutation.
+    struct Changes: Equatable {
+        var added: [VehicleRental] = []
+        var removed: [VehicleRental.ID] = []
+        var updated: [VehicleRental] = []
+
+        var isEmpty: Bool { added.isEmpty && removed.isEmpty && updated.isEmpty }
+    }
+
+    private var cache: [VehicleRental.ID: VehicleRental] = [:]
+    private var visibleIDs: Set<VehicleRental.ID> = []
+
+    private(set) var formFactors: Set<VehicleFormFactor> = []
+    private(set) var filter: RentalRangeFilter = .any
+
+    /// With no form factors selected, every layer is off and nothing is visible.
+    private func isVisible(_ rental: VehicleRental) -> Bool {
+        !formFactors.isEmpty && rental.matches(formFactors: formFactors) && filter.allows(rental)
+    }
+
+    // MARK: - Snapshot application
+
+    mutating func apply(_ snapshot: VehicleRentalSnapshot) -> Changes {
+        var changes = Changes()
+
+        for id in snapshot.removed {
+            cache.removeValue(forKey: id)
+            if visibleIDs.remove(id) != nil {
+                changes.removed.append(id)
+            }
+        }
+
+        for rental in snapshot.added where cache[rental.id] == nil {
+            cache[rental.id] = rental
+            if isVisible(rental) {
+                visibleIDs.insert(rental.id)
+                changes.added.append(rental)
+            }
+        }
+
+        for rental in snapshot.updated {
+            cache[rental.id] = rental
+            // An update that crosses the visibility boundary is an add or a
+            // removal — never an update. Emitting it as an update would leave the
+            // map showing a vehicle the rider has filtered out.
+            switch (visibleIDs.contains(rental.id), isVisible(rental)) {
+            case (true, true):
+                changes.updated.append(rental)
+            case (true, false):
+                visibleIDs.remove(rental.id)
+                changes.removed.append(rental.id)
+            case (false, true):
+                visibleIDs.insert(rental.id)
+                changes.added.append(rental)
+            case (false, false):
+                break
+            }
+        }
+
+        return changes
+    }
+
+    // MARK: - Selection changes
+
+    mutating func setFormFactors(_ formFactors: Set<VehicleFormFactor>) -> Changes {
+        guard formFactors != self.formFactors else { return Changes() }
+        self.formFactors = formFactors
+        return reconcile()
+    }
+
+    mutating func setFilter(_ filter: RentalRangeFilter) -> Changes {
+        guard filter != self.filter else { return Changes() }
+        self.filter = filter
+        return reconcile()
+    }
+
+    /// Recomputes visibility across the whole cache. Sorted by id so the emitted
+    /// changes are deterministic, mirroring `VehicleRentalSource`'s own convention
+    /// of sorting its removed array.
+    private mutating func reconcile() -> Changes {
+        var changes = Changes()
+
+        for id in cache.keys.sorted() {
+            guard let rental = cache[id] else { continue }
+
+            switch (visibleIDs.contains(id), isVisible(rental)) {
+            case (true, false):
+                visibleIDs.remove(id)
+                changes.removed.append(id)
+            case (false, true):
+                visibleIDs.insert(id)
+                changes.added.append(rental)
+            case (true, true), (false, false):
+                break
+            }
+        }
+
+        return changes
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalVisibilityTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **20 tests executed**.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalVisibility.swift \
+        OBAKitTests/Mapping/RentalVisibilityTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Add RentalVisibility: cache delivered rentals and diff visibility"
+```
+
+---
+
+## Task 5: Persist the threshold on MapRegionManager
+
+**Files:**
+- Modify: `OBAKit/Mapping/Layers/MapLayer.swift` (append to the `Notification.Name` extension)
+- Modify: `OBAKit/Mapping/MapRegionManager.swift` (add property near line 320; edit `mapLayersDifferFromDefaults` line 329 and `resetMapLayersToDefaults` line 334)
+- Modify: `OBAKit/Analytics/Analytics.swift` (add label after `rentalPlanTripTapped`, line 66)
+- Test: `OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift`
+
+**Interfaces:**
+- Consumes: `RentalRangeFilter` (Task 1).
+- Produces:
+  - `MapRegionManager.rentalMinimumRangeDefaultsKey: String` (static)
+  - `MapRegionManager.rentalRangeFilter: RentalRangeFilter` (get/set, persists + posts + reports analytics)
+  - `Notification.Name.rentalRangeFilterDidChange`
+  - `AnalyticsLabels.rentalRangeFilterChanged`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift`. It inherits `OBATestCase` for the per-instance `UserDefaults` domain — never `UserDefaults.standard`, since Swift Testing runs suites concurrently in one process.
+
+```swift
+//
+//  MapRegionManagerRentalFilterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Persistence for the shared rental minimum-range threshold. It lives on
+/// `MapRegionManager` beside the per-layer enablement so the Map sheet's Reset
+/// affordance covers it without new machinery.
+///
+/// Inherits `OBATestCase` for its per-instance `UserDefaults` domain: Swift Testing
+/// runs suites concurrently within one process, so isolation has to come from the
+/// fixture rather than from the schedule.
+@MainActor
+@Suite(.serialized)
+final class MapRegionManagerRentalFilterTests: OBATestCase {
+
+    private var manager: MapRegionManager!
+
+    override init() async throws {
+        try await super.init()
+        let queue = OperationQueue()
+        let dataLoader = MockDataLoader(testName: name)
+        manager = MapRegionManager(application: buildApplication(queue: queue, dataLoader: dataLoader))
+    }
+
+    @Test func defaultsToAny() {
+        #expect(manager.rentalRangeFilter == .any)
+        #expect(manager.rentalRangeFilter.isActive == false)
+    }
+
+    @Test func persistsTheThreshold() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(manager.rentalRangeFilter.minimumRangeMeters == 8047)
+    }
+
+    /// Asserts the write lands in the suite's scratch domain. This depends on
+    /// `buildApplication` configuring the app with `OBATestCase.userDefaults` —
+    /// check `OBATestCase.buildApplication(queue:dataLoader:)` if it fails, and
+    /// read through `manager.rentalRangeFilter` instead if the app owns a
+    /// different domain.
+    @Test func writesThroughToUserDefaults() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        let stored = userDefaults.integer(forKey: MapRegionManager.rentalMinimumRangeDefaultsKey)
+        #expect(stored == 8047)
+    }
+
+    @Test func postsOnChange() async {
+        var posted = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+        ) { _ in posted = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(posted)
+    }
+
+    /// A redundant write must not post — the coordinator would refilter for nothing.
+    @Test func doesNotPostWhenUnchanged() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+
+        var posted = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .rentalRangeFilterDidChange, object: nil, queue: nil
+        ) { _ in posted = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(posted == false)
+    }
+
+    /// An active filter is a difference from defaults, so Reset must be offered
+    /// even when every layer toggle is untouched.
+    @Test func activeFilterCountsAsDifferingFromDefaults() {
+        #expect(manager.mapLayersDifferFromDefaults == false)
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        #expect(manager.mapLayersDifferFromDefaults)
+    }
+
+    @Test func resetClearsTheFilter() {
+        manager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: 8047)
+        manager.resetMapLayersToDefaults()
+        #expect(manager.rentalRangeFilter == .any)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "value of type 'MapRegionManager' has no member 'rentalRangeFilter'".
+
+- [ ] **Step 3: Add the notification name**
+
+In `OBAKit/Mapping/Layers/MapLayer.swift`, inside the existing `extension Notification.Name`, append after `mapLayerEnabledStateDidChange`:
+
+```swift
+    /// Posted when the shared rental minimum-range filter changes. Lets
+    /// `MapViewController` push the new value into the rental coordinator without
+    /// `MapRegionManager` needing to know the coordinator exists.
+    public static let rentalRangeFilterDidChange = Notification.Name("OBARentalRangeFilterDidChange")
+```
+
+- [ ] **Step 4: Add the analytics label**
+
+In `OBAKit/Analytics/Analytics.swift`, after the `rentalPlanTripTapped` declaration:
+
+```swift
+    /// Label used when the rental minimum-range filter changes. Value: the
+    /// threshold in meters, or "0" for no minimum.
+    @objc public static let rentalRangeFilterChanged = "Rental Range Filter Changed"
+```
+
+- [ ] **Step 5: Add the property to MapRegionManager**
+
+In `OBAKit/Mapping/MapRegionManager.swift`, insert immediately after `setMapLayerEnabled(_:id:)` (which ends at line 320) and before `enabledMapLayerCount`:
+
+```swift
+    /// The UserDefaults key persisting the shared rental minimum-range threshold.
+    public static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
+
+    /// The minimum-range filter shared by the Bikes and Scooters layers — one
+    /// threshold, not one per layer.
+    ///
+    /// It lives here beside the per-layer enablement so `mapLayersDifferFromDefaults`
+    /// and `resetMapLayersToDefaults()` cover it, which is what makes the Map
+    /// sheet's Reset button honest. No `register(defaults:)` is needed: an unset
+    /// key reads as 0, which is exactly `.any`.
+    public var rentalRangeFilter: RentalRangeFilter {
+        get {
+            RentalRangeFilter(
+                minimumRangeMeters: application.userDefaults.integer(forKey: Self.rentalMinimumRangeDefaultsKey)
+            )
+        }
+        set {
+            guard rentalRangeFilter != newValue else { return }
+            application.userDefaults.set(newValue.minimumRangeMeters, forKey: Self.rentalMinimumRangeDefaultsKey)
+
+            NotificationCenter.default.post(name: .rentalRangeFilterDidChange, object: nil)
+            application.analytics?.reportEvent(
+                pageURL: "app://localhost/map",
+                label: AnalyticsLabels.rentalRangeFilterChanged,
+                value: String(newValue.minimumRangeMeters)
+            )
+        }
+    }
+```
+
+- [ ] **Step 6: Fold the filter into reset and differs-from-defaults**
+
+Replace `mapLayersDifferFromDefaults` (line ~329) with:
+
+```swift
+    /// True when any layer's on/off state differs from its default, or the rental
+    /// range filter is active — drives the Map sheet's Reset affordance.
+    public var mapLayersDifferFromDefaults: Bool {
+        if rentalRangeFilter != .any { return true }
+        return mapLayers.contains { isMapLayerEnabled(id: $0.id) != $0.isEnabledByDefault }
+    }
+```
+
+Replace `resetMapLayersToDefaults()` (line ~334) with:
+
+```swift
+    /// Restores every registered layer to its default on/off state, and clears the
+    /// rental range filter.
+    public func resetMapLayersToDefaults() {
+        for layer in mapLayers {
+            setMapLayerEnabled(layer.isEnabledByDefault, id: layer.id)
+        }
+        rentalRangeFilter = .any
+    }
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/MapRegionManagerRentalFilterTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **7 tests executed**.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/MapRegionManager.swift \
+        OBAKit/Mapping/Layers/MapLayer.swift \
+        OBAKit/Analytics/Analytics.swift \
+        OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Persist the rental range filter alongside map layer preferences"
+```
+
+---
+
+## Task 6: Fuel label on the annotation view
+
+**Files:**
+- Modify: `OBAKit/Mapping/Layers/RentalAnnotation.swift` (add a property)
+- Modify: `OBAKit/Mapping/Layers/RentalAnnotationView.swift` (add the label; extend `configure()` and `prepareForReuse()`)
+- Test: `OBAKitTests/Mapping/RentalAnnotationViewTests.swift`
+
+**Interfaces:**
+- Consumes: `RentalFormat.fuelLabelText(for:)` (Task 3), `RentalFixtures` (Task 1).
+- Produces: `RentalAnnotation.showsFuelLabel: Bool` (default `false`); `RentalAnnotationView.fuelLabel: UILabel` (internal, for tests).
+
+**Before starting — measure the geometry.** Apple documents neither what occupies `MKMarkerAnnotationView.bounds` nor its default `centerOffset`, so the constant below is an intent, not a guarantee. Add a temporary `print("bounds=\(bounds) centerOffset=\(centerOffset)")` at the end of `configure()`, run the app on the simulator with the Bikes layer on, read the values, then remove the print. If the balloon's tip is not at `bounds.maxY`, adjust the `constant:` on the top constraint accordingly and note the real value in a comment.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Mapping/RentalAnnotationViewTests.swift`:
+
+```swift
+//
+//  RentalAnnotationViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+import UIKit
+import OTPKit
+@testable import OBAKit
+
+/// The fuel figure rendered beneath a rental marker. Its visibility is driven by
+/// `RentalAnnotation.showsFuelLabel` rather than by the view reading the viewport,
+/// because the layer's dequeue path has no access to map state.
+@MainActor
+@Suite(.serialized)
+final class RentalAnnotationViewTests {
+
+    private func view(for rental: VehicleRental, showsFuelLabel: Bool) -> RentalAnnotationView {
+        let annotation = RentalAnnotation(rental: rental)
+        annotation.showsFuelLabel = showsFuelLabel
+        return RentalAnnotationView(annotation: annotation, reuseIdentifier: nil)
+    }
+
+    @Test func showsPercentWhenGatedOn() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+
+        #expect(subject.fuelLabel.text == "62%")
+        #expect(subject.fuelLabel.isHidden == false)
+    }
+
+    /// The zoom gate hides the label, but the text stays correct so re-showing it
+    /// costs nothing.
+    @Test func hidesLabelWhenGatedOff() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func hidesLabelWhenThereIsNoFuelData() throws {
+        let subject = view(for: try RentalFixtures.vehicle(rangeMeters: nil, batteryPercent: nil), showsFuelLabel: true)
+
+        #expect(subject.fuelLabel.text == nil)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func hidesLabelForStations() throws {
+        let subject = view(for: try RentalFixtures.station(), showsFuelLabel: true)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    @Test func labelIsPurpleWhenOperative() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62, operative: true), showsFuelLabel: true)
+        #expect(subject.fuelLabel.textColor == .rentalPurple)
+    }
+
+    @Test func labelIsGrayWhenNotOperative() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62, operative: false), showsFuelLabel: true)
+        #expect(subject.fuelLabel.textColor == .systemGray)
+    }
+
+    /// A visual-clutter rule must not cost a VoiceOver user information: the fuel
+    /// figure is announced even when the label is hidden by zoom.
+    @Test func accessibilityLabelCarriesFuelEvenWhenHidden() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+
+        let label = try #require(subject.accessibilityLabel)
+        #expect(label.contains("62%"))
+    }
+
+    @Test func accessibilityLabelIncludesTheDisplayLabel() throws {
+        let rental = try RentalFixtures.vehicle(batteryPercent: 0.62)
+        let subject = view(for: rental, showsFuelLabel: true)
+
+        let label = try #require(subject.accessibilityLabel)
+        #expect(label.contains(rental.displayLabel))
+    }
+
+    /// The child label must not be its own element, or VoiceOver announces the
+    /// figure twice.
+    @Test func childLabelIsNotAnAccessibilityElement() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+        #expect(subject.fuelLabel.isAccessibilityElement == false)
+    }
+
+    /// `MKAnnotationView.prepareForReuse()` does nothing by default, so subclass
+    /// state that isn't reset by hand leaks into the next annotation.
+    @Test func reuseClearsTheLabel() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: true)
+        subject.prepareForReuse()
+
+        #expect(subject.fuelLabel.text == nil)
+        #expect(subject.fuelLabel.isHidden)
+    }
+
+    /// Re-assigning the annotation is how the coordinator pushes a new gate value.
+    @Test func reassigningAnnotationRefreshesTheLabel() throws {
+        let subject = view(for: try RentalFixtures.vehicle(batteryPercent: 0.62), showsFuelLabel: false)
+        #expect(subject.fuelLabel.isHidden)
+
+        let annotation = try #require(subject.annotation as? RentalAnnotation)
+        annotation.showsFuelLabel = true
+        subject.annotation = annotation
+
+        #expect(subject.fuelLabel.isHidden == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: **build FAILS** with "value of type 'RentalAnnotation' has no member 'showsFuelLabel'" and "...'RentalAnnotationView' has no member 'fuelLabel'".
+
+- [ ] **Step 3: Add the annotation flag**
+
+In `OBAKit/Mapping/Layers/RentalAnnotation.swift`, add after the `subtitle` computed property:
+
+```swift
+    /// Whether the view should render its fuel label.
+    ///
+    /// Set by `RentalLayerCoordinator` from the current zoom. It lives on the
+    /// annotation rather than the view because `RentalMapLayer.annotationView(for:)`
+    /// only dequeues a view and has no access to viewport state.
+    public var showsFuelLabel: Bool = false
+```
+
+- [ ] **Step 4: Add the label to the annotation view**
+
+In `OBAKit/Mapping/Layers/RentalAnnotationView.swift`, add the stored property to `RentalAnnotationView` before `public override var annotation`:
+
+```swift
+    /// The fuel figure rendered beneath the balloon. A plain subview, so it does
+    /// not participate in MapKit's marker collision logic — `collisionMode`
+    /// interprets a frame derived from this view's own bounds, and the label is
+    /// drawn outside them. Some overlap in an unusually dense block is accepted.
+    let fuelLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.isHidden = true
+
+        // Start from a preferred font so Dynamic Type applies, then add weight.
+        let base = UIFont.preferredFont(forTextStyle: .caption1)
+        let descriptor = base.fontDescriptor.withSymbolicTraits(.traitBold) ?? base.fontDescriptor
+        label.font = UIFont(descriptor: descriptor, size: 0)
+        label.adjustsFontForContentSizeCategory = true
+
+        // A white halo keeps the text legible over satellite basemaps.
+        label.layer.shadowColor = UIColor.white.cgColor
+        label.layer.shadowRadius = 2
+        label.layer.shadowOpacity = 1
+        label.layer.shadowOffset = .zero
+
+        // The view composes its own accessibility label; a second element here
+        // would make VoiceOver announce the figure twice.
+        label.isAccessibilityElement = false
+
+        return label
+    }()
+```
+
+In `init(annotation:reuseIdentifier:)`, after `titleVisibility = .hidden` and before `configure()`:
+
+```swift
+        // The label sits outside bounds, so it must not be clipped.
+        clipsToBounds = false
+        addSubview(fuelLabel)
+        NSLayoutConstraint.activate([
+            fuelLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            fuelLabel.topAnchor.constraint(equalTo: bottomAnchor, constant: 1)
+        ])
+```
+
+Replace the body of `configure()` with:
+
+```swift
+    private func configure() {
+        guard let rentalAnnotation = annotation as? RentalAnnotation else { return }
+        let rental = rentalAnnotation.rental
+
+        markerTintColor = rental.isOperative ? .rentalPurple : .systemGray
+
+        switch rental {
+        case .station(let station):
+            glyphImage = nil
+            if let available = station.vehiclesAvailableCount {
+                glyphText = String(available)
+            } else {
+                glyphText = nil
+                glyphImage = UIImage(systemName: "bicycle")
+            }
+        case .vehicle(let vehicle):
+            glyphText = nil
+            glyphImage = UIImage(systemName: Self.glyphName(for: vehicle.vehicleType?.formFactor))
+        }
+
+        let fuelText = RentalFormat.fuelLabelText(for: rental)
+        fuelLabel.text = fuelText
+        fuelLabel.textColor = rental.isOperative ? .rentalPurple : .systemGray
+        fuelLabel.isHidden = fuelText == nil || !rentalAnnotation.showsFuelLabel
+
+        // VoiceOver ignores the zoom gate: a visual-density rule must not cost a
+        // VoiceOver user the fuel figure.
+        accessibilityLabel = [rental.displayLabel, fuelText]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+    }
+```
+
+Extend `prepareForReuse()`:
+
+```swift
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        clusteringIdentifier = "rentals"
+        displayPriority = .defaultLow
+        // MKAnnotationView's default implementation does nothing, so subclass
+        // state that isn't reset here leaks into the next annotation.
+        fuelLabel.text = nil
+        fuelLabel.isHidden = true
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalAnnotationViewTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: PASS, **11 tests executed**.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalAnnotation.swift \
+        OBAKit/Mapping/Layers/RentalAnnotationView.swift \
+        OBAKitTests/Mapping/RentalAnnotationViewTests.swift \
+        OBAKit.xcodeproj
+git commit -m "Render battery percent or range beneath rental markers"
+```
+
+---
+
+## Task 7: Adopt RentalVisibility in the coordinator
+
+No new tests: with `RentalVisibility` extracted, what remains here is `MKMapView` plumbing behind a 250 ms debounce and an `AsyncStream`. The logic is covered by `RentalVisibilityTests`. Verification is that every existing suite still passes plus a manual check on the simulator.
+
+**Files:**
+- Modify: `OBAKit/Mapping/Layers/RentalLayerCoordinator.swift`
+
+**Interfaces:**
+- Consumes: `RentalVisibility` (Task 4), `RentalRangeFilter` (Task 1), `RentalAnnotation.showsFuelLabel` (Task 6).
+- Produces: `RentalLayerCoordinator.setRangeFilter(_ filter: RentalRangeFilter)`.
+
+- [ ] **Step 1: Replace the annotation bookkeeping**
+
+In `OBAKit/Mapping/Layers/RentalLayerCoordinator.swift`, replace the `annotations` stored property declaration with:
+
+```swift
+    /// Decides which delivered rentals belong on the map. All the caching and
+    /// diffing lives here; this class only applies the result to the map view.
+    private var visibility = RentalVisibility()
+
+    /// The annotations currently on the map, by entity id.
+    private var annotations: [VehicleRental.ID: RentalAnnotation] = [:]
+
+    /// Visible-map-rect height (in map points) at or below which fuel labels
+    /// render. Tighter than the layer's own 20,000-point zoom window because the
+    /// labels are subviews and don't participate in MapKit's collision logic, so
+    /// they need more room than the markers do. At latitude 47.6 there are 9.9464
+    /// map points per metre, making this an 804 m-tall viewport — a few blocks.
+    private static let fuelLabelMaxVisibleHeight = 8_000.0
+
+    private var showsFuelLabels = false
+```
+
+- [ ] **Step 2: Route layer and filter changes through RentalVisibility**
+
+Replace `setLayer(id:enabled:formFactors:)` with:
+
+```swift
+    func setLayer(id: String, enabled: Bool, formFactors: Set<VehicleFormFactor>) {
+        if enabled {
+            enabledLayerFactors[id] = formFactors
+        } else {
+            enabledLayerFactors.removeValue(forKey: id)
+        }
+
+        let factors = combinedFormFactors
+        apply(visibility.setFormFactors(factors))
+
+        let mapRect = lastMapRect
+        Task {
+            if factors.isEmpty {
+                await source.reset()
+            } else {
+                await source.setFormFactors(factors)
+                // Re-prime the viewport: after a reset (all layers off) the source
+                // has no viewport to refetch with. Redundant calls coalesce into
+                // one fetch, so this is safe to do unconditionally.
+                if let mapRect {
+                    await source.setViewport(Self.boundingBox(for: mapRect))
+                }
+            }
+        }
+    }
+
+    /// Applies a new minimum-range threshold. Purely client-side: the entities are
+    /// already cached, so relaxing the threshold restores vehicles with no refetch.
+    func setRangeFilter(_ filter: RentalRangeFilter) {
+        apply(visibility.setFilter(filter))
+    }
+```
+
+- [ ] **Step 3: Split snapshot handling from map application**
+
+Replace `private func apply(_ snapshot: VehicleRentalSnapshot)` with these two methods:
+
+```swift
+    private func apply(_ snapshot: VehicleRentalSnapshot) {
+        lastSnapshotAt = snapshot.fetchedAt
+        setAvailability(.available)
+
+        if !snapshot.partialErrors.isEmpty {
+            Logger.info("Rental fetch partial errors: \(snapshot.partialErrors.joined(separator: "; "))")
+        }
+
+        apply(visibility.apply(snapshot))
+    }
+
+    /// Translates a visibility diff into map view operations. The only place this
+    /// class touches annotations.
+    private func apply(_ changes: RentalVisibility.Changes) {
+        guard let mapView, !changes.isEmpty else { return }
+
+        var removed: [RentalAnnotation] = []
+        for id in changes.removed {
+            if let annotation = annotations.removeValue(forKey: id) {
+                removed.append(annotation)
+            }
+        }
+        mapView.removeAnnotations(removed)
+
+        for rental in changes.updated {
+            guard let annotation = annotations[rental.id] else { continue }
+            annotation.update(with: rental)
+            // Re-assigning the annotation re-runs the view's configure() so glyphs
+            // (availability counts), tint (operative state), and the fuel label
+            // track the data; identity is unchanged, so selection survives.
+            if let view = mapView.view(for: annotation) as? RentalAnnotationView {
+                view.annotation = annotation
+            }
+        }
+
+        var added: [RentalAnnotation] = []
+        for rental in changes.added where annotations[rental.id] == nil {
+            let annotation = RentalAnnotation(rental: rental)
+            annotation.showsFuelLabel = showsFuelLabels
+            annotations[rental.id] = annotation
+            added.append(annotation)
+        }
+        mapView.addAnnotations(added)
+    }
+```
+
+- [ ] **Step 4: Add the fuel-label zoom gate**
+
+Replace `viewportDidChange(_:)` with:
+
+```swift
+    /// `mapRect` is nil when the zoom gate is closed — everything is removed.
+    func viewportDidChange(_ mapRect: MKMapRect?) {
+        lastMapRect = mapRect
+        updateFuelLabelVisibility(for: mapRect)
+        guard hasEnabledLayers else { return }
+
+        // The layer might have been dimmed by an earlier failure; a region change
+        // is the retry trigger, so let the next fetch decide again.
+        let boundingBox = mapRect.map(Self.boundingBox(for:))
+        Task {
+            await source.setViewport(boundingBox)
+        }
+    }
+
+    /// Pushes the current zoom's label decision onto every annotation. Cheap: it
+    /// no-ops unless the gate actually flipped.
+    private func updateFuelLabelVisibility(for mapRect: MKMapRect?) {
+        let shows = mapRect.map { $0.height <= Self.fuelLabelMaxVisibleHeight } ?? false
+        guard shows != showsFuelLabels else { return }
+        showsFuelLabels = shows
+
+        guard let mapView else { return }
+        for annotation in annotations.values {
+            annotation.showsFuelLabel = shows
+            if let view = mapView.view(for: annotation) as? RentalAnnotationView {
+                view.annotation = annotation
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Delete the superseded prune method**
+
+Delete `private func pruneAnnotations(notMatching factors: Set<VehicleFormFactor>)` in its entirety — `RentalVisibility.setFormFactors(_:)` now does this job, and does it against the full cache rather than only what is on the map.
+
+- [ ] **Step 6: Build and run the full test target**
+
+```bash
+set -o pipefail
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -30
+```
+
+Expected: PASS, with no regressions. Record the total test count.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+git commit -m "Route rental annotations through RentalVisibility"
+```
+
+---
+
+## Task 8: Map sheet picker row
+
+**Files:**
+- Modify: `OBAKit/Mapping/Layers/MapSheetView.swift`
+- Modify: `OBAKit/Strings/en.lproj/Localizable.strings`
+
+**Interfaces:**
+- Consumes: `RentalRangePreset` (Task 2), `MapRegionManager.rentalRangeFilter` (Task 5).
+- Produces: `MapSheetModel.rangeFilterPresets`, `MapSheetModel.selectedRangePresetID`, `MapSheetModel.selectRangePreset(id:)`.
+
+- [ ] **Step 1: Add the model plumbing**
+
+In `OBAKit/Mapping/Layers/MapSheetView.swift`, add to `MapSheetModel` after `resetToDefaults()`:
+
+```swift
+    // MARK: - Rental Range Filter
+
+    /// Computed once per sheet presentation: the ladder involves a
+    /// MeasurementFormatter and a localized string, neither worth redoing per render.
+    let rangeFilterPresets = RentalRangePreset.presets()
+
+    /// The rung to highlight. A stored value that isn't on the current ladder — the
+    /// rider's locale changed since they chose it — highlights the closest rung
+    /// without the stored preference being rewritten.
+    var selectedRangePresetID: Int {
+        RentalRangePreset.nearest(
+            toMeters: mapRegionManager.rentalRangeFilter.minimumRangeMeters,
+            in: rangeFilterPresets
+        )?.id ?? 0
+    }
+
+    func selectRangePreset(id: Int) {
+        objectWillChange.send()
+        mapRegionManager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: id)
+    }
+```
+
+- [ ] **Step 2: Replace the other-modes section with one that carries the row**
+
+In `MapSheetView.body`, replace the second `layerSection(...)` call (the `.otherModes` one) with:
+
+```swift
+                otherModesSection
+```
+
+Then add these two methods after `layerSection(title:group:)`:
+
+```swift
+    /// The non-transit section, which carries the range-filter row beneath its
+    /// layer toggles. The row shows whenever a rental layer row is visible — not
+    /// only when one is enabled — so it doesn't jump in and out of the sheet as the
+    /// rider toggles them, and so the filter can be set before turning a layer on.
+    @ViewBuilder
+    private var otherModesSection: some View {
+        let layers = model.visibleLayers(in: .otherModes)
+        if !layers.isEmpty {
+            Section(OBALoc("map_sheet.other_modes_group", value: "Other ways to get around", comment: "Map sheet group header for non-transit mobility layers")) {
+                ForEach(layers, id: \.id) { layer in
+                    layerRow(layer)
+                }
+                rangeFilterRow
+            }
+        }
+    }
+
+    /// `.menu` is stated explicitly rather than left to `.automatic`, which Apple
+    /// documents as "based on the picker's context" — in a List that has resolved
+    /// to a navigation link in some OS versions and a menu in others.
+    private var rangeFilterRow: some View {
+        Picker(selection: Binding(
+            get: { model.selectedRangePresetID },
+            set: { model.selectRangePreset(id: $0) }
+        )) {
+            ForEach(model.rangeFilterPresets) { preset in
+                Text(preset.title).tag(preset.meters)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "bolt")
+                    .foregroundStyle(Color(uiColor: .rentalPurple))
+                    .frame(width: 28)
+                Text(OBALoc("map_sheet.minimum_range", value: "Minimum range", comment: "Map sheet row label for the rental minimum-range filter"))
+            }
+        }
+        .pickerStyle(.menu)
+    }
+```
+
+- [ ] **Step 3: Add the localized string**
+
+Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
+
+```
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Minimum range";
+```
+
+- [ ] **Step 4: Build and verify the sheet renders**
+
+```bash
+set -o pipefail
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+```
+
+Expected: build succeeds. Then run the app on the simulator, open the Map sheet from the basemap button, and confirm: the "Minimum range" row appears under Bikes and Scooters with a trailing value of "Any"; tapping it opens a menu with Any / 1 mi / 2 mi / 5 mi / 10 mi / 15 mi; choosing a rung updates the trailing value and makes the Reset button appear.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/Layers/MapSheetView.swift \
+        OBAKit/Strings/en.lproj/Localizable.strings
+git commit -m "Add the minimum-range row to the Map sheet"
+```
+
+---
+
+## Task 9: Wire the filter through to the coordinator
+
+The last connection: the Map sheet writes to `MapRegionManager`, which posts; `MapViewController` observes and pushes into the coordinator.
+
+**Files:**
+- Modify: `OBAKit/Mapping/MapViewController.swift` (add an observer beside lines 166-167)
+- Modify: `OBAKit/Mapping/MapViewController+MapLayers.swift` (seed the filter; add the handler)
+
+**Interfaces:**
+- Consumes: `RentalLayerCoordinator.setRangeFilter(_:)` (Task 7), `MapRegionManager.rentalRangeFilter` (Task 5), `.rentalRangeFilterDidChange` (Task 5).
+- Produces: nothing for later tasks — this is the final task.
+
+- [ ] **Step 1: Register the observer**
+
+In `OBAKit/Mapping/MapViewController.swift`, after line 167 (the `.mapLayerAvailabilityDidChange` registration):
+
+```swift
+        NotificationCenter.default.addObserver(self, selector: #selector(rentalRangeFilterDidChange(_:)), name: .rentalRangeFilterDidChange, object: nil)
+```
+
+- [ ] **Step 2: Seed the coordinator with the persisted filter**
+
+In `OBAKit/Mapping/MapViewController+MapLayers.swift`, inside `configureRentalLayers()`, immediately after `rentalLayerCoordinator = coordinator`:
+
+```swift
+        // Apply a filter chosen in a previous session before the first fetch,
+        // rather than one notification late.
+        coordinator.setRangeFilter(mapRegionManager.rentalRangeFilter)
+```
+
+- [ ] **Step 3: Add the notification handler**
+
+In the same file, after `mapLayerStateDidChange(_:)`:
+
+```swift
+    /// `MapViewController` is the composition root for the rental layers, so it
+    /// carries the threshold from the Map sheet's write to the coordinator that
+    /// acts on it. `MapRegionManager` stays unaware the coordinator exists.
+    @objc func rentalRangeFilterDidChange(_ note: NSNotification) {
+        rentalLayerCoordinator?.setRangeFilter(mapRegionManager.rentalRangeFilter)
+    }
+```
+
+- [ ] **Step 4: Build and run the full test target**
+
+```bash
+set -o pipefail
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+xcodebuild test-without-building -only-testing:OBAKitTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -30
+```
+
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Verify end to end on the simulator**
+
+Run the app in a bikeshare-enabled region and confirm:
+
+1. Turn on Scooters. Zoom in until pins appear; zoom further until fuel labels appear beneath them.
+2. Set Minimum range to 5 mi. Short-range scooters disappear **without** a visible refetch flash.
+3. Set it back to Any. The removed scooters **come straight back** — this is the cache doing its job; if they only reappear after a pan, `RentalVisibility` isn't being consulted.
+4. Tap Reset. The threshold returns to Any and layer toggles return to their defaults.
+5. Turn VoiceOver on, focus a rental pin at a zoom where labels are hidden, and confirm one announcement containing both the vehicle name and the fuel figure — no duplication.
+6. Kill and relaunch the app. The chosen threshold persists.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Mapping/MapViewController.swift \
+        OBAKit/Mapping/MapViewController+MapLayers.swift
+git commit -m "Wire the rental range filter through to the map coordinator"
+```
+
+---
+
+## Deferred to implementation
+
+Two things the spec flags that can only be settled with the app running. Neither blocks a task, but both should be resolved before the branch is considered done:
+
+1. **The label's vertical offset** (Task 6). `MKMarkerAnnotationView.bounds` and its default `centerOffset` are undocumented. Measure, then set the constant.
+2. **VoiceOver's default derivation** (Task 9, step 5). If focusing a pin announces the vehicle name twice, MapKit is composing something of its own; the fix is to override `isAccessibilityElement` and compose the whole string rather than relying on `accessibilityLabel` replacing a derived value.

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -24,7 +24,7 @@ Every task's requirements implicitly include this section.
 - **Tests are Swift Testing** (`@Suite` / `@Test` / `#expect`), never XCTest. Suites are `final class`, annotated `@MainActor @Suite(.serialized)`.
 - **Test isolation comes from fixtures, not scheduling.** Swift Testing runs suites in parallel via task groups in one process. Never touch `UserDefaults.standard`; use `OBATestCase`'s per-instance `userDefaultsSuiteName`.
 - **OTPKit's rental models have no public memberwise initializer.** `RentalVehicle`, `VehicleRentalStation`, `FuelInfo`, and `VehicleType` expose only internal memberwise inits. Test fixtures must be built by decoding JSON through `VehicleRental.init(from:)`, which *is* public. Task 1 builds that helper.
-- **New user-facing strings** go in `OBAKit/Strings/en.lproj/Localizable.strings` via `OBALoc(...)` with a `value:` and a `comment:`. Do not hand-edit other locales.
+- **New user-facing strings are declared ONLY in code**, via `OBALoc("key", value: "English text", comment: "…")`. Do **not** add them to `OBAKit/Strings/en.lproj/Localizable.strings`, and do not hand-edit other locales. `OBAKitTests/Strings/LocalizationTests.swift` asserts key parity between `en` and all 12 other locales, so an en-only entry fails that suite 12 times over. Every rental string already on this branch (`map_layers.bikes`, `map_sheet.title`, `rental_detail.range`, …) has zero `.strings` entries and relies on the `value:` default — follow that.
 - **Lint before each commit:** `scripts/swiftlint.sh`.
 
 ### Standard commands
@@ -86,7 +86,6 @@ xcodebuild test-without-building -only-testing:OBAKitTests/<SuiteName> \
 | `OBAKit/Mapping/MapViewController+MapLayers.swift` | Seed the coordinator's filter; observe the change notification. |
 | `OBAKit/Mapping/MapViewController.swift:166-167` | Register the new notification observer. |
 | `OBAKit/Analytics/Analytics.swift` | Add the `rentalRangeFilterChanged` label. |
-| `OBAKit/Strings/en.lproj/Localizable.strings` | Two new strings. |
 
 ---
 
@@ -361,7 +360,6 @@ git commit -m "Add the fail-open rental range filter predicate"
 
 **Files:**
 - Create: `OBAKit/Mapping/Layers/RentalRangePreset.swift`
-- Modify: `OBAKit/Strings/en.lproj/Localizable.strings`
 - Test: `OBAKitTests/Mapping/RentalRangePresetTests.swift`
 
 **Interfaces:**
@@ -552,15 +550,6 @@ struct RentalRangePreset: Equatable, Identifiable {
 }
 ```
 
-- [ ] **Step 4: Add the localized string**
-
-Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
-
-```
-/* Range filter menu option imposing no minimum range */
-"map_sheet.minimum_range_any" = "Any";
-```
-
 - [ ] **Step 5: Run the test to verify it passes**
 
 ```bash
@@ -580,7 +569,6 @@ Expected: PASS, **13 tests executed**.
 ```bash
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalRangePreset.swift \
-        OBAKit/Strings/en.lproj/Localizable.strings \
         OBAKitTests/Mapping/RentalRangePresetTests.swift
 git commit -m "Add the locale-appropriate rental range preset ladder"
 ```
@@ -1951,7 +1939,6 @@ git commit -m "Route rental annotations through RentalVisibility"
 
 **Files:**
 - Modify: `OBAKit/Mapping/Layers/MapSheetView.swift`
-- Modify: `OBAKit/Strings/en.lproj/Localizable.strings`
 
 **Interfaces:**
 - Consumes: `RentalRangePreset` (Task 2), `MapRegionManager.rentalRangeFilter` (Task 5).
@@ -2035,15 +2022,6 @@ Then add these two methods after `layerSection(title:group:)`:
     }
 ```
 
-- [ ] **Step 3: Add the localized string**
-
-Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
-
-```
-/* Map sheet row label for the rental minimum-range filter */
-"map_sheet.minimum_range" = "Minimum range";
-```
-
 - [ ] **Step 4: Build and verify the sheet renders**
 
 ```bash
@@ -2058,8 +2036,7 @@ Expected: build succeeds. Then run the app on the simulator, open the Map sheet 
 
 ```bash
 scripts/swiftlint.sh
-git add OBAKit/Mapping/Layers/MapSheetView.swift \
-        OBAKit/Strings/en.lproj/Localizable.strings
+git add OBAKit/Mapping/Layers/MapSheetView.swift
 git commit -m "Add the minimum-range row to the Map sheet"
 ```
 

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -2120,9 +2120,41 @@ git commit -m "Wire the rental range filter through to the map coordinator"
 
 ---
 
-## Deferred to implementation
+## Deferred to implementation — status at completion
 
-Two things the spec flags that can only be settled with the app running. Neither blocks a task, but both should be resolved before the branch is considered done:
+1. **The label's vertical offset** — **RESOLVED.** Measured during Task 6 on
+   iPhone 17 Pro / iOS 26.3: `bounds` (0, 0, 31.33, 34.94), `centerOffset`
+   (0, −17.47). Since `centerOffset.y == -bounds.height/2`, MapKit places
+   `bounds.maxY` at the annotation's coordinate, which is where the balloon tip
+   sits — so the plan's assumption held and `constant: 1` is correct. Pinning to
+   `bottomAnchor` tracks the tip as the view's height changes, making the constant
+   a 1pt gap rather than a derived offset. The measurement is now recorded in a
+   comment at the constraint so it needn't be re-derived.
 
-1. **The label's vertical offset** (Task 6). `MKMarkerAnnotationView.bounds` and its default `centerOffset` are undocumented. Measure, then set the constant.
-2. **VoiceOver's default derivation** (Task 9, step 5). If focusing a pin announces the vehicle name twice, MapKit is composing something of its own; the fix is to override `isAccessibilityElement` and compose the whole string rather than relying on `accessibilityLabel` replacing a derived value.
+   Caveat: measured via a hosted unit-test probe, not on a live `MKMapView`
+   (simulator UI automation is unavailable on this machine). The label has still
+   never been *seen* rendered on a map.
+
+2. **VoiceOver's default derivation** — **STILL OPEN, and it is the most
+   important thing left.** Assigning `accessibilityLabel` does not make a
+   `UIView` an accessibility element, and Apple documents neither whether
+   `MKAnnotationView` is one by default nor what it derives from the annotation's
+   `title`/`subtitle`. If it is not an element, the entire VoiceOver story here —
+   including the pre-existing behavior this feature had to preserve — is a no-op,
+   and all twelve `RentalAnnotationViewTests` still pass. No automated test can
+   close this. Focus a rental pin with VoiceOver on: expect exactly one
+   announcement carrying the vehicle name, the station occupancy where
+   applicable, and the fuel figure. If nothing is announced, add
+   `isAccessibilityElement = true`. If the name is doubled, MapKit is composing
+   its own label and the fix is to override the composition rather than append
+   to it.
+
+## Follow-up filed during the final review
+
+A ~40-line synchronous `RentalLayerCoordinator` test — stub the one-method
+`VehicleRentalService`, drop `private` from `apply(_ snapshot:)`, drive it with no
+async at all. It would close two things with **no coverage at any level**: the
+`Set(annotations.keys)` == visible-id-set invariant, and the
+`fuelLabelMaxVisibleHeight` zoom gate. Neither is a bug today; see the spec's
+Testing section for why the original "it's all behind a debounce" reasoning was
+wrong.

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -1233,7 +1233,7 @@ xcodebuild test-without-building -only-testing:OBAKitTests/RentalVisibilityTests
   -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
-Expected: PASS, **20 tests executed**.
+Expected: PASS, **19 tests executed**.
 
 - [ ] **Step 5: Lint and commit**
 

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -573,7 +573,7 @@ xcodebuild test-without-building -only-testing:OBAKitTests/RentalRangePresetTest
   -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
-Expected: PASS, **12 tests executed**.
+Expected: PASS, **13 tests executed**.
 
 - [ ] **Step 6: Lint and commit**
 

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -16,6 +16,7 @@ Every task's requirements implicitly include this section.
 
 - **Simulator destination must pin the OS: `platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro`.** iPhone 16 is not installed, so `CLAUDE.md`'s destination string is stale. Worse, the bare form `platform=iOS Simulator,name=iPhone 17 Pro` **fails to resolve on this machine** — six iOS runtimes are installed (18.5, 26.3, and four separate 27.0 builds), and `xcodebuild` responds with "Unable to find a device matching the provided destination specifier" while listing only macOS and watchOS candidates. That error looks like a missing simulator; it is actually ambiguity. Always pin `OS=26.3.1`.
 - **Run `scripts/generate_project OneBusAway` after creating ANY new source or test file.** XcodeGen discovers files from disk. A test file the project doesn't know about does not fail — it silently runs zero tests, which reads as passing.
+- **`OBAKit.xcodeproj` is gitignored** (`.gitignore:16`, `OBAKit.xcodeproj/**`). It is generated, never committed — do not add it to any `git add`, and do not list it among changed files in a report. The proof that XcodeGen picked up a new file is the test count, not the project file.
 - **Always `set -o pipefail` before piping `xcodebuild` to `tail`.** Without it a failed build exits 0 and the failure is invisible.
 - **A failing test run stalls for ~10 minutes in `simctl diagnose`.** Once failures have printed, kill `xcodebuild` rather than waiting. Do not run two failing suites concurrently.
 - **Swift 6 language mode, main-actor default isolation** in OBAKit (OBAKitCore pins back to `nonisolated`). The five concurrency diagnostic groups are escalated to **errors** — a data-race warning fails the build.
@@ -350,8 +351,7 @@ Expected: PASS, **8 tests executed**. If it reports 0 tests, `generate_project` 
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalRangeFilter.swift \
         OBAKitTests/Mapping/RentalFixtures.swift \
-        OBAKitTests/Mapping/RentalRangeFilterTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/RentalRangeFilterTests.swift
 git commit -m "Add the fail-open rental range filter predicate"
 ```
 
@@ -581,8 +581,7 @@ Expected: PASS, **12 tests executed**.
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalRangePreset.swift \
         OBAKit/Strings/en.lproj/Localizable.strings \
-        OBAKitTests/Mapping/RentalRangePresetTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/RentalRangePresetTests.swift
 git commit -m "Add the locale-appropriate rental range preset ladder"
 ```
 
@@ -799,8 +798,7 @@ Expected: PASS, **10 tests executed**.
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalFormat.swift \
         OBAKit/Mapping/Layers/RentalDetailViewController.swift \
-        OBAKitTests/Mapping/RentalFormatTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/RentalFormatTests.swift
 git commit -m "Extract RentalFormat and add abbreviated fuel-label text"
 ```
 
@@ -1242,8 +1240,7 @@ Expected: PASS, **20 tests executed**.
 ```bash
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalVisibility.swift \
-        OBAKitTests/Mapping/RentalVisibilityTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/RentalVisibilityTests.swift
 git commit -m "Add RentalVisibility: cache delivered rentals and diff visibility"
 ```
 
@@ -1480,8 +1477,7 @@ scripts/swiftlint.sh
 git add OBAKit/Mapping/MapRegionManager.swift \
         OBAKit/Mapping/Layers/MapLayer.swift \
         OBAKit/Analytics/Analytics.swift \
-        OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/MapRegionManagerRentalFilterTests.swift
 git commit -m "Persist the rental range filter alongside map layer preferences"
 ```
 
@@ -1759,8 +1755,7 @@ Expected: PASS, **11 tests executed**.
 scripts/swiftlint.sh
 git add OBAKit/Mapping/Layers/RentalAnnotation.swift \
         OBAKit/Mapping/Layers/RentalAnnotationView.swift \
-        OBAKitTests/Mapping/RentalAnnotationViewTests.swift \
-        OBAKit.xcodeproj
+        OBAKitTests/Mapping/RentalAnnotationViewTests.swift
 git commit -m "Render battery percent or range beneath rental markers"
 ```
 

--- a/docs/superpowers/plans/2026-07-29-rental-range-filter.md
+++ b/docs/superpowers/plans/2026-07-29-rental-range-filter.md
@@ -14,7 +14,7 @@ Full design rationale: `docs/superpowers/specs/2026-07-29-rental-range-filter-de
 
 Every task's requirements implicitly include this section.
 
-- **Simulator is `iPhone 17 Pro`.** iPhone 16 is not installed on this machine; `CLAUDE.md`'s destination string is stale.
+- **Simulator destination must pin the OS: `platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro`.** iPhone 16 is not installed, so `CLAUDE.md`'s destination string is stale. Worse, the bare form `platform=iOS Simulator,name=iPhone 17 Pro` **fails to resolve on this machine** — six iOS runtimes are installed (18.5, 26.3, and four separate 27.0 builds), and `xcodebuild` responds with "Unable to find a device matching the provided destination specifier" while listing only macOS and watchOS candidates. That error looks like a missing simulator; it is actually ambiguity. Always pin `OS=26.3.1`.
 - **Run `scripts/generate_project OneBusAway` after creating ANY new source or test file.** XcodeGen discovers files from disk. A test file the project doesn't know about does not fail — it silently runs zero tests, which reads as passing.
 - **Always `set -o pipefail` before piping `xcodebuild` to `tail`.** Without it a failed build exits 0 and the failure is invisible.
 - **A failing test run stalls for ~10 minutes in `simctl diagnose`.** Once failures have printed, kill `xcodebuild` rather than waiting. Do not run two failing suites concurrently.
@@ -34,7 +34,7 @@ Build for testing (run once up front, and again after any `generate_project`):
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Run one suite:
@@ -43,7 +43,7 @@ Run one suite:
 set -o pipefail
 xcodebuild test-without-building -only-testing:OBAKitTests/<SuiteName> \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 ---
@@ -282,7 +282,7 @@ final class RentalRangeFilterTests {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "cannot find 'RentalRangeFilter' in scope". This is the red state — the type doesn't exist yet.
@@ -336,10 +336,10 @@ struct RentalRangeFilter: Equatable {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalRangeFilterTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **8 tests executed**. If it reports 0 tests, `generate_project` did not pick up the new files — re-run it and rebuild.
@@ -467,7 +467,7 @@ final class RentalRangePresetTests {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "cannot find 'RentalRangePreset' in scope".
@@ -567,10 +567,10 @@ Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalRangePresetTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **12 tests executed**.
@@ -694,7 +694,7 @@ final class RentalFormatTests {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "type 'RentalFormat' has no member 'fuelLabelText'" and "...no member 'abbreviatedDistanceFormatter'".
@@ -785,10 +785,10 @@ In `OBAKit/Mapping/Layers/RentalDetailViewController.swift`, delete the entire `
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalFormatTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **10 tests executed**.
@@ -1086,7 +1086,7 @@ final class RentalVisibilityTests {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "cannot find 'RentalVisibility' in scope".
@@ -1229,10 +1229,10 @@ struct RentalVisibility {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalVisibilityTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **20 tests executed**.
@@ -1372,7 +1372,7 @@ final class MapRegionManagerRentalFilterTests: OBATestCase {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "value of type 'MapRegionManager' has no member 'rentalRangeFilter'".
@@ -1465,10 +1465,10 @@ Replace `resetMapLayersToDefaults()` (line ~334) with:
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/MapRegionManagerRentalFilterTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **7 tests executed**.
@@ -1624,7 +1624,7 @@ final class RentalAnnotationViewTests {
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: **build FAILS** with "value of type 'RentalAnnotation' has no member 'showsFuelLabel'" and "...'RentalAnnotationView' has no member 'fuelLabel'".
@@ -1745,10 +1745,10 @@ Extend `prepareForReuse()`:
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalAnnotationViewTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: PASS, **11 tests executed**.
@@ -1934,10 +1934,10 @@ Delete `private func pruneAnnotations(notMatching factors: Set<VehicleFormFactor
 set -o pipefail
 scripts/generate_project OneBusAway
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -30
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -30
 ```
 
 Expected: PASS, with no regressions. Record the total test count.
@@ -2054,7 +2054,7 @@ Append to `OBAKit/Strings/en.lproj/Localizable.strings`:
 ```bash
 set -o pipefail
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 ```
 
 Expected: build succeeds. Then run the app on the simulator, open the Map sheet from the basemap button, and confirm: the "Minimum range" row appears under Bikes and Scooters with a trailing value of "Any"; tapping it opens a menu with Any / 1 mi / 2 mi / 5 mi / 10 mi / 15 mi; choosing a rung updates the trailing value and makes the Reset button appear.
@@ -2118,10 +2118,10 @@ In the same file, after `mapLayerStateDidChange(_:)`:
 ```bash
 set -o pipefail
 xcodebuild clean build-for-testing -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -20
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -20
 xcodebuild test-without-building -only-testing:OBAKitTests \
   -project 'OBAKit.xcodeproj' -scheme 'App' \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -30
+  -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17 Pro' 2>&1 | tail -30
 ```
 
 Expected: PASS, no regressions.

--- a/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
@@ -77,9 +77,28 @@ converted from miles — "8 km" reads as a bug:
 - Imperial: Any, 1 mi, 2 mi, 5 mi, 10 mi, 15 mi
 - Metric: Any, 2 km, 5 km, 10 km, 15 km, 25 km
 
+`Locale.MeasurementSystem` is a **struct**, not an enum — it has `.metric`,
+`.us`, and `.uk`, and can be constructed from any BCP-47 identifier, so it can
+never be switched exhaustively. The selection is therefore written to make the
+mile ladder the *explicit* case and metric the fallback:
+
+```swift
+let system = Locale.current.measurementSystem
+let usesMiles = system == .us || system == .uk
+```
+
+The `.uk` case genuinely wants miles — UK road distances are in miles even
+though the UK is otherwise metric — and any unrecognized or future system falls
+through to metric, which is right for most of the world. Testing `== .metric`
+and defaulting the other branch to miles would get `.uk` right by accident and
+every unknown system wrong.
+
 Titles come from a `MeasurementFormatter` with `unitOptions = .providedUnit` and
-zero fraction digits, so the displayed number matches the rung exactly. "Any" is
-a localized string, not a formatted measurement.
+zero fraction digits, so the displayed number matches the rung exactly. Verified
+empirically: this yields exactly "5 mi" and "10 km" under `en_US`, `de_DE`, and
+`en_GB` — `.providedUnit` suppresses both conversion and locale substitution, and
+mutating `formatter.numberFormatter` in place takes effect. "Any" is a localized
+string, not a formatted measurement.
 
 The persisted value is always meters. When it doesn't match a rung in the
 current ladder — the rider's locale changed after they chose one — the menu
@@ -176,8 +195,11 @@ arriving one notification late.
 
 ### Map sheet row
 
-A menu-style `Picker` appended to the "Other ways to get around" section, below
-the Bikes and Scooters rows. It appears whenever at least one rental layer row
+A `Picker` with an explicit `.pickerStyle(.menu)` appended to the "Other ways to
+get around" section, below the Bikes and Scooters rows. The style is stated
+explicitly rather than left to `.automatic`, which Apple documents as "based on
+the picker's context" — in a `List` that has resolved to a navigation link in some
+OS versions and a menu in others. It appears whenever at least one rental layer row
 is visible — deliberately *not* gated on those layers being enabled, so the row
 doesn't jump in and out of the sheet as the rider toggles them, and so the
 filter can be set before turning a layer on.
@@ -199,10 +221,40 @@ static func fuelLabelText(for rental: VehicleRental) -> String?
 ```
 
 Percent is clamped to 0...1 before formatting — a feed can report 1.2 — and
-reuses the existing `batteryText(_:)`. Range reuses the cached
-`distanceFormatter`. Stations return nil: they have no fuel of their own.
+reuses the existing `batteryText(_:)`. Stations return nil: they have no fuel of
+their own.
+
+The range fallback needs its **own** `MKDistanceFormatter` with
+`unitStyle = .abbreviated`. The existing shared `RentalFormat.distanceFormatter`
+uses the default style, which spells the unit out — verified: 5,470 m renders as
+`"3.4 miles"` under `en_US`, where `.abbreviated` gives `"3.4 mi"`. Only the
+abbreviated form is short enough to sit under a map pin. The detail sheet's
+existing spelled-out rendering is deliberate and stays as it is, so the two
+surfaces need two formatters rather than one mutated in place.
 
 `RentalAnnotation` gains `showsFuelLabel: Bool`, defaulting to false.
+
+#### Why not MapKit's built-in text
+
+`MKMarkerAnnotationView` already has `titleVisibility` and `subtitleVisibility`,
+documented as "the visibility of the title text rendered beneath the marker
+balloon", with `MKFeatureVisibility.adaptive` letting MapKit place the text
+according to current map state — collision-aware, which a custom subview is not.
+It was considered and rejected:
+
+- The text can only come from the annotation's `title` or `subtitle`. `title` is
+  the rider-facing display label ("Lime e-bike"), used by the callout and by
+  VoiceOver; `subtitle` is station availability. Putting "62%" in either means
+  giving up the thing that's there now.
+- `subtitleVisibility`'s documentation says "MapKit shows the text when the user
+  selects a marker" — selection-driven, not the always-on glance the mockup
+  wants.
+- Styling is not exposed: the built-in text is Maps-app styled, not bold purple.
+
+So the custom label stands, with the collision caveat below accepted knowingly
+rather than by omission.
+
+#### The label
 
 `RentalAnnotationView` gains a `UILabel`:
 
@@ -213,7 +265,9 @@ reuses the existing `batteryText(_:)`. Range reuses the cached
   `markerTintColor`
 - a white shadow, so the text stays legible over satellite basemaps
 - hidden when the text is nil or `showsFuelLabel` is false
-- cleared in `prepareForReuse()`, alongside the existing reuse resets
+- cleared in `prepareForReuse()`, alongside the existing reuse resets —
+  `MKAnnotationView`'s default implementation is documented as doing nothing, so
+  every piece of subclass state must be reset by hand or it leaks across reuse
 
 **The zoom gate lives on the annotation, not the view.**
 `RentalMapLayer.annotationView(for:)` only dequeues a view and has no access to
@@ -224,22 +278,51 @@ existing update path uses to refresh glyphs without disturbing selection. New
 annotations are created with the current value, so they render correctly on
 first appearance.
 
+Re-assigning `annotation` is not a *documented* reconfigure hook; it works
+because the subclass observes it with `didSet`. It is retained here only because
+the existing update path already relies on it and a second mechanism for the same
+job would be worse than one unofficial one. `prepareForDisplay()` is the
+documented pre-display hook and is the fallback if the re-assignment turns out to
+disturb selection or clustering.
+
 The threshold is **8,000 map points**, against the layer's own `zoomWindow` of
-20,000. These are `MKMapRect` units, not meters: at Seattle's latitude 20,000
-map points is roughly a 2 km-tall viewport, and 8,000 is roughly 800 m — a few
-blocks, where markers are far enough apart for labels to read. The exact number
-is a starting estimate and should be checked against a real dense fleet on
-device.
+20,000. These are `MKMapRect` units, not meters. Confirmed against
+`MKMapPointsPerMeterAtLatitude`: at latitude 47.6 there are 9.9464 map points per
+metre, so 20,000 map points is a **2,011 m**-tall viewport and 8,000 is
+**804 m** — a few blocks, where markers are far enough apart for labels to read.
+The exact number is a starting estimate and should be checked against a real
+dense fleet on device.
+
+**The geometry has to be measured, not assumed.** Apple documents neither what
+occupies `MKMarkerAnnotationView.bounds` (balloon only, balloon plus tip, or
+balloon plus shadow) nor its default `centerOffset`; `MKAnnotationView` only
+states that the map places the view's *center* at the annotation's coordinate
+unless `centerOffset` says otherwise. So "top pinned to `bottomAnchor` + 1"
+is an intent, not a guarantee — the first implementation step is to log the
+view's `bounds` and `centerOffset` after layout and set the constant from that.
+Budget for a gap or an overlap needing correction.
 
 The label is a plain subview, so it does not participate in MapKit's marker
-collision logic; some overlap in an unusually dense block is accepted rather
-than solved. Cluster annotations never get a label — a cluster has no single
-fuel value.
+collision logic: `collisionMode` interprets a collision frame derived from the
+view's own frame, and a subview drawn outside `bounds` is invisible to it. Some
+overlap in an unusually dense block is accepted rather than solved. The
+alternative — growing the view's frame to enclose the label and compensating
+with `centerOffset` so decluttering accounts for it — means fighting
+`MKMarkerAnnotationView`'s internally managed balloon layout, and is out of scope
+unless overlap proves bad in practice.
+
+Cluster annotations never get a label — a cluster has no single fuel value.
 
 **VoiceOver ignores the density gate.** The view's `accessibilityLabel`
 incorporates the fuel text even when the visual label is hidden by zoom: a
 visual-clutter rule should not cost a VoiceOver user information. The label
 itself is `isAccessibilityElement = false` so it isn't announced twice.
+
+Apple does not document what `MKAnnotationView` derives from an annotation's
+`title`/`subtitle` for VoiceOver, so whether setting `accessibilityLabel`
+*replaces* that or reads alongside it is unverified. Confirm with VoiceOver on
+device before considering this part done; if it duplicates, the fix is to compose
+the full string (label plus fuel) rather than append.
 
 ### Analytics
 

--- a/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
@@ -136,6 +136,16 @@ An entity is visible when it matches the current form factors **and** passes the
 filter. Every mutation returns the exact set of changes to apply to the map, so
 the caller never has to recompute anything.
 
+It needs no isolation annotation and no explicit `Sendable` conformance. OBAKit
+defaults to main-actor isolation, so `RentalVisibility` is implicitly main-actor
+isolated; it lives as a `var` on the `@MainActor` `RentalLayerCoordinator` and is
+mutated only from that class's main-actor methods. The existing
+`Task { for await snapshot in snapshots }` pattern already inherits the
+enclosing main-actor context, which is why the current `apply(_:)` call compiles
+today, and `Changes` never crosses an isolation boundary — it is returned to a
+main-actor caller. A struct is preferable to a class here precisely because it
+cannot be captured and mutated from somewhere else.
+
 Memory stays bounded without extra work: the source replaces its `delivered` map
 wholesale on each fetch and reports everything absent as `removed`, so the cache
 tracks the padded viewport rather than growing across a session.
@@ -318,11 +328,20 @@ incorporates the fuel text even when the visual label is hidden by zoom: a
 visual-clutter rule should not cost a VoiceOver user information. The label
 itself is `isAccessibilityElement = false` so it isn't announced twice.
 
-Apple does not document what `MKAnnotationView` derives from an annotation's
-`title`/`subtitle` for VoiceOver, so whether setting `accessibilityLabel`
-*replaces* that or reads alongside it is unverified. Confirm with VoiceOver on
-device before considering this part done; if it duplicates, the fix is to compose
-the full string (label plus fuel) rather than append.
+Apple documents no default VoiceOver derivation for `MKAnnotationView` — a
+documentation search turns up nothing on how (or whether) it builds a label from
+the annotation's `title`/`subtitle`. What *is* documented, in "Supporting
+VoiceOver in your app", is the general UIKit rule: `accessibilityLabel` is a
+single property supplying the text VoiceOver reads, and duplicate announcements
+come from *child* accessibility elements rather than from a set label being
+appended to a derived one. So composing the full string ourselves and setting
+`isAccessibilityElement = false` on the child label is the right shape.
+
+The one residual unknown is narrow: whether `MKAnnotationView` is an
+accessibility element at all by default, and whether MapKit synthesizes anything
+around it. Confirm with VoiceOver on device, focusing a rental pin and checking
+that exactly one announcement is heard containing both the vehicle name and the
+fuel figure.
 
 ### Analytics
 
@@ -338,6 +357,28 @@ need neither a map view nor an async pipeline to exercise.
 
 Swift Testing throughout, `.serialized` suites, per the conventions in
 `CLAUDE.md`.
+
+**Isolation must come from the fixtures, not from the schedule.** Swift Testing's
+own documentation states that tests "run in parallel with respect to each other
+using task groups, generally within the same process," with `.serialized`
+serializing only *within* a suite; global parallelization is off only under
+`--no-parallel` or `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1`. The
+`parallelizable: false` on the `OBAKitTests` scheme target governs XCTest's
+multi-process parallel testing, and nothing in the documentation establishes that
+it disables Swift Testing's in-process task-group parallelism. So the plan does
+not rely on it.
+
+Concretely, the `MapRegionManager` persistence suite must never touch
+`UserDefaults.standard`. It inherits `OBATestCase`, whose
+`userDefaultsSuiteName` is already `"OBAKitTests.\(UUID().uuidString)"` — a
+per-instance scratch domain, torn down in `deinit`. That gives real isolation
+regardless of what runs concurrently, which is the only kind worth having.
+
+Suites that construct UIKit views (`RentalAnnotationViewTests`) or touch
+`RentalLayerCoordinator` are `@MainActor`. This is not merely a UIKit
+requirement: OBAKit builds with main-actor default isolation, so
+`RentalVisibility` and `RentalRangeFilter` are themselves implicitly main-actor
+isolated and unreachable from a `nonisolated` test context.
 
 | Suite | Covers |
 | --- | --- |

--- a/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
@@ -389,11 +389,35 @@ isolated and unreachable from a `nonisolated` test context.
 | `RentalAnnotationViewTests` | label text and hidden state per `showsFuelLabel`, gray when non-operative, accessibility label present while the visual label is hidden |
 | `MapRegionManager` persistence | default is Any, round-trip through a scratch `UserDefaults`, `mapLayersDifferFromDefaults`, reset |
 
-`RentalLayerCoordinator` gets no suite of its own. With `RentalVisibility`
-extracted, what remains is `mapView.addAnnotations` plumbing behind a 250 ms
-debounce and an `AsyncStream` — a large amount of test scaffolding for very
-little logic, and the logic it would cover is tested directly in
-`RentalVisibilityTests`.
+`RentalLayerCoordinator` ships without a suite of its own — but the original
+justification for that was wrong, and is corrected here so the next maintainer
+isn't misled by it.
+
+The claim was that what remains is plumbing "behind a 250 ms debounce and an
+`AsyncStream`." That describes the *snapshot* path only. The **filter** path is
+fully synchronous and touches neither: sheet write → `MapRegionManager` setter →
+synchronous notification → `MapViewController` observer → `setRangeFilter` →
+`RentalVisibility.setFilter` → `apply(_ changes:)` → `MKMapView`. There is no
+`await` anywhere in it. The debounce and the stream govern only how the cache
+gets *seeded*.
+
+So a coordinator test is far cheaper than implied: stub the one-method
+`VehicleRentalService`, drop `private` from `apply(_ snapshot:)`, and drive the
+whole thing synchronously in roughly 40 lines. Two things currently have **no
+coverage at any level** and would be closed by it:
+
+1. The invariant that `Set(annotations.keys)` equals `RentalVisibility`'s visible
+   id set. It holds today only because `mapView` is never nil while the
+   coordinator lives. Any future early return in `apply(_ changes:)` — "skip
+   while a sheet is presented", "coalesce during a pan" — silently breaks cache
+   restore, with the whole suite still green, because the bug would live in the
+   translation layer rather than the value type.
+2. `updateFuelLabelVisibility` and the `fuelLabelMaxVisibleHeight` constant. A
+   wrong threshold or a flipped comparison means labels that never appear or
+   always appear, and nothing fails: `RentalAnnotationViewTests` sets
+   `showsFuelLabel` by hand, so the `MKMapRect` → gate mapping is unverified.
+
+Filed as a follow-up rather than a blocker, since neither is a bug today.
 
 `scripts/generate_project` must be re-run after adding each new source or test
 file. XcodeGen picks files up from disk, and a test file the project doesn't know

--- a/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
+++ b/docs/superpowers/specs/2026-07-29-rental-range-filter-design.md
@@ -1,0 +1,290 @@
+# Rental Range Filter and Fuel Labels
+
+Two related additions to the rental map layers:
+
+1. A **minimum-range filter** in the Map sheet, so riders never have to tap a
+   scooter only to discover it has two miles left in it.
+2. A **fuel label** under each rental annotation, so the same judgment can be
+   made at a glance without tapping anything.
+
+Both act on `FuelInfo`, which carries `percent` (a 0...1 charge ratio) and
+`range` (estimated remaining meters). Either may be nil, and on the launch feed
+`percent` is null across the entire fleet while `range` is populated — every
+decision below is shaped by that asymmetry.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Label content | `percent` when present, else `range`, else no label |
+| Filter control | Menu-style picker with discrete presets |
+| Entities without range data | Fail open — always shown |
+| Label density | Gated on a zoom threshold tighter than the layer's own |
+| Threshold scope | One shared value for Bikes and Scooters |
+
+## Architecture
+
+### Filtering model
+
+Three new types, all pure Swift with no MapKit and no async.
+
+**`RentalRangeFilter`** — the predicate.
+
+```swift
+struct RentalRangeFilter: Equatable {
+    /// Threshold in meters. Zero means "Any" — no filtering at all.
+    let minimumRangeMeters: Int
+
+    static let any = RentalRangeFilter(minimumRangeMeters: 0)
+    var isActive: Bool { minimumRangeMeters > 0 }
+
+    func allows(_ rental: VehicleRental) -> Bool {
+        guard isActive,
+              case .vehicle(let vehicle) = rental,
+              let range = vehicle.fuel?.range else {
+            return true
+        }
+        return range >= minimumRangeMeters
+    }
+}
+```
+
+The single `guard` encodes fail-open: docked stations, pedal bikes, and powered
+vehicles whose feed omits `range` all leave through the same early return. This
+matches the fail-open convention already established by
+`VehicleRental.matches(formFactors:)`, and it means the filter can never empty
+the map on a feed that doesn't publish range.
+
+Comparison is `>=`, so a 5 mi threshold keeps a vehicle reporting exactly
+5 mi (8,047 m at the preset's stored value).
+
+**`RentalRangePreset`** — the menu ladder.
+
+```swift
+struct RentalRangePreset: Equatable, Identifiable {
+    let meters: Int     // 0 == Any
+    let title: String   // "Any", "5 mi", "10 km"
+    var id: Int { meters }
+
+    static func presets(measurementSystem: Locale.MeasurementSystem) -> [RentalRangePreset]
+    static func nearest(toMeters: Int, in presets: [RentalRangePreset]) -> RentalRangePreset
+}
+```
+
+Rungs are whole numbers in the rider's own units rather than a metric ladder
+converted from miles — "8 km" reads as a bug:
+
+- Imperial: Any, 1 mi, 2 mi, 5 mi, 10 mi, 15 mi
+- Metric: Any, 2 km, 5 km, 10 km, 15 km, 25 km
+
+Titles come from a `MeasurementFormatter` with `unitOptions = .providedUnit` and
+zero fraction digits, so the displayed number matches the rung exactly. "Any" is
+a localized string, not a formatted measurement.
+
+The persisted value is always meters. When it doesn't match a rung in the
+current ladder — the rider's locale changed after they chose one — the menu
+highlights the nearest rung via `nearest(toMeters:in:)` while filtering
+continues to use the stored value. Snapping and rewriting on read would silently
+alter a preference the rider set deliberately.
+
+**`RentalVisibility`** — the cache that makes the filter work at all.
+
+`VehicleRentalSource` emits only diffs (`added` / `removed` / `updated`) against
+what it has previously delivered. If the coordinator simply declined to create
+an annotation for an under-threshold vehicle, that vehicle would never reappear
+when the threshold was lowered — it isn't in `added` anymore. So the client needs
+its own complete cache of delivered entities, with visibility derived from it.
+
+```swift
+struct RentalVisibility {
+    struct Changes: Equatable {
+        var added: [VehicleRental] = []
+        var removed: [VehicleRental.ID] = []
+        var updated: [VehicleRental] = []
+        var isEmpty: Bool { added.isEmpty && removed.isEmpty && updated.isEmpty }
+    }
+
+    private(set) var formFactors: Set<VehicleFormFactor> = []
+    private(set) var filter: RentalRangeFilter = .any
+
+    mutating func apply(_ snapshot: VehicleRentalSnapshot) -> Changes
+    mutating func setFormFactors(_ formFactors: Set<VehicleFormFactor>) -> Changes
+    mutating func setFilter(_ filter: RentalRangeFilter) -> Changes
+}
+```
+
+An entity is visible when it matches the current form factors **and** passes the
+filter. Every mutation returns the exact set of changes to apply to the map, so
+the caller never has to recompute anything.
+
+Memory stays bounded without extra work: the source replaces its `delivered` map
+wholesale on each fetch and reports everything absent as `removed`, so the cache
+tracks the padded viewport rather than growing across a session.
+
+The case that needs the most care is an `updated` entity that **crosses** the
+threshold — a scooter that drained below it, or fresh data that lifts one above
+it. Such an entity must be translated into an add or a remove, not an update:
+
+| Was visible | Now visible | Emitted as |
+| --- | --- | --- |
+| yes | yes | `updated` |
+| yes | no | `removed` |
+| no | yes | `added` |
+| no | no | nothing |
+
+For determinism, `apply` preserves snapshot order, while the wholesale
+recomputations in `setFormFactors` and `setFilter` sort by id — mirroring how
+`VehicleRentalSource` sorts its own `removed` array.
+
+This type also absorbs `RentalLayerCoordinator.pruneAnnotations(notMatching:)`,
+which does a subset of the same job today. The coordinator is left with what it
+should have been all along: translating `Changes` into `MKMapView` calls.
+
+### Ownership and wiring
+
+The threshold is one shared value across both rental layers, so it lives on
+`MapRegionManager` beside the existing per-layer enablement, under
+`mapLayer.rentals.minimumRangeMeters`:
+
+```swift
+public static let rentalMinimumRangeDefaultsKey = "mapLayer.rentals.minimumRangeMeters"
+public var rentalRangeFilter: RentalRangeFilter { get set }  // setter persists + posts
+```
+
+Putting it here makes the Map sheet's Reset button work without new machinery:
+`mapLayersDifferFromDefaults` ORs in `rentalRangeFilter != .any`, and
+`resetMapLayersToDefaults()` sets it back to `.any`. The manager already
+references `StopsMapLayer.layerID` directly, so a rental-specific property is
+not a new kind of coupling.
+
+The alternative — a dedicated `RentalRangeFilterStore` — was rejected because
+the Map sheet and the coordinator would each need an instance, and keeping two
+instances in sync through `UserDefaults` is more moving parts than the property
+it replaces.
+
+`MapViewController` is the composition root. It observes a new
+`.rentalRangeFilterDidChange` notification and forwards to the coordinator,
+exactly as it already handles `.mapLayerEnabledStateDidChange`:
+
+```swift
+rentalLayerCoordinator?.setRangeFilter(mapRegionManager.rentalRangeFilter)
+```
+
+`RentalLayerCoordinator` is seeded with the persisted value at construction, so
+a filter set in a previous session applies to the first fetch rather than
+arriving one notification late.
+
+### Map sheet row
+
+A menu-style `Picker` appended to the "Other ways to get around" section, below
+the Bikes and Scooters rows. It appears whenever at least one rental layer row
+is visible — deliberately *not* gated on those layers being enabled, so the row
+doesn't jump in and out of the sheet as the rider toggles them, and so the
+filter can be set before turning a layer on.
+
+New strings:
+
+- `map_sheet.minimum_range` — "Minimum range"
+- `map_sheet.minimum_range_any` — "Any"
+
+### Fuel label
+
+`RentalFormat` moves out of `RentalDetailViewController.swift` into its own
+`RentalFormat.swift`. It is shared formatting logic that was never
+detail-sheet-specific, and this change adds a third consumer. It gains:
+
+```swift
+/// Battery percent when the feed provides it, else remaining range, else nil.
+static func fuelLabelText(for rental: VehicleRental) -> String?
+```
+
+Percent is clamped to 0...1 before formatting — a feed can report 1.2 — and
+reuses the existing `batteryText(_:)`. Range reuses the cached
+`distanceFormatter`. Stations return nil: they have no fuel of their own.
+
+`RentalAnnotation` gains `showsFuelLabel: Bool`, defaulting to false.
+
+`RentalAnnotationView` gains a `UILabel`:
+
+- pinned `centerXAnchor` to the view's `centerXAnchor`, `topAnchor` to the
+  view's `bottomAnchor` + 1, with `clipsToBounds = false`
+- bold `.caption1` via a symbolic trait, so Dynamic Type applies
+- `.rentalPurple` when operative, `.systemGray` when not, matching
+  `markerTintColor`
+- a white shadow, so the text stays legible over satellite basemaps
+- hidden when the text is nil or `showsFuelLabel` is false
+- cleared in `prepareForReuse()`, alongside the existing reuse resets
+
+**The zoom gate lives on the annotation, not the view.**
+`RentalMapLayer.annotationView(for:)` only dequeues a view and has no access to
+viewport state. So `RentalLayerCoordinator` sets `showsFuelLabel` on its
+annotations from the `mapRect` it already receives in `viewportDidChange`, and
+re-assigns `view.annotation` to re-run `configure()` — the same mechanism the
+existing update path uses to refresh glyphs without disturbing selection. New
+annotations are created with the current value, so they render correctly on
+first appearance.
+
+The threshold is **8,000 map points**, against the layer's own `zoomWindow` of
+20,000. These are `MKMapRect` units, not meters: at Seattle's latitude 20,000
+map points is roughly a 2 km-tall viewport, and 8,000 is roughly 800 m — a few
+blocks, where markers are far enough apart for labels to read. The exact number
+is a starting estimate and should be checked against a real dense fleet on
+device.
+
+The label is a plain subview, so it does not participate in MapKit's marker
+collision logic; some overlap in an unusually dense block is accepted rather
+than solved. Cluster annotations never get a label — a cluster has no single
+fuel value.
+
+**VoiceOver ignores the density gate.** The view's `accessibilityLabel`
+incorporates the fuel text even when the visual label is hidden by zoom: a
+visual-clutter rule should not cost a VoiceOver user information. The label
+itself is `isAccessibilityElement = false` so it isn't announced twice.
+
+### Analytics
+
+One event when the threshold changes, reported from the same place the filter is
+persisted, alongside the existing `AnalyticsLabels.mapLayerToggled`. The value is
+the chosen threshold in meters.
+
+## Testing
+
+The rental layer currently has no test coverage at all, so this is greenfield.
+The architecture above is shaped to put nearly all of the logic in types that
+need neither a map view nor an async pipeline to exercise.
+
+Swift Testing throughout, `.serialized` suites, per the conventions in
+`CLAUDE.md`.
+
+| Suite | Covers |
+| --- | --- |
+| `RentalRangeFilterTests` | the allow matrix: station, pedal bike, unknown range, below / exactly at / above threshold, and an inactive filter admitting everything |
+| `RentalRangePresetTests` | both ladders, meters conversion, titles, nearest-rung selection for an off-ladder stored value |
+| `RentalVisibilityTests` | snapshot add/remove/update diffs; raising the threshold hides; **lowering it restores from cache with no refetch**; updates that cross the threshold in both directions; form-factor pruning; deterministic ordering |
+| `RentalFormatTests` | percent rounding and out-of-range clamping, range fallback when percent is nil, nil for stations and for vehicles with no fuel |
+| `RentalAnnotationViewTests` | label text and hidden state per `showsFuelLabel`, gray when non-operative, accessibility label present while the visual label is hidden |
+| `MapRegionManager` persistence | default is Any, round-trip through a scratch `UserDefaults`, `mapLayersDifferFromDefaults`, reset |
+
+`RentalLayerCoordinator` gets no suite of its own. With `RentalVisibility`
+extracted, what remains is `mapView.addAnnotations` plumbing behind a 250 ms
+debounce and an `AsyncStream` — a large amount of test scaffolding for very
+little logic, and the logic it would cover is tested directly in
+`RentalVisibilityTests`.
+
+`scripts/generate_project` must be re-run after adding each new source or test
+file. XcodeGen picks files up from disk, and a test file the project doesn't know
+about doesn't fail — it silently runs zero tests, which reads as passing.
+
+Test fixtures need `VehicleRental` values with controlled `FuelInfo`. OTPKit's
+own `TestFixtures` are not visible to this target, so a small local builder for
+station / pedal bike / powered vehicle with a given range and percent goes in
+the test helpers.
+
+## Out of scope
+
+- Server-side range filtering. The OTP `vehicleRentalsByBbox` query has no such
+  parameter; this is a client-side display filter over data already fetched.
+- Separate thresholds per layer. One shared value, per the request.
+- Mirroring the filter into Settings. The Map sheet owns rental layer
+  configuration.
+- Filtering by operator, price, or vehicle type.


### PR DESCRIPTION
Stacked on #1244. Base is `bikeshare`, so this diff is just the filter work.

## Summary

- **Minimum-range filter** for the Bikes and Scooters layers — a menu row in the Map sheet lets a rider hide micromobility with too little range left to be useful. One shared threshold, persisted beside the existing per-layer enablement so the sheet's Reset button covers it.
- **Fuel labels** beneath each rental pin: battery percent when the feed provides it, remaining range otherwise. On the launch feed `percent` is null fleet-wide, so range is the live path.
- **`RentalVisibility`** caches every delivered entity rather than only visible ones. `VehicleRentalSource` emits only diffs, so a vehicle dropped for being under threshold would never be re-sent — without the cache, lowering the threshold wouldn't bring it back until a refetch.

Design notes: `docs/superpowers/specs/2026-07-29-rental-range-filter-design.md`.

## Test plan

- [x] Full target: **1614 tests in 180 suites**, 0 failures. Seven new suites, 76 tests.
- [x] **Ran on device** (iPhone 17 Pro / iOS 26.3, live Seattle OTP data). Labels render as abbreviated ranges in rental purple beneath the markers — confirming the range fallback is the live path, that `.abbreviated` gives "10 mi" not "10 miles", and that the label sits at the balloon tip.
- [x] Filter verified deterministically in `RentalLayerCoordinatorTests`: raising the threshold removes the short-range vehicle, **lowering it restores from cache with no refetch**, and a vehicle with no range data survives an active filter (fail-open).
- [x] Fuel-label zoom gate covered three ways (inside window, outside, gate closed).
- [x] Map sheet row confirmed visually from a rendered capture: bolt glyph, trailing value, correct placement under Bikes/Scooters. Reset correctly absent when nothing differs from defaults.
- [x] `LocalizationTests` green — no `.strings` entries added; strings are `OBALoc` defaults, matching the convention the key-parity test enforces.
- [ ] **VoiceOver on a rental pin — not yet verified, see below.**

## Review notes

**One thing I could not verify.** Assigning `accessibilityLabel` does not make a `UIView` an accessibility element, and Apple documents neither whether `MKAnnotationView` is one by default nor what it derives from the annotation's `title`/`subtitle`. If it isn't, the whole VoiceOver story here is a no-op — *including the pre-existing behavior this change had to preserve* — and all 14 annotation-view tests still pass. Expect one announcement carrying vehicle name, station occupancy, and fuel figure. Silence means `isAccessibilityElement = true` is needed; a doubled name means MapKit composes its own label and the composition should be overridden rather than appended to.

Related and fixed here: the composed label originally dropped `RentalAnnotation.subtitle`, which silently cost stations their availability count for VoiceOver users, since assigning `accessibilityLabel` overrides MapKit's default.

**Deferred deliberately.** The fuel label's text shadow has no `shadowPath` (impossible for text), so Core Animation derives it from the glyph alpha mask — an offscreen pass per label when content invalidates. That's zoom-driven, not pan-driven. Worth watching during a dense-fleet pan; the fixes if it janks are an `NSAttributedString` halo or `shouldRasterize`.

**Considered and declined.** `RentalVisibility.Changes` mirrors OTPKit's `VehicleRentalSnapshot` field-for-field. Reusing it properly needs an upstream change making `fetchedAt` optional; without that you'd fabricate a timestamp for a diff that involved no fetch. Filed rather than forced.

**Follow-up worth having.** `MapLayerZoomWindow` could grow a second "draw detail at Y" threshold once a live-vehicle layer wants the same two-tier disclosure. One consumer today, so generalizing now would be guessing at the shape.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/onebusaway-ios/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787973635&installation_model_id=429412&pr_number=1245&repository=OneBusAway%2Fonebusaway-ios&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fonebusaway-ios%2Fpull%2F1245&signature=f0aaf28d1451c19aab1c6bd978bc4fce89cade2612a22bd24c78d01f466c662b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a minimum-range filter for rental vehicles in the map, with localized presets and persistent settings.
  * Added battery percentage or remaining-range labels to rental map pins, shown based on map zoom.
  * Added accessibility support for rental fuel information and improved label behavior when pins are reused.
* **Bug Fixes**
  * Rental filter changes now update visible map results immediately without requiring a data refresh.
  * Resetting map layers also clears the rental range filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->