### PR TITLE
Narrow PanelDetent docs to UIKit FloatingPanel

### DIFF
--- a/OBAKit/ViewModels/MapPanelViewModel.swift
+++ b/OBAKit/ViewModels/MapPanelViewModel.swift
@@ -11,9 +11,8 @@ import Foundation
 import Combine
 import OBAKitCore
 
-/// Describes the desired expansion state of the bottom panel (EC11).
+/// Desired expansion level for the map bottom panel's UIKit `FloatingPanel`.
 /// `MapFloatingPanelController` maps each case to a `FloatingPanelState`.
-/// - TODO: add a SwiftUI `PresentationDetent` mapping when the SwiftUI sheet lands.
 enum PanelDetent: Equatable {
     case tip
     case half
@@ -29,9 +28,8 @@ class MapPanelViewModel: ObservableObject {
 
     // MARK: - Published State
 
-    /// Desired panel expansion level. `MapFloatingPanelController` observes this and calls
-    /// `floatingPanel.move(to:)` (EC11).
-    /// - TODO: bind to SwiftUI `presentationDetent` when the SwiftUI sheet lands.
+    /// Desired panel expansion level. Observed by `MapFloatingPanelController`, which
+    /// calls `floatingPanel.move(to:)`.
     @Published var requestedPanelDetent: PanelDetent = .tip
 
     /// Nearby stops visible in the current map region.


### PR DESCRIPTION
## Summary
- Narrows `PanelDetent` / `requestedPanelDetent` docs to the current UIKit `FloatingPanel` mapping (`tip` / `half` / `full`).
- Removes the SwiftUI `presentationDetent` TODO that the closed enum can't deliver.
- The other #1141 follow-ups already landed on main: `bindListData` split, dropped `type_body_length` disable, and surveys fetched once via `performInitialStopSetupIfNeeded` (locked by `StopViewModelTests`).
- Closes #1141.

## Test plan
- [x] Confirmed on `upstream/main`: `StopViewModelTests` includes `Surveys refreshed exactly once across refreshes`
- [x] Doc-only change — no behavior delta
- [ ] Skim `MapPanelViewModel` comments in Xcode for accuracy