### PR TITLE
Add More tab tutorial, phone, and text config keys

### DIFF
--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -71,6 +71,7 @@ public class MoreViewController: UIViewController,
             donateSection,
             updatesAndAlertsSection,
             myLocationSection,
+            agencyContactSection,
             helpOutSection,
             customLinksSection,
             aboutSection
@@ -296,6 +297,57 @@ public class MoreViewController: UIViewController,
 
         guard !contents.isEmpty else { return nil }
         return OBAListViewSection(id: "help_out", title: header, contents: contents)
+    }
+
+    // MARK: - Agency contact (tutorial / phone / text) — #614
+    var agencyContactSection: OBAListViewSection? {
+        let config = application.applicationBundle.moreTabConfiguration
+        var contents: [AnyOBAListViewItem] = []
+
+        if let tutorialURL = config.tutorialURL {
+            contents.append(OBAListRowView.DefaultViewModel(
+                title: OBALoc(
+                    "more_controller.tutorials",
+                    value: "Tutorials",
+                    comment: "Opens the agency's tutorial or user-manual page from the More tab."),
+                onSelectAction: { [weak self] _ in
+                    self?.application.open(tutorialURL, options: [:], completionHandler: nil)
+                }
+            ).typeErased)
+        }
+
+        if let phoneURL = config.phoneURL {
+            contents.append(OBAListRowView.DefaultViewModel(
+                title: OBALoc(
+                    "more_controller.call_agency",
+                    value: "Call Agency",
+                    comment: "Opens a tel: link to call the transit agency from the More tab."),
+                onSelectAction: { [weak self] _ in
+                    self?.application.open(phoneURL, options: [:], completionHandler: nil)
+                }
+            ).typeErased)
+        }
+
+        if let textURL = config.textURL {
+            contents.append(OBAListRowView.DefaultViewModel(
+                title: OBALoc(
+                    "more_controller.text_agency",
+                    value: "Text Agency",
+                    comment: "Opens an sms: (or web) link for the agency's text information service."),
+                onSelectAction: { [weak self] _ in
+                    self?.application.open(textURL, options: [:], completionHandler: nil)
+                }
+            ).typeErased)
+        }
+
+        guard !contents.isEmpty else { return nil }
+
+        let header = OBALoc(
+            "more_controller.agency_contact.header",
+            value: "Contact & Help",
+            comment: "Header for More-tab rows that open tutorial, phone, or text links configured by the agency."
+        )
+        return OBAListViewSection(id: "agency_contact", title: header, contents: contents)
     }
 
     // MARK: - Custom Links section

