### PR TITLE
Add Report Ghost Bus to the trip page

### DIFF
--- a/OBAKit/Trip/TripPage/GhostBusReportView.swift
+++ b/OBAKit/Trip/TripPage/GhostBusReportView.swift
@@ -30,6 +30,14 @@ struct GhostBusReportView: View {
 
     static let waitChoices = [5, 10, 15, 20, 30]
 
+    /// Mirrors the server's `GhostBusReport::COMMENT_MAX_LENGTH` (obacloud
+    /// `app/models/ghost_bus_report.rb`). The submit alert can't distinguish a
+    /// too-long-comment 422 from a duplicate-report 422 (`APIError` carries no
+    /// response body), so the comment field must never be able to produce the
+    /// former — keeping this cap in sync with the server keeps that alert copy
+    /// truthful.
+    static let commentMaxLength = 1_000
+
     @State private var waitDurationMinutes = 15
     @State private var comment = ""
     @State private var shareLocation: Bool
@@ -102,6 +110,11 @@ struct GhostBusReportView: View {
                         axis: .vertical
                     )
                     .lineLimit(3...6)
+                    .onChange(of: comment) { _, newValue in
+                        if newValue.count > Self.commentMaxLength {
+                            comment = String(newValue.prefix(Self.commentMaxLength))
+                        }
+                    }
 
                     Toggle(
                         OBALoc("ghost_bus_report.share_location", value: "Share my location", comment: "Toggle on the ghost bus form for including the rider's location with the report."),

--- a/OBAKit/Trip/TripPage/GhostBusReportView.swift
+++ b/OBAKit/Trip/TripPage/GhostBusReportView.swift
@@ -1,0 +1,152 @@
+//
+//  GhostBusReportView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Context shown read-only at the top of the ghost bus report sheet, so the
+/// rider can confirm what they're reporting before they submit.
+struct GhostBusReportContext {
+    let routeAndHeadsign: String
+    let stopName: String?
+    let scheduledTime: Date?
+    let vehicleID: String?
+}
+
+/// The "Report Ghost Bus" form: confirm the trip, say how long you waited,
+/// optionally add detail, submit. Failures keep the sheet up with the rider's
+/// input intact; success dismisses.
+struct GhostBusReportView: View {
+    let context: GhostBusReportContext
+    let defaultShareLocation: Bool
+    let submit: (_ waitDurationMinutes: Int, _ comment: String?, _ shareLocation: Bool) async throws -> Void
+    let onDismiss: () -> Void
+
+    static let waitChoices = [5, 10, 15, 20, 30]
+
+    @State private var waitDurationMinutes = 15
+    @State private var comment = ""
+    @State private var shareLocation = true
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent(
+                        OBALoc("ghost_bus_report.context.route", value: "Route", comment: "Label for the route being reported on the ghost bus form."),
+                        value: context.routeAndHeadsign
+                    )
+                    if let stopName = context.stopName {
+                        LabeledContent(
+                            OBALoc("ghost_bus_report.context.stop", value: "Stop", comment: "Label for the stop being reported on the ghost bus form."),
+                            value: stopName
+                        )
+                    }
+                    if let scheduledTime = context.scheduledTime {
+                        LabeledContent(
+                            OBALoc("ghost_bus_report.context.scheduled", value: "Scheduled", comment: "Label for the scheduled time on the ghost bus form."),
+                            value: scheduledTime.formatted(date: .omitted, time: .shortened)
+                        )
+                    }
+                    if let vehicleID = context.vehicleID {
+                        LabeledContent(
+                            OBALoc("ghost_bus_report.context.vehicle", value: "Vehicle", comment: "Label for the vehicle ID on the ghost bus form."),
+                            value: vehicleID
+                        )
+                    }
+                } header: {
+                    Text(OBALoc("ghost_bus_report.context.header", value: "Reporting", comment: "Header over the trip summary on the ghost bus form."))
+                }
+
+                Section {
+                    Picker(
+                        OBALoc("ghost_bus_report.wait.label", value: "How long did you wait?", comment: "Label for the wait-duration picker on the ghost bus form."),
+                        selection: $waitDurationMinutes
+                    ) {
+                        ForEach(Self.waitChoices, id: \.self) { minutes in
+                            Text(minutes == 30
+                                 ? OBALoc("ghost_bus_report.wait.thirty_plus", value: "30+ min", comment: "Longest wait-duration choice on the ghost bus form.")
+                                 : String(format: OBALoc("ghost_bus_report.wait.minutes_fmt", value: "%d min", comment: "Wait-duration choice on the ghost bus form."), minutes))
+                                .tag(minutes)
+                        }
+                    }
+                } header: {
+                    Text(OBALoc("ghost_bus_report.wait.header", value: "Past the scheduled time", comment: "Header over the wait-duration picker on the ghost bus form."))
+                }
+
+                Section {
+                    TextField(
+                        OBALoc("ghost_bus_report.comment.placeholder", value: "Anything else we should know? (optional)", comment: "Placeholder for the optional comment field on the ghost bus form."),
+                        text: $comment,
+                        axis: .vertical
+                    )
+                    .lineLimit(3...6)
+
+                    Toggle(
+                        OBALoc("ghost_bus_report.share_location", value: "Share my location", comment: "Toggle on the ghost bus form for including the rider's location with the report."),
+                        isOn: $shareLocation
+                    )
+                }
+
+                Section {
+                    Button {
+                        Task { await performSubmit() }
+                    } label: {
+                        if isSubmitting {
+                            ProgressView().frame(maxWidth: .infinity)
+                        } else {
+                            Text(OBALoc("ghost_bus_report.submit", value: "Submit Report", comment: "Submit button on the ghost bus form."))
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(isSubmitting)
+                } footer: {
+                    Text(OBALoc("ghost_bus_report.footer", value: "Your report is anonymous and goes to the agency that runs this service.", comment: "Footer text under the submit button on the ghost bus form."))
+                }
+            }
+            .navigationTitle(OBALoc("ghost_bus_report.title", value: "Report Ghost Bus", comment: "Title of the ghost bus report sheet."))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.cancel, action: onDismiss)
+                }
+            }
+            .alert(
+                OBALoc("ghost_bus_report.error.title", value: "Unable to Submit", comment: "Title of the ghost bus submission error alert."),
+                isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
+                Button(Strings.dismiss, role: .cancel) {}
+            } message: {
+                Text(errorMessage ?? "")
+            }
+            .onAppear { shareLocation = defaultShareLocation }
+            .interactiveDismissDisabled(isSubmitting)
+        }
+    }
+
+    private func performSubmit() async {
+        isSubmitting = true
+        defer { isSubmitting = false }
+        do {
+            let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+            try await submit(waitDurationMinutes, trimmed.isEmpty ? nil : trimmed, shareLocation)
+            onDismiss()
+        } catch let error as APIError {
+            if case .requestFailure(let response) = error, response.statusCode == 422 {
+                errorMessage = OBALoc("ghost_bus_report.error.already_reported", value: "It looks like this trip has already been reported from this device.", comment: "Error message when the server rejects a duplicate ghost bus report.")
+            } else {
+                errorMessage = error.localizedDescription
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/OBAKit/Trip/TripPage/GhostBusReportView.swift
+++ b/OBAKit/Trip/TripPage/GhostBusReportView.swift
@@ -32,9 +32,22 @@ struct GhostBusReportView: View {
 
     @State private var waitDurationMinutes = 15
     @State private var comment = ""
-    @State private var shareLocation = true
+    @State private var shareLocation: Bool
     @State private var isSubmitting = false
     @State private var errorMessage: String?
+
+    init(
+        context: GhostBusReportContext,
+        defaultShareLocation: Bool,
+        submit: @escaping (_ waitDurationMinutes: Int, _ comment: String?, _ shareLocation: Bool) async throws -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.context = context
+        self.defaultShareLocation = defaultShareLocation
+        self.submit = submit
+        self.onDismiss = onDismiss
+        self._shareLocation = State(initialValue: defaultShareLocation)
+    }
 
     var body: some View {
         NavigationStack {
@@ -127,7 +140,6 @@ struct GhostBusReportView: View {
             } message: {
                 Text(errorMessage ?? "")
             }
-            .onAppear { shareLocation = defaultShareLocation }
             .interactiveDismissDisabled(isSubmitting)
         }
     }

--- a/OBAKit/Trip/TripPage/TripActionBar.swift
+++ b/OBAKit/Trip/TripPage/TripActionBar.swift
@@ -24,6 +24,7 @@ struct TripActionBar: View {
     let canSchedule: Bool
     let canAlarm: Bool
     let hasAlarm: Bool
+    let canReportGhostBus: Bool
 
     /// Ceiling on the bar's height at accessibility sizes, past which it scrolls. Supplied by the
     /// page, because the page is the only thing that knows how much room there actually is.
@@ -44,6 +45,7 @@ struct TripActionBar: View {
     let onBookmark: () -> Void
     let onSchedule: () -> Void
     let onAlarm: () -> Void
+    let onReportGhostBus: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -136,7 +138,42 @@ struct TripActionBar: View {
                     action: onAlarm
                 )
             }
+
+            if canReportGhostBus {
+                moreMenu
+            }
         }
+    }
+
+    /// Modeled on `StopPageToolbar.moreItem`, including its documented workaround: a `Menu` can't
+    /// take `FrostedActionButtonStyle`, so the label is styled directly.
+    private var moreMenu: some View {
+        Menu {
+            Section {
+                Button(action: onReportGhostBus) {
+                    Label(
+                        OBALoc("trip_page.report_ghost_bus", value: "Report Ghost Bus", comment: "Trip page menu item for reporting a scheduled vehicle that never arrived."),
+                        systemImage: "clock.badge.questionmark"
+                    )
+                }
+            }
+        } label: {
+            // Forgoes the pressed dimming the real buttons get; a menu opening over
+            // the tap is its own feedback. See `FrostedCapsuleBackground` for why a
+            // `Menu` can't take the button style.
+            VStack(spacing: 4) {
+                Image(systemName: "ellipsis")
+                Text(Strings.more)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.vertical, 5)
+            .foregroundStyle(Color(uiColor: .label))
+            .modifier(FrostedCapsuleBackground())
+        }
+        .accessibilityLabel(Strings.more)
     }
 
     private func secondaryButton(title: String, systemImage: String, action: @escaping () -> Void) -> some View {

--- a/OBAKit/Trip/TripPage/TripActionBar.swift
+++ b/OBAKit/Trip/TripPage/TripActionBar.swift
@@ -161,33 +161,31 @@ struct TripActionBar: View {
             // Forgoes the pressed dimming the real buttons get; a menu opening over
             // the tap is its own feedback. See `FrostedCapsuleBackground` for why a
             // `Menu` can't take the button style.
-            VStack(spacing: 4) {
-                Image(systemName: "ellipsis")
-                Text(Strings.more)
-                    .font(.caption)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .padding(.vertical, 5)
-            .foregroundStyle(Color(uiColor: .label))
-            .modifier(FrostedCapsuleBackground())
+            actionLabel(title: Strings.more, systemImage: "ellipsis")
+                .foregroundStyle(Color(uiColor: .label))
+                .modifier(FrostedCapsuleBackground())
         }
         .accessibilityLabel(Strings.more)
     }
 
     private func secondaryButton(title: String, systemImage: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            VStack(spacing: 4) {
-                Image(systemName: systemImage)
-                Text(title)
-                    .font(.caption)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .padding(.vertical, 5)
+            actionLabel(title: title, systemImage: systemImage)
         }
         .buttonStyle(FrostedActionButtonStyle())
+    }
+
+    /// The shared icon-over-caption layout for everything in the bar's secondary row —
+    /// plain buttons and the More menu's label alike.
+    private func actionLabel(title: String, systemImage: String) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: systemImage)
+            Text(title)
+                .font(.caption)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, minHeight: 44)
+        .padding(.vertical, 5)
     }
 }

