### PR TITLE
Filter implausible epoch arrival times from stop lists

### DIFF
--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -179,7 +179,9 @@ struct StopPageView: View {
     private var filteredDepartures: [ArrivalDeparture] {
         let all = viewModel.stopArrivals?.arrivalsAndDepartures ?? []
         let visible = viewModel.isListFiltered ? all.filter(preferences: viewModel.stopPreferences) : all
-        return visible.filteringTerminalDuplicates()
+        return visible
+            .filteringImplausibleDates()
+            .filteringTerminalDuplicates()
     }
 
     private var attributionText: String {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -698,9 +698,11 @@ public class StopViewController: UIViewController,
             if isListFiltered {
                 arrDeps = stopArrivals.arrivalsAndDepartures
                     .filter(preferences: stopPreferences)
+                    .filteringImplausibleDates()
                     .filteringTerminalDuplicates()
             } else {
                 arrDeps = stopArrivals.arrivalsAndDepartures
+                    .filteringImplausibleDates()
                     .filteringTerminalDuplicates()
             }
 
@@ -720,7 +722,9 @@ public class StopViewController: UIViewController,
 
             sections = groups.flatMap { group -> [OBAListViewSection] in
                 var groupSections: [OBAListViewSection] = []
-                let filtered = group.arrivalDepartures.filteringTerminalDuplicates()
+                let filtered = group.arrivalDepartures
+                    .filteringImplausibleDates()
+                    .filteringTerminalDuplicates()
                 let pastDeps = filtered.filter { $0.arrivalDepartureMinutes < 0 }
                 let upcomingDeps = filtered.filter { $0.arrivalDepartureMinutes >= 0 }
 

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -345,7 +345,8 @@ class StopViewModel: ObservableObject {
         guard !hasRecordedReviewSuccess else { return }
 
         let visible = arrivals.arrivalsAndDepartures.filter { arrival in
-            !isListFiltered || !stopPreferences.isRouteIDHidden(arrival.routeID)
+            arrival.hasPlausibleArrivalDepartureDate
+                && (!isListFiltered || !stopPreferences.isRouteIDHidden(arrival.routeID))
         }
         guard visible.contains(where: \.predicted) else { return }
 

--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -250,6 +250,15 @@ public final class ArrivalDeparture: NSObject, Identifiable, Decodable, HasRefer
         return stopSequence == totalStopsInTrip - 1
     }
 
+    /// The earliest date considered plausible for display. Matches the threshold used by
+    /// `ModelHelpers.nilifyDate` when nullifying predicted times during decode.
+    public static let earliestPlausibleDate = Date(timeIntervalSinceReferenceDate: 1.0)
+
+    /// Whether `arrivalDepartureDate` is after the epoch/null sentinel threshold.
+    public var hasPlausibleArrivalDepartureDate: Bool {
+        arrivalDepartureDate >= Self.earliestPlausibleDate
+    }
+
     /// A singluar value that can be displayed in the UI to represent the best date for this trip.
     public var arrivalDepartureDate: Date {
         switch arrivalDepartureStatus {

--- a/OBAKitCore/Models/REST/StopArrivals.swift
+++ b/OBAKitCore/Models/REST/StopArrivals.swift
@@ -68,7 +68,11 @@ public class StopArrivals: NSObject, Identifiable, Decodable, HasReferences {
         // Some real-time feeds briefly assign two vehicles to one trip, which makes the
         // server emit two entries for a single trip visit. Collapse those at ingestion so
         // every consumer sees one entry per visit (see `filteringDuplicateVehicleReports`).
-        arrivalsAndDepartures = try container.decode([ArrivalDeparture].self, forKey: .arrivalsAndDepartures).filteringDuplicateVehicleReports()
+        // Also drop epoch-sentinel times that would sort to the top as millions of minutes
+        // early (see `filteringImplausibleDates`).
+        arrivalsAndDepartures = try container.decode([ArrivalDeparture].self, forKey: .arrivalsAndDepartures)
+            .filteringDuplicateVehicleReports()
+            .filteringImplausibleDates()
         nearbyStopIDs = try container.decode([StopID].self, forKey: .nearbyStopIDs)
         situationIDs = try container.decode([String].self, forKey: .situationIDs)
         stopID = try container.decode(StopID.self, forKey: .stopID)

--- a/OBAKitCore/Models/ViewModels/ArrivalDeparture+Deduplication.swift
+++ b/OBAKitCore/Models/ViewModels/ArrivalDeparture+Deduplication.swift
@@ -24,6 +24,14 @@ private struct VisitIdentity: Hashable {
 
 extension Sequence where Element == ArrivalDeparture {
 
+    /// Drops entries whose best available arrival/departure time is before
+    /// `ArrivalDeparture.earliestPlausibleDate` — typically Unix epoch sentinels
+    /// with no usable predicted time. Without this filter such entries sort to the
+    /// top of departure lists as millions of minutes early.
+    public func filteringImplausibleDates() -> [ArrivalDeparture] {
+        filter(\.hasPlausibleArrivalDepartureDate)
+    }
+
     /// Collapses entries that describe the same arrival/departure — identical `id`
     /// (stop, trip, route, service date, stop sequence, and arrival/departure status) —
     /// into a single entry, keeping the most recently updated report.

--- a/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ArrivalDepartureTests.swift
@@ -170,6 +170,73 @@ final class ArrivalDepartureTests: OBATestCase {
         // ModelHelpers.nilifyDate should have converted very early dates to nil
         #expect(arrival.predictedArrival == nil)
         #expect(arrival.predictedDeparture == nil)
+        #expect(arrival.hasPlausibleArrivalDepartureDate == true)
+    }
+
+    @Test func `Epoch scheduled times are implausible`() {
+        let data: [String: Any] = [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": 1234567890,
+            "numberOfStopsAway": 1,
+            "predicted": false,
+            "routeId": "route_epoch",
+            "scheduledArrivalTime": 0,
+            "scheduledDepartureTime": 0,
+            "serviceDate": 1234512000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_epoch",
+            "stopSequence": 5,
+            "tripId": "trip_epoch",
+            "vehicleId": "vehicle_epoch"
+        ]
+
+        let arrival = try! Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: data)
+
+        #expect(arrival.hasPlausibleArrivalDepartureDate == false)
+    }
+
+    @Test func `Valid scheduled times are plausible`() throws {
+        let arrival = try Fixtures.arrivalDeparture(
+            predicted: false,
+            scheduledArrival: 1_700_000_000,
+            scheduledDeparture: 1_700_000_600
+        )
+
+        #expect(arrival.hasPlausibleArrivalDepartureDate == true)
+    }
+
+    @Test func `Nilified predicted time with valid scheduled remains plausible`() {
+        let data: [String: Any] = [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": 1234567890,
+            "numberOfStopsAway": 1,
+            "predicted": true,
+            "predictedArrivalTime": 0,
+            "predictedDepartureTime": 0,
+            "routeId": "route_fallback",
+            "scheduledArrivalTime": 1234567900,
+            "scheduledDepartureTime": 1234567930,
+            "serviceDate": 1234512000,
+            "situationIds": [],
+            "status": "SCHEDULED",
+            "stopId": "stop_fallback",
+            "stopSequence": 5,
+            "tripId": "trip_fallback",
+            "vehicleId": "vehicle_fallback"
+        ]
+
+        let arrival = try! Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: data)
+
+        #expect(arrival.predictedArrival == nil)
+        #expect(arrival.predictedDeparture == nil)
+        #expect(arrival.hasPlausibleArrivalDepartureDate == true)
     }
     
     @Test func `Has references load references`() {


### PR DESCRIPTION
## Summary
- Arrival/departures whose best time is before the existing decode threshold (`timeIntervalSinceReferenceDate < 1`) are treated as implausible.
- Filtered at `StopArrivals` decode and again in stop list UI paths, so epoch sentinels no longer pin to the top as millions of minutes early.
- Closes #638.

## Test plan
- [x] `ArrivalDepartureTests` — 13/13 on iPhone Air simulator
- [ ] If a feed emits epoch times again, confirm the row is absent from stop / bookmarks lists


Made with [Cursor](https://cursor.com)