### PR TITLE
Fix map stop route labels and zoom hide gate

### DIFF
--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -57,7 +57,7 @@ nonisolated extension Stop: @retroactive MKAnnotation {
     }
 
     public var mapTitle: String? {
-        return Formatters.formattedRoutes(routes, limit: 3)
+        Formatters.formattedMapRoutes(routes)
     }
 }
 

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -944,6 +944,10 @@ public class MapRegionManager: NSObject,
 
     /// Above this visible-map-rect height (map points), stop pins are too
     /// zoomed-out for their under-pin label. Shared with `MapPanelRootView`.
+    ///
+    /// 7,000 still showed route lists at a city-block zoom where pins overlap
+    /// and the text is unreadable. 5,000 keeps labels for street-level zoom
+    /// where they help, and hides them sooner when zoomed out (#132).
     public static let requiredHeightToShowExtraStopData = 5000.0
 
     /// Height half of the under-pin label gate. Callers combine it with the

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -944,7 +944,7 @@ public class MapRegionManager: NSObject,
 
     /// Above this visible-map-rect height (map points), stop pins are too
     /// zoomed-out for their under-pin label. Shared with `MapPanelRootView`.
-    public static let requiredHeightToShowExtraStopData = 7000.0
+    public static let requiredHeightToShowExtraStopData = 5000.0
 
     /// Height half of the under-pin label gate. Callers combine it with the
     /// standard-map-type and "show labels" default checks.

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -838,7 +838,7 @@ public class MapRegionManager: NSObject,
 
     /// Above this visible-map-rect height (map points), stop pins are too
     /// zoomed-out for their under-pin label. Shared with `MapPanelRootView`.
-    public static let requiredHeightToShowExtraStopData = 7000.0
+    public static let requiredHeightToShowExtraStopData = 5000.0
 
     /// Height half of the under-pin label gate. Callers combine it with the
     /// standard-map-type and "show labels" default checks.
@@ -893,9 +893,18 @@ public class MapRegionManager: NSObject,
             return
         }
 
