### PR TITLE
Widget: say Scheduled/not real-time for schedule-only trips, and stop large-family rows clipping

### DIFF
--- a/OBAKit/Stops/StopArrivalView.swift
+++ b/OBAKit/Stops/StopArrivalView.swift
@@ -287,12 +287,7 @@ class StopArrivalView: UIView {
 
         accessibilityTimeLabel.text = formatters.timeFormatter.string(from: arrivalDeparture.arrivalDepartureDate)
 
-        if arrivalDeparture.scheduleStatus == .unknown {
-            accessibilityScheduleDeviationLabel.text = Strings.scheduledNotRealTime
-        }
-        else {
-            accessibilityScheduleDeviationLabel.text = formatters.formattedScheduleDeviation(for: arrivalDeparture)
-        }
+        accessibilityScheduleDeviationLabel.text = formatters.deviationLabel(for: arrivalDeparture)
 
         accessibilityScheduleDeviationLabel.textColor = formatters.colorForScheduleStatus(arrivalDeparture.scheduleStatus)
         accessibilityRelativeTimeBadge.configure(with: arrivalDeparture, formatters: formatters)

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -281,6 +281,22 @@ public class Formatters: NSObject {
         return formattedScheduleDeviation(temporalState: arrivalDeparture.temporalState, arrivalDepartureStatus: arrivalDeparture.arrivalDepartureStatus, scheduleDeviation: arrivalDeparture.deviationFromScheduleInMinutes)
     }
 
+    /// The schedule-adherence half of a "time · status" line: the deviation phrase
+    /// (e.g. `"departs 3 min late"`) when a real-time prediction exists, or
+    /// `Strings.scheduledNotRealTime` when the trip is schedule-only.
+    ///
+    /// Prefer this over `formattedScheduleDeviation(for:)` anywhere the string
+    /// stands alone as a status: a schedule-only trip has a deviation of zero by
+    /// definition, so the raw deviation phrase would falsely claim the trip is
+    /// "on time" when no vehicle has reported at all. Mirrors the gate
+    /// `TripActivityPresenter.deviationLabel(for:now:)` applies for Live
+    /// Activity content states.
+    public func deviationLabel(for arrivalDeparture: ArrivalDeparture) -> String {
+        guard arrivalDeparture.predicted else { return Strings.scheduledNotRealTime }
+
+        return formattedScheduleDeviation(for: arrivalDeparture)
+    }
+
     public func formattedScheduleDeviation(temporalState: TemporalState, arrivalDepartureStatus: ArrivalDepartureStatus, scheduleDeviation: Int) -> String {
         switch (temporalState, arrivalDepartureStatus) {
         case (.past, .arriving):

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -102,4 +102,63 @@ final class FormattersTests: OBATestCase {
 
         #expect(label == Formatters.formattedAccessibilityLabel(stop: stop))
     }
+
+    // MARK: - Deviation Label
+
+    /// With a real-time prediction, the label is the plain deviation phrase.
+    ///
+    /// `Fixtures.dictionaryToModel` decodes with a plain `JSONDecoder`, whose
+    /// default date strategy reads these numbers as seconds since the 2001
+    /// reference date — so the instants land in Nov 2054, temporal state
+    /// `.future`, and the default stop sequence means `.arriving`. A +120 s
+    /// prediction therefore reads "arrives 2 min late" on any machine until
+    /// that date passes; pinning the phrase to the wall clock outright would
+    /// require injecting a clock into `ArrivalDeparture.temporalState`, which
+    /// reads `Date()` directly.
+    @Test func `Deviation label uses the deviation phrase for predicted trips`() throws {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predictedArrival: 1_700_000_120,
+            predictedDeparture: 1_700_000_120
+        )
+
+        #expect(formatters.deviationLabel(for: arrivalDeparture) == "arrives 2 min late")
+    }
+
+    /// The inverse direction: an early prediction formats with the magnitude
+    /// of the deviation, not its sign.
+    @Test func `Deviation label uses the early phrase for predicted-early trips`() throws {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predictedArrival: 1_699_999_880,
+            predictedDeparture: 1_699_999_880
+        )
+
+        #expect(formatters.deviationLabel(for: arrivalDeparture) == "arrives 2 min early")
+    }
+
+    /// A schedule-only trip has a deviation of zero by definition, so the
+    /// deviation phrase would falsely claim "on time". The label must say the
+    /// trip is schedule data instead — the widget pairs it with a concrete
+    /// clock time, which makes a false real-time claim louder.
+    @Test func `Deviation label says scheduled for unpredicted trips`() throws {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        let arrivalDeparture = try Fixtures.arrivalDeparture(predicted: false)
+
+        #expect(formatters.deviationLabel(for: arrivalDeparture) == Strings.scheduledNotRealTime)
+    }
+
+    /// A payload can carry predicted timestamps while declaring
+    /// `predicted: false`; the gate is the flag, not the fields — the same rule
+    /// `DepartureTimeDisplay` applies before striking through a time.
+    @Test func `Deviation label ignores stale predicted times when feed says not predicted`() throws {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predicted: false,
+            predictedArrival: 1_700_000_120,
+            predictedDeparture: 1_700_000_120
+        )
+
+        #expect(formatters.deviationLabel(for: arrivalDeparture) == Strings.scheduledNotRealTime)
+    }
 }

