### PR TITLE
Tick Live Activity countdowns with Text.timer

### DIFF
--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -9,6 +9,7 @@
 
 import ActivityKit
 import Combine
+import CoreLocation
 import SwiftUI
 import OBAKitCore
 

--- a/OBAKitCore/UI/LiveActivityCountdownView.swift
+++ b/OBAKitCore/UI/LiveActivityCountdownView.swift
@@ -1,0 +1,62 @@
+//
+//  LiveActivityCountdownView.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+
+/// Live Activity countdown that ticks on its own via `Text(_:style: .timer)`.
+///
+/// Unlike `CountdownView`'s static `"\(minutes)m"` string (which only changes when
+/// a push or local `Activity.update` arrives), the system redraws `.timer` text
+/// as the departure approaches — so the Lock Screen / Dynamic Island stay honest
+/// even when keepalive pushes are sparse (#1187).
+public struct LiveActivityCountdownView: View {
+    public let departureDate: Date
+    public let isRealTime: Bool
+    public let color: Color
+    /// `true` = card-header size, `false` = compact chips / island.
+    public var emphasized: Bool = true
+
+    public init(departureDate: Date, isRealTime: Bool, color: Color, emphasized: Bool = true) {
+        self.departureDate = departureDate
+        self.isRealTime = isRealTime
+        self.color = color
+        self.emphasized = emphasized
+    }
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: 2) {
+            countdownLabel
+                .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
+                .monospacedDigit()
+                .foregroundStyle(color)
+                .multilineTextAlignment(.trailing)
+            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
+                .padding(.top, 1)
+        }
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var countdownLabel: some View {
+        if LiveActivityCountdown.shouldShowNow(departureDate: departureDate) {
+            Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
+        } else {
+            Text(departureDate, style: .timer)
+        }
+    }
+}
+
+/// Pure helpers for Live Activity countdown presentation (#1187).
+public enum LiveActivityCountdown {
+    /// When the departure is at or before `now`, show "NOW" instead of a timer
+    /// that would start counting up.
+    public static func shouldShowNow(departureDate: Date, now: Date = Date()) -> Bool {
+        departureDate.timeIntervalSince(now) <= 0
+    }
+}

--- a/OBAKitCore/UI/LiveActivityCountdownView.swift
+++ b/OBAKitCore/UI/LiveActivityCountdownView.swift
@@ -9,7 +9,7 @@
 
 import SwiftUI
 
-/// Live Activity countdown that ticks on its own via `Text(_:style: .timer)`.
+/// Live Activity countdown that ticks on its own via a bounded timer interval.
 ///
 /// Unlike `CountdownView`'s static `"\(minutes)m"` string (which only changes when
 /// a push or local `Activity.update` arrives), the system redraws `.timer` text
@@ -42,21 +42,24 @@ public struct LiveActivityCountdownView: View {
         .accessibilityHidden(true)
     }
 
-    @ViewBuilder
     private var countdownLabel: some View {
-        if LiveActivityCountdown.shouldShowNow(departureDate: departureDate) {
-            Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
-        } else {
-            Text(departureDate, style: .timer)
-        }
+        Text(
+            timerInterval: LiveActivityCountdown.boundedTimerInterval(departureDate: departureDate),
+            pauseTime: departureDate,
+            countsDown: true,
+            showsHours: false
+        )
     }
 }
 
 /// Pure helpers for Live Activity countdown presentation (#1187).
 public enum LiveActivityCountdown {
-    /// When the departure is at or before `now`, show "NOW" instead of a timer
-    /// that would start counting up.
-    public static func shouldShowNow(departureDate: Date, now: Date = Date()) -> Bool {
-        departureDate.timeIntervalSince(now) <= 0
+    /// Returns a countdown interval that reaches zero at `departureDate` and
+    /// never becomes an elapsed-time counter after that instant.
+    public static func boundedTimerInterval(
+        departureDate: Date,
+        now: Date = Date()
+    ) -> ClosedRange<Date> {
+        min(now, departureDate)...departureDate
     }
 }

--- a/OBAKitCore/UI/TripActivityPresenter.swift
+++ b/OBAKitCore/UI/TripActivityPresenter.swift
@@ -27,6 +27,18 @@ public struct TripActivityPresenter {
         return formatters.shortFormattedTime(untilMinutes: minutes, temporalState: temporalState(minutes: minutes))
     }
 
+    /// Localized, expanded countdown text for assistive technologies.
+    public func countdownAccessibilityLabel(
+        for arrival: TripAttributes.ContentState.ArrivalInfo,
+        now: Date = Date()
+    ) -> String {
+        let minutes = Int(arrival.departureDate.timeIntervalSince(now) / 60.0)
+        return formatters.formattedTimeUntilArrivalDeparture(
+            arrivalDepartureMinutes: minutes,
+            temporalState: temporalState(minutes: minutes)
+        )
+    }
+
     public func color(for arrival: TripAttributes.ContentState.ArrivalInfo) -> UIColor {
         formatters.colorForScheduleStatus(arrival.scheduleStatus.scheduleStatus)
     }

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -59,7 +59,7 @@ public struct TripLiveActivityCardView: View {
             }
             Spacer(minLength: 8)
             if let primary {
-                countdownBadge(for: primary, now: now)
+                countdownBadge(for: primary)
             }
         }
     }
