### PR TITLE
feat: hide MapKit Points of Interest from the Map sheet

### DIFF
--- a/OBAKit/Mapping/Layers/MapLayer.swift
+++ b/OBAKit/Mapping/Layers/MapLayer.swift
@@ -138,4 +138,10 @@ extension Notification.Name {
     /// `MapViewController` push the new value into the rental coordinator without
     /// `MapRegionManager` needing to know the coordinator exists.
     public static let rentalRangeFilterDidChange = Notification.Name("OBARentalRangeFilterDidChange")
+
+    /// Posted when Points of Interest visibility changes. Lets an open Map sheet
+    /// refresh if Settings (or another writer) flips the same preference.
+    public static let mapPointsOfInterestVisibilityDidChange = Notification.Name(
+        "OBAMapPointsOfInterestVisibilityDidChange"
+    )
 }

--- a/OBAKit/Mapping/Layers/MapSheetView.swift
+++ b/OBAKit/Mapping/Layers/MapSheetView.swift
@@ -49,6 +49,13 @@ import UIKit
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .mapPointsOfInterestVisibilityDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Basemap
@@ -104,6 +111,17 @@ import UIKit
         objectWillChange.send()
         mapRegionManager.rentalRangeFilter = RentalRangeFilter(minimumRangeMeters: id)
     }
+
+    // MARK: - Points of Interest
+
+    var showsPointsOfInterest: Bool {
+        mapRegionManager.mapViewShowsPointsOfInterest
+    }
+
+    func setShowsPointsOfInterest(_ shows: Bool) {
+        objectWillChange.send()
+        mapRegionManager.mapViewShowsPointsOfInterest = shows
+    }
 }
 
 struct MapSheetView: View {
@@ -114,6 +132,8 @@ struct MapSheetView: View {
         NavigationStack {
             List {
                 basemapSection
+
+                mapDisplaySection
 
                 layerSection(
                     title: OBALoc("map_sheet.transit_group", value: "Transit", comment: "Map sheet group header for transit layers"),
@@ -194,6 +214,32 @@ struct MapSheetView: View {
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Map Display
+
+    /// MapKit chrome that isn't a stackable layer — currently just Points of
+    /// Interest. Lives under the basemap tiles so it's always reachable, even
+    /// in regions with no rental layers.
+    private var mapDisplaySection: some View {
+        Section(OBALoc("map_sheet.display_group", value: "Map display", comment: "Map sheet section for display options like Points of Interest")) {
+            Toggle(isOn: Binding(
+                get: { model.showsPointsOfInterest },
+                set: { model.setShowsPointsOfInterest($0) }
+            )) {
+                HStack(spacing: 12) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 28)
+                        .accessibilityHidden(true)
+                    Text(OBALoc(
+                        "map_sheet.shows_points_of_interest",
+                        value: "Points of Interest",
+                        comment: "Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.)"
+                    ))
+                }
+            }
+        }
     }
 
     // MARK: - Layer Rows

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -90,7 +90,8 @@ public class MapRegionManager: NSObject,
         mapView.mapType = .mutedStandard
         mapView.showsUserLocation = true
         mapView.isRotateEnabled = false
-        mapView.selectableMapFeatures = [.physicalFeatures, .pointsOfInterest]
+        // `pointOfInterestFilter` / `selectableMapFeatures` are applied in
+        // `applyPointsOfInterestVisibility()` once UserDefaults is registered.
 
         return mapView
     }()
@@ -148,6 +149,38 @@ public class MapRegionManager: NSObject,
     }
     private let mapViewShowsHeadingKey = "mapRegionManager.mapViewShowsHeadingKey"
 
+    /// Whether Apple MapKit Points of Interest (restaurants, shops, etc.) appear
+    /// on the browse map. Riders complained about clutter; this is the Map sheet
+    /// / Settings preference that turns them off (#1246).
+    ///
+    /// `true` by default — matches MapKit's stock appearance.
+    public var mapViewShowsPointsOfInterest: Bool {
+        get { application.userDefaults.bool(forKey: Self.mapViewShowsPointsOfInterestKey) }
+        set {
+            guard mapViewShowsPointsOfInterest != newValue else { return }
+            application.userDefaults.set(newValue, forKey: Self.mapViewShowsPointsOfInterestKey)
+            applyPointsOfInterestVisibility()
+            NotificationCenter.default.post(name: .mapPointsOfInterestVisibilityDidChange, object: nil)
+        }
+    }
+
+    /// UserDefaults key for ``mapViewShowsPointsOfInterest``. Public so Settings
+    /// and tests can address the same store the Map sheet writes.
+    public static let mapViewShowsPointsOfInterestKey = "mapRegionManager.mapViewShowsPointsOfInterest"
+
+    /// Applies the current POI preference to `mapView`. Also drops
+    /// `.pointsOfInterest` from `selectableMapFeatures` when hidden so riders
+    /// can't still tap ghosts that aren't drawn.
+    func applyPointsOfInterestVisibility() {
+        if mapViewShowsPointsOfInterest {
+            mapView.pointOfInterestFilter = .includingAll
+            mapView.selectableMapFeatures = [.physicalFeatures, .pointsOfInterest]
+        } else {
+            mapView.pointOfInterestFilter = .excludingAll
+            mapView.selectableMapFeatures = [.physicalFeatures]
+        }
+    }
+
     /// Provides storage for the last visible map rect of the map view.
     ///
     /// In the event that this value is unavailable, the getter will try to offer up an alternative,
@@ -203,6 +236,7 @@ public class MapRegionManager: NSObject,
             mapViewShowsHeadingKey: true,
             mapViewMapTypeKey: MKMapType.mutedStandard.rawValue,
             MapRegionManager.mapViewShowsStopAnnotationLabelsDefaultsKey: true,
+            MapRegionManager.mapViewShowsPointsOfInterestKey: true,
         ])
 
         super.init()