-        let visibleStops = mapView.annotations(in: mapView.visibleMapRect).filter(type: Stop.self)
-        for s in visibleStops {
-            if let stopView = mapView.view(for: s) as? StopAnnotationView {
+        // Stop and Bookmark pins share `StopAnnotationView`; both need the zoom gate
+        // refreshed on every region change (bookmarks were previously skipped).
+        let visibleRect = mapView.visibleMapRect
+        let visibleStopAnnotations = mapView.annotations(in: visibleRect).filter(type: Stop.self)
+        let visibleBookmarkAnnotations = mapView.annotations(in: visibleRect).filter(type: Bookmark.self)
+        for stop in visibleStopAnnotations {
+            if let stopView = mapView.view(for: stop) as? StopAnnotationView {
+                stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
+            }
+        }
+        for bookmark in visibleBookmarkAnnotations {
+            if let stopView = mapView.view(for: bookmark) as? StopAnnotationView {
                 stopView.isHidingExtraStopAnnotationData = shouldHideExtraStopAnnotationData
             }
         }

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -589,15 +589,9 @@ public class Formatters: NSObject {
 
     // MARK: - Routes
 
-    /// Generates a formatted, human readable list of routes.
-    ///
-    /// For example: "Routes: 10, 12, 49, + 3 more".
-    ///
-    /// - Parameter routes: An array of `Route`s from which the string will be generated.
-    /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
-    /// - Returns: A human-readable list of the passed-in `Route`s.
-    public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
-        guard routes.count > 0 else { return nil }
+    /// Sorted short names (or route-type labels when short names are absent) for display.
+    private class func sortedRouteDisplayNames(from routes: [Route]) -> [String] {
+        guard routes.count > 0 else { return [] }
 
         var routeNames = routes
             .map { $0.shortName }
@@ -609,6 +603,40 @@ public class Formatters: NSObject {
             routeNames = routes.map { $0.routeType }.uniqued.compactMap { routeTypeToString($0) }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
         }
 
+        return routeNames
+    }
+
+    /// Compact route list for map pin labels under stop icons.
+    ///
+    /// For example: "10, 12, 49..." — no "Routes:" prefix, and an explicit "..." when the
+    /// list overflows so UIKit truncation doesn't silently drop the overflow hint (#132).
+    ///
+    /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Parameter limit: The number of route names shown before appending "...".
+    /// - Returns: A comma-separated list of route short names, or `nil` when none are available.
+    public class func formattedMapRoutes(_ routes: [Route], limit: Int = 3) -> String? {
+        let routeNames = sortedRouteDisplayNames(from: routes)
+        guard !routeNames.isEmpty else {
+            return nil
+        }
+
+        if routeNames.count > limit {
+            return routeNames.prefix(limit).joined(separator: ", ") + "..."
+        }
+        else {
+            return routeNames.joined(separator: ", ")
+        }
+    }
+
+    /// Generates a formatted, human readable list of routes.
+    ///
+    /// For example: "Routes: 10, 12, 49, + 3 more".
+    ///
+    /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
+    /// - Returns: A human-readable list of the passed-in `Route`s.
+    public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
+        let routeNames = sortedRouteDisplayNames(from: routes)
         guard !routeNames.isEmpty else {
             return nil
         }

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -573,15 +573,9 @@ public class Formatters: NSObject {
 
     // MARK: - Routes
 
-    /// Generates a formatted, human readable list of routes.
-    ///
-    /// For example: "Routes: 10, 12, 49, + 3 more".
-    ///
-    /// - Parameter routes: An array of `Route`s from which the string will be generated.
-    /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
-    /// - Returns: A human-readable list of the passed-in `Route`s.
-    public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
-        guard routes.count > 0 else { return nil }
+    /// Sorted short names (or route-type labels when short names are absent) for display.
+    private class func sortedRouteDisplayNames(from routes: [Route]) -> [String] {
+        guard routes.count > 0 else { return [] }
 
         var routeNames = routes
             .map { $0.shortName }
@@ -593,6 +587,40 @@ public class Formatters: NSObject {
             routeNames = routes.map { $0.routeType }.uniqued.compactMap { routeTypeToString($0) }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
         }
 
+        return routeNames
+    }
+
+    /// Compact route list for map pin labels under stop icons.
+    ///
+    /// For example: "10, 12, 49..." — no "Routes:" prefix, and an explicit "..." when the
+    /// list overflows so UIKit truncation doesn't silently drop the overflow hint (#132).
+    ///
+    /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Parameter limit: The number of route names shown before appending "...".
+    /// - Returns: A comma-separated list of route short names, or `nil` when none are available.
+    public class func formattedMapRoutes(_ routes: [Route], limit: Int = 3) -> String? {
+        let routeNames = sortedRouteDisplayNames(from: routes)
+        guard !routeNames.isEmpty else {
+            return nil
+        }
+
+        if routeNames.count > limit {
+            return routeNames.prefix(limit).joined(separator: ", ") + "..."
+        }
+        else {
+            return routeNames.joined(separator: ", ")
+        }
+    }
+
+    /// Generates a formatted, human readable list of routes.
+    ///
+    /// For example: "Routes: 10, 12, 49, + 3 more".
+    ///
+    /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Parameter limit: The number of `Route`s that be displayed in the returned string. By default, this is `Int.max`.
+    /// - Returns: A human-readable list of the passed-in `Route`s.
+    public class func formattedRoutes(_ routes: [Route], limit: Int = .max) -> String? {
+        let routeNames = sortedRouteDisplayNames(from: routes)
         guard !routeNames.isEmpty else {
             return nil
         }

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -161,4 +161,33 @@ final class FormattersTests: OBATestCase {
 
         #expect(formatters.deviationLabel(for: arrivalDeparture) == Strings.scheduledNotRealTime)
     }
+
+    // MARK: - Map route labels (#132)
+
+    @Test func `Formatted map routes within the limit lists every route`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30"])
+        let label = try #require(Formatters.formattedMapRoutes(routes, limit: 3))
+        #expect(label == "10, 20, 30")
+        #expect(!label.contains("..."))
+        #expect(!label.hasPrefix("Routes:"))
+    }
+
+    @Test func `Formatted map routes over the limit appends ellipsis`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
+        let label = try #require(Formatters.formattedMapRoutes(routes, limit: 3))
+        #expect(label == "10, 20, 30...")
+        #expect(!label.contains("more"))
+        #expect(!label.hasPrefix("Routes:"))
+    }
+
+    private func makeRoutes(shortNames: [String]) throws -> [Route] {
+        try shortNames.enumerated().map { index, shortName in
+            try Fixtures.dictionaryToModel(type: Route.self, dictionary: [
+                "agencyId": "test_agency",
+                "id": "route_\(index)",
+                "shortName": shortName,
+                "type": 3
+            ])
+        }
+    }
 }

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -102,4 +102,33 @@ final class FormattersTests: OBATestCase {
 
         #expect(label == Formatters.formattedAccessibilityLabel(stop: stop))
     }
+
+    // MARK: - Map route labels (#132)
+
+    @Test func `Formatted map routes within the limit lists every route`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30"])
+        let label = try #require(Formatters.formattedMapRoutes(routes, limit: 3))
+        #expect(label == "10, 20, 30")
+        #expect(!label.contains("..."))
+        #expect(!label.hasPrefix("Routes:"))
+    }
+
+    @Test func `Formatted map routes over the limit appends ellipsis`() throws {
+        let routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
+        let label = try #require(Formatters.formattedMapRoutes(routes, limit: 3))
+        #expect(label == "10, 20, 30...")
+        #expect(!label.contains("more"))
+        #expect(!label.hasPrefix("Routes:"))
+    }
+
+    private func makeRoutes(shortNames: [String]) throws -> [Route] {
+        try shortNames.enumerated().map { index, shortName in
+            try Fixtures.dictionaryToModel(type: Route.self, dictionary: [
+                "agencyId": "test_agency",
+                "id": "route_\(index)",
+                "shortName": shortName,
+                "type": 3
+            ])
+        }
+    }
 }

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -498,14 +498,14 @@ final class MapRegionManagerTests: OBATestCase {
 
     /// The under-pin label height gate (routes served / bookmark name), shared
     /// by the UIKit `shouldHideExtraStopAnnotationData` and the SwiftUI
-    /// `MapPanelRootView` — labels show only at/below the 7,000-point threshold.
+    /// `MapPanelRootView` — labels show only at/below the 5,000-point threshold.
     @Test func `Should show extra stop data threshold behavior`() {
         // Zoomed in close → show labels.
         #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 1_000) == true)
         // At the threshold → still show.
-        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_000) == true)
+        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 5_000) == true)
         // Zoomed out past it → hide.
