### PR TITLE
Synthesize rental deep links so "Open in Lime" finally works

### DIFF
--- a/OBAKit/Analytics/Analytics.swift
+++ b/OBAKit/Analytics/Analytics.swift
@@ -65,6 +65,15 @@ public class AnalyticsLabels: NSObject {
     /// layer's conversion into trip planning.
     @objc public static let rentalPlanTripTapped = "Rental Plan Trip Tapped"
 
+    /// Label used when the rider taps "Open in <operator>" on the rental sheet.
+    /// Value: the network id.
+    @objc public static let rentalDeepLinkTapped = "Rental Deep Link Tapped"
+
+    /// Label used when a rental deep link failed to open and the fallback URL was
+    /// used instead. Value: the network id. A fallback rate that jumps toward
+    /// 100% is the only signal that an operator changed its URL scheme.
+    @objc public static let rentalDeepLinkFallbackFired = "Rental Deep Link Fallback Fired"
+
     /// Label used when the rental minimum-range filter changes. Value: the
     /// threshold in meters, or "0" for no minimum.
     @objc public static let rentalRangeFilterChanged = "Rental Range Filter Changed"

--- a/OBAKit/Analytics/Analytics.swift
+++ b/OBAKit/Analytics/Analytics.swift
@@ -69,9 +69,9 @@ public class AnalyticsLabels: NSObject {
     /// Value: the network id.
     @objc public static let rentalDeepLinkTapped = "Rental Deep Link Tapped"
 
-    /// Label used when a rental deep link failed to open and the fallback URL was
-    /// used instead. Value: the network id. A fallback rate that jumps toward
-    /// 100% is the only signal that an operator changed its URL scheme.
+    /// Label used when a rental deep link failed to open. Value: the network id.
+    /// A fallback rate that jumps toward 100% is the only signal that an
+    /// operator changed its URL scheme.
     @objc public static let rentalDeepLinkFallbackFired = "Rental Deep Link Fallback Fired"
 
     /// Label used when the rental minimum-range filter changes. Value: the

--- a/OBAKit/Mapping/Layers/RentalDeepLink.swift
+++ b/OBAKit/Mapping/Layers/RentalDeepLink.swift
@@ -46,6 +46,8 @@ enum RentalDeepLink {
         /// Query key carrying the vehicle id.
         let vehicleIDKey: String?
         /// Host for the plain app-launch URL: stations, untargetable operators.
+        /// Empty string for an operator whose launch URI carries no host, so the
+        /// URL keeps its `//` (`bird://`) rather than collapsing to `bird:`.
         let appHost: String?
         let appStoreID: String
     }
@@ -61,11 +63,16 @@ enum RentalDeepLink {
             appHost: "map",
             appStoreID: "1199780189"
         ),
+        // Bird cannot target an individual vehicle, so it only ever gets the
+        // app-launch form. `bird://` is the shape Bird's own GBFS
+        // `discovery_uri` publishes; LaunchServices dispatches on scheme alone,
+        // so `bird:` would likely work too, but there is no reason to differ
+        // from the operator's declared URI.
         "bird": Operator(
             scheme: "bird",
             vehicleHost: nil,
             vehicleIDKey: nil,
-            appHost: nil,
+            appHost: "",
             appStoreID: "1260842311"
         )
     ]
@@ -78,7 +85,13 @@ enum RentalDeepLink {
 
         // 1. Feed data wins, network block or not: the pre-synthesis behaviour
         //    never required one, and a feed may publish a URI without a network.
-        if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
+        //
+        //    Absolute only. `URL(string:)` happily parses a scheme-less value
+        //    like "lime.example/ride/abc" into a non-nil relative URL that
+        //    nothing can open — and because this branch outranks synthesis, one
+        //    malformed feed field would turn a working synthesized link into a
+        //    dead tap. Requiring a scheme lets it fall through instead.
+        if let ios = rental.rentalUris?.ios, let url = URL(string: ios), url.scheme != nil {
             return Target(url: url, storeFallback: webURL, operatorName: operatorName)
         }
 

--- a/OBAKit/Mapping/Layers/RentalDeepLink.swift
+++ b/OBAKit/Mapping/Layers/RentalDeepLink.swift
@@ -1,0 +1,153 @@
+//
+//  RentalDeepLink.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OTPKit
+
+/// Resolves the destination of the rental sheet's "Open in <operator>" button.
+///
+/// GBFS defines `rental_uris` for exactly this, and OTPKit asks for it — but no
+/// Lime system publishes it. A survey of all 48 Lime systems in MobilityData's
+/// catalog (~87,000 vehicles) found zero. Deep links are a Lime Transit
+/// Partnership feature; the public feed omits them worldwide. So when the feed
+/// says nothing, we synthesize the link from the operator's URL scheme and the
+/// vehicle's own id.
+///
+/// The Lime scheme is reverse-engineered (ubahnverleih/WoBike) and undocumented
+/// by Lime. That is tolerable only because failure is graceful: `UIApplication`
+/// reports `success == false` when no app claims the scheme, and the caller then
+/// opens `storeFallback`.
+enum RentalDeepLink {
+
+    /// Where the button should go, and where to land if that fails.
+    struct Target: Equatable {
+        let url: URL
+        let storeFallback: URL?
+        let operatorName: String?
+    }
+
+    /// A known operator's app-launch surface, expressed as URL *components*.
+    ///
+    /// Deliberately not a format string: `String(format:)` would bypass
+    /// percent-encoding, and `.urlQueryAllowed` does not escape `&` or `=`
+    /// inside a query value. Holding components makes the unsafe construction
+    /// unexpressible.
+    private struct Operator {
+        let scheme: String
+        /// Host of the vehicle-targeting URL. Nil when the app cannot target an
+        /// individual vehicle, in which case only `appHost` is ever used.
+        let vehicleHost: String?
+        /// Query key carrying the vehicle id.
+        let vehicleIDKey: String?
+        /// Host for the plain app-launch URL: stations, untargetable operators.
+        let appHost: String?
+        let appStoreID: String
+    }
+
+    /// Keyed by the leading token of the GBFS network id — the same tokenization
+    /// OTPKit's `RentalNetwork.displayName` uses, so the button's operator and
+    /// the sheet header's operator can never disagree.
+    private static let operators: [String: Operator] = [
+        "lime": Operator(
+            scheme: "limebike",
+            vehicleHost: "map",
+            vehicleIDKey: "selected_vehicle_id",
+            appHost: "map",
+            appStoreID: "1199780189"
+        ),
+        "bird": Operator(
+            scheme: "bird",
+            vehicleHost: nil,
+            vehicleIDKey: nil,
+            appHost: nil,
+            appStoreID: "1260842311"
+        )
+    ]
+
+    /// - Parameter now: injected so `generated_at` is deterministic in tests.
+    static func target(for rental: VehicleRental, now: Date = Date()) -> Target? {
+        guard let network = rental.rentalNetwork else { return nil }
+
+        let operatorName = network.displayName
+        let webURL = network.url.flatMap(URL.init(string:))
+
+        // 1. Feed data wins. Preserves the pre-synthesis behaviour exactly,
+        //    including the operator web page as its fallback.
+        if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
+            return Target(url: url, storeFallback: webURL, operatorName: operatorName)
+        }
+
+        // 2. Synthesize for known operators. Deliberately outranks the network
+        //    URL below: a targeted app link beats an operator homepage, which is
+        //    a dead end for someone standing next to a scooter.
+        if let synthesized = synthesize(for: rental, network: network, now: now) {
+            return Target(
+                url: synthesized.url,
+                storeFallback: synthesized.storeFallback,
+                operatorName: operatorName
+            )
+        }
+
+        // 3. The operator's web page, when the feed published one.
+        if let webURL {
+            return Target(url: webURL, storeFallback: nil, operatorName: operatorName)
+        }
+
+        // 4. Nothing to open; the caller hides the button.
+        return nil
+    }
+
+    // MARK: - Synthesis
+
+    private static func synthesize(
+        for rental: VehicleRental,
+        network: RentalNetwork,
+        now: Date
+    ) -> (url: URL, storeFallback: URL?)? {
+        guard let op = operators[networkToken(network.networkId)] else { return nil }
+
+        var components = URLComponents()
+        components.scheme = op.scheme
+
+        // Stations carry a station id, never a vehicle id, so they only ever
+        // get the app-launch form.
+        if case .vehicle(let vehicle) = rental,
+           let host = op.vehicleHost,
+           let key = op.vehicleIDKey,
+           let id = rawVehicleID(vehicle.vehicleId) {
+            components.host = host
+            components.queryItems = [
+                URLQueryItem(name: key, value: id),
+                // Epoch seconds is an inference: the documented format carries an
+                // untyped <timestamp>. Built as a string because "%d" via
+                // String(format:) is a 32-bit specifier.
+                URLQueryItem(name: "generated_at", value: String(Int(now.timeIntervalSince1970)))
+            ]
+        } else {
+            components.host = op.appHost
+        }
+
+        guard let url = components.url else { return nil }
+        return (url, URL(string: "https://apps.apple.com/app/id\(op.appStoreID)"))
+    }
+
+    /// `lime_seattle` -> `lime`, `bird-seattle-washington` -> `bird`.
+    private static func networkToken(_ networkId: String) -> String {
+        let token = networkId.split(whereSeparator: { $0 == "_" || $0 == "-" }).first
+        return (token.map(String.init) ?? networkId).lowercased()
+    }
+
+    /// OTP returns `network:id`. Strip through the first colon to recover the raw
+    /// GBFS `bike_id`. Nil when nothing usable remains, so the caller drops to the
+    /// app-launch form rather than emitting an empty parameter.
+    private static func rawVehicleID(_ vehicleId: String) -> String? {
+        let raw = vehicleId.firstIndex(of: ":").map { String(vehicleId[vehicleId.index(after: $0)...]) } ?? vehicleId
+        return raw.isEmpty ? nil : raw
+    }
+}

--- a/OBAKit/Mapping/Layers/RentalDeepLink.swift
+++ b/OBAKit/Mapping/Layers/RentalDeepLink.swift
@@ -110,8 +110,13 @@ enum RentalDeepLink {
         now: Date
     ) -> Target? {
         // Lowercasing OTPKit's own `displayName` rather than re-splitting the
-        // network id keeps the operator token single-sourced: `displayName` only
-        // uppercases the first character, which the lowercase folds straight back.
+        // network id keeps the operator token single-sourced, so the button's
+        // operator and the sheet header's can't drift apart.
+        //
+        // Not a perfect round-trip: `displayName` uppercases the first character,
+        // and a few characters expand when uppercased (ß -> SS, ﬁ -> FI), which
+        // lowercasing does not undo. Harmless here — every key in `operators` is
+        // an ASCII slug, and a miss just falls through to the web-page branch.
         guard let op = operators[network.displayName.lowercased()] else { return nil }
 
         var components = URLComponents()

--- a/OBAKit/Mapping/Layers/RentalDeepLink.swift
+++ b/OBAKit/Mapping/Layers/RentalDeepLink.swift
@@ -88,12 +88,8 @@ enum RentalDeepLink {
         // 2. Synthesize for known operators. Deliberately outranks the network
         //    URL below: a targeted app link beats an operator homepage, which is
         //    a dead end for someone standing next to a scooter.
-        if let synthesized = synthesize(for: rental, network: network, now: now) {
-            return Target(
-                url: synthesized.url,
-                storeFallback: synthesized.storeFallback,
-                operatorName: operatorName
-            )
+        if let synthesized = synthesize(for: rental, network: network, operatorName: operatorName, now: now) {
+            return synthesized
         }
 
         // 3. The operator's web page, when the feed published one.
@@ -110,9 +106,13 @@ enum RentalDeepLink {
     private static func synthesize(
         for rental: VehicleRental,
         network: RentalNetwork,
+        operatorName: String?,
         now: Date
-    ) -> (url: URL, storeFallback: URL?)? {
-        guard let op = operators[networkToken(network.networkId)] else { return nil }
+    ) -> Target? {
+        // Lowercasing OTPKit's own `displayName` rather than re-splitting the
+        // network id keeps the operator token single-sourced: `displayName` only
+        // uppercases the first character, which the lowercase folds straight back.
+        guard let op = operators[network.displayName.lowercased()] else { return nil }
 
         var components = URLComponents()
         components.scheme = op.scheme
@@ -129,6 +129,11 @@ enum RentalDeepLink {
                 // Epoch seconds is an inference: the documented format carries an
                 // untyped <timestamp>. Built as a string because "%d" via
                 // String(format:) is a 32-bit specifier.
+                //
+                // `generated_at` is Lime's, not a general rule. Bird never reaches
+                // here (no `vehicleHost`), so a shared line is honest today — but a
+                // third vehicle-targeting operator with different query quirks
+                // should move this onto `Operator` rather than branch on scheme.
                 URLQueryItem(name: "generated_at", value: String(Int(now.timeIntervalSince1970)))
             ]
         } else {
@@ -136,13 +141,11 @@ enum RentalDeepLink {
         }
 
         guard let url = components.url else { return nil }
-        return (url, URL(string: "https://apps.apple.com/app/id\(op.appStoreID)"))
-    }
-
-    /// `lime_seattle` -> `lime`, `bird-seattle-washington` -> `bird`.
-    private static func networkToken(_ networkId: String) -> String {
-        let token = networkId.split(whereSeparator: { $0 == "_" || $0 == "-" }).first
-        return (token.map(String.init) ?? networkId).lowercased()
+        return Target(
+            url: url,
+            storeFallback: URL(string: "https://apps.apple.com/app/id\(op.appStoreID)"),
+            operatorName: operatorName
+        )
     }
 
     /// OTP returns `network:id`. Strip through the first colon to recover the raw

--- a/OBAKit/Mapping/Layers/RentalDeepLink.swift
+++ b/OBAKit/Mapping/Layers/RentalDeepLink.swift
@@ -72,16 +72,18 @@ enum RentalDeepLink {
 
     /// - Parameter now: injected so `generated_at` is deterministic in tests.
     static func target(for rental: VehicleRental, now: Date = Date()) -> Target? {
-        guard let network = rental.rentalNetwork else { return nil }
+        let network = rental.rentalNetwork
+        let operatorName = network?.displayName
+        let webURL = network?.url.flatMap(URL.init(string:))
 
-        let operatorName = network.displayName
-        let webURL = network.url.flatMap(URL.init(string:))
-
-        // 1. Feed data wins. Preserves the pre-synthesis behaviour exactly,
-        //    including the operator web page as its fallback.
+        // 1. Feed data wins, network block or not: the pre-synthesis behaviour
+        //    never required one, and a feed may publish a URI without a network.
         if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
             return Target(url: url, storeFallback: webURL, operatorName: operatorName)
         }
+
+        // Synthesis and the web-page fallback both need the network block.
+        guard let network else { return nil }
 
         // 2. Synthesize for known operators. Deliberately outranks the network
         //    URL below: a targeted app link beats an operator homepage, which is

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -94,12 +94,8 @@ struct RentalDetailView: View {
                     // Re-resolve at tap time: the URL carries a `generated_at`
                     // timestamp, and a sheet left open would otherwise send a
                     // stale one that the operator's app may reject.
-                    let fresh = RentalDeepLink.target(for: rental)
-                    onOpenURL(
-                        fresh?.url ?? deepLink.url,
-                        fresh?.storeFallback ?? deepLink.webFallback,
-                        rental.rentalNetwork?.networkId
-                    )
+                    let target = RentalDeepLink.target(for: rental) ?? deepLink.target
+                    onOpenURL(target.url, target.storeFallback, rental.rentalNetwork?.networkId)
                 } label: {
                     Text(deepLink.title)
                         .font(.subheadline.weight(.medium))
@@ -219,13 +215,16 @@ struct RentalDetailView: View {
     /// Where the "Open in <operator>" button goes. Feed-published URIs win;
     /// otherwise `RentalDeepLink` synthesizes one from the operator's scheme.
     /// Nil hides the button.
-    private var deepLinkURL: (title: String, url: URL, webFallback: URL?)? {
+    ///
+    /// Carries the `Target` itself rather than flattening it, so the tap-time
+    /// re-resolution above can swap in a fresher one without renaming fields.
+    private var deepLinkURL: (title: String, target: RentalDeepLink.Target)? {
         guard let target = RentalDeepLink.target(for: rental) else { return nil }
 
         let template = OBALoc("rental_detail.open_in_fmt", value: "Open in %@", comment: "Button opening the rental operator's app or website")
         let name = target.operatorName ?? target.url.host() ?? "app"
 
-        return (String(format: template, name), target.url, target.storeFallback)
+        return (String(format: template, name), target)
     }
 
     /// Re-rendered every 30s so a sheet left open keeps telling the truth, and the

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -21,9 +21,10 @@ import UIKit
     /// the vehicle's coordinate and a rental mode preselected.
     func rentalLayer(planTripUsing rental: VehicleRental)
 
-    /// Open a rental deep link, falling back to the operator's web page when the
-    /// primary URI fails to open (e.g. custom scheme with no app installed).
-    func rentalLayer(open url: URL, webFallback: URL?)
+    /// Open a rental deep link, falling back to the operator's web page or App
+    /// Store listing when the primary URI fails to open (e.g. a synthesized
+    /// custom scheme with no app installed). `networkID` is for analytics.
+    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?)
 }
 
 // MARK: - Detail Sheet
@@ -46,7 +47,7 @@ final class RentalDetailViewController: UIHostingController<RentalDetailView> {
             staleAfter: staleAfter,
             userLocation: userLocation,
             onPlanTrip: { delegate?.rentalLayer(planTripUsing: $0) },
-            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1) }
+            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1, networkID: $2) }
         ))
     }
 
@@ -63,7 +64,7 @@ struct RentalDetailView: View {
     let staleAfter: Duration?
     let userLocation: CLLocation?
     var onPlanTrip: (VehicleRental) -> Void
-    var onOpenURL: (URL, URL?) -> Void
+    var onOpenURL: (URL, URL?, String?) -> Void
 
     /// Reverse-geocoded on selection — never in bulk. Falls back to a plain
     /// distance string while loading or when geocoding fails.
@@ -90,7 +91,7 @@ struct RentalDetailView: View {
 
             if let deepLink = deepLinkURL {
                 Button {
-                    onOpenURL(deepLink.url, deepLink.webFallback)
+                    onOpenURL(deepLink.url, deepLink.webFallback, rental.rentalNetwork?.networkId)
                 } label: {
                     Text(deepLink.title)
                         .font(.subheadline.weight(.medium))
@@ -287,7 +288,7 @@ final class RentalClusterListViewController: UIHostingController<RentalClusterLi
             staleAfter: staleAfter,
             userLocation: userLocation,
             onPlanTrip: { delegate?.rentalLayer(planTripUsing: $0) },
-            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1) }
+            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1, networkID: $2) }
         ))
     }
 
