### PR TITLE
Honor colorScheme for stop page on-time green

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -35,6 +35,7 @@ struct DepartureRowView: View {
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.obaFormatters) private var formatters
+    @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .body) private var alarmCircleSize: CGFloat = 34
     @AppStorage(UserDefaultsStore.stopUIReducedColorsKey) private var reducedColors = false
 
@@ -125,7 +126,7 @@ struct DepartureRowView: View {
     private var statusText: some View {
         Text(status.label)
             .font(.footnote.weight(.semibold))
-            .foregroundStyle(Color(uiColor: status.color))
+            .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
     }
 
     @ViewBuilder
@@ -135,7 +136,7 @@ struct DepartureRowView: View {
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(hasAlarm ? Color.white : Color.secondary)
                 .frame(width: alarmCircleSize, height: alarmCircleSize)
-                .background(hasAlarm ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                .background(hasAlarm ? ThemeSwiftUI.departureOnTime(colorScheme) : Color.clear, in: Circle())
                 .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: hasAlarm ? 0 : 1.5))
                 // Use onTapGesture, not Button: inner gestures beat the outer
                 // .onTapGesture(perform: onTap) on the row VStack, so tapping the
@@ -157,7 +158,7 @@ struct DepartureRowView: View {
         CountdownView(
             minutes: departure.arrivalDepartureMinutes,
             isRealTime: status.isRealTime,
-            color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
+            color: dimmed ? Color(uiColor: .tertiaryLabel) : ThemeSwiftUI.departureStatus(status, colorScheme)
         )
     }
 

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -41,6 +41,7 @@ struct GroupedListView: View {
 
     @Environment(\.obaFormatters) private var formatters
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
     @AppStorage(UserDefaultsStore.stopUIReducedColorsKey) private var reducedColors = false
 
     /// At accessibility sizes the card layouts "stack" (the guide's committed
@@ -128,14 +129,14 @@ struct GroupedListView: View {
                 HStack(alignment: .center) {
                     routeBadge(for: next, routeColor: routeColor)
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme))
                 }
                 headsignText(next)
                 DepartureTimeText(display: timeDisplay(next))
                     .font(.footnote).foregroundStyle(.secondary)
                 Text(status.label)
                     .font(.footnote.weight(.semibold))
-                    .foregroundStyle(Color(uiColor: status.color))
+                    .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
             } else {
                 HStack(alignment: .center, spacing: 13) {
                     routeBadge(for: next, routeColor: routeColor)
@@ -147,11 +148,11 @@ struct GroupedListView: View {
                             Text("·").foregroundStyle(.tertiary)
                             Text(status.label)
                                 .font(.footnote.weight(.semibold))
-                                .foregroundStyle(Color(uiColor: status.color))
+                                .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                         }
                     }
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme))
                 }
             }
         }
@@ -242,7 +243,7 @@ struct GroupedListView: View {
                 .font(.caption.weight(.heavy))
                 .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
                 .padding(.horizontal, 10).padding(.vertical, 6)
-                .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color(uiColor: .tertiarySystemFill), in: Capsule())
+                .background(alarm != nil ? ThemeSwiftUI.departureOnTime(colorScheme) : Color(uiColor: .tertiarySystemFill), in: Capsule())
             }
             .buttonStyle(.plain)
         }
@@ -263,14 +264,14 @@ struct GroupedListView: View {
                     HStack(spacing: 12) {
                         alarmIcon(for: departure)
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme), emphasized: false)
                         tripChevron(departure)
                     }
                     DepartureTimeText(display: timeDisplay(departure))
                         .font(.subheadline.weight(.semibold))
                     Text(status.label)
                         .font(.subheadline)
-                        .foregroundStyle(Color(uiColor: status.color))
+                        .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                     if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
                         OccupancyBadge(occupancy: occupancy)
                     }
