### PR TITLE
Coalesce Live Activity updates and re-fetch relevance

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -314,38 +314,15 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 if !application.liveActivityTracker.isForwardingPushToken(activityID: activity.id) {
                     trackLiveActivity(activity, arrivalDepartures: arrivalDepartures)
                 }
-                // `Activity` is not Sendable and this loop's instance lives in the
-                // main-actor region, so it can't be sent to ActivityKit's @concurrent
-                // `update`. Re-fetch by ID inside a detached task instead — that copy
-                // never crosses an isolation boundary.
+                // Coalesce per activity ID. The worker re-fetches the activity
+                // before applying content, so its current relevance score is
+                // preserved across the asynchronous hop (#1197).
                 let activityID = activity.id
-                Task.detached {
-                    guard let activity = Activity<TripAttributes>.activities.first(where: { $0.id == activityID }) else {
-                        // The activity ended between the loop and this task; dropping
-                        // the update is correct, but log it so a stale Lock Screen is
-                        // diagnosable.
-                        Logger.info("Live Activity \(activityID) is no longer running; skipping update.")
-                        return
-                    }
-                    // Preserve prominence via the shared helper, reading the score
-                    // off this freshly re-fetched activity — not a snapshot taken
-                    // before the hop, which can predate a concurrent
-                    // promote/demote and would silently write the stale score
-                    // back, undoing it (#1243 review follow-up).
-                    //
-                    // `staleDate` stays nil here on purpose: unlike the
-                    // score-only promote/demote touches (which must carry the
-                    // push-set marker through), this update installs fresh local
-                    // content, and carrying a possibly-past stale-date forward
-                    // could mark it stale on arrival. The next push re-arms it.
-                    await activity.update(
-                        TripLiveActivityRelevance.contentPreservingRelevance(
-                            state: contentState,
-                            staleDate: nil,
-                            existing: activity.content
-                        )
+                Task {
+                    await LiveActivityUpdateCoalescer.shared.schedule(
+                        activityID: activityID,
+                        state: contentState
                     )
-                    Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")
                 }
             } else if !application.liveActivityTracker.isTracking(activityID: activity.id) {
                 // No bookmark/arrival data to register push updates with, but the activity is

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,6 +8,7 @@
 //
 
 import ActivityKit
+import CoreLocation
 import Combine
 import SwiftUI
 import OBAKitCore

--- a/OBAKitCore/LiveActivities/LiveActivityUpdateCoalescer.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityUpdateCoalescer.swift
@@ -1,0 +1,93 @@
+//
+//  LiveActivityUpdateCoalescer.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import ActivityKit
+import Foundation
+
+/// Serializes Live Activity content refreshes per activity ID (#1197).
+///
+/// `BookmarksViewController.updateRunningLiveActivities` used to spawn an
+/// unbounded `Task.detached` per activity on every poll. Two rapid cycles could
+/// apply an older `ContentState` after a newer one. This coalescer keeps only
+/// the latest pending state per ID and drains them one at a time.
+///
+/// Relevance is always read from the **re-fetched** `Activity.content` inside
+/// the detached work — not a snapshot captured on the main actor before the
+/// hop — so a prominence change that landed between enqueue and apply is kept.
+public actor LiveActivityUpdateCoalescer {
+    public static let shared = LiveActivityUpdateCoalescer()
+
+    private var mailbox = LiveActivityUpdateMailbox()
+    private var draining: Set<String> = []
+
+    public init() {}
+
+    /// Enqueue a content refresh. Only the latest state per `activityID` is kept.
+    public func schedule(activityID: String, state: TripAttributes.ContentState) {
+        mailbox.enqueue(activityID: activityID, state: state)
+        Task { await drain(activityID: activityID) }
+    }
+
+    /// Test seam: current pending count for an ID (0 or 1 after coalescing).
+    public func pendingCount(for activityID: String) -> Int {
+        mailbox.pending[activityID] == nil ? 0 : 1
+    }
+
+    private func drain(activityID: String) async {
+        guard !draining.contains(activityID) else { return }
+        draining.insert(activityID)
+        defer { draining.remove(activityID) }
+
+        while let state = mailbox.take(activityID: activityID) {
+            await Self.apply(activityID: activityID, state: state)
+        }
+    }
+
+    /// Re-fetches the activity by ID, preserves its current relevance score, and
+    /// applies `state`. Isolated as `static` so the actor isn't held across the
+    /// ActivityKit `update` await.
+    nonisolated private static func apply(
+        activityID: String,
+        state: TripAttributes.ContentState
+    ) async {
+        guard let activity = Activity<TripAttributes>.activities.first(where: { $0.id == activityID }) else {
+            Logger.info("Live Activity \(activityID) is no longer running; skipping coalesced update.")
+            return
+        }
+
+        let existing = activity.content
+        Logger.info(
+            "Updating Live Activity \(activityID) stop=\(activity.attributes.staticData.stopID) route=\(activity.attributes.staticData.routeShortName) relevanceScore=\(existing.relevanceScore)"
+        )
+
+        await activity.update(
+            TripLiveActivityRelevance.contentPreservingRelevance(
+                state: state,
+                staleDate: nil,
+                existing: existing
+            )
+        )
+    }
+}
+
+/// Pure pending-state map used by ``LiveActivityUpdateCoalescer`` so coalescing
+/// rules can be unit-tested without ActivityKit (#1197).
+public struct LiveActivityUpdateMailbox: Sendable {
+    public private(set) var pending: [String: TripAttributes.ContentState] = [:]
+
+    public init() {}
+
+    public mutating func enqueue(activityID: String, state: TripAttributes.ContentState) {
+        pending[activityID] = state
+    }
+
+    public mutating func take(activityID: String) -> TripAttributes.ContentState? {
+        pending.removeValue(forKey: activityID)
+    }
+}

--- a/OBAKitCore/LiveActivities/LiveActivityUpdateCoalescer.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityUpdateCoalescer.swift
@@ -15,28 +15,28 @@ import Foundation
 /// `BookmarksViewController.updateRunningLiveActivities` used to spawn an
 /// unbounded `Task.detached` per activity on every poll. Two rapid cycles could
 /// apply an older `ContentState` after a newer one. This coalescer keeps only
-/// the latest pending state per ID and drains them one at a time.
-///
-/// Relevance is always read from the **re-fetched** `Activity.content` inside
-/// the detached work — not a snapshot captured on the main actor before the
-/// hop — so a prominence change that landed between enqueue and apply is kept.
+/// the latest pending state per ID and applies states for that ID serially.
 public actor LiveActivityUpdateCoalescer {
+    public typealias Apply = @Sendable (String, TripAttributes.ContentState) async -> Void
+
     public static let shared = LiveActivityUpdateCoalescer()
 
     private var mailbox = LiveActivityUpdateMailbox()
     private var draining: Set<String> = []
+    private let applyState: Apply
 
-    public init() {}
+    public init() {
+        applyState = Self.applyToActivity
+    }
+
+    public init(apply: @escaping Apply) {
+        applyState = apply
+    }
 
     /// Enqueue a content refresh. Only the latest state per `activityID` is kept.
     public func schedule(activityID: String, state: TripAttributes.ContentState) {
         mailbox.enqueue(activityID: activityID, state: state)
         Task { await drain(activityID: activityID) }
-    }
-
-    /// Test seam: current pending count for an ID (0 or 1 after coalescing).
-    public func pendingCount(for activityID: String) -> Int {
-        mailbox.pending[activityID] == nil ? 0 : 1
     }
 
     private func drain(activityID: String) async {
@@ -45,14 +45,13 @@ public actor LiveActivityUpdateCoalescer {
         defer { draining.remove(activityID) }
 
         while let state = mailbox.take(activityID: activityID) {
-            await Self.apply(activityID: activityID, state: state)
+            await applyState(activityID, state)
         }
     }
 
     /// Re-fetches the activity by ID, preserves its current relevance score, and
-    /// applies `state`. Isolated as `static` so the actor isn't held across the
-    /// ActivityKit `update` await.
-    nonisolated private static func apply(
+    /// applies `state`.
+    nonisolated private static func applyToActivity(
         activityID: String,
         state: TripAttributes.ContentState
     ) async {
@@ -62,10 +61,11 @@ public actor LiveActivityUpdateCoalescer {
         }
 
         let existing = activity.content
-        Logger.info(
-            "Updating Live Activity \(activityID) stop=\(activity.attributes.staticData.stopID) route=\(activity.attributes.staticData.routeShortName) relevanceScore=\(existing.relevanceScore)"
-        )
-
+        // `staleDate` stays nil here on purpose: unlike the score-only
+        // promote/demote touches (which must carry the push-set marker
+        // through), this installs fresh local content. Carrying a possibly
+        // past stale date forward could mark it stale on arrival; the next
+        // push re-arms it.
         await activity.update(
             TripLiveActivityRelevance.contentPreservingRelevance(
                 state: state,
@@ -73,11 +73,13 @@ public actor LiveActivityUpdateCoalescer {
                 existing: existing
             )
         )
+        Logger.info(
+            "Updated Live Activity \(activityID) stop=\(activity.attributes.staticData.stopID) route=\(activity.attributes.staticData.routeShortName) relevanceScore=\(existing.relevanceScore)"
+        )
     }
 }
 
-/// Pure pending-state map used by ``LiveActivityUpdateCoalescer`` so coalescing
-/// rules can be unit-tested without ActivityKit (#1197).
+/// Pending content state keyed by Live Activity ID.
 public struct LiveActivityUpdateMailbox: Sendable {
     public private(set) var pending: [String: TripAttributes.ContentState] = [:]
 

--- a/OBAKitTests/Models/LiveActivityUpdateMailboxTests.swift
+++ b/OBAKitTests/Models/LiveActivityUpdateMailboxTests.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+struct LiveActivityUpdateMailboxTests {
+
+    private func state(departureOffset: Int) -> TripAttributes.ContentState {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let arrival = TripAttributes.ContentState.ArrivalInfo(
+            departureTime: Int(now.timeIntervalSince1970) + departureOffset,
+            scheduleStatus: .onTime,
+            scheduleDeviation: 0,
+            isArrival: false
+        )
+        return TripAttributes.ContentState(arrivals: [arrival])
+    }
+
+    @Test func enqueueKeepsOnlyLatestStatePerActivity() {
+        var mailbox = LiveActivityUpdateMailbox()
+        let older = state(departureOffset: 600)
+        let newer = state(departureOffset: 300)
+
+        mailbox.enqueue(activityID: "a1", state: older)
+        mailbox.enqueue(activityID: "a1", state: newer)
+
+        #expect(mailbox.pending.count == 1)
+        let taken = mailbox.take(activityID: "a1")
+        #expect(taken?.arrivals.first?.departureTime == newer.arrivals.first?.departureTime)
+        #expect(mailbox.take(activityID: "a1") == nil)
+    }
+
+    @Test func differentActivityIDsStayIndependent() {
+        var mailbox = LiveActivityUpdateMailbox()
+        mailbox.enqueue(activityID: "a1", state: state(departureOffset: 100))
+        mailbox.enqueue(activityID: "a2", state: state(departureOffset: 200))
+
+        #expect(mailbox.pending.count == 2)
+        #expect(mailbox.take(activityID: "a1")?.arrivals.first?.departureTime != nil)
+        #expect(mailbox.pending.count == 1)
+    }
+}

--- a/OBAKitTests/Models/LiveActivityUpdateMailboxTests.swift
+++ b/OBAKitTests/Models/LiveActivityUpdateMailboxTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import Testing
 @testable import OBAKitCore
 
-struct LiveActivityUpdateMailboxTests {
+struct LiveActivityUpdateCoalescerTests {
 
     private func state(departureOffset: Int) -> TripAttributes.ContentState {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
@@ -21,27 +21,77 @@ struct LiveActivityUpdateMailboxTests {
         return TripAttributes.ContentState(arrivals: [arrival])
     }
 
-    @Test func enqueueKeepsOnlyLatestStatePerActivity() {
-        var mailbox = LiveActivityUpdateMailbox()
-        let older = state(departureOffset: 600)
-        let newer = state(departureOffset: 300)
+    @Test func seriallyAppliesFirstAndLatestStateWhileApplyIsInFlight() async {
+        let gate = ApplyGate()
+        let coalescer = LiveActivityUpdateCoalescer { _, state in
+            await gate.apply(state)
+        }
 
-        mailbox.enqueue(activityID: "a1", state: older)
-        mailbox.enqueue(activityID: "a1", state: newer)
+        await coalescer.schedule(activityID: "a1", state: state(departureOffset: 600))
+        await gate.waitForFirstApply()
 
-        #expect(mailbox.pending.count == 1)
-        let taken = mailbox.take(activityID: "a1")
-        #expect(taken?.arrivals.first?.departureTime == newer.arrivals.first?.departureTime)
-        #expect(mailbox.take(activityID: "a1") == nil)
+        await coalescer.schedule(activityID: "a1", state: state(departureOffset: 500))
+        await coalescer.schedule(activityID: "a1", state: state(departureOffset: 300))
+        await gate.releaseFirstApply()
+        await gate.waitForApplyCount(2)
+
+        let result = await gate.result()
+        #expect(result.departureOffsets == [600, 300])
+        #expect(!result.appliesOverlapped)
     }
 
-    @Test func differentActivityIDsStayIndependent() {
-        var mailbox = LiveActivityUpdateMailbox()
-        mailbox.enqueue(activityID: "a1", state: state(departureOffset: 100))
-        mailbox.enqueue(activityID: "a2", state: state(departureOffset: 200))
+    private actor ApplyGate {
+        private let reference = Date(timeIntervalSince1970: 1_700_000_000)
+        private var departureOffsets: [Int] = []
+        private var appliesOverlapped = false
+        private var applying = false
+        private var firstApplyWaiter: CheckedContinuation<Void, Never>?
+        private var releaseFirstApplyWaiter: CheckedContinuation<Void, Never>?
+        private var applyCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
-        #expect(mailbox.pending.count == 2)
-        #expect(mailbox.take(activityID: "a1")?.arrivals.first?.departureTime != nil)
-        #expect(mailbox.pending.count == 1)
+        func apply(_ state: TripAttributes.ContentState) async {
+            appliesOverlapped = appliesOverlapped || applying
+            applying = true
+            let departureTime = state.arrivals[0].departureTime
+            departureOffsets.append(departureTime - Int(reference.timeIntervalSince1970))
+
+            if departureOffsets.count == 1 {
+                firstApplyWaiter?.resume()
+                firstApplyWaiter = nil
+                await withCheckedContinuation { releaseFirstApplyWaiter = $0 }
+            }
+
+            applying = false
+            resumeApplyCountWaiters()
+        }
+
+        func waitForFirstApply() async {
+            if !departureOffsets.isEmpty {
+                return
+            }
+            await withCheckedContinuation { firstApplyWaiter = $0 }
+        }
+
+        func releaseFirstApply() {
+            releaseFirstApplyWaiter?.resume()
+            releaseFirstApplyWaiter = nil
+        }
+
+        func waitForApplyCount(_ count: Int) async {
+            if departureOffsets.count >= count {
+                return
+            }
+            await withCheckedContinuation { applyCountWaiters.append((count, $0)) }
+        }
+
+        func result() -> (departureOffsets: [Int], appliesOverlapped: Bool) {
+            (departureOffsets, appliesOverlapped)
+        }
+
+        private func resumeApplyCountWaiters() {
+            let ready = applyCountWaiters.filter { departureOffsets.count >= $0.0 }
+            applyCountWaiters.removeAll { departureOffsets.count >= $0.0 }
+            ready.forEach { $0.1.resume() }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Rebases the coalescer onto upstream/main and preserves the content-refresh `staleDate: nil` rationale.
- Keeps per-ID serial draining, injects the apply operation, and logs only after a successful ActivityKit update.
- Adds a drain-ordering test that holds the first apply, queues two more states, and verifies serial first/latest application.
- Closes #1197.

## Test plan
- [ ] `xcodebuild build-for-testing` is blocked on rebased upstream/main: `TripPageViewController.swift:140` cannot find `CLLocationCoordinate2D` in scope.
- [ ] On hardware: refresh a tracked bookmark rapidly and verify the final state and Dynamic Island ranking.