@@ -214,6 +248,7 @@ public class MapRegionManager: NSObject,
         mapView.showsScale = mapViewShowsScale
         mapView.showsTraffic = mapViewShowsTraffic
         mapView.mapType = userSelectedMapType
+        applyPointsOfInterestVisibility()
 
         registerAnnotationViews(mapView: mapView)
 
@@ -357,23 +392,26 @@ public class MapRegionManager: NSObject,
         mapLayers.filter { $0.availability != .unsupported && isMapLayerEnabled(id: $0.id) }.count
     }
 
-    /// True when any layer's on/off state differs from its default, or the rental
-    /// range filter is active *and visible* — drives the Map sheet's Reset
-    /// affordance. The filter row only renders when a `.otherModes` layer is
-    /// registered (rental layers are region-gated), so a non-zero filter left over
-    /// from another region must not offer a Reset that changes nothing on screen.
+    /// True when any layer's on/off state differs from its default, the rental
+    /// range filter is active *and visible*, or Points of Interest are hidden —
+    /// drives the Map sheet's Reset affordance. The filter row only renders when
+    /// a `.otherModes` layer is registered (rental layers are region-gated), so a
+    /// non-zero filter left over from another region must not offer a Reset that
+    /// changes nothing on screen.
     public var mapLayersDifferFromDefaults: Bool {
+        if !mapViewShowsPointsOfInterest { return true }
         if rentalRangeFilter != .any, mapLayers.contains(where: { $0.group == .otherModes }) { return true }
         return mapLayers.contains { isMapLayerEnabled(id: $0.id) != $0.isEnabledByDefault }
     }
 