@@ -283,14 +284,14 @@ struct GroupedListView: View {
                                     .font(.subheadline.weight(.semibold))
                                 Text("· \(status.label)")
                                     .font(.subheadline)
-                                    .foregroundStyle(Color(uiColor: status.color))
+                                    .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                             }
                             if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
                                 OccupancyBadge(occupancy: occupancy)
                             }
                         }
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme), emphasized: false)
                         tripChevron(departure)
                     }
                 }
@@ -338,7 +339,7 @@ struct GroupedListView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
                     .frame(width: alarmCircleSize, height: alarmCircleSize)
-                    .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                    .background(alarm != nil ? ThemeSwiftUI.departureOnTime(colorScheme) : Color.clear, in: Circle())
                     .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: alarm != nil ? 0 : 1.5))
             }
             .buttonStyle(.plain)

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -39,6 +39,7 @@ struct GroupedListView: View {
 
     @Environment(\.obaFormatters) private var formatters
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
     @AppStorage(UserDefaultsStore.stopUIReducedColorsKey) private var reducedColors = false
 
     /// At accessibility sizes the card layouts "stack" (the guide's committed
@@ -126,14 +127,14 @@ struct GroupedListView: View {
                 HStack(alignment: .center) {
                     routeBadge(for: next, routeColor: routeColor)
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme))
                 }
                 headsignText(next)
                 DepartureTimeText(display: timeDisplay(next))
                     .font(.footnote).foregroundStyle(.secondary)
                 Text(status.label)
                     .font(.footnote.weight(.semibold))
-                    .foregroundStyle(Color(uiColor: status.color))
+                    .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
             } else {
                 HStack(alignment: .center, spacing: 13) {
                     routeBadge(for: next, routeColor: routeColor)
@@ -145,11 +146,11 @@ struct GroupedListView: View {
                             Text("·").foregroundStyle(.tertiary)
                             Text(status.label)
                                 .font(.footnote.weight(.semibold))
-                                .foregroundStyle(Color(uiColor: status.color))
+                                .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                         }
                     }
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme))
                 }
             }
         }
@@ -212,9 +213,9 @@ struct GroupedListView: View {
             let chipStatus = statusProvider(chip)
             Text("\(chip.arrivalDepartureMinutes)m")
                 .font(.caption.weight(.heavy)).monospacedDigit()
-                .foregroundStyle(Color(uiColor: chipStatus.color))
+                .foregroundStyle(ThemeSwiftUI.departureStatus(chipStatus, colorScheme))
                 .padding(.horizontal, 8).padding(.vertical, 3)
-                .background(Color(uiColor: chipStatus.color).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                .background(ThemeSwiftUI.departureStatus(chipStatus, colorScheme).opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
         }
     }
 
@@ -240,7 +241,7 @@ struct GroupedListView: View {
                 .font(.caption.weight(.heavy))
                 .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
                 .padding(.horizontal, 10).padding(.vertical, 6)
-                .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color(uiColor: .tertiarySystemFill), in: Capsule())
+                .background(alarm != nil ? ThemeSwiftUI.departureOnTime(colorScheme) : Color(uiColor: .tertiarySystemFill), in: Capsule())
             }
             .buttonStyle(.plain)
         }
@@ -261,14 +262,14 @@ struct GroupedListView: View {
                     HStack(spacing: 12) {
                         alarmIcon(for: departure)
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme), emphasized: false)
                         tripChevron(departure)
                     }
                     DepartureTimeText(display: timeDisplay(departure))
                         .font(.subheadline.weight(.semibold))
                     Text(status.label)
                         .font(.subheadline)
-                        .foregroundStyle(Color(uiColor: status.color))
+                        .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                     if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
                         OccupancyBadge(occupancy: occupancy)
                     }
@@ -281,14 +282,14 @@ struct GroupedListView: View {
                                     .font(.subheadline.weight(.semibold))
                                 Text("· \(status.label)")
                                     .font(.subheadline)
-                                    .foregroundStyle(Color(uiColor: status.color))
+                                    .foregroundStyle(ThemeSwiftUI.departureStatus(status, colorScheme))
                             }
                             if status.showsOccupancy, let occupancy = departure.occupancyStatus, occupancy != .unknown {
                                 OccupancyBadge(occupancy: occupancy)
                             }
                         }
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: ThemeSwiftUI.departureStatus(status, colorScheme), emphasized: false)
                         tripChevron(departure)
                     }
                 }