--- a/OBAWidget/Views/WidgetRowView.swift
+++ b/OBAWidget/Views/WidgetRowView.swift
@@ -58,9 +58,10 @@ struct WidgetRowView: View {
         }
     }
 
-    /// The second line: the corrected clock time and the schedule deviation
-    /// (the "time · status" idiom the stop page and bookmark cards use), or
-    /// `fallbackLabel` when there is no departure to describe. When a
+    /// The second line: the corrected clock time and the schedule status —
+    /// the deviation phrase, or "Scheduled/not real-time" for schedule-only
+    /// trips — in the "time · status" idiom the stop page and bookmark cards
+    /// use, or `fallbackLabel` when there is no departure to describe. When a
     /// prediction moves the trip off its timetable, the scheduled time renders
     /// struck through ahead of the corrected one (#1225).
     ///
@@ -72,16 +73,24 @@ struct WidgetRowView: View {
     @ViewBuilder
     private var departureLabel: some View {
         if let first = departures?.first {
+            // `deviationLabel`, not `formattedScheduleDeviation`: a schedule-only
+            // trip has zero deviation by definition, and pairing "departs on
+            // time" with a concrete clock time reads as a real-time claim the
+            // data can't back. Schedule-only trips say "Scheduled/not real-time".
             let display = DepartureTimeDisplay(arrivalDeparture: first, formatters: formatters)
-            let deviation = formatters.formattedScheduleDeviation(for: first)
+            let deviation = formatters.deviationLabel(for: first)
 
             (DepartureTimeText.text(for: display)
                 + Text(" · ").foregroundStyle(.tertiary)
                 + Text(deviation))
                 .font(.system(size: Constants.fontSize))
                 .foregroundStyle(.secondary)
+                // No `fixedSize`: the label wraps to its two lines whenever the
+                // row has room, but under `.systemLarge` height pressure (seven
+                // rows, several of them wrapping) it compresses to a truncated
+                // line instead of forcing its full height and pushing whole
+                // rows off the bottom of the widget canvas.
                 .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
                 // The strikethrough is inaudible, so speak the correction in
                 // words instead of letting VoiceOver read two bare times.
                 .accessibilityLabel("\(display.accessibilityTimeDescription), \(deviation)")
@@ -90,7 +99,6 @@ struct WidgetRowView: View {
                 .font(.system(size: Constants.fontSize))
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the two widget follow-ups from the review of #1237.

1. **Schedule-only trips claimed "arrives on time".** The widget's deviation text comes from `deviationFromScheduleInMinutes`, which is 0 when `predicted == false` — and pairing that with a clock time made the false claim louder. The row (and its VoiceOver label) now says "Scheduled/not real-time" via a new `Formatters.deviationLabel(for:)`, the same gate `TripActivityPresenter.deviationLabel` and `DepartureTimeDisplay` already apply. `StopArrivalView`'s hand-rolled copy of the gate now delegates to it too.
2. **`.systemLarge` could clip whole rows.** The label's `fixedSize` forced full wrapped height even when seven rows didn't fit. Without it, labels still wrap where there's room and truncate under height pressure instead of pushing rows off the canvas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule deviation labels for early, late, scheduled, and stale trip data.
  * Clearly identifies trips that are scheduled only and not updated in real time.
  * Improved departure label sizing in widgets to support wrapping or truncation when space is limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->