### PR TITLE
Add setup script and local signing overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ OBAKitTests.xcresult
 
 # Review artifacts (e.g. /aaron-pr-review)
 pr-*.md
+
+# Personal XcodeGen overrides (team ID / bundle ID). See Apps/*/local.yml.example.
+Apps/*/local.yml
+

--- a/Apps/KiedyBus/local.yml.example
+++ b/Apps/KiedyBus/local.yml.example
@@ -1,0 +1,12 @@
+# Copy to Apps/KiedyBus/local.yml (gitignored) and adjust for your Apple team.
+# See Apps/OneBusAway/local.yml.example for notes.
+
+targets:
+  App:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: YOUR_TEAM_ID
+  OBAWidget:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: YOUR_TEAM_ID

--- a/Apps/KiedyBus/local.yml.example
+++ b/Apps/KiedyBus/local.yml.example
@@ -1,5 +1,8 @@
 # Copy to Apps/KiedyBus/local.yml (gitignored) and adjust for your Apple team.
-# See Apps/OneBusAway/local.yml.example for notes.
+# `scripts/generate_project` copies DEVELOPMENT_TEAM into the generated
+# project, so this file is authoritative for local signing. See
+# Apps/OneBusAway/local.yml.example before changing a bundle identifier:
+# associated identifiers must be changed together in a white-label config.
 
 targets:
   App:

--- a/Apps/KiedyBus/project.yml
+++ b/Apps/KiedyBus/project.yml
@@ -92,3 +92,4 @@ include:
   - path: OBAKit/project.yml
   - path: OBAKitTests/project.yml
   - path: OBAWidget/project.yml
+

--- a/Apps/OneBusAway/local.yml.example
+++ b/Apps/OneBusAway/local.yml.example
@@ -1,0 +1,17 @@
+# Copy to Apps/OneBusAway/local.yml (gitignored) and adjust for your Apple team.
+# Regenerated into the Xcode project via `scripts/setup` / `scripts/generate_project`.
+#
+# XcodeGen merges this file over the shared project.yml, so you can develop
+# without belonging to the OneBusAway organization team.
+
+targets:
+  App:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: YOUR_TEAM_ID
+        # PRODUCT_BUNDLE_IDENTIFIER: com.example.onebusaway
+  OBAWidget:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: YOUR_TEAM_ID
+        # PRODUCT_BUNDLE_IDENTIFIER: com.example.onebusaway.widget

--- a/Apps/OneBusAway/local.yml.example
+++ b/Apps/OneBusAway/local.yml.example
@@ -1,17 +1,20 @@
 # Copy to Apps/OneBusAway/local.yml (gitignored) and adjust for your Apple team.
 # Regenerated into the Xcode project via `scripts/setup` / `scripts/generate_project`.
 #
-# XcodeGen merges this file over the shared project.yml, so you can develop
-# without belonging to the OneBusAway organization team.
+# `scripts/generate_project` copies DEVELOPMENT_TEAM into the generated
+# project, so this file is authoritative for local signing.
+#
+# PRODUCT_BUNDLE_IDENTIFIER is intentionally not supported here. A working
+# personal bundle ID also needs matching app groups, associated domains,
+# Apple Pay, URL-scheme, and user-activity identifiers; create a complete
+# white-label configuration before changing those.
 
 targets:
   App:
     settings:
       base:
         DEVELOPMENT_TEAM: YOUR_TEAM_ID
-        # PRODUCT_BUNDLE_IDENTIFIER: com.example.onebusaway
   OBAWidget:
     settings:
       base:
         DEVELOPMENT_TEAM: YOUR_TEAM_ID
-        # PRODUCT_BUNDLE_IDENTIFIER: com.example.onebusaway.widget

--- a/Apps/OneBusAway/project.yml
+++ b/Apps/OneBusAway/project.yml
@@ -111,3 +111,4 @@ include:
   - path: OBAKit/project.yml
   - path: OBAKitTests/project.yml
   - path: OBAWidget/project.yml
+

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -9,6 +9,7 @@
 
 import ActivityKit
 import Combine
+import CoreLocation
 import SwiftUI
 import OBAKitCore
 

--- a/README.markdown
+++ b/README.markdown
@@ -25,17 +25,17 @@ brew install xcodegen          # required to generate OBAKit.xcodeproj
 open OBAKit.xcodeproj
 ```
 
-`scripts/setup` verifies `xcodebuild` + XcodeGen, reminds you about signing, and calls `scripts/generate_project`. The generated `OBAKit.xcodeproj` is gitignored — always regenerate after pulling.
+`scripts/setup` verifies `xcodebuild` + XcodeGen, reminds you about signing, and calls `scripts/generate_project`. The generated `OBAKit.xcodeproj` is gitignored — always regenerate after pulling. Xcode resolves the project's Swift Package Manager dependencies when you open it.
 
 ### Signing / bundle IDs for contributors outside the OBA org
 
 Shared `Apps/OneBusAway/project.yml` points at the Open Transit Software Foundation team. For a personal build:
 
 1. `cp Apps/OneBusAway/local.yml.example Apps/OneBusAway/local.yml`
-2. Put your 10-character Team ID in `DEVELOPMENT_TEAM` (optional: change `PRODUCT_BUNDLE_IDENTIFIER`)
+2. Put your 10-character Team ID in `DEVELOPMENT_TEAM`
 3. Re-run `./scripts/setup`
 
-`Apps/*/local.yml` is gitignored. More detail: [wiki/Get-Started](https://github.com/OneBusAway/onebusaway-ios/wiki/Get-Started).
+`Apps/*/local.yml` is gitignored and is copied into the generated project, so it overrides the shared development team. `PRODUCT_BUNDLE_IDENTIFIER` is not a self-contained local override: app groups, associated domains, Apple Pay, URL schemes, and user-activity identifiers are still branded for the official apps. Change those identifiers together in a white-label configuration before using a different bundle ID on a device. More detail: [wiki/Get-Started](https://github.com/OneBusAway/onebusaway-ios/wiki/Get-Started).
 
 ## White Labeling
 

--- a/README.markdown
+++ b/README.markdown
@@ -12,9 +12,30 @@ OBAKit is a total rewrite of OneBusAway for iOS in the Swift programming languag
 
 ## Quick Start
 
-This project requires [XcodeGen](https://github.com/yonaskolb/XcodeGen) to generate Xcode project files. Third-party dependencies are installed via Xcode's Swift Package Manager.
+You can generate the project without opening Xcode first:
 
-See [wiki/Get-Started](https://github.com/OneBusAway/onebusaway-ios/wiki/Get-Started) for instructions.
+```bash
+# Install Xcode from the App Store, then (once):
+#   sudo xcode-select -s /Applications/Xcode.app
+#   open Xcode once to finish first-launch setup
+
+brew install xcodegen          # required to generate OBAKit.xcodeproj
+./scripts/setup                # checks deps, runs generate_project for OneBusAway
+# or: ./scripts/setup KiedyBus
+open OBAKit.xcodeproj
+```
+
+`scripts/setup` verifies `xcodebuild` + XcodeGen, reminds you about signing, and calls `scripts/generate_project`. The generated `OBAKit.xcodeproj` is gitignored — always regenerate after pulling.
+
+### Signing / bundle IDs for contributors outside the OBA org
+
+Shared `Apps/OneBusAway/project.yml` points at the Open Transit Software Foundation team. For a personal build:
+
+1. `cp Apps/OneBusAway/local.yml.example Apps/OneBusAway/local.yml`
+2. Put your 10-character Team ID in `DEVELOPMENT_TEAM` (optional: change `PRODUCT_BUNDLE_IDENTIFIER`)
+3. Re-run `./scripts/setup`
+
+`Apps/*/local.yml` is gitignored. More detail: [wiki/Get-Started](https://github.com/OneBusAway/onebusaway-ios/wiki/Get-Started).
 
 ## White Labeling
 

--- a/scripts/generate_project
+++ b/scripts/generate_project
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require "yaml"
+
 app = ARGV[0]
 
 if app.nil?
@@ -38,23 +40,54 @@ BEGIN {
     `rm -rf OBAKit.xcodeproj`
     `cp #{project_yml_path(app)} .`
     append_local_overrides(app)