--- a/OBAKit/Trip/TripPage/TripPageView.swift
+++ b/OBAKit/Trip/TripPage/TripPageView.swift
@@ -18,12 +18,14 @@ struct TripPageActions {
     var canSchedule = false
     var canAlarm = false
     var canStartLiveActivity = false
+    var canReportGhostBus = false
     var onBack: () -> Void = {}
     var onSelectStop: (StopID) -> Void = { _ in }
     var onLiveActivity: () -> Void = {}
     var onBookmark: () -> Void = {}
     var onSchedule: () -> Void = {}
     var onAlarm: () -> Void = {}
+    var onReportGhostBus: () -> Void = {}
 }
 
 /// The trip page: which vehicle, when it gets to you, and every stop on its way.
@@ -145,11 +147,13 @@ struct TripPageView: View {
                     canSchedule: actions.canSchedule,
                     canAlarm: actions.canAlarm,
                     hasAlarm: hasAlarm,
+                    canReportGhostBus: actions.canReportGhostBus,
                     maxHeight: pageHeight > 0 ? pageHeight * Self.actionBarHeightShare : nil,
                     onLiveActivity: actions.onLiveActivity,
                     onBookmark: actions.onBookmark,
                     onSchedule: actions.onSchedule,
-                    onAlarm: actions.onAlarm
+                    onAlarm: actions.onAlarm,
+                    onReportGhostBus: actions.onReportGhostBus
                 )
             }
         }

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -327,10 +327,7 @@ final class TripPageViewController: UIHostingController<TripPageView>,
                 // throw, not return, or the rider is told their report went out when it
                 // never did. `obacoService` going nil is reachable while the sheet is up:
                 // a region switch rebuilds it.