@@ -303,7 +304,7 @@ struct RentalClusterListView: View {
     let staleAfter: Duration?
     let userLocation: CLLocation?
     var onPlanTrip: (VehicleRental) -> Void
-    var onOpenURL: (URL, URL?) -> Void
+    var onOpenURL: (URL, URL?, String?) -> Void
 
     @State private var selectedRental: VehicleRental?
 

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -207,20 +207,16 @@ struct RentalDetailView: View {
         }
     }
 
-    /// Deep link: the GBFS iOS URI when present, the operator's web page as
-    /// fallback, nothing (the norm on the launch feed) otherwise.
+    /// Where the "Open in <operator>" button goes. Feed-published URIs win;
+    /// otherwise `RentalDeepLink` synthesizes one from the operator's scheme.
+    /// Nil hides the button.
     private var deepLinkURL: (title: String, url: URL, webFallback: URL?)? {
-        let operatorName = rental.rentalNetwork?.displayName
-        let template = OBALoc("rental_detail.open_in_fmt", value: "Open in %@", comment: "Button opening the rental operator's app or website")
-        let webURL = rental.rentalNetwork?.url.flatMap(URL.init(string:))
+        guard let target = RentalDeepLink.target(for: rental) else { return nil }
 
-        if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
-            return (String(format: template, operatorName ?? url.host() ?? "app"), url, webURL)
-        }
-        if let webURL {
-            return (String(format: template, operatorName ?? webURL.host() ?? "web"), webURL, nil)
-        }
-        return nil
+        let template = OBALoc("rental_detail.open_in_fmt", value: "Open in %@", comment: "Button opening the rental operator's app or website")
+        let name = target.operatorName ?? target.url.host() ?? "app"
+
+        return (String(format: template, name), target.url, target.storeFallback)
     }
 
     /// Re-rendered every 30s so a sheet left open keeps telling the truth, and the

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -91,7 +91,15 @@ struct RentalDetailView: View {
 
             if let deepLink = deepLinkURL {
                 Button {
-                    onOpenURL(deepLink.url, deepLink.webFallback, rental.rentalNetwork?.networkId)
+                    // Re-resolve at tap time: the URL carries a `generated_at`
+                    // timestamp, and a sheet left open would otherwise send a
+                    // stale one that the operator's app may reject.
+                    let fresh = RentalDeepLink.target(for: rental)
+                    onOpenURL(
+                        fresh?.url ?? deepLink.url,
+                        fresh?.storeFallback ?? deepLink.webFallback,
+                        rental.rentalNetwork?.networkId
+                    )
                 } label: {
                     Text(deepLink.title)
                         .font(.subheadline.weight(.medium))

--- a/OBAKit/Mapping/MapViewController+MapLayers.swift
+++ b/OBAKit/Mapping/MapViewController+MapLayers.swift
@@ -207,15 +207,29 @@ extension MapViewController: RentalLayerActionsDelegate {
         }
     }
 
-    /// Opens a rental deep link. No `canOpenURL` pre-check: partner schemes can't
-    /// be enumerated in `LSApplicationQueriesSchemes` ahead of time, and most GBFS
-    /// iOS URIs are universal links anyway. When a custom-scheme URI fails to open
-    /// (operator app not installed), fall back to the operator's web page instead
-    /// of a dead button.
-    func rentalLayer(open url: URL, webFallback: URL?) {
+    /// Opens a rental deep link. No `canOpenURL` pre-check: Apple's own guidance
+    /// is to attempt the open and handle failure, and `open` — unlike
+    /// `canOpenURL` — is not constrained by `LSApplicationQueriesSchemes`.
+    ///
+    /// The URL is often synthesized from a reverse-engineered scheme rather than
+    /// published by the feed (see `RentalDeepLink`), so failure is expected and
+    /// routine: no app claims the scheme, `success` is false, and we fall back to
+    /// the operator's App Store page or web page.
+    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?) {
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/bikeshare",
+            label: AnalyticsLabels.rentalDeepLinkTapped,
+            value: networkID
+        )
+
         application.open(url, options: [:]) { [weak self] success in
             guard !success else { return }
             Logger.info("Rental deep link failed to open: \(url)")
+            self?.application.analytics?.reportEvent(
+                pageURL: "app://localhost/bikeshare",
+                label: AnalyticsLabels.rentalDeepLinkFallbackFired,
+                value: networkID
+            )
             if let webFallback {
                 self?.application.open(webFallback, options: [:], completionHandler: nil)
             }

--- a/OBAKitTests/Mapping/RentalDeepLinkTests.swift
+++ b/OBAKitTests/Mapping/RentalDeepLinkTests.swift
@@ -78,6 +78,7 @@ struct RentalDeepLinkTests {
         let target = try #require(RentalDeepLink.target(for: rental, now: now))
 
         #expect(target.url.scheme == "bird")
+        #expect(target.url.absoluteString == "bird:")
         #expect(query(target.url)["selected_vehicle_id"] == nil)
         #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1260842311")
         #expect(target.operatorName == "Bird")

--- a/OBAKitTests/Mapping/RentalDeepLinkTests.swift
+++ b/OBAKitTests/Mapping/RentalDeepLinkTests.swift
@@ -78,7 +78,9 @@ struct RentalDeepLinkTests {
         let target = try #require(RentalDeepLink.target(for: rental, now: now))
 
         #expect(target.url.scheme == "bird")
-        #expect(target.url.absoluteString == "bird:")
+        // Matches the `discovery_uri` Bird's own GBFS feed publishes; a bare
+        // `bird:` would be a needless divergence from it.
+        #expect(target.url.absoluteString == "bird://")
         #expect(query(target.url)["selected_vehicle_id"] == nil)
         #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1260842311")
         #expect(target.operatorName == "Bird")
@@ -130,6 +132,20 @@ struct RentalDeepLinkTests {
         #expect(target.url.absoluteString == "https://lime.example/ride/abc")
         #expect(target.storeFallback == nil)
         #expect(target.operatorName == nil)
+    }
+
+    /// A feed URI with no scheme still parses into a non-nil relative `URL`, and
+    /// this branch outranks synthesis — so without the scheme check one bad feed
+    /// field would replace a working `limebike://` link with an unopenable one.
+    @Test func schemelessFeedURIFallsThroughToSynthesis() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            rentalUris: ["ios": "lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(query(target.url)["selected_vehicle_id"] == "abc")
     }
 
     /// Pins the deliberate decision that synthesis outranks `rentalNetwork.url`.

--- a/OBAKitTests/Mapping/RentalDeepLinkTests.swift
+++ b/OBAKitTests/Mapping/RentalDeepLinkTests.swift
@@ -116,6 +116,21 @@ struct RentalDeepLinkTests {
         #expect(target.storeFallback?.absoluteString == "https://www.li.me/")
     }
 
+    /// A feed may publish a deep link without a network block. The pre-synthesis
+    /// code showed the button in that case and this must not regress it.
+    @Test func feedProvidedURIResolvesWithoutARentalNetwork() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            networkId: nil,
+            rentalUris: ["ios": "https://lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.absoluteString == "https://lime.example/ride/abc")
+        #expect(target.storeFallback == nil)
+        #expect(target.operatorName == nil)
+    }
+
     /// Pins the deliberate decision that synthesis outranks `rentalNetwork.url`.
     @Test func synthesisOutranksNetworkURLForKnownOperators() throws {
         let rental = try RentalFixtures.vehicle(id: "lime_seattle:abc", networkURL: "https://www.li.me/")

--- a/OBAKitTests/Mapping/RentalDeepLinkTests.swift
+++ b/OBAKitTests/Mapping/RentalDeepLinkTests.swift
@@ -1,0 +1,152 @@
+//
+//  RentalDeepLinkTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// `RentalDeepLink` answers "where should the Open in <operator> button go?"
+///
+/// The interesting cases are all absences: no feed publishes GBFS `rental_uris`,
+/// so synthesis from the vehicle ID is the live path, and the feed-provided
+/// branches exist only to avoid regressing a feed that someday starts sending them.
+@Suite
+struct RentalDeepLinkTests {
+
+    /// Fixed so `generated_at` renders deterministically.
+    private let now = Date(timeIntervalSince1970: 1_785_462_137)
+    private let timestamp = "1785462137"
+
+    private func query(_ url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return items.reduce(into: [:]) { $0[$1.name] = $1.value }
+    }
+
+    // MARK: - Synthesis
+
+    @Test func synthesizesLimeVehicleLink() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:e0762983-6769-4191-903e-7a9e44444ea3")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(target.url.host == "map")
+        #expect(query(target.url)["selected_vehicle_id"] == "e0762983-6769-4191-903e-7a9e44444ea3")
+        #expect(query(target.url)["generated_at"] == timestamp)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+        #expect(target.operatorName == "Lime")
+    }
+
+    @Test func usesWholeVehicleIDWhenThereIsNoColon() throws {
+        let rental = try RentalFixtures.vehicle(id: "bare-id-42")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(query(target.url)["selected_vehicle_id"] == "bare-id-42")
+    }
+
+    /// An id that is empty after the network prefix must not produce
+    /// `selected_vehicle_id=` with no value — fall back to launching the app.
+    @Test func fallsBackToAppLaunchWhenIDIsEmptyAfterPrefix() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+    }
+
+    /// The reason this type builds URLs with URLComponents: `.urlQueryAllowed`
+    /// would let `&` and `=` through and let a hostile id forge parameters.
+    @Test func escapesReservedCharactersInTheVehicleID() throws {
+        let nasty = "a&b=c d\u{00e9}?e"
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:\(nasty)")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(query(target.url)["selected_vehicle_id"] == nasty)
+        #expect(query(target.url)["generated_at"] == timestamp)
+        #expect(query(target.url).count == 2)
+    }
+
+    @Test func synthesizesAppLevelLinkForBird() throws {
+        let rental = try RentalFixtures.vehicle(id: "bird-seattle-washington:abc", networkId: "bird-seattle-washington")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "bird")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1260842311")
+        #expect(target.operatorName == "Bird")
+    }
+
+    /// A station id is not a vehicle id; it must never land in `selected_vehicle_id`.
+    @Test func stationGetsAppLevelLinkOnly() throws {
+        let rental = try RentalFixtures.station(id: "lime_seattle:station-7")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+    }
+
+    // MARK: - Feed data
+
+    @Test func feedProvidedURIWinsOverSynthesis() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            rentalUris: ["ios": "https://lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.absoluteString == "https://lime.example/ride/abc")
+    }
+
+    /// Branch 1's fallback is the operator web page, not the App Store.
+    @Test func feedProvidedURIKeepsTheNetworkURLAsFallback() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            networkURL: "https://www.li.me/",
+            rentalUris: ["ios": "https://lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.storeFallback?.absoluteString == "https://www.li.me/")
+    }
+
+    /// Pins the deliberate decision that synthesis outranks `rentalNetwork.url`.
+    @Test func synthesisOutranksNetworkURLForKnownOperators() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:abc", networkURL: "https://www.li.me/")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+    }
+
+    @Test func unknownOperatorFallsThroughToNetworkURL() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "veo_seattle:abc",
+            networkId: "veo_seattle",
+            networkURL: "https://www.veoride.com/"
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.absoluteString == "https://www.veoride.com/")
+        #expect(target.storeFallback == nil)
+        #expect(target.operatorName == "Veo")
+    }
+
+    // MARK: - Absences
+
+    @Test func unknownOperatorWithNoURLReturnsNil() throws {
+        let rental = try RentalFixtures.vehicle(id: "veo_seattle:abc", networkId: "veo_seattle")
+        #expect(RentalDeepLink.target(for: rental, now: now) == nil)
+    }
+
+    @Test func missingRentalNetworkReturnsNil() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:abc", networkId: nil)
+        #expect(RentalDeepLink.target(for: rental, now: now) == nil)
+    }
+}