-    /// Restores every registered layer to its default on/off state, and clears the
-    /// rental range filter.
+    /// Restores every registered layer to its default on/off state, clears the
+    /// rental range filter, and shows Points of Interest again.
     public func resetMapLayersToDefaults() {
         for layer in mapLayers {
             setMapLayerEnabled(layer.isEnabledByDefault, id: layer.id)
         }
         rentalRangeFilter = .any
+        mapViewShowsPointsOfInterest = true
     }
 
     /// Whether stop annotations should render. True when no stops layer is

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -55,6 +55,7 @@ class SettingsViewController: FormViewController {
             mapSectionShowsScale: application.mapRegionManager.mapViewShowsScale,
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
             mapSectionShowsHeading: application.mapRegionManager.mapViewShowsHeading,
+            mapSectionShowsPointsOfInterest: application.mapRegionManager.mapViewShowsPointsOfInterest,
             FeatureFlags.useMapPanelExperienceKey: application.userDefaults.bool(forKey: FeatureFlags.useMapPanelExperienceKey),
             FeatureFlags.useNewStopPageKey: FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults),
             privacySectionReportingEnabled: application.analytics?.reportingEnabled() ?? false,
@@ -93,6 +94,10 @@ class SettingsViewController: FormViewController {
 
         if let heading = values[mapSectionShowsHeading] as? Bool {
             application.mapRegionManager.mapViewShowsHeading = heading
+        }
+
+        if let showsPOIs = values[mapSectionShowsPointsOfInterest] as? Bool {
+            application.mapRegionManager.mapViewShowsPointsOfInterest = showsPOIs
         }
 
         saveAccessibilityValues(values)
@@ -171,6 +176,7 @@ class SettingsViewController: FormViewController {
     private let mapSectionShowsScale = "mapSectionShowsScale"
     private let mapSectionShowsTraffic = "mapSectionShowsTraffic"
     private let mapSectionShowsHeading = "mapSectionShowsHeading"
+    private let mapSectionShowsPointsOfInterest = "mapSectionShowsPointsOfInterest"
 
     private lazy var mapSection: Section = {
         let section = Section(OBALoc("settings_controller.map_section.title", value: "Map", comment: "Settings > Map section title"))
@@ -188,6 +194,17 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = mapSectionShowsHeading
             $0.title = OBALoc("settings_controller.map_section.shows_heading", value: "Show my current heading", comment: "Settings > Map section > Show my current heading")
+        }
+
+        // Mirrors the Map sheet's Points of Interest toggle (#1246). Same
+        // UserDefaults key; the Map sheet remains the canonical control.
+        section <<< SwitchRow {
+            $0.tag = mapSectionShowsPointsOfInterest
+            $0.title = OBALoc(
+                "settings_controller.map_section.shows_points_of_interest",
+                value: "Points of Interest",
+                comment: "Settings > Map section > Show Apple MapKit Points of Interest"
+            )
         }
 
         // Map layer switches mirror the Map sheet: same UserDefaults keys, written

--- a/OBAKitTests/Mapping/MapRegionManagerPointsOfInterestTests.swift
+++ b/OBAKitTests/Mapping/MapRegionManagerPointsOfInterestTests.swift
@@ -1,0 +1,98 @@
+//
+//  MapRegionManagerPointsOfInterestTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Persistence + map application for the Points of Interest visibility toggle (#1246).
+@MainActor
+@Suite(.serialized)
+final class MapRegionManagerPointsOfInterestTests: OBATestCase {
+
+    private var manager: MapRegionManager!
+
+    override init() async throws {
+        try await super.init()
+        let queue = OperationQueue()
+        let dataLoader = MockDataLoader(testName: name)
+        manager = MapRegionManager(application: buildApplication(queue: queue, dataLoader: dataLoader))
+    }
+
+    @Test func `Defaults to showing points of interest`() {
+        #expect(manager.mapViewShowsPointsOfInterest == true)
+        #expect(manager.mapView.pointOfInterestFilter == .includingAll)
+        #expect(manager.mapView.selectableMapFeatures.contains(.pointsOfInterest))
+    }
+
+    @Test func `Hiding POIs updates the map filter and selectable features`() {
+        manager.mapViewShowsPointsOfInterest = false
+
+        #expect(manager.mapViewShowsPointsOfInterest == false)
+        #expect(manager.mapView.pointOfInterestFilter == .excludingAll)
+        #expect(!manager.mapView.selectableMapFeatures.contains(.pointsOfInterest))
+        #expect(manager.mapView.selectableMapFeatures.contains(.physicalFeatures))
+    }
+
+    @Test func `Showing POIs again restores filter and selection`() {
+        manager.mapViewShowsPointsOfInterest = false
+        manager.mapViewShowsPointsOfInterest = true
+
+        #expect(manager.mapView.pointOfInterestFilter == .includingAll)
+        #expect(manager.mapView.selectableMapFeatures.contains(.pointsOfInterest))
+    }
+
+    @Test func `Persists through UserDefaults`() {
+        manager.mapViewShowsPointsOfInterest = false
+        #expect(userDefaults.bool(forKey: MapRegionManager.mapViewShowsPointsOfInterestKey) == false)
+
+        manager.mapViewShowsPointsOfInterest = true
+        #expect(userDefaults.bool(forKey: MapRegionManager.mapViewShowsPointsOfInterestKey) == true)
+    }
+
+    @Test func `Posts visibility change notification`() async {
+        await confirmation("POI visibility notification") { confirm in
+            let observer = NotificationCenter.default.addObserver(
+                forName: .mapPointsOfInterestVisibilityDidChange, object: nil, queue: nil
+            ) { _ in
+                confirm()
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            manager.mapViewShowsPointsOfInterest = false
+        }
+    }
+
+    @Test func `Identical writes do not re-post`() async {
+        manager.mapViewShowsPointsOfInterest = false
+
+        await confirmation("redundant write posts nothing", expectedCount: 0) { confirm in
+            let observer = NotificationCenter.default.addObserver(
+                forName: .mapPointsOfInterestVisibilityDidChange, object: nil, queue: nil
+            ) { _ in
+                confirm()
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            manager.mapViewShowsPointsOfInterest = false
+        }
+    }
+
+    @Test func `Hidden POIs count toward map sheet reset`() {
+        #expect(!manager.mapLayersDifferFromDefaults)
+        manager.mapViewShowsPointsOfInterest = false
+        #expect(manager.mapLayersDifferFromDefaults)
+
+        manager.resetMapLayersToDefaults()
+        #expect(manager.mapViewShowsPointsOfInterest == true)
+        #expect(!manager.mapLayersDifferFromDefaults)
+    }
+}


### PR DESCRIPTION
## Summary

People have been complaining that Apple’s Points of Interest (restaurants, shops, the usual pin soup) clutter the browse map. This adds a show/hide control on the Map sheet that landed with bikeshare.

- New **Map display** section on the Map sheet with a Points of Interest toggle (works even in regions that have no rental layers).
- Off means `pointOfInterestFilter = .excludingAll`, and `.pointsOfInterest` is removed from `selectableMapFeatures` so you can’t tap ghosts that aren’t drawn.
- Preference lives in UserDefaults (`mapRegionManager.mapViewShowsPointsOfInterest`). Settings mirrors the same key; the Map sheet stays the owner.
- Map sheet **Reset** turns POIs back on with the other layer defaults. Default remains on — same as stock MapKit.

Closes #1246

## Test plan

- [x] `xcodebuild build-for-testing -scheme App` (iOS Simulator)
- [x] `xcodebuild test-without-building -only-testing:OBAKitTests/MapRegionManagerPointsOfInterestTests` (7/7)
- [ ] On device / simulator: open Map sheet → turn off Points of Interest → pins for restaurants/shops disappear; turn back on → they return
- [ ] Settings → Map → flip the same toggle while the Map sheet is open → sheet updates
- [ ] Hide POIs → Reset on the Map sheet → POIs show again
- [ ] CI `OBAKitTests` green on this PR