### PR TITLE
Hide redundant schedule callouts on the trip map

### DIFF
--- a/OBAKit/Trip/TripMapAnnotationPolicy.swift
+++ b/OBAKit/Trip/TripMapAnnotationPolicy.swift
@@ -14,9 +14,10 @@ import MapKit
 /// Schedule-time callouts duplicated the trip list and obscured the vehicle.
 /// Pins therefore have `canShowCallout = false`. A rider tap opens the stop
 /// (the same gesture `StopAnnotationView` uses without a callout) and
-/// highlights the matching list row. Programmatic selection on load is skipped
-/// via `TripViewController.skipNextStopTimeHighlight` so opening a trip from a
-/// departure does not immediately push that stop back on top of the trip.
+/// highlights the matching list row. Programmatic selection (first load,
+/// list → map) arms `skipNextStopTimeHighlight` so that `didSelect` does
+/// not push the stop. A 30s refresh must not re-select the origin after
+/// the rider has moved the pin.
 enum TripMapAnnotationPolicy {
     static func apply(to view: MinimalStopAnnotationView) {
         view.canShowCallout = false

--- a/OBAKit/Trip/TripMapAnnotationPolicy.swift
+++ b/OBAKit/Trip/TripMapAnnotationPolicy.swift
@@ -18,13 +18,8 @@ import MapKit
 /// via `TripViewController.skipNextStopTimeHighlight` so opening a trip from a
 /// departure does not immediately push that stop back on top of the trip.
 enum TripMapAnnotationPolicy {
-    static let showsStopCallout = false
-
     static func apply(to view: MinimalStopAnnotationView) {
-        view.canShowCallout = showsStopCallout
-
-        guard !showsStopCallout else { return }
-
+        view.canShowCallout = false
         view.rightCalloutAccessoryView = nil
         view.detailCalloutAccessoryView = nil
     }

--- a/OBAKit/Trip/TripMapAnnotationPolicy.swift
+++ b/OBAKit/Trip/TripMapAnnotationPolicy.swift
@@ -11,9 +11,12 @@ import MapKit
 
 /// Callout behavior for stop annotations on the trip map.
 ///
-/// Trip stop pins are selected to highlight the corresponding row in the trip
-/// details list. Schedule-time callouts ("flags") obscure the vehicle annotation
-/// and duplicate information already shown in the list and navigation bar.
+/// Schedule-time callouts duplicated the trip list and obscured the vehicle.
+/// Pins therefore have `canShowCallout = false`. A rider tap opens the stop
+/// (the same gesture `StopAnnotationView` uses without a callout) and
+/// highlights the matching list row. Programmatic selection on load is skipped
+/// via `TripViewController.skipNextStopTimeHighlight` so opening a trip from a
+/// departure does not immediately push that stop back on top of the trip.
 enum TripMapAnnotationPolicy {
     static let showsStopCallout = false
 

--- a/OBAKit/Trip/TripMapAnnotationPolicy.swift
+++ b/OBAKit/Trip/TripMapAnnotationPolicy.swift
@@ -1,0 +1,28 @@
+//
+//  TripMapAnnotationPolicy.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import MapKit
+
+/// Callout behavior for stop annotations on the trip map.
+///
+/// Trip stop pins are selected to highlight the corresponding row in the trip
+/// details list. Schedule-time callouts ("flags") obscure the vehicle annotation
+/// and duplicate information already shown in the list and navigation bar.
+enum TripMapAnnotationPolicy {
+    static let showsStopCallout = false
+
+    static func apply(to view: MinimalStopAnnotationView) {
+        view.canShowCallout = showsStopCallout
+
+        guard !showsStopCallout else { return }
+
+        view.rightCalloutAccessoryView = nil
+        view.detailCalloutAccessoryView = nil
+    }
+}

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -427,6 +427,13 @@ class TripViewController: UIViewController,
         didSet {
             guard !isBeingPreviewed else { return }
 
+            // Value-equal write (30s refresh of the same stop): nothing to
+            // select. Drop a leaked skip so the next pin tap still opens.
+            if oldValue == selectedStopTime {
+                skipNextStopTimeHighlight = false
+                return
+            }
+
             var animated = true
             if isFirstStopTimeLoad {
                 animated = false
@@ -434,8 +441,7 @@ class TripViewController: UIViewController,
             }
             self.mapView.deselectAnnotation(oldValue, animated: animated)
 
-            guard oldValue != self.selectedStopTime,
-                let selectedStopTime = self.selectedStopTime else { return }
+            guard let selectedStopTime = self.selectedStopTime else { return }
 
             // Fixes #220: Find matching trip stop using stop ID instead of using pointers.
             if let annotation = self.mapView.annotations
@@ -447,18 +453,23 @@ class TripViewController: UIViewController,
     }
     private var isFirstStopTimeLoad = true
 
-    /// Auto-selects the rider's origin stop when trip details load. Arms the
-    /// skip flag only on the first load: `tripDetails` republishes every 30s
-    /// with a value-equal `TripStopTime`, so arming on every emission left the
-    /// flag stuck and swallowed the next pin tap.
+    /// Auto-selects the rider's origin stop when trip details first load.
+    /// Later `$tripDetails` emissions (30s refresh) must not write origin
+    /// back if the rider deselected or picked another stop — that
+    /// `selectAnnotation` would fire `didSelect` → `openStop`.
     func applyOriginStopSelection(from details: TripDetails) {
         guard let arrivalDeparture = tripConvertible.arrivalDeparture else { return }
-        if isFirstStopTimeLoad {
-            skipNextStopTimeHighlight = true
-        } else {
-            skipNextStopTimeHighlight = false
+        guard let origin = details.stopTimes.first(where: { $0.stopID == arrivalDeparture.stopID }) else { return }
+
+        if let current = selectedStopTime, current.stopID != origin.stopID {
+            return
         }
-        selectedStopTime = details.stopTimes.filter { $0.stopID == arrivalDeparture.stopID }.first
+        if selectedStopTime == nil && !isFirstStopTimeLoad {
+            return
+        }
+
+        skipNextStopTimeHighlight = true
+        selectedStopTime = origin
     }
 }
 

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -427,17 +427,7 @@ class TripViewController: UIViewController,
         }
         else if let view = annotationView as? MinimalStopAnnotationView, let arrivalDeparture = tripConvertible.arrivalDeparture {
             view.selectedArrivalDeparture = arrivalDeparture
-
-            if let stopTime = annotation as? TripStopTime {
-                view.rightCalloutAccessoryView = UIButton.chevronButton
-
-                let calloutLabel = UILabel.autolayoutNew()
-                calloutLabel.textColor = ThemeColors.shared.secondaryLabel
-                calloutLabel.text = application.formatters.timeFormatter.string(from: stopTime.arrivalDate)
-                view.detailCalloutAccessoryView = calloutLabel
-            }
-
-            view.canShowCallout = true
+            TripMapAnnotationPolicy.apply(to: view)
         }
 
         return annotationView

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -339,28 +339,8 @@ class TripViewController: UIViewController,
         defer { skipNextStopTimeHighlight = false }
         guard !skipNextStopTimeHighlight else { return }
 
-        func highlightStopInList() {
-            self.tripDetailsController.highlightStopInList(stopTime.stop)
-        }
-
-        // Callouts are off on this map. A rider tap opens the stop — the same
-        // gesture StopAnnotationView uses when `canShowCallout` is false —
-        // and still highlights the matching list row so the two surfaces agree.
-        guard view.canShowCallout else {
-            highlightStopInList()
-            openStop(stopTime)
-            return
-        }
-
-        if self.mapView.hasBeenTouched {
-            highlightStopInList()
-        } else {
-            if traitCollection.horizontalSizeClass == .regular {
-                floatingPanel.move(to: .full, animated: true, completion: highlightStopInList)
-            } else {
-                floatingPanel.move(to: .half, animated: true, completion: highlightStopInList)
-            }
-        }
+        tripDetailsController.highlightStopInList(stopTime.stop)
+        openStop(stopTime)
     }
 
     public func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
@@ -466,6 +446,20 @@ class TripViewController: UIViewController,
         }
     }
     private var isFirstStopTimeLoad = true
