### PR TITLE
Silence Bookmarks-tab 404 bulletins for missing stops

### DIFF
--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -52,13 +52,14 @@ public class BookmarkDataLoader: NSObject {
     /// Resumed when that batch drains (`taskFinished`) or is retired (`cancelUpdates`).
     @MainActor private var batchContinuations: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
 
-    /// Stops whose arrival fetch has completed successfully at least once this
-    /// session. Lets consumers distinguish "still loading" from "loaded, but no
-    /// upcoming departures".
+    /// Stops whose arrival fetch has finished this session — a successful
+    /// payload **or** a literal HTTP 404. Lets consumers distinguish "still
+    /// loading" from "loaded, but no upcoming departures". Empty HTTP 200
+    /// (also thrown as `APIError.requestNotFound`) is not recorded here.
     @MainActor private var fetchedStopIDs = Set<StopID>()
 
-    /// `true` once at least one arrival fetch for `stopID` has completed
-    /// successfully this session.
+    /// `true` once an arrival fetch for `stopID` has finished this session
+    /// (success or HTTP 404).
     @MainActor public func hasFetchedData(forStopID stopID: StopID) -> Bool {
         fetchedStopIDs.contains(stopID)
     }
@@ -178,14 +179,17 @@ public class BookmarkDataLoader: NSObject {
 
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
-            } catch APIError.requestNotFound {
-                // A bookmarked stop that no longer resolves in the current region is
-                // not a failure the rider watched happen — mirror StopViewModel's 404
-                // handling: no bulletin, no batch-error flag. Still mark it fetched so
-                // the card settles on "No upcoming departures" rather than "Loading...".
+            } catch APIError.requestNotFound(let response) where response.statusCode == 404 {
+                // Literal HTTP 404: the stop no longer exists in this region.
+                // San Diego trace 2026-08-14 against realtime.sdmts.com: a live
+                // stop (`MTS_11589`) returns HTTP 200 with a full JSON body on
+                // the app URL (`/api/api/where/...`). Empty HTTP 200 — also
+                // thrown as `requestNotFound` by `APIService+GetData` — is a
+                // transient blip and falls through to `displayError` below.
                 await MainActor.run {
                     guard batchID == self.currentBatchID else { return }
                     self.fetchedStopIDs.insert(bookmark.stopID)
+                    self.tripBookmarkKeys = self.tripBookmarkKeys.filter { $0.key.stopID != bookmark.stopID }
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
             } catch {

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -181,7 +181,13 @@ public class BookmarkDataLoader: NSObject {
             } catch APIError.requestNotFound {
                 // A bookmarked stop that no longer resolves in the current region is
                 // not a failure the rider watched happen — mirror StopViewModel's 404
-                // handling: no bulletin, no batch-error flag.
+                // handling: no bulletin, no batch-error flag. Still mark it fetched so
+                // the card settles on "No upcoming departures" rather than "Loading...".
+                await MainActor.run {
+                    guard batchID == self.currentBatchID else { return }
+                    self.fetchedStopIDs.insert(bookmark.stopID)
+                    self.delegate?.dataLoaderDidUpdate(self)
+                }
             } catch {
                 // Same staleness gate as the success path: if cancelUpdates() retired
                 // the batch (or a newer batch started) while this fetch was in flight,

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -178,6 +178,10 @@ public class BookmarkDataLoader: NSObject {
 
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
+            } catch APIError.requestNotFound {
+                // A bookmarked stop that no longer resolves in the current region is
+                // not a failure the rider watched happen — mirror StopViewModel's 404
+                // handling: no bulletin, no batch-error flag.
             } catch {
                 // Same staleness gate as the success path: if cancelUpdates() retired
                 // the batch (or a newer batch started) while this fetch was in flight,

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -64,6 +64,59 @@ final class BookmarksViewModelTests: OBATestCase {
         return Application(config: config)
     }
 
+    @MainActor
+    private final class DisplayErrorSpyApplication: Application {
+        private(set) var displayErrorCallCount = 0
+
+        override func displayError(_ error: Error) async {
+            displayErrorCallCount += 1
+        }
+    }
+
+    private func createSpyApplication(dataLoader: MockDataLoader) -> DisplayErrorSpyApplication {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return DisplayErrorSpyApplication(config: config)
+    }
+
+    private func addTripBookmark(to app: Application) throws -> Bookmark {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDep = try #require(stopArrivals.arrivalsAndDepartures.first)
+        let bookmark = Bookmark(
+            name: "Route 49",
+            regionIdentifier: pugetSoundRegionIdentifier,
+            arrivalDeparture: arrivalDep
+        )
+        app.userDataStore.add(bookmark, to: nil)
+        return bookmark
+    }
+
     // MARK: - Tests
 
     /// `init` defaults to `true` (set via `register(defaults:)`) on a clean UserDefaults.
@@ -469,5 +522,68 @@ final class BookmarksViewModelTests: OBATestCase {
         await poll(until: { cleanBatchDone }, timeout: .seconds(10), "clean batch never finished")
 
         #expect(!viewModel.lastRefreshHadError)
+    }
+
+    // MARK: - Request not found (404)
+
+    /// A 404 on a bookmarked stop must not surface a bulletin — the stop simply
+    /// no longer resolves in the current region (e.g. after switching to San Diego).
+    /// Mirrors StopViewModel's non-fatal 404 handling.
+    @Test @MainActor
+    func `Request not found does not call display error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(data: Data(), statusCode: 404) {
+            $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let viewModel = BookmarksViewModel(application: app)
+        #expect(app.displayErrorCallCount == 0)
+
+        var batchDone = false
+        var seenLoading = false
+        var cancellables = Set<AnyCancellable>()
+        viewModel.$isLoading.sink { isLoading in
+            if isLoading { seenLoading = true }
+            if seenLoading && !isLoading { batchDone = true }
+        }.store(in: &cancellables)
+
+        viewModel.refresh()
+        await poll(until: { batchDone }, timeout: .seconds(10), "404 batch never finished")
+        cancellables.removeAll()
+
+        #expect(app.displayErrorCallCount == 0)
+        #expect(!viewModel.lastRefreshHadError)
+    }
+
+    /// Non-404 fetch failures must still surface via `displayError`.
+    @Test @MainActor
+    func `Server error still calls display error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(data: Data(), statusCode: 500) {
+            $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let viewModel = BookmarksViewModel(application: app)
+
+        var batchDone = false
+        var seenLoading = false
+        var cancellables = Set<AnyCancellable>()
+        viewModel.$isLoading.sink { isLoading in
+            if isLoading { seenLoading = true }
+            if seenLoading && !isLoading { batchDone = true }
+        }.store(in: &cancellables)
+
+        viewModel.refresh()
+        await poll(until: { batchDone }, timeout: .seconds(10), "500 batch never finished")
+        cancellables.removeAll()
+
+        #expect(app.displayErrorCallCount == 1)
+        #expect(viewModel.lastRefreshHadError)
     }
 }

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -556,6 +556,11 @@ final class BookmarksViewModelTests: OBATestCase {
 
         #expect(app.displayErrorCallCount == 0)
         #expect(!viewModel.lastRefreshHadError)
+
+        // 404 is a terminal empty result, not perpetual loading (#1181 review).
+        let rows = viewModel.sections.flatMap(\.rows)
+        let row = try #require(rows.first)
+        #expect(row.hasLoadedArrivalData)
     }
 
     /// Non-404 fetch failures must still surface via `displayError`.

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -526,9 +526,8 @@ final class BookmarksViewModelTests: OBATestCase {
 
     // MARK: - Request not found (404)
 
-    /// A 404 on a bookmarked stop must not surface a bulletin — the stop simply
-    /// no longer resolves in the current region (e.g. after switching to San Diego).
-    /// Mirrors StopViewModel's non-fatal 404 handling.
+    /// A literal HTTP 404 on a bookmarked stop must not surface a bulletin — the
+    /// stop no longer resolves. Empty HTTP 200 is a different case (see below).
     @Test @MainActor
     func `Request not found does not call display error`() async throws {
         let dataLoader = MockDataLoader(testName: name)
@@ -590,5 +589,62 @@ final class BookmarksViewModelTests: OBATestCase {
 
         #expect(app.displayErrorCallCount == 1)
         #expect(viewModel.lastRefreshHadError)
+    }
+
+    /// `APIService+GetData` maps HTTP 200 + `Content-Length: 0` to
+    /// `APIError.requestNotFound` as well as a literal 404. A live San Diego
+    /// stop (`MTS_11589`) returns HTTP 200 with a full JSON body, so an empty
+    /// 200 is a transient blip, not a missing stop — it must still bulletin.
+    @Test @MainActor
+    func `Empty 200 still calls display error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(data: Data(), statusCode: 200) {
+            $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let viewModel = BookmarksViewModel(application: app)
+        await viewModel.refreshAndWait()
+
+        #expect(app.displayErrorCallCount == 1)
+        #expect(viewModel.lastRefreshHadError)
+    }
+
+    /// A 404 after a successful fetch must drop the previous departures rather
+    /// than leave a frozen countdown on the card.
+    @Test @MainActor
+    func `HTTP 404 after success clears stale departures`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(
+            data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_10914.json")
+        ) { $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false }
+
+        let viewModel = BookmarksViewModel(application: app)
+        await viewModel.refreshAndWait()
+
+        let loaded = try #require(viewModel.sections.flatMap(\.rows).first)
+        #expect(!loaded.arrivalDepartures.isEmpty)
+
+        dataLoader.replaceMappedResponses { staging in
+            stubRegions(dataLoader: staging)
+            stubAgenciesWithCoverage(dataLoader: staging, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+            Fixtures.stubAllAgencyAlerts(dataLoader: staging)
+            staging.mock(data: Data(), statusCode: 404) {
+                $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            }
+        }
+
+        await viewModel.refreshAndWait()
+
+        #expect(app.displayErrorCallCount == 0)
+        #expect(!viewModel.lastRefreshHadError)
+        let row = try #require(viewModel.sections.flatMap(\.rows).first)
+        #expect(row.hasLoadedArrivalData)
+        #expect(row.arrivalDepartures.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- Literal **HTTP 404** on a trip bookmark is silent: no bulletin, no failure haptic, the card settles on "No upcoming departures", and any previous departures for that stop are cleared.
- **Empty HTTP 200** (also thrown as `APIError.requestNotFound` by `APIService+GetData`) still bulletins. A live San Diego stop is not that case.
- Docs on `fetchedStopIDs` / `hasFetchedData` now match the 404 path.

Closes #1181

## San Diego trace (2026-08-14)

Hit `realtime.sdmts.com` the way the app builds URLs (`base https://realtime.sdmts.com/api/` + path `/api/where/...` → `/api/api/where/...`):

- Live stop `MTS_11589` arrivals: **HTTP 200**, full JSON body (`code: 200`, real `arrivalsAndDepartures`). Not empty. Same for `stop/MTS_11589` and `current-time`.
- The short path `/api/where/...` (without the doubled `/api`) is HTTP 404 — that is not the URL the app uses.
- Missing IDs (`MTS_NOPE`, `MTS_99999999`, unprefixed `11589`) came back as HTTP 500, which still takes the generic `displayError` path.

So a working San Diego bookmark is a normal 200. The 404 bulletin in #1181 is a *literal* missing resource (or a sibling bookmark that 404s while the one you tap still resolves). Empty-body 200 is not what this region returns for a live stop.

## Test plan
- [x] Literal HTTP 404 — no `displayError`, `hasLoadedArrivalData == true`
- [x] Empty HTTP 200 — still `displayError`, `lastRefreshHadError`
- [x] HTTP 500 — still `displayError`
- [x] HTTP 404 after a successful fetch — stale departures cleared
- [ ] Manual: Bookmarks tab in San Diego — no 404 bulletin on a live stop; a genuinely gone stop shows "No upcoming departures"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bookmark refreshes now complete gracefully when a stop returns no available service, without showing an error.
  * Previously displayed departure information is cleared when a stop is confirmed unavailable.
  * Genuine refresh failures continue to display an error and correctly indicate that the refresh encountered a problem.
  * Outdated refresh results are ignored to prevent stale information from replacing current data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->