-        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_001) == false)
+        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 5_001) == false)
     }
 
     // MARK: - Bookmark selection preservation

--- a/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
+++ b/OBAKitTests/Application/Mapping/MapRegionManagerTests.swift
@@ -397,13 +397,13 @@ final class MapRegionManagerTests: OBATestCase {
 
     /// The under-pin label height gate (routes served / bookmark name), shared
     /// by the UIKit `shouldHideExtraStopAnnotationData` and the SwiftUI
-    /// `MapPanelRootView` — labels show only at/below the 7,000-point threshold.
+    /// `MapPanelRootView` — labels show only at/below the 5,000-point threshold.
     @Test func `Should show extra stop data threshold behavior`() {
         // Zoomed in close → show labels.
         #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 1_000) == true)
         // At the threshold → still show.
-        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_000) == true)
+        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 5_000) == true)
         // Zoomed out past it → hide.
-        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 7_001) == false)
+        #expect(MapRegionManager.shouldShowExtraStopData(forVisibleMapRectHeight: 5_001) == false)
     }
 }


### PR DESCRIPTION
## Summary
- Add `Formatters.formattedMapRoutes` for compact under-pin labels (short names + explicit overflow marker, no `Routes:` prefix). `formattedRoutes` and the map formatter share `sortedRouteDisplayNames` so they cannot drift.
- Lower `requiredHeightToShowExtraStopData` from 7000 to 5000. At 7000, route lists were still painted at a city-block zoom where pins overlap and the text is unreadable. 5000 keeps labels at street-level zoom and hides them sooner when zoomed out.
- Bookmark pin labels refresh on every camera settle, **before** the search, zoom, and stops-layer early returns. Bookmarks stay on the map in all three states; leaving the loop below those guards froze their labels.

The previous `bookmarkLabelRefreshHandler` seam is gone. MKMapView does not vend annotation views headlessly in CI, so there is no `view(for:)` assertion for this path. The wiring is the call-site ordering: `refreshBookmarkAnnotationLabels()` runs immediately after `updateZoomWarningOverlay()` and before every early return.

Closes #132

## Test plan
- [x] `FormattersTests` — map route formatter within/over limit cases
- [x] `MapRegionManagerTests` — 5000-point threshold (`5_000 == true`, `5_001 == false`)
- [ ] Manual: zoom out on map with many-route stops — labels should show an overflow marker and hide earlier than before
- [ ] Manual: bookmark pins should lose/gain labels when zooming, including with the stops layer off and during a route search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Map stop labels now display concise route names with comma separation and an ellipsis when additional routes are available.
  - Additional stop information becomes visible at a closer zoom level.

- **Bug Fixes**
  - Selected stop and bookmark callouts now remain visible during map updates.
  - Bookmark labels refresh more reliably after the map camera settles.
  - Map updates are less likely to interrupt selected bookmark details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->