+
+    /// Auto-selects the rider's origin stop when trip details load. Arms the
+    /// skip flag only on the first load: `tripDetails` republishes every 30s
+    /// with a value-equal `TripStopTime`, so arming on every emission left the
+    /// flag stuck and swallowed the next pin tap.
+    func applyOriginStopSelection(from details: TripDetails) {
+        guard let arrivalDeparture = tripConvertible.arrivalDeparture else { return }
+        if isFirstStopTimeLoad {
+            skipNextStopTimeHighlight = true
+        } else {
+            skipNextStopTimeHighlight = false
+        }
+        selectedStopTime = details.stopTimes.filter { $0.stopID == arrivalDeparture.stopID }.first
+    }
 }
 
 // MARK: - ViewModel Binding
@@ -495,10 +489,7 @@ private extension TripViewController {
                     mapView.showAnnotations(annotationsToShow, animated: true)
                 }
 
-                if let arrivalDeparture = tripConvertible.arrivalDeparture {
-                    skipNextStopTimeHighlight = true
-                    selectedStopTime = details.stopTimes.filter { $0.stopID == arrivalDeparture.stopID }.first
-                }
+                applyOriginStopSelection(from: details)
             }
             .store(in: &cancellables)
     }

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -337,10 +337,16 @@ class TripViewController: UIViewController,
     public func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         guard let stopTime = view.annotation as? TripStopTime else { return }
         defer { skipNextStopTimeHighlight = false }