-                guard let self else {
-                    throw GhostBusReportSubmissionError.serviceUnavailable
-                }
-                guard let obacoService = self.application.obacoService else {
+                guard let self, let obacoService = self.application.obacoService else {
                     throw GhostBusReportSubmissionError.serviceUnavailable
                 }
                 self.application.userDefaults.set(shareLocation, forKey: shareLocationKey)

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -325,8 +325,9 @@ final class TripPageViewController: UIHostingController<TripPageView>,
                 // `submit` is `async throws`, and `GhostBusReportView.performSubmit` reads a
                 // plain return as success and dismisses the sheet. A guard failure has to
                 // throw, not return, or the rider is told their report went out when it
-                // never did. `obacoService` going nil is reachable while the sheet is up:
-                // a region switch rebuilds it.
+                // never did. (Today `obacoService` is never nil once set — a region switch
+                // replaces it or leaves the old one — so this guard is defense against
+                // `self` deallocating and against that invariant changing, not a live path.)
                 guard let self, let obacoService = self.application.obacoService else {
                     throw GhostBusReportSubmissionError.serviceUnavailable
                 }
@@ -356,8 +357,8 @@ final class TripPageViewController: UIHostingController<TripPageView>,
     /// Surfaced through `GhostBusReportView`'s error alert, same as a network failure —
     /// see the `submit` closure in `showGhostBusReport()`.
     enum GhostBusReportSubmissionError: LocalizedError {
-        /// No Obaco service for the current region (e.g. a region switch rebuilding it
-        /// while the sheet is still up), so the report can't be sent.
+        /// The submit closure couldn't reach an Obaco service — the presenting
+        /// controller deallocated, or `obacoService` was unexpectedly absent.
         case serviceUnavailable
 
         var errorDescription: String? {

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -243,6 +243,7 @@ final class TripPageViewController: UIHostingController<TripPageView>,
         // A Live Activity reports a countdown to a stop. Without a departure
         // there is no stop and nothing to count down to.
         actions.canStartLiveActivity = departure != nil && ActivityAuthorizationInfo().areActivitiesEnabled
+        actions.canReportGhostBus = application.features.obaco == .running
 
         actions.onBack = { [weak self] in self?.goBack() }
         actions.onSelectStop = { [weak self] stopID in
@@ -253,6 +254,7 @@ final class TripPageViewController: UIHostingController<TripPageView>,
         actions.onSchedule = { [weak self] in self?.showSchedule() }
         actions.onAlarm = { [weak self] in self?.showAlarmPicker() }
         actions.onLiveActivity = { [weak self] in self?.startLiveActivity() }
+        actions.onReportGhostBus = { [weak self] in self?.showGhostBusReport() }
 
         return actions
     }
@@ -274,6 +276,71 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             application: application
         )
         present(scheduleVC, animated: true)
+    }
+
+    /// Building the draft: prefer `ArrivalDeparture` fields (stop-level context) when a departure
+    /// is loaded, falling back to trip-level data from `TripConvertible` otherwise.
+    private func showGhostBusReport() {
+        let convertible = viewModel.tripConvertible
+        let trip = convertible.trip
+
+        var draft: GhostBusReportDraft
+        if let departure {
+            draft = GhostBusReportDraft(tripID: departure.tripID, serviceDate: departure.serviceDate)
+            draft.stopID = departure.stopID
+            draft.routeID = departure.routeID
+            draft.vehicleID = departure.vehicleID
+            draft.stopSequence = departure.stopSequence
+            draft.predicted = departure.predicted
+            draft.scheduledArrivalAt = departure.scheduledDate
+            draft.predictedArrivalAt = departure.predicted ? departure.arrivalDepartureDate : nil
+            draft.scheduleDeviationMinutes = departure.deviationFromScheduleInMinutes
+            draft.predictionLastUpdatedAt = departure.lastUpdated
+        } else {
+            // TripConvertible.serviceDate is safe here: the trip page always loads
+            // trip details. Without a departure there is no stop-level context.
+            draft = GhostBusReportDraft(tripID: trip.id, serviceDate: convertible.serviceDate)
+            draft.routeID = trip.routeID
+            draft.vehicleID = convertible.vehicleID
+        }
+
+        let context = GhostBusReportContext(
+            routeAndHeadsign: [departure?.routeShortName ?? trip.route?.shortName, departure?.tripHeadsign ?? trip.headsign]
+                .compactMap { $0 }
+                .joined(separator: " — "),
+            stopName: departure?.stop.name,
+            scheduledTime: draft.scheduledArrivalAt,
+            vehicleID: draft.vehicleID
+        )
+
+        let shareLocationKey = "GhostBusReport.shareLocation"
+        application.userDefaults.register(defaults: [shareLocationKey: true])
+
+        let host = UIHostingController(rootView: GhostBusReportView(
+            context: context,
+            defaultShareLocation: application.userDefaults.bool(forKey: shareLocationKey),
+            submit: { [weak self] waitDurationMinutes, comment, shareLocation in
+                guard let self, let obacoService = self.application.obacoService else { return }
+                self.application.userDefaults.set(shareLocation, forKey: shareLocationKey)
+
+                var submitted = draft
+                submitted.waitDurationMinutes = waitDurationMinutes
+                submitted.comment = comment
+                if shareLocation, let location = self.application.locationService.currentLocation {
+                    submitted.userLatitude = location.coordinate.latitude
+                    submitted.userLongitude = location.coordinate.longitude
+                }
+
+                _ = try await obacoService.postGhostBusReport(submitted, userID: self.application.userUUID)
+            },
+            onDismiss: { [weak self] in self?.presentedViewController?.dismiss(animated: true) }
+        ))
+
+        if let sheet = host.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(host, animated: true)
     }
 
     private func showBookmarkEditor() {

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -297,8 +297,10 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             draft.scheduleDeviationMinutes = departure.deviationFromScheduleInMinutes
             draft.predictionLastUpdatedAt = departure.lastUpdated
         } else {
-            // TripConvertible.serviceDate is safe here: the trip page always loads
-            // trip details. Without a departure there is no stop-level context.
+            // TripConvertible's initializers guarantee exactly one of arrivalDeparture,
+            // vehicleStatus, or tripDetails is set, so `serviceDate` always has a
+            // non-departure source to resolve from here. Without a departure there is
+            // no stop-level context.
             draft = GhostBusReportDraft(tripID: trip.id, serviceDate: convertible.serviceDate)
             draft.routeID = trip.routeID
             draft.vehicleID = convertible.vehicleID
@@ -320,7 +322,17 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             context: context,
             defaultShareLocation: application.userDefaults.bool(forKey: shareLocationKey),
             submit: { [weak self] waitDurationMinutes, comment, shareLocation in
-                guard let self, let obacoService = self.application.obacoService else { return }
+                // `submit` is `async throws`, and `GhostBusReportView.performSubmit` reads a
+                // plain return as success and dismisses the sheet. A guard failure has to
+                // throw, not return, or the rider is told their report went out when it
+                // never did. `obacoService` going nil is reachable while the sheet is up:
+                // a region switch rebuilds it.
+                guard let self else {
+                    throw GhostBusReportSubmissionError.serviceUnavailable
+                }
+                guard let obacoService = self.application.obacoService else {
+                    throw GhostBusReportSubmissionError.serviceUnavailable
+                }
                 self.application.userDefaults.set(shareLocation, forKey: shareLocationKey)
 
                 var submitted = draft
@@ -341,6 +353,23 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             sheet.prefersGrabberVisible = true
         }
         present(host, animated: true)
+    }
+
+    /// Why a ghost bus report couldn't be submitted before ever reaching the network.
+    /// Surfaced through `GhostBusReportView`'s error alert, same as a network failure —
+    /// see the `submit` closure in `showGhostBusReport()`.
+    enum GhostBusReportSubmissionError: LocalizedError {
+        /// No Obaco service for the current region (e.g. a region switch rebuilding it
+        /// while the sheet is still up), so the report can't be sent.
+        case serviceUnavailable
+
+        var errorDescription: String? {
+            OBALoc(
+                "trip_page.ghost_bus_report_unavailable",
+                value: "This report couldn't be submitted because the reporting service isn't available right now. Please try again later.",
+                comment: "Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable."
+            )
+        }
     }
 
     private func showBookmarkEditor() {

--- a/OBAKitCore/Models/Obaco/GhostBusReport.swift
+++ b/OBAKitCore/Models/Obaco/GhostBusReport.swift
@@ -1,0 +1,43 @@
+//
+//  GhostBusReport.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Everything the app knows about the trip the rider says never showed up.
+/// Fields mirror the sidecar's ghost_bus_reports create params; timestamps go
+/// over the wire as epoch milliseconds.
+public struct GhostBusReportDraft {
+    public var tripID: String
+    public var serviceDate: Date
+    public var routeID: String?
+    public var stopID: StopID?
+    public var vehicleID: String?
+    public var stopSequence: Int?
+    public var predicted: Bool?
+    public var scheduledArrivalAt: Date?
+    public var predictedArrivalAt: Date?
+    public var scheduleDeviationMinutes: Int?
+    public var predictionLastUpdatedAt: Date?
+    public var waitDurationMinutes: Int
+    public var comment: String?
+    public var userLatitude: Double?
+    public var userLongitude: Double?
+
+    public init(tripID: String, serviceDate: Date, waitDurationMinutes: Int = 15) {
+        self.tripID = tripID
+        self.serviceDate = serviceDate
+        self.waitDurationMinutes = waitDurationMinutes
+    }
+}
+
+/// The sidecar's acknowledgement of a submitted ghost bus report.
+public struct GhostBusReport: Codable {
+    /// Server-generated public identifier for the report.
+    public let id: String
+}

--- a/OBAKitCore/Network/NetworkHelpers.swift
+++ b/OBAKitCore/Network/NetworkHelpers.swift
@@ -35,10 +35,21 @@ class NetworkHelpers: NSObject {
                 .replacingOccurrences(of: "/", with: "%2F")
     }
 
+    /// RFC 3986 "unreserved" characters. Form values must be escaped against this set, not
+    /// `.urlQueryAllowed` — the latter leaves `&`, `+`, `;`, and `=` raw, which truncates a
+    /// free-text value at the first `&`, turns `+` into a space server-side, and injects
+    /// bogus params from a stray `=`. Rider-authored ghost-bus comments, trip headsigns
+    /// ("15th Ave & Broadway"), and device descriptions all carry those characters.
+    private static let formUnreservedCharacters: CharacterSet = {
+        var unreserved = CharacterSet.alphanumerics
+        unreserved.insert(charactersIn: "-._~")
+        return unreserved
+    }()
+
     public class func dictionary(toHTTPBodyData dict: [String: Any]) -> Data {
         return dict.map { (k, v) -> String in
-            let keyStr = k.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
-            let valueStr = "\(v)".addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+            let keyStr = k.addingPercentEncoding(withAllowedCharacters: formUnreservedCharacters) ?? k
+            let valueStr = "\(v)".addingPercentEncoding(withAllowedCharacters: formUnreservedCharacters) ?? "\(v)"
             return "\(keyStr)=\(valueStr)"
         }.joined(separator: "&").data(using: .utf8)!
     }

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -189,32 +189,10 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let lat = draft.userLatitude { params["user_latitude"] = lat }
         if let lon = draft.userLongitude { params["user_longitude"] = lon }
 
-        urlRequest.httpBody = Self.strictlyFormEncoded(params)
+        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
 
         let (data, _) = try await data(for: urlRequest as URLRequest)
         return try JSONDecoder.obacoServiceDecoder.decode(GhostBusReport.self, from: data)
-    }
-
-    /// Form-encodes `params` for `postGhostBusReport` using RFC 3986's "unreserved" character
-    /// set (alphanumerics plus `-._~`) rather than `NetworkHelpers.dictionary(toHTTPBodyData:)`'s
-    /// `.urlQueryAllowed`, which leaves `&`, `+`, `;`, and `=` unescaped. Free-text rider
-    /// comments routinely contain those characters (e.g. "Sat 20+ min & it vanished = gone;
-    /// really"), and `.urlQueryAllowed` would truncate the comment at `&`, turn `+` into a
-    /// literal space on the server, and inject bogus extra params from a stray `=`.
-    ///
-    /// This is scoped to this one call site so the alarm/push-registration callers of
-    /// `NetworkHelpers.dictionary(toHTTPBodyData:)` are untouched.
-    private static func strictlyFormEncoded(_ params: [String: Any]) -> Data {
-        var unreserved = CharacterSet.alphanumerics
-        unreserved.insert(charactersIn: "-._~")
-
-        let pairs = params.map { key, value -> String in
-            let keyStr = key.addingPercentEncoding(withAllowedCharacters: unreserved) ?? key
-            let valueStr = "\(value)".addingPercentEncoding(withAllowedCharacters: unreserved) ?? "\(value)"
-            return "\(keyStr)=\(valueStr)"
-        }.joined(separator: "&")
-
-        return pairs.data(using: .utf8)!
     }
 
     // MARK: - APNs Environment

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -152,6 +152,49 @@ public actor ObacoAPIService: @preconcurrency APIService {
         return try await data(for: request as URLRequest)
     }
 
+    // MARK: - Ghost Bus Reports
+
+    /// Reports a "ghost bus" — a scheduled (possibly real-time-tracked) vehicle
+    /// that never arrived — to the sidecar for the current region.
+    /// - parameter draft: The captured trip context plus the rider's answers.
+    /// - parameter userID: The app's anonymous, persisted user UUID.
+    public nonisolated func postGhostBusReport(_ draft: GhostBusReportDraft, userID: String) async throws -> GhostBusReport {
+        let url = await buildURL(path: String(format: "/api/v2/regions/%d/ghost_bus_reports", regionID))
+        let urlRequest = NSMutableURLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
+        urlRequest.httpMethod = "POST"
+
+        var params: [String: Any] = [
+            "user_identifier": userID,
+            "trip_identifier": draft.tripID,
+            "service_date": Int64(draft.serviceDate.timeIntervalSince1970 * 1000),
+            "wait_duration_minutes": draft.waitDurationMinutes
+        ]
+
+        if let routeID = draft.routeID { params["route_identifier"] = routeID }
+        if let stopID = draft.stopID { params["stop_identifier"] = stopID }
+        if let vehicleID = draft.vehicleID { params["vehicle_identifier"] = vehicleID }
+        if let stopSequence = draft.stopSequence { params["stop_sequence"] = stopSequence }
+        if let predicted = draft.predicted { params["predicted"] = predicted ? "1" : "0" }
+        if let scheduled = draft.scheduledArrivalAt {
+            params["scheduled_arrival_at"] = Int64(scheduled.timeIntervalSince1970 * 1000)
+        }
+        if let predictedAt = draft.predictedArrivalAt {
+            params["predicted_arrival_at"] = Int64(predictedAt.timeIntervalSince1970 * 1000)
+        }
+        if let deviation = draft.scheduleDeviationMinutes { params["schedule_deviation_minutes"] = deviation }
+        if let lastUpdated = draft.predictionLastUpdatedAt {
+            params["prediction_last_updated_at"] = Int64(lastUpdated.timeIntervalSince1970 * 1000)
+        }
+        if let comment = draft.comment, !comment.isEmpty { params["comment"] = comment }
+        if let lat = draft.userLatitude { params["user_latitude"] = lat }
+        if let lon = draft.userLongitude { params["user_longitude"] = lon }
+
+        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
+
+        let (data, _) = try await data(for: urlRequest as URLRequest)
+        return try JSONDecoder.obacoServiceDecoder.decode(GhostBusReport.self, from: data)
+    }
+
     // MARK: - APNs Environment
 
     /// Stamps `apns_sandbox=1` onto a token-registering request in debug builds.

--- a/OBAKitCore/Network/ObacoAPIService.swift
+++ b/OBAKitCore/Network/ObacoAPIService.swift
@@ -189,10 +189,32 @@ public actor ObacoAPIService: @preconcurrency APIService {
         if let lat = draft.userLatitude { params["user_latitude"] = lat }
         if let lon = draft.userLongitude { params["user_longitude"] = lon }
 
-        urlRequest.httpBody = NetworkHelpers.dictionary(toHTTPBodyData: params)
+        urlRequest.httpBody = Self.strictlyFormEncoded(params)
 
         let (data, _) = try await data(for: urlRequest as URLRequest)
         return try JSONDecoder.obacoServiceDecoder.decode(GhostBusReport.self, from: data)
+    }
+
+    /// Form-encodes `params` for `postGhostBusReport` using RFC 3986's "unreserved" character
+    /// set (alphanumerics plus `-._~`) rather than `NetworkHelpers.dictionary(toHTTPBodyData:)`'s
+    /// `.urlQueryAllowed`, which leaves `&`, `+`, `;`, and `=` unescaped. Free-text rider
+    /// comments routinely contain those characters (e.g. "Sat 20+ min & it vanished = gone;
+    /// really"), and `.urlQueryAllowed` would truncate the comment at `&`, turn `+` into a
+    /// literal space on the server, and inject bogus extra params from a stray `=`.
+    ///
+    /// This is scoped to this one call site so the alarm/push-registration callers of
+    /// `NetworkHelpers.dictionary(toHTTPBodyData:)` are untouched.
+    private static func strictlyFormEncoded(_ params: [String: Any]) -> Data {
+        var unreserved = CharacterSet.alphanumerics
+        unreserved.insert(charactersIn: "-._~")
+
+        let pairs = params.map { key, value -> String in
+            let keyStr = key.addingPercentEncoding(withAllowedCharacters: unreserved) ?? key
+            let valueStr = "\(value)".addingPercentEncoding(withAllowedCharacters: unreserved) ?? "\(value)"
+            return "\(keyStr)=\(valueStr)"
+        }.joined(separator: "&")
+
+        return pairs.data(using: .utf8)!
     }
 
     // MARK: - APNs Environment

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/GhostBusReportOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/GhostBusReportOperationTests.swift
@@ -88,4 +88,38 @@ final class GhostBusReportOperationTests: OBATestCase {
         #expect(!body.contains("predicted"))
         #expect(!body.contains("user_latitude"))
     }
+
+    @Test func `Comment with form-special characters is strictly escaped, not corrupted`() async throws {
+        let data = Fixtures.loadData(file: "create_ghost_bus_report.json")
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: data) { request in
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            return request.httpMethod == "POST"
+        }
+
+        var draft = makeDraft()
+        draft.comment = "Sat 20+ min & it vanished = gone; really"
+        _ = try await obacoService.postGhostBusReport(draft, userID: "device-uuid-1")
+
+        let body = try #require(capture.body)
+
+        // `.urlQueryAllowed` (the bug) leaves &, +, ;, and = unescaped, which would
+        // truncate the comment param at the first & and turn + into a space server-side.
+        // A strictly-escaped comment value must contain none of those raw characters.
+        let commentParam = try #require(body.components(separatedBy: "&").first { $0.hasPrefix("comment=") })
+        let commentValue = String(commentParam.dropFirst("comment=".count))
+        #expect(!commentValue.contains("&"))
+        #expect(!commentValue.contains("+"))
+        #expect(!commentValue.contains("="))
+        #expect(!commentValue.contains(";"))
+
+        // Percent-decoding the escaped value recovers the original comment exactly.
+        let decoded = commentValue.removingPercentEncoding
+        #expect(decoded == "Sat 20+ min & it vanished = gone; really")
+
+        // Other params must still be intact and unaffected by the comment's encoding.
+        #expect(body.contains("user_identifier=device-uuid-1"))
+        #expect(body.contains("trip_identifier=1_604825"))
+    }
 }