@@ -330,7 +331,7 @@ struct GroupedListView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(alarm != nil ? Color.white : Color.secondary)
                     .frame(width: alarmCircleSize, height: alarmCircleSize)
-                    .background(alarm != nil ? Color(uiColor: ThemeColors.shared.departureOnTime) : Color.clear, in: Circle())
+                    .background(alarm != nil ? ThemeSwiftUI.departureOnTime(colorScheme) : Color.clear, in: Circle())
                     .overlay(Circle().strokeBorder(Color(uiColor: .separator), lineWidth: alarm != nil ? 0 : 1.5))
             }
             .buttonStyle(.plain)

--- a/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
+++ b/OBAKit/Stops/StopPage/Shared/DepartureStatus.swift
@@ -33,9 +33,23 @@ struct DepartureStatus {
     var showsOccupancy: Bool { isRealTime }
 
     var color: UIColor {
+        // Prefer `color(for:)` from SwiftUI so on-time green follows
+        // `colorScheme` (#1255). This path keeps UIKit call sites working.
+        color(for: .unspecified)
+    }
+
+    /// Resolves status colors against an explicit interface style.
+    ///
+    /// On-time green is a dynamic `UIColor`; passing `.dark` / `.light` forces
+    /// the matching provider so SwiftUI doesn't get stuck on the light hex.
+    func color(for userInterfaceStyle: UIUserInterfaceStyle) -> UIColor {
         guard isRealTime else { return .secondaryLabel }
         switch scheduleStatus {
-        case .onTime: return ThemeColors.shared.departureOnTime
+        case .onTime:
+            if userInterfaceStyle == .unspecified {
+                return ThemeColors.shared.departureOnTime
+            }
+            return ThemeColors.shared.departureOnTime(for: userInterfaceStyle)
         case .early: return ThemeColors.shared.departureEarly
         case .delayed: return ThemeColors.shared.departureLate
         default: return .secondaryLabel

--- a/OBAKit/Stops/StopPage/Shared/ThemeSwiftUI.swift
+++ b/OBAKit/Stops/StopPage/Shared/ThemeSwiftUI.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Bridges dynamic `ThemeColors` into SwiftUI using the environment's
+/// `colorScheme`, so providers like `departureOnTime` resolve against dark
+/// traits instead of getting stuck on the light hex (#1255).
+enum ThemeSwiftUI {
+    static func departureOnTime(_ colorScheme: ColorScheme) -> Color {
+        Color(uiColor: ThemeColors.shared.departureOnTime(for: uiStyle(colorScheme)))
+    }
+
+    static func departureStatus(_ status: DepartureStatus, _ colorScheme: ColorScheme) -> Color {
+        Color(uiColor: status.color(for: uiStyle(colorScheme)))
+    }
+
+    private static func uiStyle(_ colorScheme: ColorScheme) -> UIUserInterfaceStyle {
+        colorScheme == .dark ? .dark : .light
+    }
+}

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -13,9 +13,10 @@ struct WalkLineDivider: View {
     let walkMinutes: Int
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Matches the walk pill on the header card (§4.5).
-    private let lineColor = Color(uiColor: ThemeColors.shared.departureOnTime)
+    private var lineColor: Color { ThemeSwiftUI.departureOnTime(colorScheme) }
 
     private var text: String {
         let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -36,6 +36,7 @@ struct StopPageHeaderView: View {
     @State private var cardWidth: CGFloat = 0
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Minimum card height; the card grows beyond it when the identity block
     /// needs more room (wrapped chips, Dynamic Type). Scales with Dynamic Type
@@ -90,7 +91,7 @@ struct StopPageHeaderView: View {
                         .font(.footnote.weight(.heavy))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 12).padding(.vertical, 6)
-                        .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+                        .background(ThemeSwiftUI.departureOnTime(colorScheme), in: Capsule())
                         .contentShape(Capsule())
                 }
                 .buttonStyle(.plain)
@@ -218,12 +219,13 @@ private struct HeaderStatusLine: View {
     let statusText: String
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @State private var pulsing = false
 
     var body: some View {
         HStack(spacing: 6) {
             Circle()
-                .fill(Color(uiColor: ThemeColors.shared.departureOnTime))
+                .fill(ThemeSwiftUI.departureOnTime(colorScheme))
                 .frame(width: 7, height: 7)
                 .opacity(reduceMotion ? 1 : (pulsing ? 1 : 0.35))
             Text(statusText)

--- a/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
@@ -46,6 +46,8 @@ nonisolated enum StopSheetHeaderMetrics {
 ///
 /// A plain-value view — it never touches `StopViewModel`.
 struct StopPageSheetHeaderView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let stop: Stop
     let walkTime: WalkTimeInfo?
     /// Opens walking directions to the stop (VC-owned; disambiguates between maps apps when more
@@ -167,10 +169,10 @@ struct StopPageSheetHeaderView: View {
                     .fixedSize(horizontal: true, vertical: false)
             }
             .font(.subheadline.weight(.semibold))
-            .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+            .foregroundStyle(ThemeSwiftUI.departureOnTime(colorScheme))
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(Color(uiColor: ThemeColors.shared.departureOnTime).opacity(0.14), in: Capsule())
+            .background(ThemeSwiftUI.departureOnTime(colorScheme).opacity(0.14), in: Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
@@ -63,6 +63,7 @@ struct StopPageSheetHeaderView: View {
     /// observes it — see `StopPageView`'s note on observation discipline.
     @ObservedObject var mapFocus: StopMapFocus
 
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private var subtitle: String {
@@ -213,10 +214,10 @@ struct StopPageSheetHeaderView: View {
                 .fixedSize(horizontal: true, vertical: false)
         }
         .font(chipFont)
-        .foregroundStyle(Color(uiColor: ThemeColors.shared.departureOnTime))
+        .foregroundStyle(ThemeSwiftUI.departureOnTime(colorScheme))
         .padding(.horizontal, chipHorizontalPadding)
         .padding(.vertical, chipVerticalPadding)
-        .background(Color(uiColor: ThemeColors.shared.departureOnTime).opacity(0.14), in: Capsule())
+        .background(ThemeSwiftUI.departureOnTime(colorScheme).opacity(0.14), in: Capsule())
         .contentShape(Capsule())
         .onTapGesture(perform: onWalkingDirections)
         // `.accessibilityHidden(true)` on the glyph above was not enough on its

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -9,6 +9,7 @@
 
 import ActivityKit
 import Combine
+import CoreLocation
 import SwiftUI
 import OBAKitCore
 

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -171,4 +171,14 @@ public final class ThemeColors: NSObject, @unchecked Sendable {
         lightText = .white
         errorColor = .systemRed
     }
+
+    /// Resolves `departureOnTime` against an explicit interface style.
+    ///
+    /// SwiftUI's `Color(uiColor:)` can keep the light provider when the hosting
+    /// environment doesn't push a dark trait collection into UIKit (#1255).
+    /// Call sites that already know the SwiftUI `colorScheme` should use this
+    /// so dark mode gets `.systemGreen` instead of the light hex green.
+    public func departureOnTime(for userInterfaceStyle: UIUserInterfaceStyle) -> UIColor {
+        departureOnTime.resolvedColor(with: UITraitCollection(userInterfaceStyle: userInterfaceStyle))
+    }
 }

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -172,4 +172,14 @@ public final class ThemeColors: NSObject, @unchecked Sendable {
         lightText = .white
         errorColor = .systemRed
     }
+
+    /// Resolves `departureOnTime` against an explicit interface style.
+    ///
+    /// SwiftUI's `Color(uiColor:)` can keep the light provider when the hosting
+    /// environment doesn't push a dark trait collection into UIKit (#1255).
+    /// Call sites that already know the SwiftUI `colorScheme` should use this
+    /// so dark mode gets `.systemGreen` instead of the light hex green.
+    public func departureOnTime(for userInterfaceStyle: UIUserInterfaceStyle) -> UIColor {
+        departureOnTime.resolvedColor(with: UITraitCollection(userInterfaceStyle: userInterfaceStyle))
+    }
 }

--- a/OBAKitTests/Extensions/UIColorWCAGTests.swift
+++ b/OBAKitTests/Extensions/UIColorWCAGTests.swift
@@ -92,4 +92,28 @@ struct UIColorWCAGTests {
         )
         #expect(light.wcagContrastRatio(against: .white) >= 4.5)
     }
+
+    // MARK: - departureOnTime trait resolution (#1255)
+
+    @Test func departureOnTimeForDarkStyleMatchesSystemGreen() {
+        let themes = ThemeColors()
+        let resolved = themes.departureOnTime(for: .dark)
+        let expected = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        #expect(colorsMatch(resolved, expected))
+    }
+
+    @Test func departureOnTimeForLightStyleKeepsConfiguredGreen() {
+        let themes = ThemeColors()
+        let resolved = themes.departureOnTime(for: .light)
+        let configured = UIColor(red: 0.00, green: 0.45, blue: 0.00, alpha: 1.00)
+        #expect(colorsMatch(resolved, configured))
+    }
+
+    private func colorsMatch(_ a: UIColor, _ b: UIColor) -> Bool {
+        var ar: CGFloat = 0, ag: CGFloat = 0, ab: CGFloat = 0, aa: CGFloat = 0
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        a.getRed(&ar, green: &ag, blue: &ab, alpha: &aa)
+        b.getRed(&br, green: &bg, blue: &bb, alpha: &ba)
+        return abs(ar - br) < 0.01 && abs(ag - bg) < 0.01 && abs(ab - bb) < 0.01 && abs(aa - ba) < 0.01
+    }
 }

--- a/OBAKitTests/Extensions/UIColorWCAGTests.swift
+++ b/OBAKitTests/Extensions/UIColorWCAGTests.swift
@@ -79,4 +79,28 @@ struct UIColorWCAGTests {
         let midGray = UIColor(red: 127.0/255.0, green: 127.0/255.0, blue: 127.0/255.0, alpha: 1.0)
         #expect(midGray.badgeTextColor(preferring: .white, minimumRatio: 7.0) == UIColor.black)
     }
+
+    // MARK: - departureOnTime trait resolution (#1255)
+
+    @Test func departureOnTimeForDarkStyleMatchesSystemGreen() {
+        let themes = ThemeColors()
+        let resolved = themes.departureOnTime(for: .dark)
+        let expected = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        #expect(colorsMatch(resolved, expected))
+    }
+
+    @Test func departureOnTimeForLightStyleIsNotSystemGreen() {
+        let themes = ThemeColors()
+        let resolved = themes.departureOnTime(for: .light)
+        let systemGreenLight = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        #expect(!colorsMatch(resolved, systemGreenLight))
+    }
+
+    private func colorsMatch(_ a: UIColor, _ b: UIColor) -> Bool {
+        var ar: CGFloat = 0, ag: CGFloat = 0, ab: CGFloat = 0, aa: CGFloat = 0
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        a.getRed(&ar, green: &ag, blue: &ab, alpha: &aa)
+        b.getRed(&br, green: &bg, blue: &bb, alpha: &ba)
+        return abs(ar - br) < 0.01 && abs(ag - bg) < 0.01 && abs(ab - bb) < 0.01 && abs(aa - ba) < 0.01
+    }
 }

--- a/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
@@ -26,6 +26,30 @@ final class DepartureStatusTests {
         #expect(status.showsOccupancy)
     }
 
+    /// #1255: SwiftUI must be able to force the dark provider so on-time green
+    /// becomes systemGreen rather than the light-mode hex.
+    @Test func `On time color for dark style matches system green`() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        let resolved = status.color(for: .dark)
+        let expected = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        #expect(colorsMatch(resolved, expected))
+    }
+
+    @Test func `On time color for light style keeps high-contrast green`() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        let resolved = status.color(for: .light)
+        let systemGreenLight = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        #expect(!colorsMatch(resolved, systemGreenLight))
+    }
+
+    private func colorsMatch(_ a: UIColor, _ b: UIColor) -> Bool {
+        var ar: CGFloat = 0, ag: CGFloat = 0, ab: CGFloat = 0, aa: CGFloat = 0
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        a.getRed(&ar, green: &ag, blue: &ab, alpha: &aa)
+        b.getRed(&br, green: &bg, blue: &bb, alpha: &ba)
+        return abs(ar - br) < 0.01 && abs(ag - bg) < 0.01 && abs(ab - bb) < 0.01 && abs(aa - ba) < 0.01
+    }
+
     @Test func `Late is blue with minute count`() {
         let status = DepartureStatus(isRealTime: true, scheduleStatus: .delayed, deviationMinutes: 4)
         #expect(status.color == ThemeColors.shared.departureLate)

--- a/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureStatusTests.swift
@@ -37,4 +37,28 @@ final class DepartureStatusTests {
         #expect(status.color == ThemeColors.shared.departureEarly)
         #expect(status.label == "3 min early")
     }
+
+    /// #1255: SwiftUI must be able to force the dark provider so on-time green
+    /// becomes systemGreen rather than the light-mode hex.
+    @Test func `On time color for dark style matches system green`() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        let resolved = status.color(for: .dark)
+        let expected = UIColor.systemGreen.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        #expect(colorsMatch(resolved, expected))
+    }
+
+    @Test func `On time color for light style keeps configured green`() {
+        let status = DepartureStatus(isRealTime: true, scheduleStatus: .onTime, deviationMinutes: 0)
+        let resolved = status.color(for: .light)
+        let configured = UIColor(red: 0.00, green: 0.45, blue: 0.00, alpha: 1.00)
+        #expect(colorsMatch(resolved, configured))
+    }
+
+    private func colorsMatch(_ a: UIColor, _ b: UIColor) -> Bool {
+        var ar: CGFloat = 0, ag: CGFloat = 0, ab: CGFloat = 0, aa: CGFloat = 0
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        a.getRed(&ar, green: &ag, blue: &ab, alpha: &aa)
+        b.getRed(&br, green: &bg, blue: &bb, alpha: &ba)
+        return abs(ar - br) < 0.01 && abs(ag - bg) < 0.01 && abs(ab - bb) < 0.01 && abs(aa - ba) < 0.01
+    }
 }


### PR DESCRIPTION
## Summary
- Stop page header, sheet walk pill, and departure rows resolve `ThemeColors.departureOnTime` against the SwiftUI `colorScheme`, so dark mode gets `.systemGreen` instead of the light hex green.
- Adds `ThemeColors.departureOnTime(for:)` / `DepartureStatus.color(for:)` plus a small `ThemeSwiftUI` bridge.
- Closes #1255.

There wasn't a hardcoded `.colorScheme(.light)` on `main` — `Color(uiColor:)` was just resolving the dynamic color against light traits. Explicit resolution fixes that.

## Test plan
- [x] `DepartureStatusTests` + `UIColorWCAGTests` (19 tests) on iPhone Air simulator
- [ ] Dark mode: open a stop sheet / push header and confirm on-time green matches system green
- [ ] Light mode: on-time green still uses the high-contrast hex


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved departure, status, alarm, walking-direction, and divider colors across stop pages for light and dark mode.
  * Ensured on-time departure colors consistently adapt to the current appearance.

* **Tests**
  * Added coverage validating correct color resolution in both light and dark interface styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->