--- a/OBAKitTests/Mapping/RentalFixtures.swift
+++ b/OBAKitTests/Mapping/RentalFixtures.swift
@@ -52,11 +52,7 @@ enum RentalFixtures {
             vehicleType["propulsionType"] = NSNull()
         }
 
-        let networkValue: Any = networkId.map { id in
-            ["networkId": id, "url": networkURL ?? NSNull()] as [String: Any]
-        } ?? NSNull()
-
-        let dictionary: [String: Any] = [
+        var dictionary: [String: Any] = [
             "__typename": "RentalVehicle",
             "vehicleId": id,
             "name": "Default vehicle type",
@@ -64,11 +60,13 @@ enum RentalFixtures {
             "lon": lon,
             "allowPickupNow": true,
             "operative": operative,
-            "rentalNetwork": networkValue,
             "rentalUris": rentalUris ?? NSNull(),
             "vehicleType": vehicleType,
             "fuel": fuelValue
         ]
+        if let networkId {
+            dictionary["rentalNetwork"] = ["networkId": networkId, "url": networkURL ?? NSNull()] as [String: Any]
+        }
         return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
     }
 

--- a/OBAKitTests/Mapping/RentalFixtures.swift
+++ b/OBAKitTests/Mapping/RentalFixtures.swift
@@ -24,6 +24,9 @@ enum RentalFixtures {
 
     /// A free-floating rental vehicle. Pass `rangeMeters: nil, batteryPercent: nil`
     /// for a vehicle whose feed publishes no fuel data at all.
+    ///
+    /// `networkId: nil` omits `rentalNetwork` entirely — the shape a feed takes
+    /// when it publishes no network block, which deep-link resolution must survive.
     static func vehicle(
         id: String = "v1",
         formFactor: String = "SCOOTER",
@@ -32,7 +35,10 @@ enum RentalFixtures {
         batteryPercent: Double? = nil,
         operative: Bool = true,
         lat: Double = 47.6,
-        lon: Double = -122.3
+        lon: Double = -122.3,
+        networkId: String? = "lime_seattle",
+        networkURL: String? = nil,
+        rentalUris: [String: String]? = nil
     ) throws -> VehicleRental {
         var fuel: [String: Any] = [:]
         if let batteryPercent { fuel["percent"] = batteryPercent }
@@ -46,6 +52,10 @@ enum RentalFixtures {
             vehicleType["propulsionType"] = NSNull()
         }
 
+        let networkValue: Any = networkId.map { id in
+            ["networkId": id, "url": networkURL ?? NSNull()] as [String: Any]
+        } ?? NSNull()
+
         let dictionary: [String: Any] = [
             "__typename": "RentalVehicle",
             "vehicleId": id,
@@ -54,8 +64,8 @@ enum RentalFixtures {
             "lon": lon,
             "allowPickupNow": true,
             "operative": operative,
-            "rentalNetwork": ["networkId": "lime_seattle", "url": NSNull()] as [String: Any],
-            "rentalUris": NSNull(),
+            "rentalNetwork": networkValue,
+            "rentalUris": rentalUris ?? NSNull(),
             "vehicleType": vehicleType,
             "fuel": fuelValue
         ]
@@ -73,7 +83,8 @@ enum RentalFixtures {
         vehiclesAvailable: Int? = 4,
         operative: Bool = true,
         lat: Double = 47.6,
-        lon: Double = -122.3
+        lon: Double = -122.3,
+        networkId: String? = "lime_seattle"
     ) throws -> VehicleRental {
         var dictionary: [String: Any] = [
             "__typename": "VehicleRentalStation",
@@ -87,6 +98,9 @@ enum RentalFixtures {
             dictionary["vehiclesAvailable"] = vehiclesAvailable
         } else {
             dictionary["vehiclesAvailable"] = NSNull()
+        }
+        if let networkId {
+            dictionary["rentalNetwork"] = ["networkId": networkId, "url": NSNull()] as [String: Any]
         }
         return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
     }

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -754,7 +754,7 @@ git log --oneline origin/main..HEAD
 
 This cannot be automated — the unit tests prove we build the URL we intend, not that Lime honours it. The PR body must carry:
 
-```
+```text
 ### Manual verification (required before merge)
 - [ ] Install Lime on a device running this build
 - [ ] Open a Lime vehicle sheet, tap "Open in Lime"

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -686,19 +686,7 @@ Make these five edits in `OBAKit/Mapping/Layers/RentalDetailViewController.swift
 
 Line 334 (`onOpenURL: onOpenURL`, the cluster list handing its closure to `RentalDetailView`) needs no edit — the type widens with the declarations.
 
-Then in `MapViewController+MapLayers.swift`, change the signature written in Step 2 to accept the parameter and delete the `let networkID = selectedRentalNetworkID` line:
-
-```swift
-    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?) {
-        application.analytics?.reportEvent(
-            pageURL: "app://localhost/bikeshare",
-            label: AnalyticsLabels.rentalDeepLinkTapped,
-            value: networkID
-        )
-        ...
-```
-
-The rest of the method body from Step 2 is unchanged.
+`MapViewController+MapLayers.swift` needs no further edit: the method written in Step 2 already declares `networkID: String?` and uses it directly. These five edits exist to make that parameter reach it.
 
 - [ ] **Step 4: Build and test**
 

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -1,0 +1,783 @@
+# Synthesized Rental Deep Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a rental feed publishes no GBFS `rental_uris`, synthesize an operator deep link from the vehicle ID so the rental sheet's "Open in Lime" button finally works.
+
+**Architecture:** One new pure-Swift type, `RentalDeepLink`, in OBAKit. It holds a static table of known operators keyed by GBFS network prefix, and resolves a `VehicleRental` to a `Target` (URL + App Store fallback + operator name). `RentalDetailView.deepLinkURL` becomes a thin call into it. No OTPKit changes.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Test`/`@Suite`), OTPKit models, xcodegen.
+
+## Global Constraints
+
+- **Build URLs with `URLComponents` + `URLQueryItem`, never `String(format:)`.** `.urlQueryAllowed` does not escape `&`, `=`, `?`, `/`, or `+` inside a query *value*. This is the spec's central correctness requirement.
+- **Never emit `%d` via `String(format:)` for the timestamp** — 32-bit specifier. Use `String(Int(now.timeIntervalSince1970))`.
+- **No new localized strings.** Reuse `rental_detail.open_in_fmt` ("Open in %@").
+- **No OTPKit changes.** No `canOpenURL`, no `LSApplicationQueriesSchemes` entry.
+- Copyright header on every new file, matching sibling files verbatim (see Task 1 Step 3).
+- Tests are Swift Testing (`import Testing`, `@Test`, `@Suite`), not XCTest.
+- SwiftLint must pass: `scripts/swiftlint.sh`.
+- Branch is `rental-deep-links`, already created off `origin/main` with the spec committed.
+
+**Known operator values** (do not re-derive):
+
+| Operator | Scheme | Vehicle host | Query key | App Store ID |
+| --- | --- | --- | --- | --- |
+| `lime` | `limebike` | `map` | `selected_vehicle_id` | `1199780189` |
+| `bird` | `bird` | *(none — cannot target)* | *(none)* | `1260842311` |
+
+**Build/test commands** (run from `/Users/aaron/repos/onebusaway/ios-bikeshare`):
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalDeepLinkTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+`scripts/generate_project` is only needed after adding a NEW file (Task 1 and Task 2 add files; Tasks 3–5 do not).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `OBAKit/Mapping/Layers/RentalDeepLink.swift` *(new)* | Operator table + resolution. Pure Swift: no UIKit, no MapKit, no async. Sibling of `RentalFormat.swift`, same shape. |
+| `OBAKitTests/Mapping/RentalDeepLinkTests.swift` *(new)* | Full behavioral coverage of the above. |
+| `OBAKitTests/Mapping/RentalFixtures.swift` *(modify)* | Gains `networkId`, `networkURL`, `rentalUris` parameters. |
+| `OBAKit/Mapping/Layers/RentalDetailViewController.swift` *(modify)* | `deepLinkURL` collapses to a `RentalDeepLink` call. |
+| `OBAKit/Analytics/Analytics.swift` *(modify)* | Two new labels. |
+| `OBAKit/Mapping/MapViewController+MapLayers.swift` *(modify)* | Report those labels; correct a now-false comment. |
+
+---
+
+## Task 1: Fixture parameters
+
+Widen `RentalFixtures` first, because every later test depends on it.
+
+**Files:**
+- Modify: `OBAKitTests/Mapping/RentalFixtures.swift:27-63` (`vehicle`) and `:71-92` (`station`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `RentalFixtures.vehicle(id:formFactor:propulsion:rangeMeters:batteryPercent:operative:lat:lon:networkId:networkURL:rentalUris:) throws -> VehicleRental`
+  - `RentalFixtures.station(id:vehiclesAvailable:operative:lat:lon:networkId:) throws -> VehicleRental`
+  - New params are all trailing with defaults matching today's hardcoded values, so existing call sites compile unchanged.
+  - `networkId: String?` — `nil` produces a vehicle with **no** `rentalNetwork` at all.
+  - `rentalUris: [String: String]?` — `nil` (default) produces `NSNull()`; a dictionary like `["ios": "..."]` produces a populated object.
+
+- [ ] **Step 1: Add the parameters to `vehicle(...)`**
+
+Replace the signature and the `rentalNetwork`/`rentalUris` entries in the dictionary. The full method becomes:
+
+```swift
+    /// A free-floating rental vehicle. Pass `rangeMeters: nil, batteryPercent: nil`
+    /// for a vehicle whose feed publishes no fuel data at all.
+    ///
+    /// `networkId: nil` omits `rentalNetwork` entirely — the shape a feed takes
+    /// when it publishes no network block, which deep-link resolution must survive.
+    static func vehicle(
+        id: String = "v1",
+        formFactor: String = "SCOOTER",
+        propulsion: String? = "ELECTRIC",
+        rangeMeters: Int? = nil,
+        batteryPercent: Double? = nil,
+        operative: Bool = true,
+        lat: Double = 47.6,
+        lon: Double = -122.3,
+        networkId: String? = "lime_seattle",
+        networkURL: String? = nil,
+        rentalUris: [String: String]? = nil
+    ) throws -> VehicleRental {
+        var fuel: [String: Any] = [:]
+        if let batteryPercent { fuel["percent"] = batteryPercent }
+        if let rangeMeters { fuel["range"] = rangeMeters }
+        let fuelValue: Any = fuel.isEmpty ? NSNull() : fuel
+
+        var vehicleType: [String: Any] = ["formFactor": formFactor]
+        if let propulsion {
+            vehicleType["propulsionType"] = propulsion
+        } else {
+            vehicleType["propulsionType"] = NSNull()
+        }
+
+        let networkValue: Any = networkId.map { id in
+            ["networkId": id, "url": networkURL ?? NSNull()] as [String: Any]
+        } ?? NSNull()
+
+        let dictionary: [String: Any] = [
+            "__typename": "RentalVehicle",
+            "vehicleId": id,
+            "name": "Default vehicle type",
+            "lat": lat,
+            "lon": lon,
+            "allowPickupNow": true,
+            "operative": operative,
+            "rentalNetwork": networkValue,
+            "rentalUris": rentalUris ?? NSNull(),
+            "vehicleType": vehicleType,
+            "fuel": fuelValue
+        ]
+        return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
+    }
+```
+
+- [ ] **Step 2: Add `networkId` to `station(...)`**
+
+Append the parameter and set the key. The signature gains `networkId: String? = "lime_seattle"` after `lon`, and immediately before `return try Fixtures.dictionaryToModel(...)` insert:
+
+```swift
+        if let networkId {
+            dictionary["rentalNetwork"] = ["networkId": networkId, "url": NSNull()] as [String: Any]
+        }
+```
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalVisibilityTests -only-testing:OBAKitTests/RentalAnnotationViewTests -only-testing:OBAKitTests/RentalLayerCoordinatorTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: PASS. Defaults reproduce the old dictionaries exactly, so nothing should change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OBAKitTests/Mapping/RentalFixtures.swift
+git commit -m "Let rental fixtures vary network id, network url, and rental uris"
+```
+
+---
+
+## Task 2: `RentalDeepLink` resolution
+
+The whole feature. TDD: tests first, all failing, then one implementation.
+
+**Files:**
+- Create: `OBAKit/Mapping/Layers/RentalDeepLink.swift`
+- Create: `OBAKitTests/Mapping/RentalDeepLinkTests.swift`
+
+**Interfaces:**
+- Consumes: `RentalFixtures` from Task 1.
+- Produces:
+  - `RentalDeepLink.Target` — `struct Target: Equatable { let url: URL; let storeFallback: URL?; let operatorName: String? }`, internal.
+  - `RentalDeepLink.target(for rental: VehicleRental, now: Date = Date()) -> Target?`
+  - Task 3 calls exactly this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OBAKitTests/Mapping/RentalDeepLinkTests.swift`:
+
+```swift
+//
+//  RentalDeepLinkTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// `RentalDeepLink` answers "where should the Open in <operator> button go?"
+///
+/// The interesting cases are all absences: no feed publishes GBFS `rental_uris`,
+/// so synthesis from the vehicle ID is the live path, and the feed-provided
+/// branches exist only to avoid regressing a feed that someday starts sending them.
+@Suite
+struct RentalDeepLinkTests {
+
+    /// Fixed so `generated_at` renders deterministically.
+    private let now = Date(timeIntervalSince1970: 1_785_462_137)
+    private let timestamp = "1785462137"
+
+    private func query(_ url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return items.reduce(into: [:]) { $0[$1.name] = $1.value }
+    }
+
+    // MARK: - Synthesis
+
+    @Test func synthesizesLimeVehicleLink() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:e0762983-6769-4191-903e-7a9e44444ea3")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(target.url.host == "map")
+        #expect(query(target.url)["selected_vehicle_id"] == "e0762983-6769-4191-903e-7a9e44444ea3")
+        #expect(query(target.url)["generated_at"] == timestamp)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+        #expect(target.operatorName == "Lime")
+    }
+
+    @Test func usesWholeVehicleIDWhenThereIsNoColon() throws {
+        let rental = try RentalFixtures.vehicle(id: "bare-id-42")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(query(target.url)["selected_vehicle_id"] == "bare-id-42")
+    }
+
+    /// An id that is empty after the network prefix must not produce
+    /// `selected_vehicle_id=` with no value — fall back to launching the app.
+    @Test func fallsBackToAppLaunchWhenIDIsEmptyAfterPrefix() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+    }
+
+    /// The reason this type builds URLs with URLComponents: `.urlQueryAllowed`
+    /// would let `&` and `=` through and let a hostile id forge parameters.
+    @Test func escapesReservedCharactersInTheVehicleID() throws {
+        let nasty = "a&b=c d\u{00e9}?e"
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:\(nasty)")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(query(target.url)["selected_vehicle_id"] == nasty)
+        #expect(query(target.url)["generated_at"] == timestamp)
+        #expect(query(target.url).count == 2)
+    }
+
+    @Test func synthesizesAppLevelLinkForBird() throws {
+        let rental = try RentalFixtures.vehicle(id: "bird-seattle-washington:abc", networkId: "bird-seattle-washington")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "bird")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1260842311")
+        #expect(target.operatorName == "Bird")
+    }
+
+    /// A station id is not a vehicle id; it must never land in `selected_vehicle_id`.
+    @Test func stationGetsAppLevelLinkOnly() throws {
+        let rental = try RentalFixtures.station(id: "lime_seattle:station-7")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(query(target.url)["selected_vehicle_id"] == nil)
+    }
+
+    // MARK: - Feed data
+
+    @Test func feedProvidedURIWinsOverSynthesis() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            rentalUris: ["ios": "https://lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.absoluteString == "https://lime.example/ride/abc")
+    }
+
+    /// Branch 1's fallback is the operator web page, not the App Store.
+    @Test func feedProvidedURIKeepsTheNetworkURLAsFallback() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "lime_seattle:abc",
+            networkURL: "https://www.li.me/",
+            rentalUris: ["ios": "https://lime.example/ride/abc"]
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.storeFallback?.absoluteString == "https://www.li.me/")
+    }
+
+    /// Pins the deliberate decision that synthesis outranks `rentalNetwork.url`.
+    @Test func synthesisOutranksNetworkURLForKnownOperators() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:abc", networkURL: "https://www.li.me/")
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.scheme == "limebike")
+        #expect(target.storeFallback?.absoluteString == "https://apps.apple.com/app/id1199780189")
+    }
+
+    @Test func unknownOperatorFallsThroughToNetworkURL() throws {
+        let rental = try RentalFixtures.vehicle(
+            id: "veo_seattle:abc",
+            networkId: "veo_seattle",
+            networkURL: "https://www.veoride.com/"
+        )
+        let target = try #require(RentalDeepLink.target(for: rental, now: now))
+
+        #expect(target.url.absoluteString == "https://www.veoride.com/")
+        #expect(target.storeFallback == nil)
+        #expect(target.operatorName == "Veo")
+    }
+
+    // MARK: - Absences
+
+    @Test func unknownOperatorWithNoURLReturnsNil() throws {
+        let rental = try RentalFixtures.vehicle(id: "veo_seattle:abc", networkId: "veo_seattle")
+        #expect(RentalDeepLink.target(for: rental, now: now) == nil)
+    }
+
+    @Test func missingRentalNetworkReturnsNil() throws {
+        let rental = try RentalFixtures.vehicle(id: "lime_seattle:abc", networkId: nil)
+        #expect(RentalDeepLink.target(for: rental, now: now) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: BUILD FAILURE — `cannot find 'RentalDeepLink' in scope`. That is the correct red state; the type does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKit/Mapping/Layers/RentalDeepLink.swift`:
+
+```swift
+//
+//  RentalDeepLink.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OTPKit
+
+/// Resolves the destination of the rental sheet's "Open in <operator>" button.
+///
+/// GBFS defines `rental_uris` for exactly this, and OTPKit asks for it — but no
+/// Lime system publishes it. A survey of all 48 Lime systems in MobilityData's
+/// catalog (~87,000 vehicles) found zero. Deep links are a Lime Transit
+/// Partnership feature; the public feed omits them worldwide. So when the feed
+/// says nothing, we synthesize the link from the operator's URL scheme and the
+/// vehicle's own id.
+///
+/// The Lime scheme is reverse-engineered (ubahnverleih/WoBike) and undocumented
+/// by Lime. That is tolerable only because failure is graceful: `UIApplication`
+/// reports `success == false` when no app claims the scheme, and the caller then
+/// opens `storeFallback`.
+enum RentalDeepLink {
+
+    /// Where the button should go, and where to land if that fails.
+    struct Target: Equatable {
+        let url: URL
+        let storeFallback: URL?
+        let operatorName: String?
+    }
+
+    /// A known operator's app-launch surface, expressed as URL *components*.
+    ///
+    /// Deliberately not a format string: `String(format:)` would bypass
+    /// percent-encoding, and `.urlQueryAllowed` does not escape `&` or `=`
+    /// inside a query value. Holding components makes the unsafe construction
+    /// unexpressible.
+    private struct Operator {
+        let scheme: String
+        /// Host of the vehicle-targeting URL. Nil when the app cannot target an
+        /// individual vehicle, in which case only `appHost` is ever used.
+        let vehicleHost: String?
+        /// Query key carrying the vehicle id.
+        let vehicleIDKey: String?
+        /// Host for the plain app-launch URL: stations, untargetable operators.
+        let appHost: String?
+        let appStoreID: String
+    }
+
+    /// Keyed by the leading token of the GBFS network id — the same tokenization
+    /// OTPKit's `RentalNetwork.displayName` uses, so the button's operator and
+    /// the sheet header's operator can never disagree.
+    private static let operators: [String: Operator] = [
+        "lime": Operator(
+            scheme: "limebike",
+            vehicleHost: "map",
+            vehicleIDKey: "selected_vehicle_id",
+            appHost: "map",
+            appStoreID: "1199780189"
+        ),
+        "bird": Operator(
+            scheme: "bird",
+            vehicleHost: nil,
+            vehicleIDKey: nil,
+            appHost: nil,
+            appStoreID: "1260842311"
+        )
+    ]
+
+    /// - Parameter now: injected so `generated_at` is deterministic in tests.
+    static func target(for rental: VehicleRental, now: Date = Date()) -> Target? {
+        guard let network = rental.rentalNetwork else { return nil }
+
+        let operatorName = network.displayName
+        let webURL = network.url.flatMap(URL.init(string:))
+
+        // 1. Feed data wins. Preserves the pre-synthesis behaviour exactly,
+        //    including the operator web page as its fallback.
+        if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
+            return Target(url: url, storeFallback: webURL, operatorName: operatorName)
+        }
+
+        // 2. Synthesize for known operators. Deliberately outranks the network
+        //    URL below: a targeted app link beats an operator homepage, which is
+        //    a dead end for someone standing next to a scooter.
+        if let synthesized = synthesize(for: rental, network: network, now: now) {
+            return Target(
+                url: synthesized.url,
+                storeFallback: synthesized.storeFallback,
+                operatorName: operatorName
+            )
+        }
+
+        // 3. The operator's web page, when the feed published one.
+        if let webURL {
+            return Target(url: webURL, storeFallback: nil, operatorName: operatorName)
+        }
+
+        // 4. Nothing to open; the caller hides the button.
+        return nil
+    }
+
+    // MARK: - Synthesis
+
+    private static func synthesize(
+        for rental: VehicleRental,
+        network: RentalNetwork,
+        now: Date
+    ) -> (url: URL, storeFallback: URL?)? {
+        guard let op = operators[networkToken(network.networkId)] else { return nil }
+
+        var components = URLComponents()
+        components.scheme = op.scheme
+
+        // Stations carry a station id, never a vehicle id, so they only ever
+        // get the app-launch form.
+        if case .vehicle(let vehicle) = rental,
+           let host = op.vehicleHost,
+           let key = op.vehicleIDKey,
+           let id = rawVehicleID(vehicle.vehicleId) {
+            components.host = host
+            components.queryItems = [
+                URLQueryItem(name: key, value: id),
+                // Epoch seconds is an inference: the documented format carries an
+                // untyped <timestamp>. Built as a string because "%d" via
+                // String(format:) is a 32-bit specifier.
+                URLQueryItem(name: "generated_at", value: String(Int(now.timeIntervalSince1970)))
+            ]
+        } else {
+            components.host = op.appHost
+        }
+
+        guard let url = components.url else { return nil }
+        return (url, URL(string: "https://apps.apple.com/app/id\(op.appStoreID)"))
+    }
+
+    /// `lime_seattle` -> `lime`, `bird-seattle-washington` -> `bird`.
+    private static func networkToken(_ networkId: String) -> String {
+        let token = networkId.split(whereSeparator: { $0 == "_" || $0 == "-" }).first
+        return (token.map(String.init) ?? networkId).lowercased()
+    }
+
+    /// OTP returns `network:id`. Strip through the first colon to recover the raw
+    /// GBFS `bike_id`. Nil when nothing usable remains, so the caller drops to the
+    /// app-launch form rather than emitting an empty parameter.
+    private static func rawVehicleID(_ vehicleId: String) -> String? {
+        let raw = vehicleId.firstIndex(of: ":").map { String(vehicleId[vehicleId.index(after: $0)...]) } ?? vehicleId
+        return raw.isEmpty ? nil : raw
+    }
+}
+```
+
+Note: `components.url` produces `limebike://map?...`. `URLComponents` escapes `&` and `=` inside the value; `URLQueryItem` round-trips them.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalDeepLinkTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: PASS, 13 tests.
+
+If `escapesReservedCharactersInTheVehicleID` fails on the `?` character, check that you used `URLQueryItem` and not manual string building — that test exists precisely to catch it.
+
+- [ ] **Step 5: Lint**
+
+```bash
+scripts/swiftlint.sh
+```
+
+Expected: no new violations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add OBAKit/Mapping/Layers/RentalDeepLink.swift OBAKitTests/Mapping/RentalDeepLinkTests.swift
+git commit -m "Synthesize rental deep links when the feed publishes none
+
+No Lime system anywhere publishes GBFS rental_uris, so the Open in
+Lime button has never rendered. Build the link from the vehicle id
+instead, with the App Store as the failure path."
+```
+
+---
+
+## Task 3: Wire the detail sheet to it
+
+**Files:**
+- Modify: `OBAKit/Mapping/Layers/RentalDetailViewController.swift:210-224`
+
+**Interfaces:**
+- Consumes: `RentalDeepLink.target(for:now:)` and `RentalDeepLink.Target` from Task 2.
+- Produces: no new API. `deepLinkURL` keeps its existing tuple shape `(title: String, url: URL, webFallback: URL?)` so the `body` call site at `:91-100` is untouched.
+
+- [ ] **Step 1: Replace `deepLinkURL`**
+
+Replace the whole computed property (currently lines 210–224, from the `/// Deep link:` comment through its closing brace) with:
+
+```swift
+    /// Where the "Open in <operator>" button goes. Feed-published URIs win;
+    /// otherwise `RentalDeepLink` synthesizes one from the operator's scheme.
+    /// Nil hides the button.
+    private var deepLinkURL: (title: String, url: URL, webFallback: URL?)? {
+        guard let target = RentalDeepLink.target(for: rental) else { return nil }
+
+        let template = OBALoc("rental_detail.open_in_fmt", value: "Open in %@", comment: "Button opening the rental operator's app or website")
+        let name = target.operatorName ?? target.url.host() ?? "app"
+
+        return (String(format: template, name), target.url, target.storeFallback)
+    }
+```
+
+- [ ] **Step 2: Build and run the full rental test suite**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/RentalDeepLinkTests -only-testing:OBAKitTests/RentalVisibilityTests -only-testing:OBAKitTests/RentalAnnotationViewTests -only-testing:OBAKitTests/RentalLayerCoordinatorTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: PASS. No project regeneration needed — no files added.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add OBAKit/Mapping/Layers/RentalDetailViewController.swift
+git commit -m "Route the rental sheet's deep link through RentalDeepLink"
+```
+
+---
+
+## Task 4: Analytics
+
+Scheme rot is invisible client-side — `open` reports false whether Lime is absent or Lime changed the scheme. Tap and fallback counts are the only field signal.
+
+**Files:**
+- Modify: `OBAKit/Analytics/Analytics.swift:66-71` (insert after `rentalPlanTripTapped`)
+- Modify: `OBAKit/Mapping/MapViewController+MapLayers.swift:209-223`
+
+**Interfaces:**
+- Consumes: `AnalyticsLabels.rentalPlanTripTapped` as the style precedent; `application.analytics?.reportEvent(pageURL:label:value:)`.
+- Produces: `AnalyticsLabels.rentalDeepLinkTapped`, `AnalyticsLabels.rentalDeepLinkFallbackFired`.
+
+- [ ] **Step 1: Add the labels**
+
+In `OBAKit/Analytics/Analytics.swift`, directly after the `rentalPlanTripTapped` declaration, insert:
+
+```swift
+    /// Label used when the rider taps "Open in <operator>" on the rental sheet.
+    /// Value: the network id.
+    @objc public static let rentalDeepLinkTapped = "Rental Deep Link Tapped"
+
+    /// Label used when a rental deep link failed to open and the fallback URL was
+    /// used instead. Value: the network id. A fallback rate that jumps toward
+    /// 100% is the only signal that an operator changed its URL scheme.
+    @objc public static let rentalDeepLinkFallbackFired = "Rental Deep Link Fallback Fired"
+```
+
+- [ ] **Step 2: Report them, and correct the stale comment**
+
+In `OBAKit/Mapping/MapViewController+MapLayers.swift`, replace the `rentalLayer(open:webFallback:)` method **and its doc comment** with:
+
+```swift
+    /// Opens a rental deep link. No `canOpenURL` pre-check: Apple's own guidance
+    /// is to attempt the open and handle failure, and `open` — unlike
+    /// `canOpenURL` — is not constrained by `LSApplicationQueriesSchemes`.
+    ///
+    /// The URL is often synthesized from a reverse-engineered scheme rather than
+    /// published by the feed (see `RentalDeepLink`), so failure is expected and
+    /// routine: no app claims the scheme, `success` is false, and we fall back to
+    /// the operator's App Store page or web page.
+    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?) {
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/bikeshare",
+            label: AnalyticsLabels.rentalDeepLinkTapped,
+            value: networkID
+        )
+
+        application.open(url, options: [:]) { [weak self] success in
+            guard !success else { return }
+            Logger.info("Rental deep link failed to open: \(url)")
+            self?.application.analytics?.reportEvent(
+                pageURL: "app://localhost/bikeshare",
+                label: AnalyticsLabels.rentalDeepLinkFallbackFired,
+                value: networkID
+            )
+            if let webFallback {
+                self?.application.open(webFallback, options: [:], completionHandler: nil)
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Thread the network id through the delegate**
+
+`MapViewController` holds no selected-rental state (verified: the only `VehicleRental` reference in `MapViewController+MapLayers.swift` is `rentalLayer(planTripUsing:)`'s parameter), so `selectedRentalNetworkID` used in Step 2 does not exist and must be a parameter instead. `RentalDetailView` already has `rental` in hand, so the value is free at the call site.
+
+Make these five edits in `OBAKit/Mapping/Layers/RentalDetailViewController.swift`:
+
+**3a — protocol method, line 25-26:**
+
+```swift
+    /// Open a rental deep link, falling back to the operator's web page or App
+    /// Store listing when the primary URI fails to open (e.g. a synthesized
+    /// custom scheme with no app installed). `networkID` is for analytics.
+    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?)
+```
+
+**3b — `RentalDetailViewController.init`, line 49:**
+
+```swift
+            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1, networkID: $2) }
+```
+
+**3c — `RentalDetailView.onOpenURL`, line 66:**
+
+```swift
+    var onOpenURL: (URL, URL?, String?) -> Void
+```
+
+**3d — the button action, line 93:**
+
+```swift
+                    onOpenURL(deepLink.url, deepLink.webFallback, rental.rentalNetwork?.networkId)
+```
+
+**3e — `RentalClusterListViewController.init` (line 294) and `RentalClusterListView.onOpenURL` (line 310):**
+
+```swift
+            onOpenURL: { delegate?.rentalLayer(open: $0, webFallback: $1, networkID: $2) }
+```
+
+```swift
+    var onOpenURL: (URL, URL?, String?) -> Void
+```
+
+Line 334 (`onOpenURL: onOpenURL`, the cluster list handing its closure to `RentalDetailView`) needs no edit — the type widens with the declarations.
+
+Then in `MapViewController+MapLayers.swift`, change the signature written in Step 2 to accept the parameter and delete the `let networkID = selectedRentalNetworkID` line:
+
+```swift
+    func rentalLayer(open url: URL, webFallback: URL?, networkID: String?) {
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/bikeshare",
+            label: AnalyticsLabels.rentalDeepLinkTapped,
+            value: networkID
+        )
+        ...
+```
+
+The rest of the method body from Step 2 is unchanged.
+
+- [ ] **Step 4: Build and test**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: PASS. Full suite, because Step 3(b) can touch shared signatures.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+scripts/swiftlint.sh
+git add OBAKit/Analytics/Analytics.swift OBAKit/Mapping/MapViewController+MapLayers.swift OBAKit/Mapping/Layers/RentalDetailViewController.swift
+git commit -m "Report rental deep link taps and fallbacks
+
+A synthesized scheme can rot without warning. The ratio of fallbacks
+to taps is the only field signal that an operator changed it."
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none modified.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Clean build and the entire test suite**
+
+```bash
+cd /Users/aaron/repos/onebusaway/ios-bikeshare
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: PASS, no new failures versus `origin/main`.
+
+- [ ] **Step 2: Lint the whole repo**
+
+```bash
+scripts/swiftlint.sh
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Confirm no stray files are staged**
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+`Apps/Shared/app_shared.yml` **must not** appear. A local `path:` override for it is parked in `git stash` (message: "local OTPKit path override (pre-deep-links)") and must stay out of the branch.
+
+- [ ] **Step 4: Record the manual verification checklist in the PR**
+
+This cannot be automated — the unit tests prove we build the URL we intend, not that Lime honours it. The PR body must carry:
+
+```
+### Manual verification (required before merge)
+- [ ] Install Lime on a device running this build
+- [ ] Open a Lime vehicle sheet, tap "Open in Lime"
+- [ ] Lime opens AND focuses that specific vehicle (not a generic map)
+- [ ] If it opens to a generic map, retry with `generated_at` in
+      milliseconds, then omitted, before concluding targeting is
+      unsupported — the unit is an inference, not documented
+- [ ] Delete Lime, repeat, confirm the App Store fallback opens
+- [ ] Confirm bare `limebike://map` (the station form) launches the app
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not** add `limebike` to `LSApplicationQueriesSchemes`. `canOpenURL` is deprecated; `open` is not constrained by that key. This was an explicit design decision.
+- **Do not** touch OTPKit. It is a separate repo and this feature needs nothing from it.
+- **Do not** consult `rentalUris.web`. It has never been read and this change does not alter that.
+- If a test seems wrong, re-read the spec at `docs/superpowers/specs/2026-07-30-lime-deep-links-design.md` before changing it. Several tests encode decisions that look arbitrary without it — particularly `synthesisOutranksNetworkURLForKnownOperators`.

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -511,7 +511,7 @@ xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simu
 xcodebuild test-without-building -only-testing:OBAKitTests/RentalDeepLinkTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 ```
 
-Expected: PASS, 13 tests.
+Expected: PASS, 12 tests.
 
 If `escapesReservedCharactersInTheVehicleID` fails on the `?` character, check that you used `URLQueryItem` and not manual string building — that test exists precisely to catch it.
 

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -419,16 +419,18 @@ enum RentalDeepLink {
 
     /// - Parameter now: injected so `generated_at` is deterministic in tests.
     static func target(for rental: VehicleRental, now: Date = Date()) -> Target? {
-        guard let network = rental.rentalNetwork else { return nil }
+        let network = rental.rentalNetwork
+        let operatorName = network?.displayName
+        let webURL = network?.url.flatMap(URL.init(string:))
 
-        let operatorName = network.displayName
-        let webURL = network.url.flatMap(URL.init(string:))
-
-        // 1. Feed data wins. Preserves the pre-synthesis behaviour exactly,
-        //    including the operator web page as its fallback.
+        // 1. Feed data wins, network block or not. The pre-synthesis behaviour
+        //    never required one, and the two fields are independently optional.
         if let ios = rental.rentalUris?.ios, let url = URL(string: ios) {
             return Target(url: url, storeFallback: webURL, operatorName: operatorName)
         }
+
+        // Synthesis and the web-page fallback both need the network block.
+        guard let network else { return nil }
 
         // 2. Synthesize for known operators. Deliberately outranks the network
         //    URL below: a targeted app link beats an operator homepage, which is

--- a/docs/superpowers/plans/2026-07-30-lime-deep-links.md
+++ b/docs/superpowers/plans/2026-07-30-lime-deep-links.md
@@ -102,11 +102,7 @@ Replace the signature and the `rentalNetwork`/`rentalUris` entries in the dictio
             vehicleType["propulsionType"] = NSNull()
         }
 
-        let networkValue: Any = networkId.map { id in
-            ["networkId": id, "url": networkURL ?? NSNull()] as [String: Any]
-        } ?? NSNull()
-
-        let dictionary: [String: Any] = [
+        var dictionary: [String: Any] = [
             "__typename": "RentalVehicle",
             "vehicleId": id,
             "name": "Default vehicle type",
@@ -114,11 +110,18 @@ Replace the signature and the `rentalNetwork`/`rentalUris` entries in the dictio
             "lon": lon,
             "allowPickupNow": true,
             "operative": operative,
-            "rentalNetwork": networkValue,
             "rentalUris": rentalUris ?? NSNull(),
             "vehicleType": vehicleType,
             "fuel": fuelValue
         ]
+
+        // Conditional insertion, not a NSNull() value: `networkId: nil` must
+        // produce a payload with the key absent, which is the shape a feed takes
+        // when it publishes no network block.
+        if let networkId {
+            dictionary["rentalNetwork"] = ["networkId": networkId, "url": networkURL ?? NSNull()] as [String: Any]
+        }
+
         return try Fixtures.dictionaryToModel(type: VehicleRental.self, dictionary: dictionary)
     }
 ```

--- a/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
@@ -147,6 +147,13 @@ enum RentalDeepLink {
 1. **`rentalUris.ios`, when present.** Feed data always beats a guess.
    Fallback stays `rentalNetwork.url`. This preserves today's behavior byte for
    byte on any feed that ever starts publishing deep links.
+
+   This branch must not require a `rentalNetwork` block. `rentalNetwork` and
+   `rentalUris` are independently optional, the pre-synthesis code never
+   required one, and a feed could publish a URI without a network. Only steps 2
+   and 3 need the network — step 2 to identify the operator, step 3 for the URL
+   itself. A guard placed above step 1 would silently hide the button for
+   exactly the feeds this branch exists to serve.
 2. **Synthesized, when the network is in the table.** A `.vehicle` whose
    operator has a `vehicleHost` gets the targeted URL; a `.station`, or an
    operator like Bird that cannot target, gets the bare `scheme://appHost`.

--- a/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
@@ -1,0 +1,257 @@
+# Synthesized Rental Deep Links
+
+The rental detail sheet already has an "Open in %@" button. It has never once
+rendered, because the only thing that can populate it — GBFS `rental_uris` —
+is absent from every feed we consume.
+
+This spec adds a fallback: when the feed publishes no deep link, synthesize one
+from the operator's known URL scheme and the vehicle's ID.
+
+## Why the button never appears
+
+Verified 2026-07-30 against live feeds:
+
+- Surveyed **all 48 Lime systems** in MobilityData's `systems.csv` (41 fetched
+  successfully, ~87,000 vehicles across Seattle, Paris, Chicago, Tel Aviv, DC,
+  and 36 more). **Zero** publish `rental_uris` on any vehicle. **Zero** publish
+  `rental_apps` in `system_information`.
+- This is not OTP dropping data and not OTPKit failing to request it. OTPKit's
+  query already asks for `rentalUris { ios android web }`; the upstream feed has
+  nothing to give.
+- Deep links are a Lime **Transit Partnership Program** feature. The public
+  `data.lime.bike` tier omits them worldwide.
+- `rentalNetwork.url` — the existing second-choice fallback — is also null for
+  `lime_seattle`, so branch two of `deepLinkURL` is dead as well.
+
+Bird is a partial exception worth recording: it publishes `rental_apps` with
+`ios.discovery_uri: "bird://"` and a store URI. But OTP's schema has no
+`rental_apps` field at all (`VehicleRentalNetwork` exposes only `networkId` and
+`url`), so it is discarded before it reaches the app. Bird's scheme is
+app-level regardless — it cannot target an individual vehicle.
+
+## What we know about the schemes
+
+| Fact | Value | Source |
+| --- | --- | --- |
+| Lime scheme | `limebike://map?selected_vehicle_id=<uuid>&generated_at=<ts>` | [ubahnverleih/WoBike](https://github.com/ubahnverleih/WoBike/blob/master/Lime.md) — reverse-engineered, **not** official |
+| Lime bundle / App Store ID | `com.limebike` / `1199780189` | iTunes lookup API |
+| Lime universal links | `limebike.app.link`, AASA registered to `5NK4W853JQ.com.limebike` | fetched AASA directly |
+| Bird scheme | `bird://` (app-level only) | Bird GBFS `system_information.rental_apps` |
+| Bird App Store ID | `1260842311` | Bird GBFS `rental_apps.ios.store_uri` |
+
+The Lime scheme is the weak link: community-documented, undocumented by Lime,
+and liable to change without notice. Every decision below is shaped by that.
+
+`limebike.app.link` is deliberately unused. Branch links are opaque and
+generated server-side; we cannot mint a per-vehicle one without Lime's Branch
+key, and a bare domain hit is an interstitial, not a deep link.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Where the logic lives | OBAKit only — OTPKit stays spec-pure |
+| App not installed | Never gate on it; fall back to the App Store |
+| Operator coverage | Small table, seeded with Lime and Bird |
+| Feed vs. synthesized | Feed data always wins |
+| Stations | App-level link; never vehicle-targeted |
+| Before merge | Manual on-device verification |
+
+### Why host-side and not OTPKit
+
+OTPKit is consumed by other agencies. Baking an unofficial, reverse-engineered
+scheme into a library means every host inherits our guess, and correcting it
+requires a package tag plus a host bump in every downstream app. Host-side, a
+broken scheme is fixed in an app release.
+
+The cost is that another OTPKit host wanting the same feature reimplements it.
+That is acceptable for one operator's undocumented scheme.
+
+### Why always-show rather than `canOpenURL`
+
+Gating on `canOpenURL` would need `limebike` in `LSApplicationQueriesSchemes`
+and would hide the button from riders who do not have Lime — which is precisely
+the population an App Store fallback serves. `application.open`'s completion
+handler already distinguishes the two cases at zero cost and requires no
+Info.plist declaration.
+
+## Architecture
+
+One new file, `OBAKit/Mapping/Layers/RentalDeepLink.swift`, sibling to
+`RentalFormat.swift` and following the same shape: a plain enum of static
+helpers that views call, with no MapKit, no UIKit, and no async — so it is
+directly unit-testable.
+
+```swift
+enum RentalDeepLink {
+    /// What the sheet should open, and where to land if that fails.
+    struct Target: Equatable {
+        let url: URL
+        let storeFallback: URL?
+        let operatorName: String?
+    }
+
+    /// A known operator's app-launch surface.
+    private struct Operator {
+        /// Format string taking the raw vehicle ID and a timestamp.
+        /// Nil when the app cannot target an individual vehicle.
+        let vehicleURLFormat: String?
+        /// Plain app-launch URL, used for stations and untargetable operators.
+        let appURL: String
+        let appStoreID: String
+    }
+
+    private static let operators: [String: Operator] = [
+        "lime": Operator(
+            vehicleURLFormat: "limebike://map?selected_vehicle_id=%@&generated_at=%d",
+            appURL: "limebike://map",
+            appStoreID: "1199780189"
+        ),
+        "bird": Operator(
+            vehicleURLFormat: nil,
+            appURL: "bird://",
+            appStoreID: "1260842311"
+        )
+    ]
+
+    static func target(for rental: VehicleRental, now: Date = Date()) -> Target?
+}
+```
+
+`now` is injected so tests are deterministic; production callers omit it.
+
+### Resolution order
+
+1. **`rentalUris.ios`, when present.** Feed data always beats a guess.
+   Fallback stays `rentalNetwork.url`. This preserves today's behavior byte for
+   byte on any feed that ever starts publishing deep links.
+2. **Synthesized, when the network is in the table.** A `.vehicle` whose
+   operator has a `vehicleURLFormat` gets the targeted URL; a `.station`, or an
+   operator like Bird that cannot target, gets `appURL`. Fallback is
+   `https://apps.apple.com/app/id<appStoreID>`.
+3. **`rentalNetwork.url`, when present.** Today's second branch, unchanged.
+4. **Otherwise nil** — the button does not render, exactly as now.
+
+To be explicit about a distinction the decisions table compresses: whether the
+rider has the app installed never affects whether the button appears. Whether
+we can construct *any* URL for the operator does. An unknown network with no
+`rentalNetwork.url` still yields no button.
+
+`operatorName` is `rentalNetwork?.displayName`, falling back to the resolved
+URL's host — the same derivation `deepLinkURL` uses today, so the button text
+does not change for any feed that already produced one.
+
+### Operator lookup
+
+The table is keyed by the leading token of the GBFS network ID: split
+`networkId` on `_` or `-`, take the first element, lowercase it. So
+`lime_seattle` → `lime` and `bird-seattle-washington` → `bird`.
+
+This is the same rule OTPKit already applies in `RentalNetwork.displayName`,
+which is what renders "Lime" in the sheet header. Reusing it means the button's
+operator and the header's operator can never disagree.
+
+### Vehicle ID extraction
+
+OTP returns `vehicleId` in the form `network:id` —
+`lime_seattle:e0762983-6769-4191-903e-7a9e44444ea3`. Everything up to and
+including the first `:` is stripped, leaving the raw GBFS `bike_id`. Verified:
+the UUIDs OTP returns match `free_bike_status.bike_id` exactly.
+
+An ID with no colon is used whole. The result is percent-encoded for the query
+slot — UUIDs need no escaping, but the input is a third-party string and we
+should not assume its shape.
+
+`generated_at` is included as epoch seconds because the documented format
+carries it. Its purpose is unknown; omitting it risks Lime ignoring the whole
+query string, and including it costs nothing.
+
+## Error handling
+
+Nothing new is required. `MapViewController+MapLayers.swift:215` already does
+the right thing:
+
+```swift
+application.open(url, options: [:]) { [weak self] success in
+    guard !success else { return }
+    Logger.info("Rental deep link failed to open: \(url)")
+    if let webFallback { self?.application.open(webFallback, ...) }
+}
+```
+
+No app claims `limebike://` ⇒ `success` is false ⇒ the App Store page opens. A
+wrong scheme degrades to "Lime's App Store listing," never a crash or a dead
+tap. That property is what makes shipping an unofficial scheme defensible.
+
+## Call site
+
+`RentalDetailView.deepLinkURL` collapses from its current two-branch body into
+a call to `RentalDeepLink.target(for: rental)`, mapped onto the existing
+`rental_detail.open_in_fmt` ("Open in %@") string. The button, its styling, and
+`onOpenURL` are untouched.
+
+The cluster list is untouched — its rows push to the detail sheet and have
+never shown a deep-link button.
+
+**No new localized strings.** `rental_detail.open_in_fmt` already covers both
+operators via `rentalNetwork.displayName`.
+
+## Testing
+
+New `OBAKitTests/Mapping/RentalDeepLinkTests.swift`:
+
+| Case | Expectation |
+| --- | --- |
+| Lime vehicle, null `rentalUris` | `limebike://map?selected_vehicle_id=<uuid>&generated_at=<ts>`, App Store fallback `id1199780189` |
+| Feed publishes `rentalUris.ios` | Feed URI wins; synthesis is not consulted |
+| Bird vehicle | `bird://`, store ID `1260842311`, no `selected_vehicle_id` |
+| Lime station | App-level `limebike://map` — never a station ID in `selected_vehicle_id` |
+| `vehicleId` with no colon | Whole string used as the ID |
+| Unknown network with `rentalNetwork.url` | Falls through to the web URL |
+| Unknown network, no URL | Returns nil |
+| Fixed `now` | Timestamp renders deterministically |
+
+`RentalFixtures` needs two additions: `vehicle(...)` currently hardcodes
+`networkId: "lime_seattle"` and `rentalUris: NSNull()`, so both become
+parameters with those values as defaults; `station(...)` gains `networkId:`.
+Existing call sites are unaffected.
+
+### Manual verification, before merge
+
+The unit tests prove we construct the URL we intend. They cannot prove Lime
+honors it. Required on a real device:
+
+1. Install Lime alongside the OBA build.
+2. Open a Lime vehicle sheet, tap "Open in Lime".
+3. Confirm Lime opens **and focuses that specific vehicle** — not a generic map.
+4. Delete Lime, repeat, confirm the App Store fallback fires.
+5. Record the findings in the PR.
+
+If step 3 opens Lime but lands on a generic map, the scheme works and the
+parameter does not: keep the button, drop to `appURL`, and note it.
+
+One assumption rides on this pass: that bare `limebike://map` — the station and
+fallback form — launches the app at all. It is the documented path with its
+query string removed, which is usually safe but is not attested anywhere. If it
+fails, stations get no button rather than a broken one.
+
+## Out of scope
+
+- Any change to OTPKit.
+- `canOpenURL` gating and the `LSApplicationQueriesSchemes` entry.
+- Branch / universal-link handling.
+- Pricing. Bird publishes `system_pricing_plans` and Lime publishes none;
+  neither reaches us through OTP. Answering "what will this cost" means talking
+  to GBFS directly, which is its own project.
+- Pursuing a Lime Transit Partnership feed. Worth doing — it would make this
+  entire spec obsolete — but it is a business conversation, not a code change.
+
+## Base branch
+
+`main`. It already contains the full rental stack including the range filter
+(squash-merged, so the local `bikeshare-range-filter` branch shows 31 unmerged
+commits despite the content having landed). `main` is ahead of that branch;
+branch fresh from it.
+
+Note that `Apps/Shared/app_shared.yml` carries an uncommitted local `path:`
+override pointing at the OTPKit working copy. It must stay uncommitted.

--- a/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
@@ -46,6 +46,19 @@ and liable to change without notice. Every decision below is shaped by that.
 generated server-side; we cannot mint a per-vehicle one without Lime's Branch
 key, and a bare domain hit is an interstitial, not a deep link.
 
+### Risks we are accepting
+
+- **Scheme rot.** If Lime renames or drops `limebike://`, a rider who *has* Lime
+  installed gets bounced to the App Store page of an app they already own. This
+  is the most likely real-world failure and it is not detectable client-side —
+  `open` reports false either way. Analytics (below) is the only early warning.
+- **Scheme squatting.** Any app may register `limebike://`. `open` would report
+  success into the wrong app. Not mitigable; `canOpenURL` would not help.
+- **App Store URL form.** `https://apps.apple.com/app/id<id>` is the standard
+  form Apple's own marketing tools emit, but the current Apple documentation
+  attesting it is archived (QA1633 still shows `itunes.apple.com`). Manual
+  verification step 4 is what actually confirms it.
+
 ## Decisions
 
 | Question | Decision |
@@ -53,8 +66,9 @@ key, and a bare domain hit is an interstitial, not a deep link.
 | Where the logic lives | OBAKit only — OTPKit stays spec-pure |
 | App not installed | Never gate on it; fall back to the App Store |
 | Operator coverage | Small table, seeded with Lime and Bird |
-| Feed vs. synthesized | Feed data always wins |
+| Feed vs. synthesized | Feed `rentalUris` wins; synthesis outranks `rentalNetwork.url` |
 | Stations | App-level link; never vehicle-targeted |
+| URL construction | `URLComponents`, never `String(format:)` |
 | Before merge | Manual on-device verification |
 
 ### Why host-side and not OTPKit
@@ -91,25 +105,33 @@ enum RentalDeepLink {
         let operatorName: String?
     }
 
-    /// A known operator's app-launch surface.
+    /// A known operator's app-launch surface, expressed as URL *components*
+    /// rather than a format string — see "Vehicle ID extraction" for why.
     private struct Operator {
-        /// Format string taking the raw vehicle ID and a timestamp.
-        /// Nil when the app cannot target an individual vehicle.
-        let vehicleURLFormat: String?
-        /// Plain app-launch URL, used for stations and untargetable operators.
-        let appURL: String
+        let scheme: String
+        /// Host of the vehicle-targeting URL. Nil when the app cannot target an
+        /// individual vehicle, in which case only `appHost` is ever used.
+        let vehicleHost: String?
+        /// Query key carrying the vehicle ID, e.g. `selected_vehicle_id`.
+        let vehicleIDKey: String?
+        /// Host for the plain app-launch URL: stations, untargetable operators.
+        let appHost: String?
         let appStoreID: String
     }
 
     private static let operators: [String: Operator] = [
         "lime": Operator(
-            vehicleURLFormat: "limebike://map?selected_vehicle_id=%@&generated_at=%d",
-            appURL: "limebike://map",
+            scheme: "limebike",
+            vehicleHost: "map",
+            vehicleIDKey: "selected_vehicle_id",
+            appHost: "map",
             appStoreID: "1199780189"
         ),
         "bird": Operator(
-            vehicleURLFormat: nil,
-            appURL: "bird://",
+            scheme: "bird",
+            vehicleHost: nil,
+            vehicleIDKey: nil,
+            appHost: nil,
             appStoreID: "1260842311"
         )
     ]
@@ -126,11 +148,25 @@ enum RentalDeepLink {
    Fallback stays `rentalNetwork.url`. This preserves today's behavior byte for
    byte on any feed that ever starts publishing deep links.
 2. **Synthesized, when the network is in the table.** A `.vehicle` whose
-   operator has a `vehicleURLFormat` gets the targeted URL; a `.station`, or an
-   operator like Bird that cannot target, gets `appURL`. Fallback is
-   `https://apps.apple.com/app/id<appStoreID>`.
+   operator has a `vehicleHost` gets the targeted URL; a `.station`, or an
+   operator like Bird that cannot target, gets the bare `scheme://appHost`.
+   Fallback is `https://apps.apple.com/app/id<appStoreID>`.
 3. **`rentalNetwork.url`, when present.** Today's second branch, unchanged.
 4. **Otherwise nil** — the button does not render, exactly as now.
+
+**Step 2 deliberately outranks step 3.** For a table operator that publishes
+`rentalNetwork.url` but no `rentalUris` — no Lime system does today, but a feed
+update could — the synthesized app link wins and the published web URL is never
+used. This is a real narrowing of "feed data always wins," and it is
+intentional: `rentalNetwork.url` is an operator *homepage*, and a marketing page
+is a dead end for someone standing next to a scooter, which is the same
+reasoning behind choosing the App Store over `li.me` as the fallback. A targeted
+app link serves the rider better than a generic web page.
+
+The consequence to accept: if a feed ever starts publishing a genuinely useful
+`rentalNetwork.url`, this ordering hides it, and reversing the decision means
+editing this file. A test pins the ordering so the choice can never drift
+silently.
 
 To be explicit about a distinction the decisions table compresses: whether the
 rider has the app installed never affects whether the button appears. Whether
@@ -158,13 +194,31 @@ OTP returns `vehicleId` in the form `network:id` —
 including the first `:` is stripped, leaving the raw GBFS `bike_id`. Verified:
 the UUIDs OTP returns match `free_bike_status.bike_id` exactly.
 
-An ID with no colon is used whole. The result is percent-encoded for the query
-slot — UUIDs need no escaping, but the input is a third-party string and we
-should not assume its shape.
+An ID with no colon is used whole. An ID that is *empty* after stripping (a bare
+`lime_seattle:`) is treated as untargetable: fall through to the app-launch URL
+rather than emitting `selected_vehicle_id=` with no value.
 
-`generated_at` is included as epoch seconds because the documented format
-carries it. Its purpose is unknown; omitting it risks Lime ignoring the whole
-query string, and including it costs nothing.
+**Build the URL with `URLComponents` and `URLQueryItem`, never `String(format:)`.**
+This is load-bearing, not style. The obvious encoding call,
+`addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)`, does *not*
+make a string safe as a query **value**: `urlQueryAllowed` is the set legal in
+the whole query component, so `&`, `=`, `?`, `/`, and `+` all survive unescaped.
+An ID containing `&` or `=` would inject or corrupt parameters, and `+` may be
+read as a space by the receiver. `URLComponents` escapes those correctly inside
+a value. Compounding it, on iOS 17+ `URL(string:)` silently percent-encodes
+invalid characters instead of returning nil, so a malformed construction yields
+a plausible-looking wrong URL rather than a visible failure.
+
+That is why the operator table above holds `scheme`/`host`/`key` components
+rather than a format string: the type makes the unsafe construction
+unexpressible.
+
+`generated_at` is included because the documented format carries it, and
+omitting it risks Lime ignoring the query string. **The unit is a guess.** The
+cited WoBike source documents an untyped `<timestamp>` placeholder; epoch
+seconds is our inference, not attested. Emit it as `String(Int(now.timeIntervalSince1970))` —
+using `%d` with `String(format:)` would additionally be a 32-bit specifier,
+correct for epoch seconds only until 2038 and silently wrong for milliseconds.
 
 ## Error handling
 
@@ -196,6 +250,20 @@ never shown a deep-link button.
 **No new localized strings.** `rental_detail.open_in_fmt` already covers both
 operators via `rentalNetwork.displayName`.
 
+`rentalUris.web` stays unconsulted. The model carries it
+(`VehicleRentalSupportingTypes.swift:40-44`) and `deepLinkURL` has never read
+it; this change does not alter that. Recorded so the omission reads as a
+decision rather than an oversight.
+
+### Analytics
+
+`rentalLayer(planTripUsing:)` reports an event
+(`MapViewController+MapLayers.swift:200`); `rentalLayer(open:webFallback:)`
+reports nothing. Add two: the tap, and the fallback firing. For a
+reverse-engineered scheme these counts are the only field signal that Lime
+changed something — a fallback rate that jumps from near-zero to near-total is
+exactly the scheme-rot alarm the risk register has no other way to raise.
+
 ## Testing
 
 New `OBAKitTests/Mapping/RentalDeepLinkTests.swift`:
@@ -204,17 +272,24 @@ New `OBAKitTests/Mapping/RentalDeepLinkTests.swift`:
 | --- | --- |
 | Lime vehicle, null `rentalUris` | `limebike://map?selected_vehicle_id=<uuid>&generated_at=<ts>`, App Store fallback `id1199780189` |
 | Feed publishes `rentalUris.ios` | Feed URI wins; synthesis is not consulted |
+| Feed publishes `rentalUris.ios` **and** `rentalNetwork.url` | Fallback is the web URL, not the App Store — branch 1's fallback is preserved |
 | Bird vehicle | `bird://`, store ID `1260842311`, no `selected_vehicle_id` |
 | Lime station | App-level `limebike://map` — never a station ID in `selected_vehicle_id` |
 | `vehicleId` with no colon | Whole string used as the ID |
+| `vehicleId` of `"lime_seattle:"` | Empty after stripping ⇒ app-launch URL, no empty `selected_vehicle_id=` |
+| ID containing `&`, `=`, a space, non-ASCII | Escaped inside the value; round-trips through `URLComponents(url:)` to the original ID |
+| Lime vehicle **with** `rentalNetwork.url` | Synthesis still wins — pins the deliberate step-2-over-step-3 ordering |
+| Vehicle with no `rentalNetwork` at all | Returns nil; no crash, no host-derived title |
 | Unknown network with `rentalNetwork.url` | Falls through to the web URL |
 | Unknown network, no URL | Returns nil |
 | Fixed `now` | Timestamp renders deterministically |
 
-`RentalFixtures` needs two additions: `vehicle(...)` currently hardcodes
-`networkId: "lime_seattle"` and `rentalUris: NSNull()`, so both become
-parameters with those values as defaults; `station(...)` gains `networkId:`.
-Existing call sites are unaffected.
+`RentalFixtures` needs three additions to `vehicle(...)`, which currently
+hardcodes `"rentalNetwork": ["networkId": "lime_seattle", "url": NSNull()]` and
+`"rentalUris": NSNull()` (`RentalFixtures.swift:57-58`): `networkId`,
+`networkURL`, and `rentalUris` all become parameters defaulting to today's
+values. `networkId` must accept nil to express "no rentalNetwork at all".
+`station(...)` gains `networkId:`. Existing call sites are unaffected.
 
 ### Manual verification, before merge
 
@@ -227,8 +302,12 @@ honors it. Required on a real device:
 4. Delete Lime, repeat, confirm the App Store fallback fires.
 5. Record the findings in the PR.
 
-If step 3 opens Lime but lands on a generic map, the scheme works and the
-parameter does not: keep the button, drop to `appURL`, and note it.
+If step 3 opens Lime but lands on a generic map, do **not** immediately conclude
+the parameter is useless. Because the `generated_at` unit is a guess, a stale
+timestamp could make Lime discard the targeting — indistinguishable from the
+parameter being unsupported. Before dropping to the app-launch URL, retry with
+(a) milliseconds and (b) `generated_at` omitted entirely. Only if all three fail
+does the vehicle-targeting come out.
 
 One assumption rides on this pass: that bare `limebike://map` — the station and
 fallback form — launches the app at all. It is the documented path with its

--- a/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-30-lime-deep-links-design.md
@@ -287,6 +287,7 @@ New `OBAKitTests/Mapping/RentalDeepLinkTests.swift`:
 | ID containing `&`, `=`, a space, non-ASCII | Escaped inside the value; round-trips through `URLComponents(url:)` to the original ID |
 | Lime vehicle **with** `rentalNetwork.url` | Synthesis still wins — pins the deliberate step-2-over-step-3 ordering |
 | Vehicle with no `rentalNetwork` at all | Returns nil; no crash, no host-derived title |
+| Feed publishes `rentalUris.ios` but there is no `rentalNetwork` | Still resolves to the feed URI — the network block is not required for branch 1 |
 | Unknown network with `rentalNetwork.url` | Falls through to the web URL |
 | Unknown network, no URL | Returns nil |
 | Fixed `now` | Timestamp renders deterministically |


### PR DESCRIPTION
## Summary

The rental detail sheet has an "Open in *operator*" button that has **never once rendered**. It reads GBFS `rental_uris`, and no feed we consume publishes it.

I surveyed all 48 Lime systems in MobilityData's catalog (41 fetched, ~87,000 vehicles across Seattle, Paris, Chicago, Tel Aviv, DC and 36 more): **zero** publish `rental_uris` on any vehicle, and **zero** publish `rental_apps` in `system_information`. Deep links are a Lime Transit Partnership feature absent from the public `data.lime.bike` tier worldwide. `rentalNetwork.url` is null for `lime_seattle` too, so the button's second branch was dead as well. This is not OTP dropping data or OTPKit failing to ask — the upstream feed has nothing to give.

So this synthesizes the link instead:

- **`RentalDeepLink`** (new, OBAKit-only) resolves a `VehicleRental` to a URL: feed-published `rental_uris.ios` always wins; otherwise a small operator table synthesizes `limebike://map?selected_vehicle_id=<gbfs-bike-id>&generated_at=<ts>` from the vehicle's own id. Stations and Bird (which can't target a vehicle) get an app-launch URL.
- **Failure is graceful by design.** The Lime scheme is reverse-engineered ([WoBike](https://github.com/ubahnverleih/WoBike/blob/master/Lime.md)), undocumented by Lime, and can break without notice. `UIApplication.open` reports `success == false` when no app claims it, and we fall back to the operator's App Store page. A wrong scheme degrades to "Lime's App Store listing," never a crash or a dead tap.
- **Analytics on taps and fallbacks.** Scheme rot is invisible client-side — `open` returns false whether Lime is missing or Lime changed the scheme. The fallback-to-tap *ratio* is the only field warning.
- Kept out of OTPKit deliberately: other agencies consume it, and baking an unofficial scheme into a shared library makes every host inherit our guess with fixes gated on a package release.

Design doc and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] 1690 unit tests / 186 suites passing; 13 new tests in `RentalDeepLinkTests`
- [x] SwiftLint clean (5 → 4 violations; the `large_tuple` one cleared incidentally)
- [x] **Exercised in simulator against the live Seattle feed** — "Open in Lime" renders on a real e-bike with range and type populated
- [x] Tapping it emits `limebike://map?selected_vehicle_id=2b1b5b90-0760-4e10-8743-c409ca67bb1e&generated_at=1785473837` — real GBFS uuid, correct query key, fresh timestamp
- [x] LaunchServices rejects it (Lime not installed) → **App Store fallback fires** with the correct id `1199780189`; app does not crash
- [x] URL built with `URLComponents`/`URLQueryItem`, with a test proving an id containing `&`, `=`, space and non-ASCII round-trips — it fails against a `String(format:)` implementation

### Manual verification still required before merge

The unit tests prove we build the URL we intend. Nothing yet proves Lime *honors* it.

- [ ] Install Lime on a device running this build
- [ ] Open a Lime vehicle sheet, tap "Open in Lime"
- [ ] Lime opens **and focuses that specific vehicle**, not a generic map
- [ ] If it opens to a generic map, retry with `generated_at` in **milliseconds**, then **omitted**, before concluding targeting is unsupported — the unit is an inference, not documented
- [ ] Delete Lime, repeat, confirm the App Store fallback opens (simulator can't confirm this — it has no App Store app)
- [ ] Confirm bare `limebike://map` (the station/fallback form) launches the app at all

## Review notes

Non-blocking items surfaced by review, recorded rather than fixed:

- **`+` and `;` pass through unescaped.** `URLComponents` emits them literally in a query value. Neither can forge a parameter under RFC-3986, but a form-urlencoded receiver reads `+` as a space. Real Lime ids are UUIDs. A test here would be documentation, not protection — Foundation's own parser doesn't do the `+`→space conversion either.
- **Bird emits `bird:`, not `bird://`.** No host, so `URLComponents` drops the slashes. Bird's own GBFS `discovery_uri` is `bird://`. LaunchServices dispatches on scheme so these should be equivalent; now pinned by an assertion.
- **Feed-supplied `rentalUris.ios` is opened without a scheme check**, so a hostile feed could route to `tel:`/`sms:`. Pre-existing on `main`, unreachable today since no feed publishes the field. Flagged as accepted, not introduced here.
- **No test asserts the fallback analytics event fires when `webFallback` is nil.** The placement is correct today, but this instrumentation is purely a silent-regression detector, so a future refactor could nest it back inside `if let webFallback` with nothing to object.
- **`generated_at` is Lime-specific but lives in shared `synthesize`.** Free today since Bird never reaches that branch; a third vehicle-targeting operator should move it onto `Operator` rather than branch on scheme. Marked with a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening Lime and Bird rental apps from vehicle and station details.
  * Uses feed-provided links when available, with generated app links and App Store or web fallbacks when needed.
  * Added analytics tracking for rental deep-link taps and fallback launches.
* **Bug Fixes**
  * Improved handling of missing, invalid, or unavailable rental destinations.
* **Documentation**
  * Added design and implementation documentation for rental deep-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->