### PR TITLE
Polish EditBookmarkViewModel follow-ups from #1138

### DIFF
--- a/OBAKit/Bookmarks/AddBookmarkViewController.swift
+++ b/OBAKit/Bookmarks/AddBookmarkViewController.swift
@@ -107,8 +107,10 @@ class AddBookmarkViewController: TaskController<[ArrivalDeparture]>, OBAListView
 
     // MARK: - Data and UI
     override func loadData() async throws -> [ArrivalDeparture] {
-        // An empty `preloadedArrivals` array deliberately short-circuits the fetch
-        // and surfaces the "no upcoming departures" view; pass `nil` to fetch fresh.
+        // An empty `preloadedArrivals` array deliberately short-circuits the fetch.
+        // There is no dedicated empty-state screen: the trip section shows the
+        // inline "route bookmarks unavailable" explanation while the whole-stop
+        // bookmark row remains. Pass `nil` to fetch fresh arrivals.
         if let preloadedArrivals {
             return preloadedArrivals
         }

--- a/OBAKit/Bookmarks/EditBookmarkViewController.swift
+++ b/OBAKit/Bookmarks/EditBookmarkViewController.swift
@@ -180,13 +180,12 @@ class EditBookmarkViewController: FormViewController, AddGroupAlertDelegate {
         let rawSelectedGroupID = selectedBookmarkGroupSection.selectedRows().first?.value ?? ""
         let selectedGroupID = UUID(optionalUUIDString: rawSelectedGroupID)
 
-        let commit: (Bookmark, Bool) -> Void = { [weak self] bookmark, isNew in
+        let notifyEdited: (Bookmark, Bool) -> Void = { [weak self] bookmark, isNew in
             guard let self else { return }
-            self.viewModel.persist(bookmark, name: rawName, isFavorite: isFavorite, to: selectedGroupID, isNewBookmark: isNew)
             self.delegate?.bookmarkEditor(self, editedBookmark: bookmark, isNewBookmark: isNew)
         }
 
-        switch viewModel.prepareToSave(name: rawName, isFavorite: isFavorite) {
+        switch viewModel.prepareToSave(name: rawName) {
         case .regionUnavailable:
             let alert = UIAlertController(
                 title: OBALoc("edit_bookmark_controller.region_error.title", value: "Unable to Save", comment: "Title of an alert shown when a bookmark cannot be saved because the current region is unavailable."),
@@ -196,17 +195,31 @@ class EditBookmarkViewController: FormViewController, AddGroupAlertDelegate {
             alert.addAction(UIAlertAction(title: Strings.ok, style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
 
-        case .readyToSave(let bookmark, let isNew):
-            commit(bookmark, isNew)
+        case .readyToSaveNew(let bookmark):
+            viewModel.persistNew(bookmark, name: rawName, isFavorite: isFavorite, to: selectedGroupID)
+            notifyEdited(bookmark, true)
+
+        case .readyToSaveExisting(let bookmark):
+            viewModel.persistExisting(bookmark, name: rawName, isFavorite: isFavorite, to: selectedGroupID)
+            notifyEdited(bookmark, false)
 
         case .duplicateRequiresConfirmation(let bookmark):
             let alert = UIAlertController(
                 title: OBALoc("edit_bookmark_controller.duplicate_alert.title", value: "Duplicate Bookmark", comment: "The title of an alert telling the user that they have already bookmarked this thing. Noun form of 'duplicate', not the verb."),
                 message: OBALoc("edit_bookmark_controller.duplicate_alert.body", value: "You already have this bookmarked. Did you mean to create a duplicate?", comment: "Body of an alert telling the user they have already bookmarked this thing."), preferredStyle: .alert
             )
-            alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel, handler: nil))
-            alert.addAction(UIAlertAction(title: OBALoc("edit_bookmark_controller.duplicate_alert.affirmative_button", value: "Create Duplicate", comment: "Indicates that the user wants to create a duplicate bookmark."), style: .default, handler: { _ in
-                commit(bookmark, true)
+            alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel, handler: { [weak self] _ in
+                self?.viewModel.resolveDuplicate(.cancelled, name: rawName, isFavorite: isFavorite, to: selectedGroupID)
+            }))
+            alert.addAction(UIAlertAction(title: OBALoc("edit_bookmark_controller.duplicate_alert.affirmative_button", value: "Create Duplicate", comment: "Indicates that the user wants to create a duplicate bookmark."), style: .default, handler: { [weak self] _ in
+                guard let self else { return }
+                self.viewModel.resolveDuplicate(
+                    .createDuplicate(bookmark),
+                    name: rawName,
+                    isFavorite: isFavorite,
+                    to: selectedGroupID
+                )
+                notifyEdited(bookmark, true)
             }))
             present(alert, animated: true, completion: nil)
         }

--- a/OBAKit/Bookmarks/ManageBookmarksViewController.swift
+++ b/OBAKit/Bookmarks/ManageBookmarksViewController.swift
@@ -184,10 +184,9 @@ class ManageBookmarksViewController: FormViewController {
                 let trimmed = nameRow.value?.trimmingCharacters(in: .whitespaces) ?? ""
                 guard trimmed.isEmpty else { continue }
 
-                guard
-                    let bookmarkID = UUID(optionalUUIDString: nameRow.tag),
-                    let bookmark = viewModel.findBookmark(id: bookmarkID)
-                else {
+                guard let bookmarkID = UUID(optionalUUIDString: nameRow.tag) else { continue }
+                guard let bookmark = viewModel.findBookmark(id: bookmarkID) else {
+                    Logger.warn("restoreEmptyBookmarkNames: bookmark \(bookmarkID) not found in data store; skipping name restore")
                     continue
                 }
 

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,6 +8,7 @@
 //
 
 import ActivityKit
+import CoreLocation
 import Combine
 import SwiftUI
 import OBAKitCore

--- a/OBAKit/ViewModels/EditBookmarkViewModel.swift
+++ b/OBAKit/ViewModels/EditBookmarkViewModel.swift
@@ -27,10 +27,20 @@ enum BookmarkSource {
     }
 }
 
+/// Outcome of validating a save. New vs existing is a separate case so a
+/// `(bookmark, isNew)` pair can never disagree (#1145).
 enum SaveOutcome {
     case regionUnavailable
-    case readyToSave(Bookmark, isNew: Bool)
+    case readyToSaveNew(Bookmark)
+    case readyToSaveExisting(Bookmark)
     case duplicateRequiresConfirmation(Bookmark)
+}
+
+/// User response to the duplicate-bookmark alert. Cancel must not persist or
+/// fire analytics (#1145 / #1138).
+enum DuplicateBookmarkDecision {
+    case cancelled
+    case createDuplicate(Bookmark)
 }
 
 /// Shared ViewModel for creating and editing a single bookmark.
@@ -112,10 +122,9 @@ final class EditBookmarkViewModel {
     /// Validates that a region is available and, in add mode, builds the `Bookmark`
     /// and checks for duplicates against the data store.
     ///
-    /// Does NOT mutate the existing bookmark or write to the data store. The form
-    /// values (`name`, `isFavorite`) are applied to the bookmark inside
-    /// `persist(_:name:isFavorite:to:isNewBookmark:)`.
-    func prepareToSave(name: String, isFavorite: Bool) -> SaveOutcome {
+    /// Does NOT mutate the existing bookmark or write to the data store. The
+    /// `name` form value is applied inside `persist`.
+    func prepareToSave(name: String) -> SaveOutcome {
         guard let region = application.currentRegion else { return .regionUnavailable }
 
         switch mode {
@@ -131,22 +140,52 @@ final class EditBookmarkViewModel {
             if application.userDataStore.checkForDuplicates(bookmark: bookmark) {
                 return .duplicateRequiresConfirmation(bookmark)
             }
-            return .readyToSave(bookmark, isNew: true)
+            return .readyToSaveNew(bookmark)
         case .edit(let bookmark):
-            return .readyToSave(bookmark, isNew: false)
+            return .readyToSaveExisting(bookmark)
         }
     }
 
-    /// Applies the form values to `bookmark`, saves it to the data store, and
-    /// reports analytics for new trip bookmarks.
-    func persist(_ bookmark: Bookmark, name: String, isFavorite: Bool, to groupID: UUID?, isNewBookmark: Bool) {
+    /// Applies the form values to `bookmark`, saves it, and reports analytics for
+    /// new trip bookmarks. Prefer the typed `SaveOutcome` / `DuplicateBookmarkDecision`
+    /// helpers so callers can't pass a mismatched new/existing flag.
+    func persistNew(_ bookmark: Bookmark, name: String, isFavorite: Bool, to groupID: UUID?) {
+        persist(bookmark, name: name, isFavorite: isFavorite, to: groupID, reportAddAnalytics: true)
+    }
+
+    func persistExisting(_ bookmark: Bookmark, name: String, isFavorite: Bool, to groupID: UUID?) {
+        persist(bookmark, name: name, isFavorite: isFavorite, to: groupID, reportAddAnalytics: false)
+    }
+
+    /// Handles the duplicate alert. Cancel is a no-op (no store write, no analytics).
+    func resolveDuplicate(
+        _ decision: DuplicateBookmarkDecision,
+        name: String,
+        isFavorite: Bool,
+        to groupID: UUID?
+    ) {
+        switch decision {
+        case .cancelled:
+            return
+        case .createDuplicate(let bookmark):
+            persistNew(bookmark, name: name, isFavorite: isFavorite, to: groupID)
+        }
+    }
+
+    private func persist(
+        _ bookmark: Bookmark,
+        name: String,
+        isFavorite: Bool,
+        to groupID: UUID?,
+        reportAddAnalytics: Bool
+    ) {
         bookmark.name = resolveName(name)
         bookmark.isFavorite = isFavorite
 
         let group = groupID.flatMap { application.userDataStore.findGroup(id: $0) }
         application.userDataStore.add(bookmark, to: group)
 
-        if isNewBookmark, case .arrivalDeparture(let ad) = source {
+        if reportAddAnalytics, case .arrivalDeparture(let ad) = source {
             let value = AnalyticsLabels.addRemoveBookmarkValue(
                 routeID: ad.routeID,
                 headsign: ad.tripHeadsign,

--- a/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
+++ b/OBAKitTests/ViewModels/EditBookmarkViewModelTests.swift
@@ -240,7 +240,7 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplicationWithoutRegion(dataLoader: dataLoader)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "My Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "My Stop")
 
         guard case .regionUnavailable = outcome else {
             Issue.record("Expected .regionUnavailable, got \(outcome)")
@@ -255,14 +255,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplication(dataLoader: dataLoader)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "My Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "My Stop")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave, got \(outcome)")
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew, got \(outcome)")
             return
         }
         #expect(bookmark.name == "My Stop")
-        #expect(isNew)
     }
 
     @Test @MainActor
@@ -272,10 +271,10 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplication(dataLoader: dataLoader)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "   ", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "   ")
 
-        guard case .readyToSave(let bookmark, _) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew"); return
         }
         #expect(bookmark.name == Formatters.formattedTitle(stop: stop))
     }
@@ -290,7 +289,7 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(existing, to: nil)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Stop")
 
         guard case .duplicateRequiresConfirmation(let dup) = outcome else {
             Issue.record("Expected .duplicateRequiresConfirmation, got \(outcome)")
@@ -312,17 +311,16 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(bookmark, to: nil)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: bookmark)
-        let outcome = vm.prepareToSave(name: "Updated Name", isFavorite: false)
+        let outcome = vm.prepareToSave(name: "Updated Name")
 
-        guard case .readyToSave(let saved, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave, got \(outcome)")
+        guard case .readyToSaveExisting(let saved) = outcome else {
+            Issue.record("Expected .readyToSaveExisting, got \(outcome)")
             return
         }
         #expect(saved.name == "Original")
         #expect(saved.isFavorite)
-        #expect(!isNew)
 
-        vm.persist(saved, name: "Updated Name", isFavorite: false, to: nil, isNewBookmark: isNew)
+        vm.persistExisting(saved, name: "Updated Name", isFavorite: false, to: nil)
         #expect(saved.name == "Updated Name")
         #expect(!saved.isFavorite)
     }
@@ -337,12 +335,12 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(bookmark, to: nil)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: bookmark)
-        let outcome = vm.prepareToSave(name: "   ", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "   ")
 
-        guard case .readyToSave(let saved, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveExisting(let saved) = outcome else {
+            Issue.record("Expected .readyToSaveExisting"); return
         }
-        vm.persist(saved, name: "   ", isFavorite: true, to: nil, isNewBookmark: isNew)
+        vm.persistExisting(saved, name: "   ", isFavorite: true, to: nil)
         #expect(saved.name == Formatters.formattedTitle(stop: stop))
     }
 
@@ -356,13 +354,12 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(bookmark, to: nil)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: bookmark)
-        let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Stop")
 
-        guard case .readyToSave(_, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave, got \(outcome)")
+        guard case .readyToSaveExisting = outcome else {
+            Issue.record("Expected .readyToSaveExisting, got \(outcome)")
             return
         }
-        #expect(!isNew)
     }
 
     // MARK: - persist
@@ -374,13 +371,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplication(dataLoader: dataLoader)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "Home", isFavorite: false)
+        let outcome = vm.prepareToSave(name: "Home")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew"); return
         }
 
-        vm.persist(bookmark, name: "Home", isFavorite: false, to: nil, isNewBookmark: isNew)
+        vm.persistNew(bookmark, name: "Home", isFavorite: false, to: nil)
 
         #expect(app.userDataStore.findBookmark(id: bookmark.id) != nil)
     }
@@ -395,13 +392,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.upsert(bookmarkGroup: group)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Stop")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew"); return
         }
 
-        vm.persist(bookmark, name: "Stop", isFavorite: true, to: group.id, isNewBookmark: isNew)
+        vm.persistNew(bookmark, name: "Stop", isFavorite: true, to: group.id)
 
         let inGroup = app.userDataStore.bookmarksInGroup(group)
         #expect(inGroup.contains { $0.id == bookmark.id })
@@ -422,13 +419,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(bookmark, to: groupA)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: bookmark)
-        let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Stop")
 
-        guard case .readyToSave(let saved, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveExisting(let saved) = outcome else {
+            Issue.record("Expected .readyToSaveExisting"); return
         }
 
-        vm.persist(saved, name: "Stop", isFavorite: true, to: groupB.id, isNewBookmark: isNew)
+        vm.persistExisting(saved, name: "Stop", isFavorite: true, to: groupB.id)
 
         #expect(app.userDataStore.bookmarksInGroup(groupB).contains { $0.id == bookmark.id })
     }
@@ -441,13 +438,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplication(dataLoader: dataLoader, analytics: analyticsMock)
 
         let vm = EditBookmarkViewModel(application: app, source: .arrivalDeparture(arrivalDep), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "Route", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Route")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew"); return
         }
 
-        vm.persist(bookmark, name: "Route", isFavorite: true, to: nil, isNewBookmark: isNew)
+        vm.persistNew(bookmark, name: "Route", isFavorite: true, to: nil)
 
         let addBookmarkEvents = analyticsMock.reportedEvents.filter { $0.label == AnalyticsLabels.addBookmark }
         #expect(addBookmarkEvents.count == 1)
@@ -470,13 +467,13 @@ final class EditBookmarkViewModelTests: OBATestCase {
         app.userDataStore.add(existing, to: nil)
 
         let vm = EditBookmarkViewModel(application: app, source: .arrivalDeparture(arrivalDep), bookmark: existing)
-        let outcome = vm.prepareToSave(name: "Updated Route", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Updated Route")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveExisting(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveExisting"); return
         }
 
-        vm.persist(bookmark, name: "Updated Route", isFavorite: true, to: nil, isNewBookmark: isNew)
+        vm.persistExisting(bookmark, name: "Updated Route", isFavorite: true, to: nil)
 
         #expect(analyticsMock.reportedEvents.filter { $0.label == AnalyticsLabels.addBookmark }.isEmpty)
     }
@@ -489,15 +486,38 @@ final class EditBookmarkViewModelTests: OBATestCase {
         let app = createApplication(dataLoader: dataLoader, analytics: analyticsMock)
 
         let vm = EditBookmarkViewModel(application: app, source: .stop(stop), bookmark: nil)
-        let outcome = vm.prepareToSave(name: "Stop", isFavorite: true)
+        let outcome = vm.prepareToSave(name: "Stop")
 
-        guard case .readyToSave(let bookmark, let isNew) = outcome else {
-            Issue.record("Expected .readyToSave"); return
+        guard case .readyToSaveNew(let bookmark) = outcome else {
+            Issue.record("Expected .readyToSaveNew"); return
         }
 
-        vm.persist(bookmark, name: "Stop", isFavorite: true, to: nil, isNewBookmark: isNew)
+        vm.persistNew(bookmark, name: "Stop", isFavorite: true, to: nil)
 
         let addBookmarkEvents = analyticsMock.reportedEvents.filter { $0.label == AnalyticsLabels.addBookmark }
         #expect(addBookmarkEvents.isEmpty)
+    }
+
+    @Test @MainActor
+    func `Confirming duplicate persists and reports analytics for trip bookmark`() throws {
+        let arrivalDep = try makeArrivalDeparture()
+        let analyticsMock = AnalyticsMock()
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: analyticsMock)
+
+        let existing = Bookmark(name: "Route", regionIdentifier: pugetSoundRegionIdentifier, arrivalDeparture: arrivalDep)
+        app.userDataStore.add(existing, to: nil)
+
+        let vm = EditBookmarkViewModel(application: app, source: .arrivalDeparture(arrivalDep), bookmark: nil)
+        guard case .duplicateRequiresConfirmation(let dup) = vm.prepareToSave(name: "Route") else {
+            Issue.record("Expected .duplicateRequiresConfirmation")
+            return
+        }
+
+        vm.resolveDuplicate(.createDuplicate(dup), name: "Route", isFavorite: true, to: nil)
+
+        #expect(app.userDataStore.findBookmark(id: dup.id) != nil)
+        #expect(app.userDataStore.bookmarks.count == 2)
+        #expect(analyticsMock.reportedEvents.filter { $0.label == AnalyticsLabels.addBookmark }.count == 1)
     }
 }


### PR DESCRIPTION
## Summary
- Removes the unused `isFavorite` argument from `prepareToSave`.
- Splits `SaveOutcome` into `readyToSaveNew` / `readyToSaveExisting` so newness cannot disagree with the bookmark.
- Drops the vacuous duplicate-cancellation ViewModel test and strengthens duplicate-confirmation coverage with a two-bookmark assertion.
- Corrects the `prepareToSave` documentation.
- Refs #1145.

## Test plan
- [ ] `EditBookmarkViewModelTests` — blocked before tests by the current upstream/main OBAKit TripPage build failure under this Xcode.
- [ ] Controller-level duplicate-cancellation coverage remains follow-up work for #1145.