--- a/OBAKitTests/Modeling/Obaco Model Service Tests/GhostBusReportOperationTests.swift
+++ b/OBAKitTests/Modeling/Obaco Model Service Tests/GhostBusReportOperationTests.swift
@@ -1,0 +1,91 @@
+//
+//  GhostBusReportOperationTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_cast
+
+@Suite(.serialized)
+final class GhostBusReportOperationTests: OBATestCase {
+
+    private final class RequestCapture: @unchecked Sendable {
+        nonisolated(unsafe) var body: String?
+    }
+
+    private func makeDraft() -> GhostBusReportDraft {
+        var draft = GhostBusReportDraft(
+            tripID: "1_604825",
+            serviceDate: Date(timeIntervalSince1970: 1_754_352_000)
+        )
+        draft.routeID = "1_100223"
+        draft.stopID = "1_75403"
+        draft.vehicleID = "1_4361"
+        draft.stopSequence = 12
+        draft.predicted = true
+        draft.scheduleDeviationMinutes = 2
+        draft.waitDurationMinutes = 15
+        draft.comment = "Watched it disappear off the map."
+        return draft
+    }
+
+    @Test func `Successful ghost bus report submission`() async throws {
+        let data = Fixtures.loadData(file: "create_ghost_bus_report.json")
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(URLString: "https://alerts.example.com/api/v2/regions/1/ghost_bus_reports", with: data)
+
+        let report = try await obacoService.postGhostBusReport(makeDraft(), userID: "device-uuid-1")
+        #expect(report.id == "c0ffee00c0ffee00c0ff")
+    }
+
+    @Test func `Submission sends the captured trip context form-encoded`() async throws {
+        let data = Fixtures.loadData(file: "create_ghost_bus_report.json")
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: data) { request in
+            guard request.httpMethod == "POST", request.url?.path.hasSuffix("/ghost_bus_reports") ?? false else {
+                return false
+            }
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            return true
+        }
+
+        _ = try await obacoService.postGhostBusReport(makeDraft(), userID: "device-uuid-1")
+
+        let body = try #require(capture.body)
+        #expect(body.contains("user_identifier=device-uuid-1"))
+        #expect(body.contains("trip_identifier=1_604825"))
+        #expect(body.contains("service_date=1754352000000"))
+        #expect(body.contains("wait_duration_minutes=15"))
+        #expect(body.contains("predicted=1"))
+        #expect(body.contains("vehicle_identifier=1_4361"))
+        #expect(body.contains("stop_sequence=12"))
+    }
+
+    @Test func `Optional fields are omitted, not sent empty`() async throws {
+        let data = Fixtures.loadData(file: "create_ghost_bus_report.json")
+        let capture = RequestCapture()
+        let dataLoader = (obacoService.dataLoader as! MockDataLoader)
+        dataLoader.mock(data: data) { request in
+            capture.body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            return request.httpMethod == "POST"
+        }
+
+        let minimal = GhostBusReportDraft(tripID: "1_604825", serviceDate: Date(timeIntervalSince1970: 1_754_352_000))
+        _ = try await obacoService.postGhostBusReport(minimal, userID: "device-uuid-1")
+
+        let body = try #require(capture.body)
+        #expect(!body.contains("vehicle_identifier"))
+        #expect(!body.contains("comment"))
+        #expect(!body.contains("predicted"))
+        #expect(!body.contains("user_latitude"))
+    }
+}