-    puts `xcodegen`
+    system("xcodegen")
+    abort "XcodeGen failed; OBAKit.xcodeproj was not generated." unless $?.success?
     `mkdir -p OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm`
     `cp #{package_resolved_path(app)} OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/`
   end
 
   # XcodeGen's `optional: true` include still errors when the file is absent, so
   # we only wire Apps/<App>/local.yml when the contributor created it (#326).
+  #
+  # The including project.yml takes precedence over includes, so DEVELOPMENT_TEAM
+  # must also be copied into its target settings for local.yml to be authoritative.
   def append_local_overrides(app)
     local = "Apps/#{app}/local.yml"
     return unless File.exist?(local)
 
-    File.open("project.yml", "a") do |f|
-      f.puts ""
-      f.puts "include:"
-      f.puts "  - path: #{local}"
+    local_settings = YAML.load_file(local)
+    project = File.read("project.yml")
+    project = splice_include(project, local)
+
+    local_settings.fetch("targets", {}).each do |target, target_settings|
+      team = target_settings.dig("settings", "base", "DEVELOPMENT_TEAM")
+      next unless team
+
+      project = replace_development_team(project, target, team)
     end
+
+    File.write("project.yml", project)
     puts "Applying local overrides from #{local}"
+  end
+
+  def splice_include(project, local)
+    include = project.index(/^include:\s*$/)
+    abort "Could not find include list in project.yml." unless include
+
+    line_end = project.index("\n", include)
+    project.insert(line_end + 1, "  - path: #{local}\n")
+  end
+
+  def replace_development_team(project, target, team)
+    target_start = project.index(/^  #{Regexp.escape(target)}:\s*$/)
+    abort "Could not find target #{target} in project.yml." unless target_start
+
+    next_target = project.index(/^  \S/, target_start + 1) || project.length
+    target_spec = project[target_start...next_target]
+    replacement_count = target_spec.sub!(/^(\s{8}DEVELOPMENT_TEAM:\s*).+$/, "\\1#{team}")
+    abort "Could not find DEVELOPMENT_TEAM for target #{target} in project.yml." unless replacement_count
+
+    project[0...target_start] + target_spec + project[next_target..]
   end
 
   def project_yml_path(app)

--- a/scripts/generate_project
+++ b/scripts/generate_project
@@ -37,9 +37,24 @@ BEGIN {
   def generate_project(app)
     `rm -rf OBAKit.xcodeproj`
     `cp #{project_yml_path(app)} .`
+    append_local_overrides(app)
     puts `xcodegen`
     `mkdir -p OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm`
     `cp #{package_resolved_path(app)} OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/`
+  end
+
+  # XcodeGen's `optional: true` include still errors when the file is absent, so
+  # we only wire Apps/<App>/local.yml when the contributor created it (#326).
+  def append_local_overrides(app)
+    local = "Apps/#{app}/local.yml"
+    return unless File.exist?(local)
+
+    File.open("project.yml", "a") do |f|
+      f.puts ""
+      f.puts "include:"
+      f.puts "  - path: #{local}"
+    end
+    puts "Applying local overrides from #{local}"
   end
 
   def project_yml_path(app)

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Checks tooling needed to generate and open the OneBusAway iOS project,
+# then runs scripts/generate_project. See README.markdown Quick Start (#326).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+APP="${1:-OneBusAway}"
+MISSING=0
+
+say() { printf '%s\n' "$*"; }
+ok() { say "  ✓ $*"; }
+fail() { say "  ✗ $*"; MISSING=1; }
+
+say "Checking setup dependencies…"
+
+if command -v xcodebuild >/dev/null 2>&1; then
+  ok "Xcode / xcodebuild: $(xcodebuild -version 2>/dev/null | head -1)"
+else
+  fail "Xcode is not installed (or xcode-select path is wrong). Install Xcode from the App Store, then: sudo xcode-select -s /Applications/Xcode.app"
+fi
+
+if xcodebuild -checkFirstLaunchStatus >/dev/null 2>&1; then
+  ok "Xcode first-launch / license looks accepted"
+else
+  # -checkFirstLaunchStatus returns non-zero when setup is incomplete.
+  say "  ! If builds fail with license errors, open Xcode once or run: sudo xcodebuild -license accept"
+fi
+
+if command -v xcodegen >/dev/null 2>&1; then
+  ok "XcodeGen: $(xcodegen --version 2>/dev/null | head -1)"
+else
+  fail "XcodeGen missing. Install with: brew install xcodegen"
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  ok "Homebrew available"
+else
+  say "  ! Homebrew not found (optional, but easiest way to install XcodeGen)"
+fi
+
+if [[ -f "Apps/${APP}/project.yml" ]]; then
+  ok "App config present: Apps/${APP}/project.yml"
+else
+  fail "Missing Apps/${APP}/project.yml — pass a valid app name (OneBusAway, KiedyBus, …)"
+fi
+
+if [[ -f "Apps/${APP}/local.yml" ]]; then
+  ok "Local overrides: Apps/${APP}/local.yml (gitignored)"
+else
+  say "  · No Apps/${APP}/local.yml yet. Copy Apps/${APP}/local.yml.example to override DEVELOPMENT_TEAM / bundle ID without editing the shared project.yml."
+fi
+
+say ""
+if [[ "$MISSING" -ne 0 ]]; then
+  say "Fix the items marked ✗, then re-run: scripts/setup ${APP}"
+  exit 1
+fi
+
+say "Generating Xcode project for ${APP}…"
+./scripts/generate_project "$APP"
+
+say ""
+say "Next steps:"
+say "  1. Open OBAKit.xcodeproj in Xcode (do not commit the generated .xcodeproj)."
+say "  2. If signing fails, set DEVELOPMENT_TEAM in Apps/${APP}/local.yml (see local.yml.example) and re-run this script,"
+say "     or change the team in Xcode for your local build only."
+say "  3. Product → Test (scheme App) to verify the toolchain."


### PR DESCRIPTION
## Summary
- Adds `scripts/setup` to check Xcode / XcodeGen and generate the project without opening Xcode first.
- Makes a present `Apps/*/local.yml` authoritative for `DEVELOPMENT_TEAM` in the generated project while retaining the shared include list.
- Documents why a standalone `PRODUCT_BUNDLE_IDENTIFIER` override cannot produce a working personal device build.
- Closes #326.

## Test plan
- [x] `ruby -c scripts/generate_project`
- [x] Generate OneBusAway with a temporary `local.yml`; verify the temporary team ID appears four times in `project.pbxproj`
- [x] Substitute a failing `xcodegen`; verify `scripts/generate_project` exits nonzero without success output
- [ ] On a clean machine: install XcodeGen, run setup, open `OBAKit.xcodeproj`