### PR TITLE
Fix bookmark callout dismissed on map pan

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -430,11 +430,24 @@ public class MapRegionManager: NSObject,
         }
     }
 
+    /// Stop IDs the rider is actively looking at — from either a `Stop` or `Bookmark`
+    /// annotation selection. Used to preserve callouts when annotations reload.
+    private var selectedStopIDs: Set<StopID> {
+        Set(mapView.selectedAnnotations.compactMap { annotation -> StopID? in
+            if let stop = annotation as? Stop {
+                return stop.id
+            }
+            if let bookmark = annotation as? Bookmark {
+                return bookmark.stopID
+            }
+            return nil
+        })
+    }
+
     /// Removes stop annotations for the layer toggle, but never a stop the rider is
     /// actively looking at: a searched or selected stop is explicit user intent and
     /// outranks the browse-layer preference (bookmarks get the same exemption).
     private func removeStopAnnotationsPreservingSelection() {
-        let selectedStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Stop)?.id })
         let stopsToRemove = mapView.annotations.compactMap { $0 as? Stop }.filter { !selectedStopIDs.contains($0.id) }
         mapView.removeAnnotations(stopsToRemove)
     }
@@ -626,6 +639,12 @@ public class MapRegionManager: NSObject,
             !existingStopIDs.contains($0.id)
         } : []
         mapView.addAnnotations(stopsToAdd)
+
+        // Removing a sibling Stop for a bookmarked stopID shouldn't refresh a
+        // selected Bookmark — rebinding its view dismisses an open callout.
+        let selectedBookmarkStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Bookmark)?.stopID })
+        affectedStopIDs.subtract(selectedBookmarkStopIDs)
+
         refreshAnnotationViews(for: Array(affectedStopIDs))
         notifyDelegatesStopsChanged()
     }
@@ -645,6 +664,12 @@ public class MapRegionManager: NSObject,
                   let view = mapView.view(for: annotation) as? StopAnnotationView else {
                 continue
             }
+
+            // Rebinding a selected annotation dismisses its callout; skip it.
+            guard !mapView.selectedAnnotations.contains(where: { $0 === annotation }) else {
+                continue
+            }
+
             view.prepareForReuse()
             view.annotation = annotation
             view.delegate = self
@@ -893,9 +918,13 @@ public class MapRegionManager: NSObject,
             return
         }
 
-        let visibleStops = mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self)
-        for s in visibleStops {
-            if let stopView = mapView.view(for: s) as? StopAnnotationView {
+        for stop in mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self) {
+            if let stopView = mapView.view(for: stop) as? StopAnnotationView {
+                stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
+            }
+        }
+        for bookmark in mapView.annotations(in: mapView.visibleMapRect).filter(type: Bookmark.self) {
+            if let stopView = mapView.view(for: bookmark) as? StopAnnotationView {
                 stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
             }
         }

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -501,11 +501,24 @@ public class MapRegionManager: NSObject,
         }
     }
 
+    /// Stop IDs the rider is actively looking at — from either a `Stop` or `Bookmark`
+    /// annotation selection. Used to preserve callouts when annotations reload.
+    private var selectedStopIDs: Set<StopID> {
+        Set(mapView.selectedAnnotations.compactMap { annotation -> StopID? in
+            if let stop = annotation as? Stop {
+                return stop.id
+            }
+            if let bookmark = annotation as? Bookmark {
+                return bookmark.stopID
+            }
+            return nil
+        })
+    }
+
     /// Removes stop annotations for the layer toggle, but never a stop the rider is
     /// actively looking at: a searched or selected stop is explicit user intent and
     /// outranks the browse-layer preference (bookmarks get the same exemption).
     private func removeStopAnnotationsPreservingSelection() {
-        let selectedStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Stop)?.id })
         let stopsToRemove = mapView.annotations.compactMap { $0 as? Stop }.filter { !selectedStopIDs.contains($0.id) }
         mapView.removeAnnotations(stopsToRemove)
     }
@@ -697,6 +710,12 @@ public class MapRegionManager: NSObject,
             !existingStopIDs.contains($0.id)
         } : []
         mapView.addAnnotations(stopsToAdd)
+
+        // Removing a sibling Stop for a bookmarked stopID shouldn't refresh a
+        // selected Bookmark — rebinding its view dismisses an open callout.
+        let selectedBookmarkStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Bookmark)?.stopID })
+        affectedStopIDs.subtract(selectedBookmarkStopIDs)
+
         refreshAnnotationViews(for: Array(affectedStopIDs))
         notifyDelegatesStopsChanged()
     }