--- a/OBAKitTests/fixtures/create_ghost_bus_report.json
+++ b/OBAKitTests/fixtures/create_ghost_bus_report.json
@@ -1,0 +1,3 @@
+{
+  "id": "c0ffee00c0ffee00c0ff"
+}


### PR DESCRIPTION
## Summary
- Adds a "More" menu to the trip page action bar (modeled on `StopPageToolbar.moreItem`, including its documented Menu-styling workaround) whose first item is **Report Ghost Bus** — for reporting a scheduled vehicle that never showed up. Gated on `features.obaco == .running`; modern trip page only (the legacy `TripViewController` entry points are deliberate follow-up work).
- The sheet (SwiftUI in a `UIHostingController`, medium/large detents) confirms the trip context, asks how long the rider waited (5/10/15/20/30+ min), takes an optional comment (capped at 1,000 chars to mirror the server) and a location opt-in, and submits via a new `ObacoAPIService.postGhostBusReport` to the obacloud sidecar (`POST /api/v2/regions/:id/ghost_bus_reports`). Failures keep the rider's input; a duplicate report gets friendly copy.
- Fixes a latent bug in the shared `NetworkHelpers.dictionary(toHTTPBodyData:)` encoder: `.urlQueryAllowed` left `&`, `+`, `;`, `=` unescaped, corrupting any free-text value (rider comments, live-activity trip headsigns like "15th Ave & Broadway", push-registration device descriptions). Values are now escaped against RFC 3986 unreserved characters; existing callers' tests are unaffected.