-        guard !skipNextStopTimeHighlight else { return }
+        if skipNextStopTimeHighlight {
+            // Programmatic select leaves the pin selected. MapKit will not
+            // re-fire `didSelect` for an already-selected annotation, so the
+            // first tap on the origin stop would do nothing.
+            mapView.deselectAnnotation(view.annotation, animated: false)
+            return
+        }
 
         tripDetailsController.highlightStopInList(stopTime.stop)
-        openStop(stopTime)
+        openStop(stopTime, on: mapView)
     }
 
     public func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
@@ -350,12 +356,16 @@ class TripViewController: UIViewController,
         self.selectedStopTime = nil
     }
 
-    private func openStop(_ stopTime: TripStopTime) {
+    private func openStop(_ stopTime: TripStopTime, on mapView: MKMapView) {
         var transferContext: TransferContext?
         if let arrivalDeparture = tripConvertible.arrivalDeparture,
            stopTime.stopID != arrivalDeparture.stopID {
             transferContext = .from(arrivalDeparture: arrivalDeparture, arrivalDate: stopTime.arrivalDate)
         }
+
+        // Same reason as `MapViewController`: leaving the tapped pin selected
+        // only strands a highlight. MapKit will not fire `didSelect` again.
+        mapView.deselectAnnotation(stopTime, animated: false)
 
         application.viewRouter.navigateTo(stop: stopTime.stop, from: self, transferContext: transferContext)
     }

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -421,17 +421,7 @@ class TripViewController: UIViewController,
         }
         else if let view = annotationView as? MinimalStopAnnotationView, let arrivalDeparture = tripConvertible.arrivalDeparture {
             view.selectedArrivalDeparture = arrivalDeparture
-
-            if let stopTime = annotation as? TripStopTime {
-                view.rightCalloutAccessoryView = UIButton.chevronButton
-
-                let calloutLabel = UILabel.autolayoutNew()
-                calloutLabel.textColor = ThemeColors.shared.secondaryLabel
-                calloutLabel.text = application.formatters.timeFormatter.string(from: stopTime.arrivalDate)
-                view.detailCalloutAccessoryView = calloutLabel
-            }
-
-            view.canShowCallout = true
+            TripMapAnnotationPolicy.apply(to: view)
         }
 
         return annotationView

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -339,6 +339,11 @@ class TripViewController: UIViewController,
         defer { skipNextStopTimeHighlight = false }
         guard !skipNextStopTimeHighlight else { return }
 
+        guard view.canShowCallout else {
+            openStop(stopTime)
+            return
+        }
+
         func mapViewAnnotationSelectionComplete() {
             self.tripDetailsController.highlightStopInList(stopTime.stop)
         }
@@ -363,7 +368,10 @@ class TripViewController: UIViewController,
 
     public func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
         guard let stopTime = view.annotation as? TripStopTime else { return }
+        openStop(stopTime)
+    }
 
