### PR TITLE
Clarify Report Problem trip section copy

### DIFF
--- a/OBAKit/Reporting/ReportProblemCopy.swift
+++ b/OBAKit/Reporting/ReportProblemCopy.swift
@@ -1,0 +1,29 @@
+//
+//  ReportProblemCopy.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OBAKitCore
+
+/// User-facing copy for the Report Problem hub screen.
+enum ReportProblemCopy {
+    static var stopProblemHeader: String {
+        OBALoc(
+            "report_problem_controller.stop_problem.header",
+            value: "Problem with the Stop",
+            comment: "Section header for reporting incorrect stop names, numbers, locations, or missing routes or trips, not app bugs."
+        )
+    }
+
+    static var vehicleProblemHeader: String {
+        OBALoc(
+            "report_problem_controller.trip_problem.header",
+            value: "Problem with a Trip",
+            comment: "Section header for reporting a problem with a specific trip or vehicle service. Feedback helps improve transit data."
+        )
+    }
+}

--- a/OBAKit/Reporting/ReportProblemViewController.swift
+++ b/OBAKit/Reporting/ReportProblemViewController.swift
@@ -12,7 +12,9 @@ import OBAKitCore
 
 /// The 'hub' view controller for reporting problems about stops and trips.
 ///
-/// From here, a user can report a problem either about a `Stop` or about a trip at that stop.
+/// From here, a user can report incorrect stop details or a problem with a specific
+/// trip's service. These reports are sent to the transit agency to improve data and
+/// service — they are not app bug reports.
 ///
 /// - Note: This view controller expects to be presented modally.
 class ReportProblemViewController: TaskController<StopArrivals>,
@@ -98,7 +100,7 @@ class ReportProblemViewController: TaskController<StopArrivals>,
             self.navigationController?.pushViewController(stopProblemController, animated: true)
         }
 
-        return OBAListViewSection(id: "stop_problem_section", title: OBALoc("report_problem_controller.stop_problem.header", value: "Problem with the Stop", comment: "A table header in the 'Report Problem' view controller."), contents: [row])
+        return OBAListViewSection(id: "stop_problem_section", title: ReportProblemCopy.stopProblemHeader, contents: [row])
     }
 
     private var vehicleProblemSection: OBAListViewSection? {
@@ -108,7 +110,7 @@ class ReportProblemViewController: TaskController<StopArrivals>,
 
         let rows = arrivalsAndDepartures.map { ArrivalDepartureItem(arrivalDeparture: $0, isAlarmAvailable: false, onSelectAction: onSelectArrivalDeparture) }
 
-        return OBAListViewSection(id: "vehicle_problem_section", title: OBALoc("report_problem_controller.vehicle_problem.header", value: "Problem with a Vehicle at the Stop", comment: "A table header in the 'Report Problem' view controller."), contents: rows)
+        return OBAListViewSection(id: "vehicle_problem_section", title: ReportProblemCopy.vehicleProblemHeader, contents: rows)
     }
 
     func onSelectArrivalDeparture(_ arrivalDepartureItem: ArrivalDepartureItem) {

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "مشكلة في الموقف";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "مشكلة في مركبة عند الموقف";
+"report_problem_controller.trip_problem.header" = "مشكلة في رحلة";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "الموقع غير متاح. يُرجى تفعيل خدمات الموقع للعثور على الخطوط القريبة.";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -837,11 +837,11 @@
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Report a problem with the stop at %@";
 
-/* A table header in the 'Report Problem' view controller. */
+/* Section header for reporting incorrect stop names, numbers, locations, or missing routes or trips, not app bugs. */
 "report_problem_controller.stop_problem.header" = "Problem with the Stop";
 
-/* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problem with a Vehicle at the Stop";
+/* Section header for reporting a problem with a specific trip service, not app bugs. */
+"report_problem_controller.trip_problem.header" = "Problem with a Trip";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Location unavailable. Please enable location services to find nearby routes.";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problema con la parada";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problema con un vehículo en la parada";
+"report_problem_controller.trip_problem.header" = "Problema con un viaje";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Ubicación no disponible. Por favor active los servicios de ubicación para encontrar rutas cercanas.";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problema sa Hintuan";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problema sa Sasakyan sa Hintuan";
+"report_problem_controller.trip_problem.header" = "Problema sa Biyahe";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Hindi available ang lokasyon. Paki-enable ang mga serbisyo ng lokasyon para makahanap ng mga kalapit na ruta.";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problème concernant l'arrêt";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problème concernant un véhicule à cet arrêt";
+"report_problem_controller.trip_problem.header" = "Problème concernant un trajet";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Position indisponible. Veuillez activer les services de localisation pour trouver les lignes à proximité.";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problema con la fermata";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problema con un mezzo alla fermata";
+"report_problem_controller.trip_problem.header" = "Problema con una corsa";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Posizione non disponibile. Abilita i servizi di localizzazione per trovare le linee vicine.";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "정류장 관련 문제";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "정류장의 차량 관련 문제";
+"report_problem_controller.trip_problem.header" = "운행 관련 문제";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "위치를 사용할 수 없습니다. 주변 노선을 찾으려면 위치 서비스를 활성화해 주세요.";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problem z przystankiem";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problem z pojazdem na przystanku";
+"report_problem_controller.trip_problem.header" = "Problem z kursem";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Lokalizacja niedostępna. Włącz usługi lokalizacji, aby znaleźć pobliskie linie.";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Problema com a Parada";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Problema com um Veículo na Parada";
+"report_problem_controller.trip_problem.header" = "Problema com uma Viagem";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Localização indisponível. Ative os serviços de localização para encontrar linhas próximas.";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Проблема с остановкой";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Проблема с транспортом на остановке";
+"report_problem_controller.trip_problem.header" = "Проблема с рейсом";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Геопозиция недоступна. Включите службы геолокации, чтобы найти маршруты поблизости.";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "Sự cố với điểm dừng";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "Sự cố với phương tiện tại điểm dừng";
+"report_problem_controller.trip_problem.header" = "Sự cố với chuyến đi";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "Không có thông tin vị trí. Vui lòng bật dịch vụ định vị để tìm các tuyến lân cận.";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "该车站有问题";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "在该车站停靠的一辆公交车有问题";
+"report_problem_controller.trip_problem.header" = "行程问题";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "无法获取位置。请开启定位服务以查找附近的线路。";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -841,7 +841,7 @@
 "report_problem_controller.stop_problem.header" = "站牌問題";
 
 /* A table header in the 'Report Problem' view controller. */
-"report_problem_controller.vehicle_problem.header" = "此站牌車輛的問題";
+"report_problem_controller.trip_problem.header" = "行程問題";
 
 /* Error when location is unavailable in the route picker. */
 "route_picker.error_no_location" = "無法取得位置。請開啟定位服務以尋找附近路線。";

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,6 +8,7 @@
 //
 
 import ActivityKit
+import CoreLocation
 import Combine
 import SwiftUI
 import OBAKitCore


### PR DESCRIPTION
## Summary
- Renames the Report Problem hub section from “Problem with a Vehicle at the Stop” to “Problem with a Trip”.
- Doc comments spell out that these reports are agency/service feedback, not app bugs.
- Closes #451.

## Test plan
- [x] `ReportProblemCopyTests` — 2/2 on iPhone Air simulator
- [ ] Open Report a Problem from a stop and confirm the trip section header reads “Problem with a Trip”
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified report categories by distinguishing stop-related issues from trip-related issues.
  * Updated the reporting interface to use consistent section labels.
  * Refined translations for trip-problem reporting across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->