@@ -716,6 +735,12 @@ public class MapRegionManager: NSObject,
                   let view = mapView.view(for: annotation) as? StopAnnotationView else {
                 continue
             }
+
+            // Rebinding a selected annotation dismisses its callout; skip it.
+            guard !mapView.selectedAnnotations.contains(where: { $0 === annotation }) else {
+                continue
+            }
+
             view.prepareForReuse()
             view.annotation = annotation
             view.delegate = self
@@ -981,9 +1006,13 @@ public class MapRegionManager: NSObject,
             return
         }
 
-        let visibleStops = mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self)
-        for s in visibleStops {
-            if let stopView = mapView.view(for: s) as? StopAnnotationView {
+        for stop in mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self) {
+            if let stopView = mapView.view(for: stop) as? StopAnnotationView {
+                stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
+            }
+        }
+        for bookmark in mapView.annotations(in: mapView.visibleMapRect).filter(type: Bookmark.self) {
+            if let stopView = mapView.view(for: bookmark) as? StopAnnotationView {
                 stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
             }
         }

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -976,6 +976,18 @@ public class MapRegionManager: NSObject,
 
     // MARK: - Map View Delegate
 
+    /// Applies the current under-pin label gate to every bookmark pin on the map.
+    /// Bookmarks stay visible through search, zoom, and a disabled stops layer,
+    /// so this must run before those early returns.
+    func refreshBookmarkAnnotationLabels() {
+        let hideExtra = shouldHideExtraStopAnnotationData
+        for annotation in mapView.annotations where annotation is Bookmark {
+            if let stopView = mapView.view(for: annotation) as? StopAnnotationView {
+                stopView.isHidingExtraStopAnnotationData = hideExtra
+            }
+        }
+    }
+
     private func reloadStopAnnotations() {
         // Ahead of every early return below, including the search-result guard.
         // The pill states something about the current zoom, so it has to be
@@ -985,6 +997,10 @@ public class MapRegionManager: NSObject,
         // cancelled. Mirrors the ordering `MapPanelRootView.onMapCameraChange`
         // already uses.
         updateZoomWarningOverlay()
+
+        // Bookmark pins are user content, so their label gate must refresh even
+        // when stop loading is suppressed by search, zoom, or a disabled layer.
+        refreshBookmarkAnnotationLabels()
 
         if searchResponseOverridesStopLoading() {
             return
@@ -1008,11 +1024,6 @@ public class MapRegionManager: NSObject,
 
         for stop in mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self) {
             if let stopView = mapView.view(for: stop) as? StopAnnotationView {
-                stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
-            }
-        }
-        for bookmark in mapView.annotations(in: mapView.visibleMapRect).filter(type: Bookmark.self) {
-            if let stopView = mapView.view(for: bookmark) as? StopAnnotationView {
                 stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
             }
         }

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -527,13 +527,25 @@ final class MapRegionManagerTests: OBATestCase {
             PrepareForReuseCountingStopAnnotationView.self,
             forAnnotationViewWithReuseIdentifier: MKMapView.reuseIdentifier(for: StopAnnotationView.self)
         )
+
+        // Host the map so MapKit vends annotation views. Calling `viewFor`
+        // directly hands the dequeued view to the test, not the map, so
+        // `mapView.view(for:)` would observe a different instance (or nil).
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        mgr.mapView.frame = window.bounds
+        window.addSubview(mgr.mapView)
+        window.makeKeyAndVisible()
+
         let stop = try #require(Fixtures.loadSomeStops().first)
         let bookmark = Bookmark(name: "Home", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
 
         mgr.mapView.addAnnotations([stop, bookmark])
+        mgr.mapView.setCenter(stop.coordinate, animated: false)
+        mgr.mapView.layoutIfNeeded()
         mgr.mapView.selectAnnotation(bookmark, animated: false)
+
         let bookmarkView = try #require(
-            mgr.mapView(mgr.mapView, viewFor: bookmark) as? PrepareForReuseCountingStopAnnotationView
+            mgr.mapView.view(for: bookmark) as? PrepareForReuseCountingStopAnnotationView
         )
 
         // Simulate a stale sibling Stop lingering after a stops reload.
@@ -543,6 +555,7 @@ final class MapRegionManagerTests: OBATestCase {
         #expect(mgr.mapView.annotations.contains { $0 === bookmark })
         #expect(!mgr.mapView.annotations.contains { ($0 as? Stop)?.id == stop.id })
         #expect(bookmarkView.prepareForReuseCount == 0)
+        #expect(mgr.mapView.view(for: bookmark) === bookmarkView)
     }
 
     /// Disabling the stops layer removes browse stops but must not deselect a

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -497,4 +497,58 @@ final class MapRegionManagerTests: OBATestCase {
         // Zoomed out past it → hide.
         #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_001) == false)
     }
+
+    // MARK: - Bookmark selection preservation
+
+    private func makeBookmarkManager() -> MapRegionManager {
+        let queue = OperationQueue()
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        return MapRegionManager(application: application)
+    }
+
+    /// When stop annotations reload, a sibling `Stop` for a bookmarked stopID is
+    /// removed but the selected `Bookmark` must stay selected — rebinding its view
+    /// dismisses the callout (#782).
+    @Test @MainActor
+    func `Display unique stop annotations preserves selected bookmark`() throws {
+        let mgr = makeBookmarkManager()
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let bookmark = Bookmark(name: "Home", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+
+        mgr.mapView.addAnnotations([stop, bookmark])
+        mgr.bookmarks = [bookmark]
+        mgr.mapView.selectAnnotation(bookmark, animated: false)
+        _ = mgr.mapView(mgr.mapView, viewFor: bookmark)
+
+        // Simulate a stale sibling Stop lingering after a stops reload.
+        mgr.mapView.addAnnotation(stop)
+        mgr.bookmarks = [bookmark]
+
+        #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
+        #expect(mgr.mapView.annotations.contains { $0 === bookmark })
+        #expect(!mgr.mapView.annotations.contains { ($0 as? Stop)?.id == stop.id })
+    }
+
+    /// Disabling the stops layer removes browse stops but must not deselect a
+    /// bookmark the rider is actively previewing.
+    @Test @MainActor
+    func `Remove stop annotations preserving selection keeps selected bookmark`() throws {
+        let mgr = makeBookmarkManager()
+        mgr.registerMapLayer(StopsMapLayer(manager: mgr))
+
+        let stops = try Fixtures.loadSomeStops()
+        let stop = try #require(stops.first)
+        let otherStop = try #require(stops.dropFirst().first)
+        let bookmark = Bookmark(name: "Work", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+
+        mgr.bookmarks = [bookmark]
+        mgr.mapView.addAnnotation(otherStop)
+        mgr.mapView.selectAnnotation(bookmark, animated: false)
+
+        mgr.setMapLayerEnabled(false, id: StopsMapLayer.layerID)
+
+        #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
+        #expect(mgr.mapView.annotations.contains { $0 === bookmark })
+    }
 }

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -20,6 +20,16 @@ import Testing
 final class MapRegionManagerTests: OBATestCase {
     var queue: OperationQueue!
 
+    @MainActor
+    private final class PrepareForReuseCountingStopAnnotationView: StopAnnotationView {
+        var prepareForReuseCount = 0
+
+        override func prepareForReuse() {
+            prepareForReuseCount += 1
+            super.prepareForReuse()
+        }
+    }
+
     override init() async throws {
         try await super.init()
 
@@ -513,21 +523,26 @@ final class MapRegionManagerTests: OBATestCase {
     @Test @MainActor
     func `Display unique stop annotations preserves selected bookmark`() throws {
         let mgr = makeBookmarkManager()
+        mgr.mapView.register(
+            PrepareForReuseCountingStopAnnotationView.self,
+            forAnnotationViewWithReuseIdentifier: MKMapView.reuseIdentifier(for: StopAnnotationView.self)
+        )
         let stop = try #require(Fixtures.loadSomeStops().first)
         let bookmark = Bookmark(name: "Home", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
 
         mgr.mapView.addAnnotations([stop, bookmark])
-        mgr.bookmarks = [bookmark]
         mgr.mapView.selectAnnotation(bookmark, animated: false)
-        _ = mgr.mapView(mgr.mapView, viewFor: bookmark)
+        let bookmarkView = try #require(
+            mgr.mapView(mgr.mapView, viewFor: bookmark) as? PrepareForReuseCountingStopAnnotationView
+        )
 
         // Simulate a stale sibling Stop lingering after a stops reload.
-        mgr.mapView.addAnnotation(stop)
         mgr.bookmarks = [bookmark]
 
         #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
         #expect(mgr.mapView.annotations.contains { $0 === bookmark })
         #expect(!mgr.mapView.annotations.contains { ($0 as? Stop)?.id == stop.id })
+        #expect(bookmarkView.prepareForReuseCount == 0)
     }
 
     /// Disabling the stops layer removes browse stops but must not deselect a
@@ -543,6 +558,7 @@ final class MapRegionManagerTests: OBATestCase {
         let bookmark = Bookmark(name: "Work", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
 
         mgr.bookmarks = [bookmark]
+        mgr.mapView.addAnnotation(stop)
         mgr.mapView.addAnnotation(otherStop)
         mgr.mapView.selectAnnotation(bookmark, animated: false)
 
@@ -550,5 +566,6 @@ final class MapRegionManagerTests: OBATestCase {
 
         #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
         #expect(mgr.mapView.annotations.contains { $0 === bookmark })
+        #expect(mgr.mapView.annotations.contains { ($0 as? Stop)?.id == stop.id })
     }
 }

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -406,4 +406,58 @@ final class MapRegionManagerTests: OBATestCase {
         // Zoomed out past it → hide.
         #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_001) == false)
     }
+
+    // MARK: - Bookmark selection preservation
+
+    private func makeBookmarkManager() -> MapRegionManager {
+        let queue = OperationQueue()
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        return MapRegionManager(application: application)
+    }
+
+    /// When stop annotations reload, a sibling `Stop` for a bookmarked stopID is
+    /// removed but the selected `Bookmark` must stay selected — rebinding its view
+    /// dismisses the callout (#782).
+    @Test @MainActor
+    func `Display unique stop annotations preserves selected bookmark`() throws {
+        let mgr = makeBookmarkManager()
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let bookmark = Bookmark(name: "Home", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+
+        mgr.mapView.addAnnotations([stop, bookmark])
+        mgr.bookmarks = [bookmark]
+        mgr.mapView.selectAnnotation(bookmark, animated: false)
+        _ = mgr.mapView(mgr.mapView, viewFor: bookmark)
+
+        // Simulate a stale sibling Stop lingering after a stops reload.
+        mgr.mapView.addAnnotation(stop)
+        mgr.bookmarks = [bookmark]
+
+        #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
+        #expect(mgr.mapView.annotations.contains { $0 === bookmark })
+        #expect(!mgr.mapView.annotations.contains { ($0 as? Stop)?.id == stop.id })
+    }
+
+    /// Disabling the stops layer removes browse stops but must not deselect a
+    /// bookmark the rider is actively previewing.
+    @Test @MainActor
+    func `Remove stop annotations preserving selection keeps selected bookmark`() throws {
+        let mgr = makeBookmarkManager()
+        mgr.registerMapLayer(StopsMapLayer(manager: mgr))
+
+        let stops = try Fixtures.loadSomeStops()
+        let stop = try #require(stops.first)
+        let otherStop = try #require(stops.dropFirst().first)
+        let bookmark = Bookmark(name: "Work", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+
+        mgr.bookmarks = [bookmark]
+        mgr.mapView.addAnnotation(otherStop)
+        mgr.mapView.selectAnnotation(bookmark, animated: false)
+
+        mgr.setMapLayerEnabled(false, id: StopsMapLayer.layerID)
+
+        #expect(mgr.mapView.selectedAnnotations.contains { $0 === bookmark })
+        #expect(mgr.mapView.annotations.contains { $0 === bookmark })
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve selected bookmark annotations when `displayUniqueStopAnnotations` removes a sibling `Stop` during stop reloads
- Skip `prepareForReuse`/rebind for selected annotations in `refreshAnnotationViews` so open callouts stay open
- Fold `Bookmark.stopID` into `selectedStopIDs` so `removeStopAnnotationsPreservingSelection` matches its existing "(bookmarks get the same exemption)" comment
- Bookmark label refresh now runs **before** the zoom and stops-layer guards (same arrangement as #1267). Bookmarks survive both of those returns; leaving the loop below them froze expanded labels when zoomed out or with the stops layer off.

Closes #782

## Test plan
- [x] `Display unique stop annotations preserves selected bookmark` — hosts the map in a window, selects the bookmark, then asserts `mapView.view(for:)` is the map-vended spy subclass (`prepareForReuseCount == 0`, same instance after reload). Calling `viewFor` directly is not used; that handed the test a view the map never owned.
- [x] `Remove stop annotations preserving selection keeps selected bookmark` — adds both the bookmarked `Stop` and a sibling `Stop`, then disables the stops layer. This fails on `main` because `selectedStopIDs` did not include bookmark stop IDs.
- [x] Manual: bookmark a stop, pan so the pin sits near the top of the screen, tap once — map shifts and the callout stays open. Reproduced on iPhone 17 Pro simulator (this branch). Non-bookmarked stops were already fine.