### PR TITLE
Use ellipsis for overflowing stop route labels

### DIFF
--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -597,14 +597,15 @@ public class Formatters: NSObject {
             return nil
         }
 
+        // When the list overflows the limit (map pins use 3), append "..." rather
+        // than "+ N more". Callers were inconsistent — some labels truncated to
+        // "+..." while others showed a count — and #514 asks for a single "...".
+        let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
         if routeNames.count > limit {
-            let fmt = OBALoc("formatters.routes_label_plus_more_fmt", value: "Routes: %@, + %d more", comment: "A format string used to denote the overflowing list of routes served by this stop. e.g. 'Routes: 10, 12, 49, + 3 more")
             let shortList = routeNames.prefix(limit).joined(separator: ", ")
-            let overflowCount = routeNames.count - limit
-            return String(format: fmt, shortList, overflowCount)
+            return String(format: fmt, shortList) + "..."
         }
         else {
-            let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
             return String(format: fmt, routeNames.joined(separator: ", "))
         }
     }

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -102,4 +102,32 @@ final class FormattersTests: OBATestCase {
 
         #expect(label == Formatters.formattedAccessibilityLabel(stop: stop))
     }
+
+    // MARK: - Route overflow labels (#514)
+
+    @Test func `Formatted routes within the limit lists every route`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30"])
+        let label = try #require(Formatters.formattedRoutes(routes, limit: 3))
+        #expect(label == "Routes: 10, 20, 30")
+        #expect(!label.contains("..."))
+        #expect(!label.contains("more"))
+    }
+
+    @Test func `Formatted routes over the limit appends ellipsis`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "50"])
+        let label = try #require(Formatters.formattedRoutes(routes, limit: 3))
+        #expect(label == "Routes: 10, 20, 30...")
+        #expect(!label.contains("more"))
+    }
+
+    private func makeRoutes(shortNames: [String]) throws -> [Route] {
+        try shortNames.enumerated().map { index, shortName in
+            try Fixtures.dictionaryToModel(type: Route.self, dictionary: [
+                "agencyId": "test_agency",
+                "id": "route_\(index)",
+                "shortName": shortName,
+                "type": 3
+            ])
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- When a stop serves more routes than the display limit (map pins use 3), `Formatters.formattedRoutes` now appends `...` instead of `+ N more`.
- Closes #514.

## Test plan
- [x] `FormattersTests` — 10/10 on iPhone Air simulator (includes overflow / no-overflow cases)
- [ ] On the map, find a stop with 4+ routes and confirm the pin subtitle ends with `...` and never shows `+ N more`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Route lists exceeding the display limit now end with an ellipsis (`...`) for a cleaner, more concise presentation.
  - Route lists at or below the limit continue to display all available routes.

- **Bug Fixes**
  - Removed the previous overflow-count format (`+ N more`) to provide more consistent route labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->