+    private func openStop(_ stopTime: TripStopTime) {
         var transferContext: TransferContext?
         if let arrivalDeparture = tripConvertible.arrivalDeparture,
            stopTime.stopID != arrivalDeparture.stopID {

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -339,22 +339,26 @@ class TripViewController: UIViewController,
         defer { skipNextStopTimeHighlight = false }
         guard !skipNextStopTimeHighlight else { return }
 
+        func highlightStopInList() {
+            self.tripDetailsController.highlightStopInList(stopTime.stop)
+        }
+
+        // Callouts are off on this map. A rider tap opens the stop — the same
+        // gesture StopAnnotationView uses when `canShowCallout` is false —
+        // and still highlights the matching list row so the two surfaces agree.
         guard view.canShowCallout else {
+            highlightStopInList()
             openStop(stopTime)
             return
         }
 
-        func mapViewAnnotationSelectionComplete() {
-            self.tripDetailsController.highlightStopInList(stopTime.stop)
-        }
-
         if self.mapView.hasBeenTouched {
-            mapViewAnnotationSelectionComplete()
+            highlightStopInList()
         } else {
             if traitCollection.horizontalSizeClass == .regular {
-                floatingPanel.move(to: .full, animated: true, completion: mapViewAnnotationSelectionComplete)
+                floatingPanel.move(to: .full, animated: true, completion: highlightStopInList)
             } else {
-                floatingPanel.move(to: .half, animated: true, completion: mapViewAnnotationSelectionComplete)
+                floatingPanel.move(to: .half, animated: true, completion: highlightStopInList)
             }
         }
     }
@@ -364,11 +368,6 @@ class TripViewController: UIViewController,
             stopTime == self.selectedStopTime else { return }
 
         self.selectedStopTime = nil
-    }
-
-    public func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
-        guard let stopTime = view.annotation as? TripStopTime else { return }
-        openStop(stopTime)
     }
 
     private func openStop(_ stopTime: TripStopTime) {
@@ -497,6 +496,7 @@ private extension TripViewController {
                 }
 
                 if let arrivalDeparture = tripConvertible.arrivalDeparture {
+                    skipNextStopTimeHighlight = true
                     selectedStopTime = details.stopTimes.filter { $0.stopID == arrivalDeparture.stopID }.first
                 }
             }

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -78,8 +78,12 @@ class Fixtures {
         scheduledDeparture: Int = 1_700_000_000,
         predictedDeparture: Int? = nil,
         stopSequence: Int = 5,
+<<<<<<< HEAD
         routeID: String = "route_1",
         tripID: String = "trip_1"
+=======
+        stopID: String = "stop_1"
+>>>>>>> a39cbe3c (Stop a 30s trip refresh from reopening the origin stop.)
     ) throws -> ArrivalDeparture {
         var dictionary: [String: Any] = [
             "arrivalEnabled": true,
@@ -95,7 +99,7 @@ class Fixtures {
             "serviceDate": scheduledArrival,
             "situationIds": [],
             "status": "SCHEDULED",
-            "stopId": "stop_1",
+            "stopId": stopID,
             "stopSequence": stopSequence,
             "tripId": tripID,
             "vehicleId": "vehicle_1"

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -78,12 +78,9 @@ class Fixtures {
         scheduledDeparture: Int = 1_700_000_000,
         predictedDeparture: Int? = nil,
         stopSequence: Int = 5,
-<<<<<<< HEAD
+        stopID: String = "stop_1",
         routeID: String = "route_1",
         tripID: String = "trip_1"
-=======
-        stopID: String = "stop_1"
->>>>>>> a39cbe3c (Stop a 30s trip refresh from reopening the origin stop.)
     ) throws -> ArrivalDeparture {
         var dictionary: [String: Any] = [
             "arrivalEnabled": true,

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -87,9 +87,17 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
     }
 
     /// A rider tap with callouts off still opens the stop.
+    ///
+    /// Needs a referenced `ArrivalDeparture`: `openStop` builds `TransferContext.from`,
+    /// which reads `routeShortName`. `Fixtures.arrivalDeparture()` leaves `route` nil
+    /// and crashed CI at `ArrivalDeparture.swift:221`.
     @Test @MainActor
     func `User tap opens the stop when callouts are hidden`() throws {
-        let arrivalDeparture = try Fixtures.arrivalDeparture()
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
         let controller = makeController(arrivalDeparture: arrivalDeparture)
         let nav = UINavigationController(rootViewController: controller)
 

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -150,4 +150,56 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
 
         #expect(controller.selectedStopTime == nil)
     }
+
+    /// Callouts are off, so selection is the only open gesture. Leaving the
+    /// pin selected after `openStop` (or after the load-time skip) means
+    /// MapKit will not fire `didSelect` again. Use the `mapView` MapKit
+    /// passed in — not `self.mapView`, which would load `.view`.
+    @Test @MainActor
+    func `Opening a stop deselects the pin so a second tap still opens`() throws {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let nav = UINavigationController(rootViewController: controller)
+        let mapView = MKMapView()
+        let stopTime = try #require(try loadTripDetails().stopTimes.first)
+        mapView.addAnnotation(stopTime)
+        mapView.selectAnnotation(stopTime, animated: false)
+
+        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
+        annotationView.canShowCallout = false
+
+        controller.skipNextStopTimeHighlight = false
+        controller.mapView(mapView, didSelect: annotationView)
+
+        #expect(mapView.selectedAnnotations.isEmpty)
+        #expect(nav.viewControllers.count == 2)
+
+        mapView.selectAnnotation(stopTime, animated: false)
+        controller.mapView(mapView, didSelect: annotationView)
+
+        #expect(mapView.selectedAnnotations.isEmpty)
+        #expect(nav.viewControllers.count == 3)
+    }
+
+    /// Load-time `selectAnnotation` arms skip and must still deselect, or
+    /// the first tap on the origin pin is a no-op.
+    @Test @MainActor
+    func `Programmatic selection deselects so the origin pin can be tapped`() throws {
+        let arrivalDeparture = try Fixtures.arrivalDeparture()
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let mapView = MKMapView()
+        let stopTime = try #require(try loadTripDetails().stopTimes.first)
+        mapView.addAnnotation(stopTime)
+        mapView.selectAnnotation(stopTime, animated: false)
+
+        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
+        controller.skipNextStopTimeHighlight = true
+        controller.mapView(mapView, didSelect: annotationView)
+
+        #expect(mapView.selectedAnnotations.isEmpty)
+    }
 }

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -110,4 +110,34 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
 
         #expect(nav.viewControllers.count == 2)
     }
+
+    /// `$tripDetails` republishes every 30s. Arming skip on every emission left
+    /// the flag stuck (value-equal `TripStopTime` skips `didSelect`). A refresh
+    /// must clear a leaked arm so the next pin tap still opens the stop.
+    ///
+    /// Uses a referenced `ArrivalDeparture` because the post-refresh tap path
+    /// hits `openStop`. Do not load `controller.view`.
+    @Test @MainActor
+    func `Origin selection arms skip only on first load`() throws {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let nav = UINavigationController(rootViewController: controller)
+        let details = try loadTripDetails()
+
+        controller.applyOriginStopSelection(from: details)
+        #expect(controller.skipNextStopTimeHighlight)
+
+        controller.applyOriginStopSelection(from: details)
+        #expect(!controller.skipNextStopTimeHighlight)
+
+        let stopTime = try #require(details.stopTimes.first)
+        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
+        controller.mapView(MKMapView(), didSelect: annotationView)
+
+        #expect(nav.viewControllers.count == 2)
+    }
 }

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -1,0 +1,34 @@
+//
+//  TripMapAnnotationPolicyTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import MapKit
+@testable import OBAKit
+import Testing
+
+@Suite(.serialized)
+final class TripMapAnnotationPolicyTests {
+
+    @Test func `Trip map suppresses stop callouts`() {
+        #expect(!TripMapAnnotationPolicy.showsStopCallout)
+    }
+
+    @Test @MainActor
+    func `Applying policy clears callout accessories`() {
+        let view = MinimalStopAnnotationView(annotation: nil, reuseIdentifier: "test")
+        view.canShowCallout = true
+        view.rightCalloutAccessoryView = UIButton.chevronButton
+        view.detailCalloutAccessoryView = UILabel.autolayoutNew()
+
+        TripMapAnnotationPolicy.apply(to: view)
+
+        #expect(!view.canShowCallout)
+        #expect(view.rightCalloutAccessoryView == nil)
+        #expect(view.detailCalloutAccessoryView == nil)
+    }
+}

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -63,13 +63,17 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
 
     /// Opening a trip from a departure auto-selects the rider's stop. That
     /// programmatic select must not push the stop page back on top (#713).
+    ///
+    /// Do not load `controller.view`. `viewDidLoad` reads `ArrivalDeparture.route`,
+    /// which `Fixtures.arrivalDeparture()` leaves unresolved, and spinning up the
+    /// trip map plus floating panel crashed CI then hung the simulator for 10 minutes.
+    /// `didSelect` is the production path under test; wrapping in a nav controller
+    /// is enough for `ViewRouter.navigateTo` to push.
     @Test @MainActor
     func `Programmatic selection does not open the stop`() throws {
         let arrivalDeparture = try Fixtures.arrivalDeparture()
         let controller = makeController(arrivalDeparture: arrivalDeparture)
         let nav = UINavigationController(rootViewController: controller)
-        _ = nav.view
-        _ = controller.view
 
         let stopTime = try #require(try loadTripDetails().stopTimes.first)
         let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
@@ -88,8 +92,6 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         let arrivalDeparture = try Fixtures.arrivalDeparture()
         let controller = makeController(arrivalDeparture: arrivalDeparture)
         let nav = UINavigationController(rootViewController: controller)
-        _ = nav.view
-        _ = controller.view
 
         let stopTime = try #require(try loadTripDetails().stopTimes.first)
         let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -7,15 +7,34 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import Foundation
 import MapKit
 @testable import OBAKit
+@testable import OBAKitCore
 import Testing
 
 @Suite(.serialized)
-final class TripMapAnnotationPolicyTests {
+final class TripMapAnnotationPolicyTests: OBATestCase {
 
-    @Test func `Trip map suppresses stop callouts`() {
-        #expect(!TripMapAnnotationPolicy.showsStopCallout)
+    @Test @MainActor
+    func `Trip controller applies the no-callout policy to stop views`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: OperationQueue(), dataLoader: dataLoader)
+        let tripDetails = try JSONDecoder.RESTDecoder().decode(
+            RESTAPIResponse<TripDetails>.self,
+            from: Fixtures.loadData(file: "trip_details_1_18196913.json")
+        ).entry
+        let controller = TripViewController(
+            application: application,
+            tripConvertible: TripConvertible(tripDetails: tripDetails)
+        )
+        let mapView = MKMapView()
+        mapView.registerAnnotationView(MinimalStopAnnotationView.self)
+        let stopTime = try #require(tripDetails.stopTimes.first)
+
+        let view = try #require(controller.mapView(mapView, viewFor: stopTime) as? MinimalStopAnnotationView)
+
+        #expect(!view.canShowCallout)
     }
 
     @Test @MainActor

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -111,33 +111,43 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         #expect(nav.viewControllers.count == 2)
     }
 
-    /// `$tripDetails` republishes every 30s. Arming skip on every emission left
-    /// the flag stuck (value-equal `TripStopTime` skips `didSelect`). A refresh
-    /// must clear a leaked arm so the next pin tap still opens the stop.
-    ///
-    /// Uses a referenced `ArrivalDeparture` because the post-refresh tap path
-    /// hits `openStop`. Do not load `controller.view`.
+    /// `$tripDetails` republishes every 30s. Re-assigning origin on every
+    /// emission is a value-equal write, so `didSet` must drop a leaked skip
+    /// arm — otherwise the next pin tap is swallowed. Do not load `.view`.
+    /// Does not tap-to-open: `Fixtures.arrivalDeparture` leaves `route` nil.
     @Test @MainActor
-    func `Origin selection arms skip only on first load`() throws {
-        let stopArrivals = try Fixtures.loadRESTAPIPayload(
-            type: StopArrivals.self,
-            fileName: "arrivals-and-departures-for-stop-1_10914.json"
-        )
-        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
-        let controller = makeController(arrivalDeparture: arrivalDeparture)
-        let nav = UINavigationController(rootViewController: controller)
+    func `Value-equal origin refresh clears a leaked skip arm`() throws {
         let details = try loadTripDetails()
+        let originID = try #require(details.stopTimes.first?.stopID)
+        let arrivalDeparture = try Fixtures.arrivalDeparture(stopID: originID)
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
 
         controller.applyOriginStopSelection(from: details)
         #expect(controller.skipNextStopTimeHighlight)
+        #expect(controller.selectedStopTime?.stopID == originID)
 
         controller.applyOriginStopSelection(from: details)
         #expect(!controller.skipNextStopTimeHighlight)
+        #expect(controller.selectedStopTime?.stopID == originID)
+    }
 
-        let stopTime = try #require(details.stopTimes.first)
-        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
-        controller.mapView(MKMapView(), didSelect: annotationView)
+    /// After the rider deselects (or picks another stop), a 30s refresh must
+    /// not write the origin back. That re-select would fire `didSelect` →
+    /// `openStop`. Setting `selectedStopTime = nil` is the production
+    /// `didDeselect` assignment. Do not load `.view`.
+    @Test @MainActor
+    func `Refresh does not reselect origin after the rider deselects`() throws {
+        let details = try loadTripDetails()
+        let originID = try #require(details.stopTimes.first?.stopID)
+        let arrivalDeparture = try Fixtures.arrivalDeparture(stopID: originID)
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
 
-        #expect(nav.viewControllers.count == 2)
+        controller.applyOriginStopSelection(from: details)
+        #expect(controller.selectedStopTime?.stopID == originID)
+
+        controller.selectedStopTime = nil
+        controller.applyOriginStopSelection(from: details)
+
+        #expect(controller.selectedStopTime == nil)
     }
 }

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -16,25 +16,35 @@ import Testing
 @Suite(.serialized)
 final class TripMapAnnotationPolicyTests: OBATestCase {
 
-    @Test @MainActor
-    func `Trip controller applies the no-callout policy to stop views`() throws {
+    private func makeController(arrivalDeparture: ArrivalDeparture) -> TripViewController {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: OperationQueue(), dataLoader: dataLoader)
-        let tripDetails = try JSONDecoder.RESTDecoder().decode(
+        return TripViewController(application: application, arrivalDeparture: arrivalDeparture)
+    }
+
+    private func loadTripDetails() throws -> TripDetails {
+        try JSONDecoder.RESTDecoder().decode(
             RESTAPIResponse<TripDetails>.self,
             from: Fixtures.loadData(file: "trip_details_1_18196913.json")
         ).entry
-        let controller = TripViewController(
-            application: application,
-            tripConvertible: TripConvertible(tripDetails: tripDetails)
-        )
+    }
+
+    /// `viewFor` only applies the policy when `arrivalDeparture` is set. Building
+    /// the controller from `TripConvertible(tripDetails:)` skipped that branch,
+    /// so `canShowCallout` was just MKAnnotationView's default `false`.
+    @Test @MainActor
+    func `Trip controller applies the no-callout policy to stop views`() throws {
+        let arrivalDeparture = try Fixtures.arrivalDeparture()
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
         let mapView = MKMapView()
         mapView.registerAnnotationView(MinimalStopAnnotationView.self)
-        let stopTime = try #require(tripDetails.stopTimes.first)
+        let stopTime = try #require(try loadTripDetails().stopTimes.first)
 
         let view = try #require(controller.mapView(mapView, viewFor: stopTime) as? MinimalStopAnnotationView)
 
         #expect(!view.canShowCallout)
+        #expect(view.rightCalloutAccessoryView == nil)
+        #expect(view.detailCalloutAccessoryView == nil)
     }
 
     @Test @MainActor
@@ -49,5 +59,45 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         #expect(!view.canShowCallout)
         #expect(view.rightCalloutAccessoryView == nil)
         #expect(view.detailCalloutAccessoryView == nil)
+    }
+
+    /// Opening a trip from a departure auto-selects the rider's stop. That
+    /// programmatic select must not push the stop page back on top (#713).
+    @Test @MainActor
+    func `Programmatic selection does not open the stop`() throws {
+        let arrivalDeparture = try Fixtures.arrivalDeparture()
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let nav = UINavigationController(rootViewController: controller)
+        _ = nav.view
+        _ = controller.view
+
+        let stopTime = try #require(try loadTripDetails().stopTimes.first)
+        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
+        annotationView.canShowCallout = false
+
+        controller.skipNextStopTimeHighlight = true
+        controller.mapView(MKMapView(), didSelect: annotationView)
+
+        #expect(nav.viewControllers.count == 1)
+        #expect(nav.viewControllers.first === controller)
+    }
+
+    /// A rider tap with callouts off still opens the stop.
+    @Test @MainActor
+    func `User tap opens the stop when callouts are hidden`() throws {
+        let arrivalDeparture = try Fixtures.arrivalDeparture()
+        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let nav = UINavigationController(rootViewController: controller)
+        _ = nav.view
+        _ = controller.view
+
+        let stopTime = try #require(try loadTripDetails().stopTimes.first)
+        let annotationView = MinimalStopAnnotationView(annotation: stopTime, reuseIdentifier: "test")
+        annotationView.canShowCallout = false
+
+        controller.skipNextStopTimeHighlight = false
+        controller.mapView(MKMapView(), didSelect: annotationView)
+
+        #expect(nav.viewControllers.count == 2)
     }
 }

--- a/docs/trip-map-callouts.md
+++ b/docs/trip-map-callouts.md
@@ -1,0 +1,27 @@
+# Trip map stop selection
+
+Trip-map stop pins have no MapKit callout (`TripMapAnnotationPolicy`). A rider
+tap on a pin opens that stop. Opening a trip from a departure auto-selects the
+origin pin; that programmatic select must not push the stop back on top.
+
+## Skip flag
+
+`TripViewController.skipNextStopTimeHighlight` is armed on every programmatic
+assignment of `selectedStopTime` (first load, and `showStopOnMap` from the
+list). `mapView(_:didSelect:)` consumes the flag and skips `openStop`.
+
+A value-equal assignment (same `TripStopTime` on a 30s refresh) clears the
+flag in `selectedStopTime`'s `didSet` so a leaked arm cannot swallow the next
+tap.
+
+## Refresh
+
+`$tripDetails` republishes about every 30 seconds. `applyOriginStopSelection`
+writes the origin only on the first load, or while the origin is still the
+selected stop. After the rider deselects (`didDeselect` → `selectedStopTime =
+nil`) or picks another stop, a later emission leaves that choice alone.
+
+`didSelect` still skips list highlight and the floating-panel move when the
+flag is set: those share the same `didSelect` entry. The origin pin is
+selected on the map. Tests must not load `TripViewController.view`
+(`viewDidLoad` reads an unresolved `ArrivalDeparture.route`).

--- a/docs/trip-map-callouts.md
+++ b/docs/trip-map-callouts.md
@@ -8,11 +8,17 @@ origin pin; that programmatic select must not push the stop back on top.
 
 `TripViewController.skipNextStopTimeHighlight` is armed on every programmatic
 assignment of `selectedStopTime` (first load, and `showStopOnMap` from the
-list). `mapView(_:didSelect:)` consumes the flag and skips `openStop`.
+list). `mapView(_:didSelect:)` consumes the flag and skips `openStop`. It
+still deselects the pin: MapKit will not re-fire `didSelect` for an
+already-selected annotation, and the first tap on the origin stop would
+otherwise do nothing.
 
 A value-equal assignment (same `TripStopTime` on a 30s refresh) clears the
 flag in `selectedStopTime`'s `didSet` so a leaked arm cannot swallow the next
 tap.
+
+`didSelect` also skips `highlightStopInList` when the flag is set. The origin
+pin is not highlighted in the trip list on load.
 
 ## Refresh
 
@@ -21,7 +27,11 @@ writes the origin only on the first load, or while the origin is still the
 selected stop. After the rider deselects (`didDeselect` → `selectedStopTime =
 nil`) or picks another stop, a later emission leaves that choice alone.
 
-`didSelect` still skips list highlight and the floating-panel move when the
-flag is set: those share the same `didSelect` entry. The origin pin is
-selected on the map. Tests must not load `TripViewController.view`
-(`viewDidLoad` reads an unresolved `ArrivalDeparture.route`).
+## Deselect after open
+
+`openStop` deselects the annotation on the `MKMapView` MapKit passed into
+`didSelect` (same pattern as `MapViewController`). Come back from the stop
+page and the same pin can be tapped again.
+
+Tests must not load `TripViewController.view` (`viewDidLoad` reads an
+unresolved `ArrivalDeparture.route`).


### PR DESCRIPTION
## Summary
- Trip map stop pins no longer show schedule-time callout flags that covered the vehicle annotation.
- Opening a trip from a departure arms `skipNextStopTimeHighlight` before the load-time `selectAnnotation`, so the rider is not bounced straight back to the stop page.
- A rider tap with callouts off still highlights the matching list row and opens the stop (the same gesture `StopAnnotationView` uses when `canShowCallout` is false).
- Unreachable `mapView(_:annotationView:calloutAccessoryControlTapped:)` on this screen is deleted.
- Refs #713.

## Test plan
- [x] `TripMapAnnotationPolicyTests` — `viewFor` is built from an `arrivalDeparture` fixture so the policy actually runs (not MKAnnotationView's default `canShowCallout`).
- [x] Programmatic `didSelect` with the skip flag does not push a stop page.
- [x] A rider tap with callouts off does push the stop page.
- [ ] Open a trip from a stop's departure: stay on the trip screen; the origin stop is selected on the map and highlighted in the list, but the stop page is not pushed.
- [ ] Tap a different stop pin: list row highlights and the stop page opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified trip map stop annotations by removing callouts and accessory controls.
  * Selecting a stop highlights the matching itinerary row.
  * Tapping a stop opens its details directly.
  * Programmatic stop selection no longer navigates unexpectedly.
  * Initial arrival/departure selection no longer highlights the next stop.
  * Refreshes preserve rider-selected or deselected stops and avoid stale highlights.

* **Tests**
  * Added coverage for stop annotation behavior, selection, navigation, and refresh handling.

* **Documentation**
  * Documented trip map stop selection and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->