Companion server PR: OneBusAway/obacloud#1053.

## Test plan
- [x] Full suite green on iPhone 17e simulator (1,878 tests / 206 suites), including 4 new `GhostBusReportOperationTests` covering the request path, form-body contents, optional-field omission, and strict encoding of `& + = ;` in comments.
- [x] Server-side round-trip of the same tricky comment proven against a live obacloud dev server (see companion PR).
- [x] Simulator walkthrough: More button renders in the action bar, menu item shows `clock.badge.questionmark`, sheet presents at medium detent with all fields, cancel dismisses cleanly.

## Review notes
- `interactiveDismissDisabled` doesn't bridge from a UIKit-presented hosting controller, so a swipe-down mid-submit can dismiss with the request in flight; worst case the retry shows "already reported." Accepted for now.
- Pre-existing, untouched: `LiveActivityModelOperationTests.formParams(from:)` still has the decode bugs CodeRabbit flagged on #1179 (drops values containing `=`, never converts `+`); the new tests do their own correct decoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to report a ghost bus from the trip page.
  * Report forms include trip details, wait time, optional comments, location-sharing preferences, and a 1,000-character comment limit.
  * Reports submit securely with loading states, confirmation, and clear error messages.
  * Added feature-gated support for regional report submission.

* **Bug Fixes**
  * Improved form-data encoding so special characters in comments and other fields are transmitted correctly.
  * Improved trip-page back navigation and action-bar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->