--- a/OBAKitCore/Models/MoreTab/MoreTabConfiguration.swift
+++ b/OBAKitCore/Models/MoreTab/MoreTabConfiguration.swift
@@ -43,6 +43,15 @@ public struct MoreTabConfiguration: Sendable {
     /// Custom URL for "Help Develop" link. nil = hide the row.
     public let developURL: URL?
 
+    /// Optional tutorial / user-manual page. Shown as "Tutorials" when set (#614).
+    public let tutorialURL: URL?
+
+    /// Optional `tel:` (or https) URL to call the agency. Shown as "Call Agency" when set (#614).
+    public let phoneURL: URL?
+
+    /// Optional `sms:` (or https) URL for an agency text service. Shown as "Text Agency" when set (#614).
+    public let textURL: URL?
+
     /// Additional custom link items displayed in a "Resources" section.
     public let customLinks: [MoreTabLinkItem]
 
@@ -54,6 +63,9 @@ public struct MoreTabConfiguration: Sendable {
         showHelpOutSection: true,
         translateURL: nil,
         developURL: URL(string: "https://github.com/oneBusAway/onebusaway-ios"),
+        tutorialURL: nil,
+        phoneURL: nil,
+        textURL: nil,
         customLinks: []
     )
 
@@ -75,6 +87,10 @@ public struct MoreTabConfiguration: Sendable {
             self.developURL = MoreTabConfiguration.default.developURL
         }
 
+        self.tutorialURL = Self.url(from: dictionary, key: "TutorialURL")
+        self.phoneURL = Self.url(from: dictionary, key: "PhoneURL")
+        self.textURL = Self.url(from: dictionary, key: "TextURL")
+
         if let linksArray = dictionary["CustomLinks"] as? [[AnyHashable: Any]] {
             self.customLinks = linksArray.compactMap { MoreTabLinkItem(dictionary: $0) }
         } else {
@@ -87,12 +103,25 @@ public struct MoreTabConfiguration: Sendable {
         showHelpOutSection: Bool,
         translateURL: URL?,
         developURL: URL?,
+        tutorialURL: URL? = nil,
+        phoneURL: URL? = nil,
+        textURL: URL? = nil,
         customLinks: [MoreTabLinkItem]
     ) {
         self.headerSupportText = headerSupportText
         self.showHelpOutSection = showHelpOutSection
         self.translateURL = translateURL
         self.developURL = developURL
+        self.tutorialURL = tutorialURL
+        self.phoneURL = phoneURL
+        self.textURL = textURL
         self.customLinks = customLinks
+    }
+
+    private static func url(from dictionary: [AnyHashable: Any], key: String) -> URL? {
+        guard let urlString = dictionary[key] as? String, !urlString.isEmpty else {
+            return nil
+        }
+        return URL(string: urlString)
     }
 }

--- a/OBAKitTests/Modeling/MoreTabConfigurationTests.swift
+++ b/OBAKitTests/Modeling/MoreTabConfigurationTests.swift
@@ -23,6 +23,9 @@ final class MoreTabConfigurationTests {
         #expect(config.showHelpOutSection)
         #expect(config.translateURL == nil)
         #expect(config.developURL?.absoluteString == "https://github.com/oneBusAway/onebusaway-ios")
+        #expect(config.tutorialURL == nil)
+        #expect(config.phoneURL == nil)
+        #expect(config.textURL == nil)
         #expect(config.customLinks.isEmpty)
     }
 
@@ -34,6 +37,9 @@ final class MoreTabConfigurationTests {
             "ShowHelpOutSection": false,
             "TranslateURL": "https://example.com/translate",
             "DevelopURL": "https://example.com/develop",
+            "TutorialURL": "https://example.com/tutorials",
+            "PhoneURL": "tel:+1234567890",
+            "TextURL": "sms:+1234567890",
             "CustomLinks": [
                 ["Title": "Agency Site", "URL": "https://example.com"],
                 ["Title": "Call Us", "URL": "tel:+1234567890"]
@@ -46,11 +52,26 @@ final class MoreTabConfigurationTests {
         #expect(!config.showHelpOutSection)
         #expect(config.translateURL?.absoluteString == "https://example.com/translate")
         #expect(config.developURL?.absoluteString == "https://example.com/develop")
+        #expect(config.tutorialURL?.absoluteString == "https://example.com/tutorials")
+        #expect(config.phoneURL?.absoluteString == "tel:+1234567890")
+        #expect(config.textURL?.absoluteString == "sms:+1234567890")
         #expect(config.customLinks.count == 2)
         #expect(config.customLinks[0].title == "Agency Site")
         #expect(config.customLinks[0].url.absoluteString == "https://example.com")
         #expect(config.customLinks[1].title == "Call Us")
         #expect(config.customLinks[1].url.absoluteString == "tel:+1234567890")
+    }
+
+    @Test func `Parse ignores empty agency contact URLs`() {
+        let dict: [AnyHashable: Any] = [
+            "TutorialURL": "",
+            "PhoneURL": "",
+            "TextURL": ""
+        ]
+        let config = MoreTabConfiguration(from: dict)
+        #expect(config.tutorialURL == nil)
+        #expect(config.phoneURL == nil)
+        #expect(config.textURL == nil)
     }
 
     @Test func `Parse from dictionary with minimal fields`() {

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,19 @@ See [wiki/Get-Started](https://github.com/OneBusAway/onebusaway-ios/wiki/Get-Sta
 
 The iOS codebase is a white-label product, read more about white-labeling at [wiki/White-Label](https://github.com/OneBusAway/onebusaway-ios/wiki/White-Label).
 
+### More tab contact links
+
+Under `OBAKitConfig.MoreTab` in your app's `project.yml` / Info.plist you can add:
+
+| Key | Example | More-tab row |
+|-----|---------|--------------|
+| `TutorialURL` | `https://example.com/help` | Tutorials |
+| `PhoneURL` | `tel:+12065551212` | Call Agency |
+| `TextURL` | `sms:+12065551212` | Text Agency |
+| `CustomLinks` | `[{Title, URL}, …]` | Resources (any extra links) |
+
+Rows only appear when their URL is set. `tel:` / `sms:` open the system Phone / Messages apps.
+
 ### Custom Regions
 
 You can quickly add a custom region to the app by creating a specially formed link and then tapping on it in Mobile Safari:


### PR DESCRIPTION
## Summary
- Adds optional `TutorialURL`, `PhoneURL`, and `TextURL` under `OBAKitConfig.MoreTab`.
- When set, the More tab shows a Contact & Help section (Tutorials / Call Agency / Text Agency).
- Documents the keys in `README.markdown`. `CustomLinks` still covers arbitrary extra URLs.
- Closes #614.

## Test plan
- [x] `MoreTabConfigurationTests` — 11/11 on iPhone Air simulator
- [ ] Set `PhoneURL: tel:+1…` in a white-label `project.yml`, regenerate, confirm Call Agency opens Phone
- [ ] Leave keys unset on OneBusAway — no Contact & Help section appears


Made with [Cursor](https://cursor.com)