### PR TITLE
Live Activity: close the stale-score refresh race and preserve staleDate on promotion

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -319,10 +319,6 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 // `update`. Re-fetch by ID inside a detached task instead — that copy
                 // never crosses an isolation boundary.
                 let activityID = activity.id
-                // Preserve prominence via the shared helper — rebuilding with the
-                // default score of 0 would hand the Island back to the first-
-                // started trip after every arrivals refresh (#1189 Problem 2).
-                let existingContent = activity.content
                 Task.detached {
                     guard let activity = Activity<TripAttributes>.activities.first(where: { $0.id == activityID }) else {
                         // The activity ended between the loop and this task; dropping
@@ -331,11 +327,22 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                         Logger.info("Live Activity \(activityID) is no longer running; skipping update.")
                         return
                     }
+                    // Preserve prominence via the shared helper, reading the score
+                    // off this freshly re-fetched activity — not a snapshot taken
+                    // before the hop, which can predate a concurrent
+                    // promote/demote and would silently write the stale score
+                    // back, undoing it (#1243 review follow-up).
+                    //
+                    // `staleDate` stays nil here on purpose: unlike the
+                    // score-only promote/demote touches (which must carry the
+                    // push-set marker through), this update installs fresh local
+                    // content, and carrying a possibly-past stale-date forward
+                    // could mark it stale on arrival. The next push re-arms it.
                     await activity.update(
                         TripLiveActivityRelevance.contentPreservingRelevance(
                             state: contentState,
                             staleDate: nil,
-                            existing: existingContent
+                            existing: activity.content
                         )
                     )
                     Logger.info("Updated Live Activity for stop: \(staticData.stopID) route: \(staticData.routeShortName)")

--- a/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
+++ b/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
@@ -67,10 +67,14 @@ extension Activity where Attributes == TripAttributes {
             return
         }
         let prominence = TripLiveActivityRelevance.prominenceScore()
+        // A promotion only touches the score; the content is unchanged, so the
+        // push-set stale marker must survive it — the server always sends
+        // `stale-date`, and clearing it here left a re-Tracked card unmarked as
+        // stale until the next push arrived. Mirrors `demoteLivePeers`.
         await activity.update(
             TripLiveActivityRelevance.content(
                 state: activity.content.state,
-                staleDate: nil,
+                staleDate: activity.content.staleDate,
                 relevanceScore: prominence
             )
         )

--- a/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
+++ b/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
@@ -50,6 +50,25 @@ final class TripLiveActivityRelevanceTests {
         #expect(content.staleDate == nil)
     }
 
+    /// Pins the score-only touch pattern `promoteToDynamicIsland` and
+    /// `demoteLivePeers` share: rebuilding content to change the score must
+    /// carry the existing `staleDate` through — clearing it would strip the
+    /// push-set stale marker from a card whose content didn't change
+    /// (#1243 review follow-up).
+    @Test func `Content carries the supplied stale date through a score change`() {
+        let state = TripAttributes.ContentState(arrivals: [])
+        let staleDate = Date(timeIntervalSince1970: 1_700_000_200)
+
+        let promoted = TripLiveActivityRelevance.content(
+            state: state,
+            staleDate: staleDate,
+            relevanceScore: 7
+        )
+
+        #expect(promoted.staleDate == staleDate)
+        #expect(promoted.relevanceScore == 7)
+    }
+
     /// Pins the refresh path used by `updateRunningLiveActivities`: the new
     /// content state may change, but the score must come from the *existing*
     /// content — not a literal, and not the ActivityContent default of `0`.


### PR DESCRIPTION
## Summary

Implements the two follow-ups from the review of #1243.

1. **A refresh could silently undo a promotion.** `updateRunningLiveActivities` snapshotted `activity.content` on the main actor, then applied it later inside `Task.detached` — a promote/demote landing in between got overwritten with the stale score. The score is now read off the freshly re-fetched activity inside the task. This shrinks the window to the unavoidable read-before-commit gap inside one update (ActivityKit has no compare-and-swap), rather than the unbounded snapshot-to-task gap.
2. **Promotion cleared the push-set stale marker.** `promoteToDynamicIsland` rebuilt content with `staleDate: nil` while `demoteLivePeers` preserved it. Promotion is a score-only touch of unchanged content, so it now carries `staleDate` through too. The refresh path deliberately keeps `staleDate: nil` — it installs fresh local content, and carrying a possibly-past marker forward could flag it stale on arrival; that distinction is now documented at the call site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Live Activity updates to preserve current relevance and prominence information.
  * Preserved expiration timing when promoting trips to the Dynamic Island.
  * Prevented stale or missing activity data during updates.

* **Tests**
  * Added regression coverage to verify that activity expiration dates and relevance scores are retained correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->