@@ -90,9 +90,11 @@ public struct TripLiveActivityCardView: View {
     }
 
     @ViewBuilder
-    private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
-        // `.timer` ticks without a push; static minute strings only moved on
-        // keepalive updates (#1187).
+    private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo) -> some View {
+        // The countdown ticks without a push; static minute strings only moved
+        // on keepalive updates (#1187). The adjacent deviation remains a
+        // content-snapshot value: deriving live adherence from a ticking timer
+        // requires a separate card redesign and is intentionally out of scope.
         LiveActivityCountdownView(
             departureDate: arrival.departureDate,
             isRealTime: arrival.scheduleStatus != .unknown,
@@ -121,13 +123,15 @@ public struct TripLiveActivityCardView: View {
     @ViewBuilder
     private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
         let color = Color(uiColor: presenter.color(for: arrival))
-        Group {
-            if LiveActivityCountdown.shouldShowNow(departureDate: arrival.departureDate, now: now) {
-                Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
-            } else {
-                Text(arrival.departureDate, style: .timer)
-            }
-        }
+        Text(
+            timerInterval: LiveActivityCountdown.boundedTimerInterval(
+                departureDate: arrival.departureDate,
+                now: now
+            ),
+            pauseTime: arrival.departureDate,
+            countsDown: true,
+            showsHours: false
+        )
             .font(.caption.weight(.heavy))
             .monospacedDigit()
             .foregroundStyle(color)

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -91,8 +91,10 @@ public struct TripLiveActivityCardView: View {
 
     @ViewBuilder
     private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
-        CountdownView(
-            minutes: Int(arrival.departureDate.timeIntervalSince(now) / 60.0),
+        // `.timer` ticks without a push; static minute strings only moved on
+        // keepalive updates (#1187).
+        LiveActivityCountdownView(
+            departureDate: arrival.departureDate,
             isRealTime: arrival.scheduleStatus != .unknown,
             color: Color(uiColor: presenter.color(for: arrival))
         )
@@ -119,10 +121,13 @@ public struct TripLiveActivityCardView: View {
     @ViewBuilder
     private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
         let color = Color(uiColor: presenter.color(for: arrival))
-        let minutes = max(0, Int(arrival.departureDate.timeIntervalSince(now) / 60.0))
-        Text(minutes == 0
-             ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now")
-             : "\(minutes)m")
+        Group {
+            if LiveActivityCountdown.shouldShowNow(departureDate: arrival.departureDate, now: now) {
+                Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
+            } else {
+                Text(arrival.departureDate, style: .timer)
+            }
+        }
             .font(.caption.weight(.heavy))
             .monospacedDigit()
             .foregroundStyle(color)

--- a/OBAKitTests/UI/LiveActivityCountdownTests.swift
+++ b/OBAKitTests/UI/LiveActivityCountdownTests.swift
@@ -12,17 +12,19 @@ struct LiveActivityCountdownTests {
 
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
 
-    @Test func futureDepartureUsesTimerNotNow() {
+    @Test func boundedTimerIntervalCountsDownToDeparture() {
         let departure = now.addingTimeInterval(300)
-        #expect(!LiveActivityCountdown.shouldShowNow(departureDate: departure, now: now))
+        let interval = LiveActivityCountdown.boundedTimerInterval(departureDate: departure, now: now)
+
+        #expect(interval.lowerBound == now)
+        #expect(interval.upperBound == departure)
     }
 
-    @Test func presentDepartureShowsNow() {
-        #expect(LiveActivityCountdown.shouldShowNow(departureDate: now, now: now))
-    }
-
-    @Test func pastDepartureShowsNow() {
+    @Test func boundedTimerIntervalClampsPastDepartureToZero() {
         let departure = now.addingTimeInterval(-60)
-        #expect(LiveActivityCountdown.shouldShowNow(departureDate: departure, now: now))
+        let interval = LiveActivityCountdown.boundedTimerInterval(departureDate: departure, now: now)
+
+        #expect(interval.lowerBound == departure)
+        #expect(interval.upperBound == departure)
     }
 }

--- a/OBAKitTests/UI/LiveActivityCountdownTests.swift
+++ b/OBAKitTests/UI/LiveActivityCountdownTests.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+struct LiveActivityCountdownTests {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func futureDepartureUsesTimerNotNow() {
+        let departure = now.addingTimeInterval(300)
+        #expect(!LiveActivityCountdown.shouldShowNow(departureDate: departure, now: now))
+    }
+
+    @Test func presentDepartureShowsNow() {
+        #expect(LiveActivityCountdown.shouldShowNow(departureDate: now, now: now))
+    }
+
+    @Test func pastDepartureShowsNow() {
+        let departure = now.addingTimeInterval(-60)
+        #expect(LiveActivityCountdown.shouldShowNow(departureDate: departure, now: now))
+    }
+}

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -63,6 +63,9 @@ struct TripLiveActivity: Widget {
                             .font(.system(size: 32, weight: .bold, design: .rounded))
                             .foregroundColor(Color(presenter.color(for: primary)))
                             .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                            .frame(maxWidth: 112, alignment: .trailing)
                             .padding(.trailing, 6)
                     }
                 }
@@ -102,6 +105,9 @@ struct TripLiveActivity: Widget {
                                         .fontWeight(.bold)
                                         .foregroundColor(Color(presenter.color(for: arrivalInfo)))
                                         .monospacedDigit()
+                                        .lineLimit(1)
+                                        .minimumScaleFactor(0.7)
+                                        .frame(maxWidth: 64, alignment: .trailing)
                                 }
                             }
                             .padding(.trailing, 6)
@@ -122,7 +128,9 @@ struct TripLiveActivity: Widget {
                         .fontWeight(.bold)
                         .foregroundColor(Color(presenter.color(for: primary)))
                         .monospacedDigit()
-                        .frame(minWidth: 20)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .frame(minWidth: 20, maxWidth: 56, alignment: .trailing)
                 }
             } minimal: {
                 if let primary {
@@ -131,17 +139,21 @@ struct TripLiveActivity: Widget {
                         .fontWeight(.heavy)
                         .foregroundColor(Color(presenter.color(for: primary)))
                         .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .frame(maxWidth: 48, alignment: .trailing)
                 }
             }
         }
     }
 
-    @ViewBuilder
     private func liveTimerText(for arrival: TripAttributes.ContentState.ArrivalInfo) -> some View {
-        if LiveActivityCountdown.shouldShowNow(departureDate: arrival.departureDate) {
-            Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
-        } else {
-            Text(arrival.departureDate, style: .timer)
-        }
+        Text(
+            timerInterval: LiveActivityCountdown.boundedTimerInterval(departureDate: arrival.departureDate),
+            pauseTime: arrival.departureDate,
+            countsDown: true,
+            showsHours: false
+        )
+        .accessibilityLabel(presenter.countdownAccessibilityLabel(for: arrival))
     }
 }

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -57,11 +57,12 @@ struct TripLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     if let primary {
-                        let primaryMinuteText = presenter.minuteText(for: primary)
-                        Text(primaryMinuteText)
+                        // System-driven `.timer` so the Island ticks without
+                        // keepalive pushes (#1187).
+                        liveTimerText(for: primary)
                             .font(.system(size: 32, weight: .bold, design: .rounded))
                             .foregroundColor(Color(presenter.color(for: primary)))
-                            .contentTransition(.numericText(value: Double(primaryMinuteText.filter("0123456789".contains)) ?? 0))
+                            .monospacedDigit()
                             .padding(.trailing, 6)
                     }
                 }
@@ -96,10 +97,11 @@ struct TripLiveActivity: Widget {
                             VStack(alignment: .trailing, spacing: 4) {
                                 let nextDepartures = upcoming.dropFirst().prefix(2)
                                 ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, arrivalInfo in
-                                    Text(presenter.minuteText(for: arrivalInfo))
+                                    liveTimerText(for: arrivalInfo)
                                         .font(.system(.callout, design: .rounded))
                                         .fontWeight(.bold)
                                         .foregroundColor(Color(presenter.color(for: arrivalInfo)))
+                                        .monospacedDigit()
                                 }
                             }
                             .padding(.trailing, 6)
@@ -115,20 +117,31 @@ struct TripLiveActivity: Widget {
                     .padding(.leading, 4)
             } compactTrailing: {
                 if let primary {
-                    Text(presenter.minuteText(for: primary))
+                    liveTimerText(for: primary)
                         .font(.system(.body, design: .rounded))
                         .fontWeight(.bold)
                         .foregroundColor(Color(presenter.color(for: primary)))
+                        .monospacedDigit()
                         .frame(minWidth: 20)
                 }
             } minimal: {
                 if let primary {
-                    Text(presenter.minuteText(for: primary))
+                    liveTimerText(for: primary)
                         .font(.system(.callout, design: .rounded))
                         .fontWeight(.heavy)
                         .foregroundColor(Color(presenter.color(for: primary)))
+                        .monospacedDigit()
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func liveTimerText(for arrival: TripAttributes.ContentState.ArrivalInfo) -> some View {
+        if LiveActivityCountdown.shouldShowNow(departureDate: arrival.departureDate) {
+            Text(OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
+        } else {
+            Text(arrival.departureDate, style: .timer)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces unbounded Live Activity timer labels with `Text(timerInterval:pauseTime:countsDown:showsHours:)`, clamped at departure.
- Removes the unreachable NOW branch, keeps Dynamic Island labels compact, and gives them localized VoiceOver countdown labels.
- Scope: the countdown is deliberately live while deviation/status text remains content-snapshot data; making the whole card internally time-consistent needs a separate redesign.
- Closes #1187.

## Test plan
- [x] `LiveActivityCountdownTests` — 2/2 on iPhone 17 Pro simulator
- [ ] Start a Live Activity on hardware and confirm all Island layouts fit the bounded timer
- [ ] Verify Lock Screen and always-on-display redaction behavior on hardware