### PR TITLE
Native search for the SwiftUI map panel

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1210,23 +1210,18 @@ class MapViewController: UIViewController,
 
         self.floatingPanel.move(to: .tip, animated: true)
 
-        let mapItemController = MapItemViewController { [weak self] controller in
-            guard let self else {
-                fatalError("MapItemViewController outlived its presenting MapViewController")
+        let mapItemController = MapItemViewController(
+            application: application,
+            mapItem: mapItem,
+            delegate: self,
+            removePinHandler: removePinHandler,
+            planTripHandler: { [weak self] in
+                guard let self else { return }
+                self.dismissExistingMapItemController(animated: true)
+                self.showTripPlanner(destination: mapItem)
+                self.semiModalPanel?.move(to: .tip, animated: false)
             }
-            return MapItemViewModel(
-                mapItem: mapItem,
-                application: self.application,
-                actions: .uiKit(presenter: controller, delegate: self, application: self.application),
-                removePinHandler: removePinHandler,
-                planTripHandler: { [weak self] in
-                    guard let self else { return }
-                    self.dismissExistingMapItemController(animated: true)
-                    self.showTripPlanner(destination: mapItem)
-                    self.semiModalPanel?.move(to: .tip, animated: false)
-                }
-            )
-        }
+        )
         let semiModal = createSemiModalPanel(childController: mapItemController)
         semiModal.addPanel(toParent: self)
         self.semiModalMapItemController = semiModal

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1208,17 +1208,25 @@ class MapViewController: UIViewController,
             removePinHandler = nil
         }
 
-        let viewModel = MapItemViewModel(mapItem: mapItem, application: application, delegate: self, removePinHandler: removePinHandler) { [weak self] in
-            guard let self else { return }
-
-            self.dismissExistingMapItemController(animated: true)
-            self.showTripPlanner(destination: mapItem)
-            self.semiModalPanel?.move(to: .tip, animated: false)
-        }
-
         self.floatingPanel.move(to: .tip, animated: true)
 
-        let mapItemController = MapItemViewController(viewModel)
+        let mapItemController = MapItemViewController { [weak self] controller in
+            guard let self else {
+                fatalError("MapItemViewController outlived its presenting MapViewController")
+            }
+            return MapItemViewModel(
+                mapItem: mapItem,
+                application: self.application,
+                actions: .uiKit(presenter: controller, delegate: self, application: self.application),
+                removePinHandler: removePinHandler,
+                planTripHandler: { [weak self] in
+                    guard let self else { return }
+                    self.dismissExistingMapItemController(animated: true)
+                    self.showTripPlanner(destination: mapItem)
+                    self.semiModalPanel?.move(to: .tip, animated: false)
+                }
+            )
+        }
         let semiModal = createSemiModalPanel(childController: mapItemController)
         semiModal.addPanel(toParent: self)
         self.semiModalMapItemController = semiModal

--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -124,7 +124,7 @@ class SearchInteractor: NSObject {
     // MARK: - Bookmarks
     private func buildBookmarksSection(searchText: String) -> SearchListSection? {
         let bookmarks = userDataStore.findBookmarks(matching: searchText).map { bookmark in
-            SearchListRow(kind: .bookmark, title: bookmark.name, accessory: .disclosureIndicator) { [weak self] in
+            SearchListRow(kind: .bookmark(id: bookmark.id.uuidString), title: bookmark.name, accessory: .disclosureIndicator) { [weak self] in
                 guard let self else { return }
                 self.delegate?.searchInteractor(self, showStop: bookmark.stop)
             }

--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -108,7 +108,7 @@ class SearchInteractor: NSObject {
     // MARK: - Recent Stops
     private func buildRecentStopsSection(searchText: String) -> SearchListSection? {
         let recentStops = userDataStore.findRecentStops(matching: searchText).map { stop in
-            SearchListRow(kind: .recentStop, title: stop.name, accessory: .disclosureIndicator) { [weak self] in
+            SearchListRow(kind: .recentStop(id: stop.id), title: stop.name, accessory: .disclosureIndicator) { [weak self] in
                 guard let self else { return }
                 self.delegate?.searchInteractor(self, showStop: stop)
             }

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -17,7 +17,10 @@ struct SearchListRow: Identifiable {
 
     enum Kind {
         case quickSearch(SearchType)
-        case recentStop
+        /// Carries the stop's id for the same reason `searchResult` does: recent
+        /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
+        /// corner share a name.
+        case recentStop(id: String)
         case bookmark
         case placemark(MKMapItem)
         /// A row in a disambiguation list. Carries the underlying model's id
@@ -40,8 +43,8 @@ struct SearchListRow: Identifiable {
             switch self {
             case .quickSearch(let type):
                 return "quickSearch-\(type.rawValue)"
-            case .recentStop:
-                return "recentStop"
+            case .recentStop(let id):
+                return "recentStop-\(id)"
             case .bookmark:
                 return "bookmark"
             case .placemark(let item):

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -20,6 +20,12 @@ struct SearchListRow: Identifiable {
         case recentStop
         case bookmark
         case placemark(MKMapItem)
+        /// A row in a disambiguation list. Carries the underlying model's id
+        /// because titles are not identity — two stops on opposite sides of the
+        /// same corner share a name, and two agencies can both run a route "1".
+        /// Deriving the row id from the title alone collides in exactly the case
+        /// a disambiguation list exists to handle.
+        case searchResult(id: String)
         case clearRecents
         case loading
         case noResults
@@ -41,6 +47,8 @@ struct SearchListRow: Identifiable {
             case .placemark(let item):
                 let coord = item.placemark.coordinate
                 return "placemark-\(coord.latitude)-\(coord.longitude)"
+            case .searchResult(let id):
+                return "searchResult-\(id)"
             case .clearRecents:
                 return "clearRecents"
             case .loading:

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -21,7 +21,10 @@ struct SearchListRow: Identifiable {
         /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
         /// corner share a name.
         case recentStop(id: String)
-        case bookmark
+        /// Carries the bookmark's id for the same reason `recentStop` does: a
+        /// bookmark's default name is its stop's name, so two bookmarks on
+        /// opposite sides of one street would otherwise share a row id.
+        case bookmark(id: String)
         case placemark(MKMapItem)
         /// A row in a disambiguation list. Carries the underlying model's id
         /// because titles are not identity — two stops on opposite sides of the
@@ -45,8 +48,8 @@ struct SearchListRow: Identifiable {
                 return "quickSearch-\(type.rawValue)"
             case .recentStop(let id):
                 return "recentStop-\(id)"
-            case .bookmark:
-                return "bookmark"
+            case .bookmark(let id):
+                return "bookmark-\(id)"
             case .placemark(let item):
                 let coord = item.placemark.coordinate
                 return "placemark-\(coord.latitude)-\(coord.longitude)"

--- a/OBAKit/Search/SearchList/SearchListRowView.swift
+++ b/OBAKit/Search/SearchList/SearchListRowView.swift
@@ -23,7 +23,7 @@ struct SearchListRowView: View {
             errorRow
         case .clearRecents:
             clearRecentsRow
-        case .quickSearch, .recentStop, .bookmark, .placemark:
+        case .quickSearch, .recentStop, .bookmark, .placemark, .searchResult:
             actionRow
         }
     }
@@ -135,7 +135,7 @@ struct SearchListRowView: View {
             switch row.kind {
             case .placemark:
                 badgedIcon(icon, size: 32, imagePadding: 14)
-            case .quickSearch, .recentStop, .bookmark:
+            case .quickSearch, .recentStop, .bookmark, .searchResult:
                 badgedIcon(icon, size: 24, imagePadding: 8)
             case .error:
                 plainIcon(icon, size: 20, tint: .orange)

--- a/OBAKit/Search/SearchList/SearchListView.swift
+++ b/OBAKit/Search/SearchList/SearchListView.swift
@@ -24,6 +24,40 @@ struct SearchListView: View {
     }
 }
 
+// MARK: - Shared list chrome
+
+extension View {
+    /// The list treatment shared by every search surface: inset-grouped cards on no
+    /// background of the list's own.
+    ///
+    /// Pairs with `searchSheetBackground()` on the enclosing sheet — hiding the
+    /// list's background only works if something behind it supplies the contrast the
+    /// cards need.
+    func searchListChrome() -> some View {
+        self
+            .listStyle(.insetGrouped)
+            .scrollDismissesKeyboard(.interactively)
+            .scrollContentBackground(.hidden)
+            .contentMargins(.horizontal, 8, for: .scrollContent)
+            .background(.clear)
+    }
+
+    /// Grouped background for a sheet hosting a search list.
+    ///
+    /// Sheets default to `systemBackground`, and `insetGrouped` rows are filled with
+    /// `secondarySystemGroupedBackground` — the same colour in light mode. The cards
+    /// are drawn, but they're white on white, so the rows read as plain text with no
+    /// list edges at all. Painting the sheet with `systemGroupedBackground` is what
+    /// a grouped list normally sits on and gives the cards their contrast back.
+    ///
+    /// Applied to the whole sheet rather than left to the `List`'s own background so
+    /// the colour runs edge to edge, instead of starting below the search field and
+    /// leaving the header two-tone.
+    func searchSheetBackground() -> some View {
+        presentationBackground(Color(.systemGroupedBackground))
+    }
+}
+
 // MARK: - SearchListContentView
 
 private struct SearchListContentView: View {
@@ -43,11 +77,7 @@ private struct SearchListContentView: View {
                 }
             }
         }
-        .listStyle(.insetGrouped)
-        .scrollDismissesKeyboard(.interactively)
-        .scrollContentBackground(.hidden)
-        .contentMargins(.horizontal, 8, for: .scrollContent)
-        .background(.clear)
+        .searchListChrome()
     }
 }
 

--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -95,6 +95,11 @@ public class SearchManager: NSObject {
     ///   - `.route` / `.vehicleID` show an alert only; publishing an empty response
     ///     would additionally trigger the "No search results were found" alert via
     ///     `notifyDelegatesNoSearchResults`, double-alerting the user.
+    ///
+    /// A failed vehicle *details* fetch used to be the one exception, alerting and
+    /// publishing an empty error response from inside `fetchVehicleID` — i.e. the
+    /// double alert the `.vehicleID` rule above exists to avoid. It now propagates
+    /// like every other failure and lands in the same branch.
     public func search(request: SearchRequest) async {
         if request.searchType == .vehicleID {
             ProgressHUD.show()
@@ -182,16 +187,15 @@ public class SearchManager: NSObject {
             return SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
         }
 
-        do {
-            let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
-            return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
-        } catch {
-            // Preserved from `processSearchResults`: this inner failure alerted and
-            // published an empty error response rather than propagating. Kept as-is
-            // so the UIKit path is unchanged; revisit when the SwiftUI panel is the
-            // only surface.
-            await application.displayError(error)
-            return SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-        }
+        // Propagated, not swallowed. `processSearchResults` used to alert here and
+        // return an empty error response, which put a *failed* lookup and a query
+        // that genuinely matched nothing into the same shape — fine while
+        // `MapRegionManager` was the only consumer, wrong now that `fetchResults` is
+        // also the SwiftUI entry point and classifies purely on `results`. Letting it
+        // throw sends it to the `.vehicleID` branch of `search(request:)`, which is
+        // where every other vehicle-search failure is already alerted, and lets the
+        // SwiftUI sheet report it as the error it is.
+        let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
+        return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
     }
 }

--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -84,119 +84,114 @@ public class SearchManager: NSObject {
         self.application = application
     }
 
+    // MARK: - Publishing entry point (UIKit)
+
+    /// Performs `request` and publishes the result through `MapRegionManager`, which
+    /// fans out to `MapRegionDelegate`. Error handling deliberately differs per
+    /// search type — that asymmetry is pre-existing behavior the UIKit map depends
+    /// on, not an oversight:
+    ///   - `.address` publishes an error response and shows no alert.
+    ///   - `.stopNumber` shows an alert *and* publishes an error response.
+    ///   - `.route` / `.vehicleID` show an alert only; publishing an empty response
+    ///     would additionally trigger the "No search results were found" alert via
+    ///     `notifyDelegatesNoSearchResults`, double-alerting the user.
     public func search(request: SearchRequest) async {
+        if request.searchType == .vehicleID {
+            ProgressHUD.show()
+        }
+        defer {
+            if request.searchType == .vehicleID {
+                ProgressHUD.dismiss()
+            }
+        }
+
+        do {
+            guard let response = try await fetchResults(for: request) else { return }
+            application.mapRegionManager.searchResponse = response
+        } catch {
+            switch request.searchType {
+            case .address:
+                application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
+            case .stopNumber:
+                await application.displayError(error)
+                application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
+            case .route, .vehicleID:
+                await application.displayError(error)
+            }
+        }
+    }
+
+    // MARK: - Returning entry point (SwiftUI)
+
+    /// Performs `request` and returns the response instead of publishing it.
+    ///
+    /// Returns `nil` when the search could not run at all — no API service, no
+    /// Obaco service, or no map rect — mirroring the `guard … else { return }`
+    /// bail-outs the publishing path has always had.
+    func fetchResults(for request: SearchRequest) async throws -> SearchResponse? {
         switch request.searchType {
-        case .address:    await searchAddress(request: request)
-        case .route:      await searchRoute(request: request)
-        case .stopNumber: searchStopNumber(request: request)
-        case .vehicleID:  await searchVehicleID(request: request)
+        case .address:    return try await fetchAddress(request: request)
+        case .route:      return try await fetchRoute(request: request)
+        case .stopNumber: return try await fetchStopNumber(request: request)
+        case .vehicleID:  return try await fetchVehicleID(request: request)
         }
     }
 
-    private func searchAddress(request: SearchRequest) async {
+    private func fetchAddress(request: SearchRequest) async throws -> SearchResponse? {
         guard
             let apiService = application.apiService,
             let mapRect = application.mapRegionManager.lastVisibleMapRect
-        else {
-            return
-        }
+        else { return nil }
 
-        let searchResponse: SearchResponse
-        do {
-            let results = try await apiService.getPlacemarks(query: request.query, region: MKCoordinateRegion(mapRect))
-            searchResponse = SearchResponse(request: request, results: results.mapItems, boundingRegion: results.boundingRegion, error: nil)
-        } catch {
-            searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-        }
-
-        await MainActor.run {
-            self.application.mapRegionManager.searchResponse = searchResponse
-        }
+        let results = try await apiService.getPlacemarks(query: request.query, region: MKCoordinateRegion(mapRect))
+        return SearchResponse(request: request, results: results.mapItems, boundingRegion: results.boundingRegion, error: nil)
     }
 
-    private func searchRoute(request: SearchRequest) async {
+    private func fetchRoute(request: SearchRequest) async throws -> SearchResponse? {
         guard
             let apiService = application.apiService,
             let mapRect = application.mapRegionManager.lastVisibleMapRect
-        else {
-            return
-        }
+        else { return nil }
 
-        do {
-            let response = try await apiService.getRoute(query: request.query, region: CLCircularRegion(mapRect: mapRect))
-            await MainActor.run {
-                self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
-            }
-        } catch {
-            await self.application.displayError(error)
-        }
+        let response = try await apiService.getRoute(query: request.query, region: CLCircularRegion(mapRect: mapRect))
+        return SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
     }
 
-    private func searchStopNumber(request: SearchRequest) {
-        guard let apiService = application.apiService else {
-            return
-        }
+    private func fetchStopNumber(request: SearchRequest) async throws -> SearchResponse? {
+        guard
+            let apiService = application.apiService,
+            let serviceRect = application.regionsService.currentRegion?.serviceRect
+        else { return nil }
 
-        let region = CLCircularRegion(mapRect: application.regionsService.currentRegion!.serviceRect)
-
-        Task(priority: .userInitiated) {
-            do {
-                let stops = try await apiService.getStops(circularRegion: region, query: request.query).list
-                await MainActor.run {
-                    self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: stops, boundingRegion: nil, error: nil)
-                }
-            } catch {
-                await self.application.displayError(error)
-                await MainActor.run {
-                    self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-                }
-            }
-        }
+        let stops = try await apiService.getStops(circularRegion: CLCircularRegion(mapRect: serviceRect), query: request.query).list
+        return SearchResponse(request: request, results: stops, boundingRegion: nil, error: nil)
     }
 
-    private func searchVehicleID(request: SearchRequest) async {
-        guard let obacoService = application.obacoService else { return }
+    private func fetchVehicleID(request: SearchRequest) async throws -> SearchResponse? {
+        guard let obacoService = application.obacoService else { return nil }
 
-        ProgressHUD.show()
+        let matchingVehicles = try await obacoService.getVehicles(matching: request.query)
 
-        do {
-            let vehicles = try await obacoService.getVehicles(matching: request.query)
-            self.processSearchResults(request: request, matchingVehicles: vehicles)
-        } catch {
-            await self.application.displayError(error)
-        }
-
-        ProgressHUD.dismiss()
-    }
-
-    private func processSearchResults(request: SearchRequest, matchingVehicles: [AgencyVehicle]) {
-        guard let apiService = application.apiService else { return }
+        guard let apiService = application.apiService else { return nil }
 
         if matchingVehicles.count > 1 {
-            // Show a disambiguation UI.
-            application.mapRegionManager.searchResponse = SearchResponse(request: request, results: matchingVehicles, boundingRegion: nil, error: nil)
-            return
+            return SearchResponse(request: request, results: matchingVehicles, boundingRegion: nil, error: nil)
         }
 
-        if matchingVehicles.count == 1, let vehicleID = matchingVehicles.first?.vehicleID {
-            // One result. Find that vehicle and show it.
-            Task(priority: .userInitiated) {
-                do {
-                    let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
-                    await MainActor.run {
-                        self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
-                    }
-                } catch {
-                    await self.application.displayError(error)
-                    await MainActor.run {
-                        self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-                    }
-                }
+        guard matchingVehicles.count == 1, let vehicleID = matchingVehicles.first?.vehicleID else {
+            return SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        }
 
-            }
-        } else {
-            // No results :(
-            self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        do {
+            let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
+            return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
+        } catch {
+            // Preserved from `processSearchResults`: this inner failure alerted and
+            // published an empty error response rather than propagating. Kept as-is
+            // so the UIKit path is unchanged; revisit when the SwiftUI panel is the
+            // only surface.
+            await application.displayError(error)
+            return SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
         }
     }
 }

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -15,13 +15,16 @@ final class SearchViewModel: ObservableObject {
 
     @Published private(set) var vehicleSearchResponse: SearchResponse?
     @Published private(set) var vehicleError: Error?
+    /// The vehicle whose details are being fetched, or `nil` when idle. Published so
+    /// the results sheet can show progress on the tapped row — the UIKit controller
+    /// showed none at all.
+    @Published private(set) var loadingVehicleID: String?
 
     let subtitle: String
     let results: [Any]
 
     private let searchResponse: SearchResponse
     private let apiService: RESTAPIService?
-    private var isLoading = false
 
     convenience init(searchResponse: SearchResponse, application: Application) {
         self.init(searchResponse: searchResponse, apiService: application.apiService)
@@ -39,7 +42,7 @@ final class SearchViewModel: ObservableObject {
     }
 
     func selectVehicle(vehicleID: String) async {
-        guard !isLoading else { return }
+        guard loadingVehicleID == nil else { return }
         guard let apiService else {
             // Misconfiguration (no API service available). Surface it through the same
             // error channel as a request failure so the screen doesn't silently no-op.
@@ -50,10 +53,10 @@ final class SearchViewModel: ObservableObject {
             ))
             return
         }
-        isLoading = true
+        loadingVehicleID = vehicleID
         vehicleError = nil
         vehicleSearchResponse = nil
-        defer { isLoading = false }
+        defer { loadingVehicleID = nil }
         do {
             let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
             vehicleSearchResponse = SearchResponse(response: searchResponse, substituteResult: vehicle)

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -20,6 +20,10 @@ final class SearchViewModel: ObservableObject {
     /// showed none at all.
     @Published private(set) var loadingVehicleID: String?
 
+    /// The vehicle whose lookup produced `vehicleError`, so the inline error row can
+    /// offer a retry rather than dead-ending the user.
+    @Published private(set) var failedVehicleID: String?
+
     let subtitle: String
     let results: [Any]
 
@@ -46,6 +50,7 @@ final class SearchViewModel: ObservableObject {
         guard let apiService else {
             // Misconfiguration (no API service available). Surface it through the same
             // error channel as a request failure so the screen doesn't silently no-op.
+            failedVehicleID = vehicleID
             vehicleError = UnstructuredError(OBALoc(
                 "search_results_controller.no_api_service_error",
                 value: "No transit data service is available. Please choose a region in Settings.",
@@ -55,6 +60,7 @@ final class SearchViewModel: ObservableObject {
         }
         loadingVehicleID = vehicleID
         vehicleError = nil
+        failedVehicleID = nil
         vehicleSearchResponse = nil
         defer { loadingVehicleID = nil }
         do {
@@ -64,9 +70,11 @@ final class SearchViewModel: ObservableObject {
             // VehicleStatus requires `tripId`; its absence means the vehicle isn't on
             // any trip right now. Any *other* missing key signals a real decode failure
             // (renamed field, malformed payload) and should surface as-is.
+            failedVehicleID = vehicleID
             vehicleError = SearchError.noTripsAvailable
         } catch {
             Logger.error("selectVehicle decode failure: \(error)")
+            failedVehicleID = vehicleID
             vehicleError = error
         }
     }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,32 +31,23 @@ struct HomeSheetView: View {
     // MARK: - Search Bar
 
     private var searchBarRow: some View {
-        // Non-interactive while the `.search` route lacks a real view with a
-        // back affordance — a tap would otherwise animate to the largest detent
-        // and strand the user there (the route is base-layer with
-        // `isDismissDisabled: true`). Rendered as an `HStack` (not a disabled
-        // `Button`) so the shape communicates "not actionable yet" honestly to
-        // both readers and assistive tech — VoiceOver announces it as static
-        // text rather than a disabled button.
-        HStack(spacing: 12) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            Text(OBALoc(
-                "home_sheet.search_bar.coming_soon",
-                value: "Search coming soon",
-                comment: "Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented."
-            ))
-                .foregroundStyle(.secondary)
-            Spacer()
+        Button {
+            coordinator.push(.search)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                Text(viewModel.searchPlaceholder)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background { Capsule().fill(Color(.tertiarySystemFill)) }
+            .contentShape(.capsule)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background {
-            Capsule()
-                .fill(Color(.tertiarySystemFill))
-        }
+        .buttonStyle(.plain)
         .padding(.horizontal, 12)
-        .accessibilityElement(children: .combine)
     }
 
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -17,27 +17,32 @@ import OBAKitCore
 // `@StateObject` + `@autoclosure` plumbing is already in place and the
 // next reader sees the intended shape rather than an unexplained empty type.
 @MainActor
-final class HomeSheetViewModel: ObservableObject {
+final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelegate {
     // TODO: Populate from `RESTAPIService` / `LocationService` once the
     // home sheet renders nearby stops.
     @Published private(set) var nearbyStops: [Stop] = []
+
+    /// Published rather than computed so a region change repaints the search bar.
+    /// The UIKit panel gets this from its own `RegionsServiceDelegate` callback
+    /// (`MapFloatingPanelController.regionsService(_:updatedRegion:)`); a plain
+    /// computed property would leave the placeholder naming the old region until
+    /// something unrelated happened to invalidate the view.
+    @Published private(set) var searchPlaceholder: String
 
     private let application: Application
 
     init(application: Application) {
         self.application = application
+        self.searchPlaceholder = SearchPlaceholder.text(for: application)
+        super.init()
+
+        // `RegionsService` holds delegates weakly, so there's nothing to unregister.
+        application.regionsService.addDelegate(self)
     }
 
-    /// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
-    var searchPlaceholder: String {
-        guard let region = application.regionsService.currentRegion else { return "" }
-        if application.features.tripPlanning == .running {
-            return OBALoc(
-                "map_floating_panel.where_are_you_going",
-                value: "Where are you going?",
-                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
-            )
-        }
-        return Formatters.searchPlaceholderText(region: region)
+    // MARK: - RegionsServiceDelegate
+
+    func regionsService(_ service: RegionsService, updatedRegion region: Region) {
+        searchPlaceholder = SearchPlaceholder.text(for: application)
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -21,4 +21,23 @@ final class HomeSheetViewModel: ObservableObject {
     // TODO: Populate from `RESTAPIService` / `LocationService` once the
     // home sheet renders nearby stops.
     @Published private(set) var nearbyStops: [Stop] = []
+
+    private let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    /// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
+    var searchPlaceholder: String {
+        guard let region = application.regionsService.currentRegion else { return "" }
+        if application.features.tripPlanning == .running {
+            return OBALoc(
+                "map_floating_panel.where_are_you_going",
+                value: "Where are you going?",
+                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
+            )
+        }
+        return Formatters.searchPlaceholderText(region: region)
+    }
 }

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -17,10 +17,13 @@ import OBAKitCore
 /// Wraps the shared `MapItemView` with sheet-native actions: Close pops the stacked
 /// sheet, Nearby Stops pushes its own route, and the website opens in a local Safari
 /// sheet rather than being presented from a view controller.
+///
+/// The searched place marker is drawn by `MapPanelRootView`, which drops it when this
+/// route leaves the sheet stack — the sheet doesn't clear the map itself. See
+/// `MapSearchDisplayModel.owner`.
 struct MapItemSheetView: View {
     let application: Application
     let mapItem: MKMapItem
-    let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
@@ -67,10 +70,6 @@ struct MapItemSheetView: View {
                 planTripHandler: nil
             )
         }
-        // The searched place marker belongs to this sheet. Pushing `.nearbyStops`
-        // from a row *stacks* over this sheet rather than dismissing it, so this
-        // only fires on a real exit.
-        .onDisappear { displayModel.clear() }
         .sheet(item: $website) { link in
             SafariSheetView(url: link.url)
         }

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -1,0 +1,72 @@
+//
+//  MapItemSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// `AppSheetRoute.mapItem` — the place-detail card, at the medium detent so the map
+/// stays visible behind it.
+///
+/// Wraps the shared `MapItemView` with sheet-native actions: Close pops the stacked
+/// sheet, Nearby Stops pushes its own route, and the website opens in a local Safari
+/// sheet rather than being presented from a view controller.
+struct MapItemSheetView: View {
+    let application: Application
+    let mapItem: MKMapItem
+
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var websiteURL: URL?
+    @State private var viewModel: MapItemViewModel?
+
+    var body: some View {
+        Group {
+            if let viewModel {
+                VStack(spacing: 0) {
+                    MapItemView(viewModel: viewModel, showsShareButton: false)
+                }
+                .overlay(alignment: .topTrailing) {
+                    if let shareURL = viewModel.shareURL {
+                        ShareLink(item: shareURL)
+                            .labelStyle(.iconOnly)
+                            .padding()
+                    }
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .onAppear {
+            guard viewModel == nil else { return }
+            viewModel = MapItemViewModel(
+                mapItem: mapItem,
+                application: application,
+                actions: MapItemActions(
+                    openWebsite: { websiteURL = $0 },
+                    showNearbyStops: { coordinator.push(.nearbyStops(coordinate: $0)) },
+                    dismiss: { dismiss() }
+                ),
+                removePinHandler: nil,
+                // Trip planning has no SwiftUI route yet: the button renders for
+                // layout parity and does nothing. Wire this up when the trip
+                // planner lands on this surface.
+                planTripHandler: { }
+            )
+        }
+        .sheet(item: $websiteURL) { url in
+            SafariSheetView(url: url)
+        }
+    }
+}
+
+extension URL: @retroactive Identifiable {
+    public var id: String { absoluteString }
+}

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -20,53 +20,69 @@ import OBAKitCore
 struct MapItemSheetView: View {
     let application: Application
     let mapItem: MKMapItem
+    let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
 
-    @State private var websiteURL: URL?
+    @State private var website: WebsiteLink?
     @State private var viewModel: MapItemViewModel?
 
     var body: some View {
         Group {
             if let viewModel {
-                VStack(spacing: 0) {
-                    MapItemView(viewModel: viewModel, showsShareButton: false)
-                }
-                .overlay(alignment: .topTrailing) {
-                    if let shareURL = viewModel.shareURL {
-                        ShareLink(item: shareURL)
-                            .labelStyle(.iconOnly)
-                            .padding()
+                MapItemView(viewModel: viewModel, showsShareButton: false)
+                    // Top-*leading*, matching where `MapItemView` puts Share in the
+                    // UIKit host. `.topTrailing` would land on top of that view's
+                    // own Close button and swallow its taps.
+                    .overlay(alignment: .topLeading) {
+                        if let shareURL = viewModel.shareURL {
+                            ShareLink(item: shareURL)
+                                .labelStyle(.iconOnly)
+                                .padding()
+                        }
                     }
-                }
             } else {
                 Color.clear
             }
         }
+        // Built here rather than in `init`: `MapItemViewModel.init` kicks off a Look
+        // Around scene request, and `@State`'s initial value would be re-evaluated on
+        // every body pass of the sheet container — one network request per detent
+        // drag frame.
         .onAppear {
             guard viewModel == nil else { return }
             viewModel = MapItemViewModel(
                 mapItem: mapItem,
                 application: application,
                 actions: MapItemActions(
-                    openWebsite: { websiteURL = $0 },
+                    openWebsite: { website = WebsiteLink(url: $0) },
                     showNearbyStops: { coordinator.push(.nearbyStops(coordinate: $0)) },
                     dismiss: { dismiss() }
                 ),
                 removePinHandler: nil,
-                // Trip planning has no SwiftUI route yet: the button renders for
-                // layout parity and does nothing. Wire this up when the trip
-                // planner lands on this surface.
-                planTripHandler: { }
+                // No trip-planner route on this surface yet. `nil` hides the button
+                // rather than rendering one that does nothing; wire it up when the
+                // trip planner lands here.
+                planTripHandler: nil
             )
         }
-        .sheet(item: $websiteURL) { url in
-            SafariSheetView(url: url)
+        // The searched place marker belongs to this sheet. Pushing `.nearbyStops`
+        // from a row *stacks* over this sheet rather than dismissing it, so this
+        // only fires on a real exit.
+        .onDisappear { displayModel.clear() }
+        .sheet(item: $website) { link in
+            SafariSheetView(url: link.url)
         }
     }
 }
 
-extension URL: @retroactive Identifiable {
-    public var id: String { absoluteString }
+/// `.sheet(item:)` needs an `Identifiable` payload. A local wrapper rather than a
+/// retroactive `Identifiable` conformance on `URL` — protocol conformances aren't
+/// access-controlled, so conforming a Foundation type here would make it OBAKit's
+/// answer for every consumer of the framework and collide with any other module
+/// (or a future Foundation version) that declares the same thing.
+private struct WebsiteLink: Identifiable {
+    let url: URL
+    var id: String { url.absoluteString }
 }

--- a/OBAKit/Sheet/Content/Search/NearbyStopsSheetHost.swift
+++ b/OBAKit/Sheet/Content/Search/NearbyStopsSheetHost.swift
@@ -1,0 +1,43 @@
+//
+//  NearbyStopsSheetHost.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import MapKit
+import OBAKitCore
+
+/// UIKit wiring wrapper for `AppSheetRoute.nearbyStops`, mirroring
+/// `StopDetailSheetHost`. Replace with a native list when one exists.
+struct NearbyStopsSheetHost: UIViewControllerRepresentable {
+    let application: Application
+    let coordinate: CLLocationCoordinate2D
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let dismiss = context.environment.dismiss
+        return Self.makeNavigationController(application: application, coordinate: coordinate, onClose: { dismiss() })
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+
+    /// Factory seam mirroring `StopDetailSheetHost`, so tests can drive the wiring
+    /// without a `UIHostingController`.
+    static func makeNavigationController(
+        application: Application,
+        coordinate: CLLocationCoordinate2D,
+        onClose: @escaping () -> Void
+    ) -> UINavigationController {
+        let controller = NearbyStopsViewController(coordinate: coordinate, application: application)
+        let closeButton = UIBarButtonItem(primaryAction: UIAction(title: Strings.close) { _ in onClose() })
+        for state: UIControl.State in [.normal, .highlighted] {
+            closeButton.setTitleTextAttributes([.foregroundColor: UIColor.label], for: state)
+        }
+        controller.navigationItem.leftBarButtonItem = closeButton
+        return UINavigationController(rootViewController: controller)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -56,6 +56,44 @@ struct RouteStopsSheetView: View {
 
     var body: some View {
         NavigationStack {
+            content
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        VStack(spacing: 0) {
+                            Text(stopsForRoute.route?.shortName ?? "")
+                                .font(.headline)
+                            if let subtitle = routeSubtitle {
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { dismiss() }
+                    }
+                }
+        }
+        .searchSheetBackground()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if rows.isEmpty {
+            // `RouteStopsRow.rows(from:)` yields nothing for an unresolved payload.
+            // Say so, rather than showing a blank list the user can only read as a
+            // broken screen — the same treatment `SearchResultsSheetView` gives its
+            // empty case.
+            EmptyStateView(
+                title: OBALoc(
+                    "route_stops_sheet.empty.title",
+                    value: "No stops",
+                    comment: "Title shown when a route's stop list could not be loaded or is empty."
+                ),
+                systemImage: AppSymbol.error
+            )
+        } else {
             List(rows) { row in
                 Button {
                     // Keep the map in step with the list — something the UIKit
@@ -83,25 +121,7 @@ struct RouteStopsSheetView: View {
                 .buttonStyle(.plain)
             }
             .searchListChrome()
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    VStack(spacing: 0) {
-                        Text(stopsForRoute.route?.shortName ?? "")
-                            .font(.headline)
-                        if let subtitle = routeSubtitle {
-                            Text(subtitle)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(Strings.close) { dismiss() }
-                }
-            }
         }
-        .searchSheetBackground()
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -1,0 +1,104 @@
+//
+//  RouteStopsSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// One row of the route-stops list. A plain value so the mapping — including the
+/// direction formatting and the unresolved-stops case — is testable without a view.
+struct RouteStopsRow: Identifiable {
+    let stopID: Stop.ID
+    let title: String
+    let subtitle: String
+    let coordinate: CLLocationCoordinate2D
+
+    var id: Stop.ID { stopID }
+
+    /// `StopsForRoute.stops` is an implicitly-unwrapped optional filled in by
+    /// `HasReferences`; an unresolved payload yields no rows rather than a crash.
+    static func rows(from stopsForRoute: StopsForRoute) -> [RouteStopsRow] {
+        (stopsForRoute.stops ?? []).map { stop in
+            RouteStopsRow(
+                stopID: stop.id,
+                title: stop.name,
+                subtitle: Formatters.adjectiveFormOfCardinalDirection(stop.direction) ?? "",
+                coordinate: stop.coordinate
+            )
+        }
+    }
+}
+
+/// `AppSheetRoute.routeStops` — the stop list for a searched route, opening at the
+/// medium detent so the polyline stays on screen. Native replacement for
+/// `RouteStopsViewController`.
+struct RouteStopsSheetView: View {
+    let stopsForRoute: StopsForRoute
+    let displayModel: MapSearchDisplayModel
+
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    private var rows: [RouteStopsRow] { RouteStopsRow.rows(from: stopsForRoute) }
+
+    var body: some View {
+        NavigationStack {
+            List(rows) { row in
+                Button {
+                    // Keep the map in step with the list — something the UIKit
+                    // controller can't do, since it has no handle on the map.
+                    displayModel.focus(coordinate: row.coordinate)
+                    coordinator.push(.stopDetails(stopID: row.stopID))
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.title)
+                            if !row.subtitle.isEmpty {
+                                Text(row.subtitle)
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color(uiColor: ThemeColors.shared.brand))
+                    }
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+            .navigationTitle(stopsForRoute.route?.shortName ?? "")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    VStack(spacing: 0) {
+                        Text(stopsForRoute.route?.shortName ?? "")
+                            .font(.headline)
+                        if let subtitle = routeSubtitle {
+                            Text(subtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(Strings.close) { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var routeSubtitle: String? {
+        guard let route = stopsForRoute.route else { return nil }
+        return route.longName ?? route.agency.name
+    }
+}

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -76,7 +76,6 @@ struct RouteStopsSheetView: View {
                 .buttonStyle(.plain)
             }
             .listStyle(.plain)
-            .navigationTitle(stopsForRoute.route?.shortName ?? "")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -95,6 +94,12 @@ struct RouteStopsSheetView: View {
                 }
             }
         }
+        // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
+        // also gates the ambient stop layer, so leaving it set after the sheet goes
+        // away would strand the map with a dismissed route drawn on it and no stop
+        // pins at all. Pushing `.stopDetails` from a row *stacks* over this sheet
+        // rather than dismissing it, so this only fires on a real exit.
+        .onDisappear { displayModel.clear() }
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -75,7 +75,7 @@ struct RouteStopsSheetView: View {
                 }
                 .buttonStyle(.plain)
             }
-            .listStyle(.plain)
+            .searchListChrome()
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -94,6 +94,7 @@ struct RouteStopsSheetView: View {
                 }
             }
         }
+        .searchSheetBackground()
         // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
         // also gates the ambient stop layer, so leaving it set after the sheet goes
         // away would strand the map with a dismissed route drawn on it and no stop

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -38,8 +38,15 @@ struct RouteStopsRow: Identifiable {
 /// `AppSheetRoute.routeStops` — the stop list for a searched route, opening at the
 /// medium detent so the polyline stays on screen. Native replacement for
 /// `RouteStopsViewController`.
+///
+/// The polyline itself is drawn by `MapPanelRootView` and dropped when this route
+/// leaves the sheet stack — the sheet doesn't clear the map on its own way out. See
+/// `MapSearchDisplayModel.owner`.
 struct RouteStopsSheetView: View {
     let stopsForRoute: StopsForRoute
+
+    /// Only used to pan the map alongside the list; the drawn route's lifetime is
+    /// not this view's business.
     let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
@@ -95,12 +102,6 @@ struct RouteStopsSheetView: View {
             }
         }
         .searchSheetBackground()
-        // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
-        // also gates the ambient stop layer, so leaving it set after the sheet goes
-        // away would strand the map with a dismissed route drawn on it and no stop
-        // pins at all. Pushing `.stopDetails` from a row *stacks* over this sheet
-        // rather than dismissing it, so this only fires on a real exit.
-        .onDisappear { displayModel.clear() }
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/SafariSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SafariSheetView.swift
@@ -1,0 +1,23 @@
+//
+//  SafariSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import SafariServices
+
+/// In-app browser for SwiftUI sheets, matching the UIKit path's
+/// `SFSafariViewController` presentation.
+struct SafariSheetView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) { }
+}

--- a/OBAKit/Sheet/Content/Search/SearchPlaceholder.swift
+++ b/OBAKit/Sheet/Content/Search/SearchPlaceholder.swift
@@ -1,0 +1,35 @@
+//
+//  SearchPlaceholder.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The search field's placeholder copy, shared by the home sheet's search bar and
+/// the search sheet's field so the text doesn't change when the user taps through.
+///
+/// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
+enum SearchPlaceholder {
+
+    /// Empty when no region is selected, matching the UIKit panel, which sets the
+    /// search bar's placeholder to `nil` in that case.
+    @MainActor
+    static func text(for application: Application) -> String {
+        guard let region = application.regionsService.currentRegion else { return "" }
+
+        if application.features.tripPlanning == .running {
+            return OBALoc(
+                "map_floating_panel.where_are_you_going",
+                value: "Where are you going?",
+                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
+            )
+        }
+
+        return Formatters.searchPlaceholderText(region: region)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -1,0 +1,109 @@
+//
+//  SearchResultRouter.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Turns a single search result into a map display plus a sheet route.
+///
+/// Shared by `SearchSheetViewModel` (single-result searches) and
+/// `SearchResultsSheetView` (a row picked out of a disambiguation list), so the two
+/// can't drift on what "opening a result" means.
+///
+/// The UIKit equivalent is split across `MapRegionManager.searchResponse.didSet` and
+/// `MapViewController.mapRegionManager(_:showSearchResult:)`.
+@MainActor
+final class SearchResultRouter {
+
+    private let application: Application
+    private let coordinator: SheetCoordinator<AppSheetRoute>
+    private let displayModel: MapSearchDisplayModel
+    private let onPresentVehicleTrip: (VehicleStatus) -> Void
+
+    /// Set when resolving a result fails, so the presenting screen can render the
+    /// failure inline instead of popping a modal over the sheet.
+    private(set) var lastError: Error?
+
+    init(
+        application: Application,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        displayModel: MapSearchDisplayModel,
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void
+    ) {
+        self.application = application
+        self.coordinator = coordinator
+        self.displayModel = displayModel
+        self.onPresentVehicleTrip = onPresentVehicleTrip
+    }
+
+    /// Routes `response` when it holds exactly one result. Returns `false` when it
+    /// doesn't, leaving the decision (disambiguate, or report no results) to the
+    /// caller.
+    func presentSingleResult(from response: SearchResponse) async -> Bool {
+        guard response.results.count == 1, let result = response.results.first else {
+            return false
+        }
+        await present(result: result)
+        return true
+    }
+
+    func present(result: Any) async {
+        lastError = nil
+
+        switch result {
+        case let stop as Stop:
+            displayModel.show(stop: stop)
+            coordinator.push(.stopDetails(stopID: stop.id))
+
+        case let mapItem as MKMapItem:
+            // Matches the UIKit rule: only animate the recenter for nearby
+            // destinations, so a cross-region jump doesn't fly the camera across
+            // the map.
+            let animated = isWithinAnimationRange(mapItem.placemark.coordinate)
+            displayModel.show(mapItem: mapItem, animated: animated)
+            coordinator.push(.mapItem(mapItem))
+
+        case let route as Route:
+            await presentRoute(route)
+
+        case let stopsForRoute as StopsForRoute:
+            displayModel.show(stopsForRoute: stopsForRoute)
+            coordinator.push(.routeStops(stopsForRoute))
+
+        case let vehicle as VehicleStatus:
+            onPresentVehicleTrip(vehicle)
+
+        default:
+            Logger.error("SearchResultRouter: unhandled result type \(type(of: result))")
+        }
+    }
+
+    /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
+    /// and stop list — before anything can be drawn or listed.
+    private func presentRoute(_ route: Route) async {
+        guard let apiService = application.apiService else { return }
+
+        do {
+            let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry
+            displayModel.show(stopsForRoute: stopsForRoute)
+            coordinator.push(.routeStops(stopsForRoute))
+        } catch {
+            Logger.error("SearchResultRouter: failed to load stops for route \(route.id): \(error)")
+            lastError = error
+        }
+    }
+
+    private static let animationDistanceThreshold: CLLocationDistance = 1609 // roughly a mile
+
+    private func isWithinAnimationRange(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        guard let currentLocation = application.locationService.currentLocation else { return false }
+        return coordinate.distance(from: currentLocation.coordinate) <= Self.animationDistanceThreshold
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -43,67 +43,112 @@ final class SearchResultRouter {
         self.onPresentVehicleTrip = onPresentVehicleTrip
     }
 
-    /// Routes `response` when it holds exactly one result. Returns `false` when it
-    /// doesn't, leaving the decision (disambiguate, or report no results) to the
-    /// caller.
-    func presentSingleResult(from response: SearchResponse) async -> Bool {
-        guard response.results.count == 1, let result = response.results.first else {
-            return false
-        }
-        await present(result: result)
-        return true
+    /// A search result that has been resolved into everything needed to show it, with
+    /// any network work already done.
+    ///
+    /// Separating this from `present(_:)` lets a caller finish the slow part while its
+    /// own screen is still up — so a failure can be reported where the user is looking,
+    /// and the sheet stack isn't torn down around an in-flight request.
+    enum Resolved {
+        case stop(Stop)
+        case mapItem(MKMapItem, animated: Bool)
+        case route(StopsForRoute)
+        /// Handed to the trip bridge rather than a sheet, so it has no sheet route.
+        case vehicle(VehicleStatus)
     }
 
-    func present(result: Any) async {
+    /// Resolves the single result in `response`. Returns `nil` when the response holds
+    /// anything other than exactly one result, leaving that decision (disambiguate, or
+    /// report no results) to the caller.
+    func resolveSingleResult(from response: SearchResponse) async -> Resolved? {
+        guard response.results.count == 1, let result = response.results.first else {
+            return nil
+        }
+        return await resolve(result: result)
+    }
+
+    /// Turns a raw search result into a `Resolved`, performing whatever network work
+    /// the result needs. Records `lastError` and returns `nil` when it can't be
+    /// resolved. Touches neither the map nor the sheet stack.
+    func resolve(result: Any) async -> Resolved? {
         lastError = nil
 
         switch result {
         case let stop as Stop:
-            displayModel.show(stop: stop)
-            coordinator.push(.stopDetails(stopID: stop.id))
+            return .stop(stop)
 
         case let mapItem as MKMapItem:
             // Matches the UIKit rule: only animate the recenter for nearby
             // destinations, so a cross-region jump doesn't fly the camera across
             // the map.
-            let animated = isWithinAnimationRange(mapItem.placemark.coordinate)
-            displayModel.show(mapItem: mapItem, animated: animated)
-            coordinator.push(.mapItem(mapItem))
+            return .mapItem(mapItem, animated: isWithinAnimationRange(mapItem.placemark.coordinate))
 
         case let route as Route:
-            await presentRoute(route)
+            return await resolveRoute(route)
 
         case let stopsForRoute as StopsForRoute:
-            displayModel.show(stopsForRoute: stopsForRoute)
-            coordinator.push(.routeStops(stopsForRoute))
+            return .route(stopsForRoute)
 
         case let vehicle as VehicleStatus:
-            onPresentVehicleTrip(vehicle)
+            return .vehicle(vehicle)
 
         default:
             Logger.error("SearchResultRouter: unhandled result type \(type(of: result))")
+            return nil
         }
+    }
+
+    /// Draws the result and opens its sheet in one synchronous step, so the stacked
+    /// layer never sits empty between the two.
+    ///
+    /// Each display is handed the same route value that gets pushed: the display lives
+    /// exactly as long as its sheet route is on the stack, so the two must not drift.
+    func present(_ resolved: Resolved) {
+        switch resolved {
+        case .stop(let stop):
+            let route = AppSheetRoute.stopDetails(stopID: stop.id)
+            displayModel.show(stop: stop, owner: route)
+            coordinator.push(route)
+
+        case .mapItem(let mapItem, let animated):
+            let route = AppSheetRoute.mapItem(mapItem)
+            displayModel.show(mapItem: mapItem, animated: animated, owner: route)
+            coordinator.push(route)
+
+        case .route(let stopsForRoute):
+            let route = AppSheetRoute.routeStops(stopsForRoute)
+            displayModel.show(stopsForRoute: stopsForRoute, owner: route)
+            coordinator.push(route)
+
+        case .vehicle(let vehicle):
+            onPresentVehicleTrip(vehicle)
+        }
+    }
+
+    /// Resolve-and-present for callers with nothing to unwind first.
+    func present(result: Any) async {
+        guard let resolved = await resolve(result: result) else { return }
+        present(resolved)
     }
 
     /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
     /// and stop list — before anything can be drawn or listed.
-    private func presentRoute(_ route: Route) async {
+    private func resolveRoute(_ route: Route) async -> Resolved? {
         guard let apiService = application.apiService else {
             // Every other failure here records `lastError` so the presenting screen
             // can say something. Returning silently would leave the caller reading
             // "succeeded, nothing happened" and the tapped row doing nothing.
             Logger.error("SearchResultRouter: no API service; cannot resolve route \(route.id).")
             lastError = APIError.noRegionSelected
-            return
+            return nil
         }
 
         do {
-            let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry
-            displayModel.show(stopsForRoute: stopsForRoute)
-            coordinator.push(.routeStops(stopsForRoute))
+            return .route(try await apiService.getStopsForRoute(routeID: route.id).entry)
         } catch {
             Logger.error("SearchResultRouter: failed to load stops for route \(route.id): \(error)")
             lastError = error
+            return nil
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -88,7 +88,14 @@ final class SearchResultRouter {
     /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
     /// and stop list — before anything can be drawn or listed.
     private func presentRoute(_ route: Route) async {
-        guard let apiService = application.apiService else { return }
+        guard let apiService = application.apiService else {
+            // Every other failure here records `lastError` so the presenting screen
+            // can say something. Returning silently would leave the caller reading
+            // "succeeded, nothing happened" and the tapped row doing nothing.
+            Logger.error("SearchResultRouter: no API service; cannot resolve route \(route.id).")
+            lastError = APIError.noRegionSelected
+            return
+        }
 
         do {
             let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -1,0 +1,83 @@
+//
+//  SearchResultRow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Builds `SearchListRow`s for disambiguation results, so the results sheet renders
+/// through the same row view as the search list above it.
+enum SearchResultRow {
+
+    static func row(for result: Any, application: Application, onSelect: @escaping () -> Void) -> SearchListRow? {
+        switch result {
+        case let stop as Stop:
+            return SearchListRow(
+                kind: .recentStop,
+                title: stop.name,
+                subtitle: stopSubtitle(application, stop),
+                icon: .uiImage(Icons.stop),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let route as Route:
+            return SearchListRow(
+                kind: .quickSearch(.route),
+                title: route.shortName,
+                subtitle: route.longName ?? route.agency.name,
+                icon: .uiImage(Icons.route),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let mapItem as MKMapItem:
+            guard let title = mapItem.name ?? mapItem.placemark.title, !title.isEmpty else { return nil }
+            return SearchListRow(
+                kind: .placemark(mapItem),
+                title: title,
+                subtitle: SearchListRow.subtitleForMapItem(application, mapItem),
+                icon: SearchListRow.systemImageForMapItem(mapItem),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let vehicle as AgencyVehicle:
+            guard let vehicleID = vehicle.vehicleID else { return nil }
+            return SearchListRow(
+                kind: .quickSearch(.vehicleID),
+                title: vehicleID,
+                subtitle: vehicle.agencyName,
+                icon: .uiImage(Icons.busTransport),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        default:
+            return nil
+        }
+    }
+
+    /// Direction plus distance from the user, mirroring what the placemark rows in
+    /// the search list already show. Distance is dropped when there's no fix.
+    private static func stopSubtitle(_ application: Application, _ stop: Stop) -> String? {
+        var parts: [String] = []
+
+        if let currentLocation = application.locationService.currentLocation {
+            let distance = currentLocation.distance(from: CLLocation(latitude: stop.coordinate.latitude, longitude: stop.coordinate.longitude))
+            parts.append(application.formatters.distanceFormatter.string(fromDistance: distance))
+        }
+
+        if let direction = Formatters.adjectiveFormOfCardinalDirection(stop.direction), !direction.isEmpty {
+            parts.append(direction)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " • ")
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -19,7 +19,7 @@ enum SearchResultRow {
         switch result {
         case let stop as Stop:
             return SearchListRow(
-                kind: .recentStop,
+                kind: .searchResult(id: stop.id),
                 title: stop.name,
                 subtitle: stopSubtitle(application, stop),
                 icon: .uiImage(Icons.stop),
@@ -29,7 +29,7 @@ enum SearchResultRow {
 
         case let route as Route:
             return SearchListRow(
-                kind: .quickSearch(.route),
+                kind: .searchResult(id: route.id),
                 title: route.shortName,
                 subtitle: route.longName ?? route.agency.name,
                 icon: .uiImage(Icons.route),
@@ -51,7 +51,7 @@ enum SearchResultRow {
         case let vehicle as AgencyVehicle:
             guard let vehicleID = vehicle.vehicleID else { return nil }
             return SearchListRow(
-                kind: .quickSearch(.vehicleID),
+                kind: .searchResult(id: vehicleID),
                 title: vehicleID,
                 subtitle: vehicle.agencyName,
                 icon: .uiImage(Icons.busTransport),

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -15,6 +15,78 @@ import OBAKitCore
 /// through the same row view as the search list above it.
 enum SearchResultRow {
 
+    /// The whole disambiguation list, including the in-place progress swap for a
+    /// vehicle whose details are being fetched. A static function rather than a
+    /// computed property on the view so the mapping can be asserted without a view
+    /// host — the same shape `RouteStopsRow.rows(from:)` uses.
+    static func rows(
+        for results: [Any],
+        loadingVehicleID: String?,
+        application: Application,
+        onSelectVehicle: @escaping (String) -> Void,
+        onSelect: @escaping (Any) -> Void
+    ) -> [SearchListRow] {
+        results.compactMap { result in
+            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
+                // Vehicles need a second request before they can be routed, so the
+                // row shows progress in place instead of navigating immediately.
+                if loadingVehicleID == vehicleID {
+                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
+                }
+                return row(for: result, application: application) { onSelectVehicle(vehicleID) }
+            }
+
+            return row(for: result, application: application) { onSelect(result) }
+        }
+    }
+
+    /// The one inline error row the results sheet shows, from either of the two things
+    /// that can fail there: looking a vehicle's details up, or resolving any other
+    /// tapped row. A failed resolve used to be dropped on the floor, which left the
+    /// tapped row doing nothing at all with no explanation.
+    ///
+    /// Rendered inline rather than as a modal alert: the sheet is already the user's
+    /// context, and a bulletin over it hides what failed. `SearchListRowView.errorRow`
+    /// shows a retry badge and enables the row only when there's an action, so a
+    /// failure the user can re-attempt isn't a dead end.
+    ///
+    /// Static, and taking the state rather than reading it, so the choice of which
+    /// failure wins and whether a retry is offered is assertable without a view host.
+    static func inlineErrorRow(
+        vehicleError: Error?,
+        failedVehicleID: String?,
+        selectionError: Error?,
+        failedResult: Any?,
+        onRetryVehicle: @escaping (String) -> Void,
+        onRetrySelect: @escaping (Any) -> Void
+    ) -> SearchListRow? {
+        if let vehicleError {
+            return errorRow(
+                message: vehicleError.localizedDescription,
+                retry: failedVehicleID.map { vehicleID in { onRetryVehicle(vehicleID) } }
+            )
+        }
+
+        if let selectionError {
+            return errorRow(
+                message: selectionError.localizedDescription,
+                retry: failedResult.map { result in { onRetrySelect(result) } }
+            )
+        }
+
+        return nil
+    }
+
+    private static func errorRow(message: String, retry: (() -> Void)?) -> SearchListRow {
+        SearchListRow(
+            kind: .error(message, systemImage: AppSymbol.error),
+            title: message,
+            subtitle: Strings.retry,
+            icon: .system(AppSymbol.error),
+            action: retry
+        )
+    }
+
     static func row(for result: Any, application: Application, onSelect: @escaping () -> Void) -> SearchListRow? {
         switch result {
         case let stop as Stop:

--- a/OBAKit/Sheet/Content/Search/SearchResultsSelection.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSelection.swift
@@ -1,0 +1,71 @@
+//
+//  SearchResultsSelection.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Opening a row picked out of a disambiguation list, plus whatever failure that
+/// left behind.
+///
+/// A separate object rather than `@State` on `SearchResultsSheetView` so the two
+/// things worth pinning — the resolve/unwind/present ordering, and the fact that a
+/// failed resolve is reported instead of dropped — can be asserted without a view
+/// host. `SearchSheetViewModel` plays the same role for the search sheet.
+@MainActor
+final class SearchResultsSelection: ObservableObject {
+
+    /// Set when `select(_:coordinator:)` could not resolve a result, so the sheet can
+    /// render the failure inline rather than leaving the tapped row doing nothing.
+    @Published private(set) var error: Error?
+
+    /// The result the failure belongs to, kept so the inline error row can offer a
+    /// retry instead of dead-ending the user.
+    @Published private(set) var failedResult: Any?
+
+    private let router: SearchResultRouter
+
+    init(router: SearchResultRouter) {
+        self.router = router
+    }
+
+    /// Unwinds back to home and opens `result` — the SwiftUI equivalent of the UIKit
+    /// path's `exitSearchMode()`.
+    ///
+    /// Resolution comes first so the results sheet stays up while the request runs: a
+    /// failure leaves the user on their results rather than dropping them on home, and
+    /// the stacked layer isn't emptied and refilled around a network call.
+    ///
+    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
+    /// (the stacked results sheet and the `.search` route beneath it), and `pop()` acts
+    /// on whichever layer is topmost *at the moment it runs* — racing the SwiftUI
+    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
+    /// deterministically in one step.
+    func select(_ result: Any, coordinator: SheetCoordinator<AppSheetRoute>) async {
+        error = nil
+        failedResult = nil
+
+        guard let resolved = await router.resolve(result: result) else {
+            // `router.lastError` is nil only for a result type `resolve` doesn't
+            // handle, which is a programming error rather than anything the user did
+            // — but the row still has to say *something*, or tapping it is a no-op.
+            error = router.lastError ?? UnstructuredError(Self.unresolvableText)
+            failedResult = result
+            return
+        }
+
+        coordinator.popToRoot()
+        router.present(resolved)
+    }
+
+    static let unresolvableText = OBALoc(
+        "search_results_sheet.unresolvable_result",
+        value: "This search result could not be opened.",
+        comment: "Error shown when a tapped search result cannot be turned into something to display."
+    )
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -42,6 +42,7 @@ struct SearchResultsSheetView: View {
                     }
                 }
         }
+        .searchSheetBackground()
         .onChange(of: viewModel.vehicleSearchResponse) { _, response in
             guard let result = response?.results.first else { return }
             Task { await select(result) }
@@ -91,7 +92,7 @@ struct SearchResultsSheetView: View {
                     }
                 }
             }
-            .listStyle(.insetGrouped)
+            .searchListChrome()
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -124,8 +124,12 @@ struct SearchResultsSheetView: View {
         }
     }
 
-    /// Unwinds back to home before opening the result — the SwiftUI equivalent of
-    /// the UIKit path's `exitSearchMode()`.
+    /// Unwinds back to home and opens the result — the SwiftUI equivalent of the UIKit
+    /// path's `exitSearchMode()`.
+    ///
+    /// Resolution comes first so this sheet stays up while the request runs: a failure
+    /// leaves the user on their results rather than dropping them on home, and the
+    /// stacked layer isn't emptied and refilled around a network call.
     ///
     /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
     /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
@@ -133,7 +137,8 @@ struct SearchResultsSheetView: View {
     /// binding write that `dismiss()` triggers. `popToRoot()` clears both
     /// deterministically in one step.
     private func select(_ result: Any) async {
+        guard let resolved = await router.resolve(result: result) else { return }
         coordinator.popToRoot()
-        await router.present(result: result)
+        router.present(resolved)
     }
 }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -1,0 +1,131 @@
+//
+//  SearchResultsSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// `AppSheetRoute.searchResults` — disambiguation for a search that matched several
+/// things. Native replacement for `SearchResultsController`, on the stacked layer so
+/// the search sheet stays alive beneath with its query intact.
+struct SearchResultsSheetView: View {
+    let application: Application
+    let router: SearchResultRouter
+
+    @StateObject private var viewModel: SearchViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    init(application: Application, response: SearchResponse, router: SearchResultRouter) {
+        self.application = application
+        self.router = router
+        _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(OBALoc(
+                    "search_results_controller.title",
+                    value: "Search Results",
+                    comment: "The title of the Search Results controller."
+                )))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { dismiss() }
+                    }
+                }
+        }
+        .onChange(of: viewModel.vehicleSearchResponse) { _, response in
+            guard let result = response?.results.first else { return }
+            Task { await select(result) }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.results.isEmpty {
+            EmptyStateView(
+                title: OBALoc(
+                    "search_results_sheet.empty.title",
+                    value: "No results",
+                    comment: "Title shown when a disambiguation sheet has no results to show."
+                ),
+                systemImage: AppSymbol.error
+            )
+        } else {
+            List {
+                Section {
+                    ForEach(rows) { row in
+                        SearchListRowView(row: row)
+                    }
+                } header: {
+                    // "12 results · Route 44" — the count is the enhancement over
+                    // `SearchResultsController`, which showed the subtitle alone.
+                    Text("\(resultCountText) · \(viewModel.subtitle)")
+                        .font(.headline)
+                }
+
+                if let error = viewModel.vehicleError {
+                    // Inline rather than a modal alert: the sheet is already the
+                    // user's context, and a bulletin over it hides what failed.
+                    Section {
+                        SearchListRowView(row: SearchListRow(
+                            kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
+                            title: error.localizedDescription,
+                            icon: .system("exclamationmark.triangle")
+                        ))
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+    }
+
+    private var resultCountText: String {
+        let format = OBALoc(
+            "search_results_sheet.result_count_fmt",
+            value: "%d results",
+            comment: "Header showing how many results a search matched, e.g. '12 results'."
+        )
+        return String(format: format, viewModel.results.count)
+    }
+
+    private var rows: [SearchListRow] {
+        viewModel.results.compactMap { result in
+            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
+                // Vehicles need a second request before they can be routed, so the
+                // row shows progress in place instead of navigating immediately.
+                if viewModel.loadingVehicleID == vehicleID {
+                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
+                }
+                return SearchResultRow.row(for: result, application: application) {
+                    Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+                }
+            }
+
+            return SearchResultRow.row(for: result, application: application) {
+                Task { await select(result) }
+            }
+        }
+    }
+
+    /// Unwinds back to home before opening the result — the SwiftUI equivalent of
+    /// the UIKit path's `exitSearchMode()`.
+    ///
+    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
+    /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
+    /// whichever layer is topmost *at the moment it runs* — racing the SwiftUI
+    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
+    /// deterministically in one step.
+    private func select(_ result: Any) async {
+        coordinator.popToRoot()
+        await router.present(result: result)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -18,6 +18,7 @@ struct SearchResultsSheetView: View {
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
+    @StateObject private var selection: SearchResultsSelection
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
 
@@ -25,6 +26,7 @@ struct SearchResultsSheetView: View {
         self.application = application
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
+        _selection = StateObject(wrappedValue: SearchResultsSelection(router: router))
     }
 
     var body: some View {
@@ -73,27 +75,29 @@ struct SearchResultsSheetView: View {
                         .font(.headline)
                 }
 
-                if let error = viewModel.vehicleError {
-                    // Inline rather than a modal alert: the sheet is already the
-                    // user's context, and a bulletin over it hides what failed.
+                if let errorRow {
                     Section {
-                        SearchListRowView(row: SearchListRow(
-                            kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
-                            title: error.localizedDescription,
-                            subtitle: Strings.retry,
-                            icon: .system("exclamationmark.triangle"),
-                            // `SearchListRowView.errorRow` renders a retry badge and
-                            // enables the row only when there's an action, so a
-                            // failure the user can re-attempt isn't a dead end.
-                            action: viewModel.failedVehicleID.map { vehicleID in
-                                { Task { await viewModel.selectVehicle(vehicleID: vehicleID) } }
-                            }
-                        ))
+                        SearchListRowView(row: errorRow)
                     }
                 }
             }
             .searchListChrome()
         }
+    }
+
+    private var errorRow: SearchListRow? {
+        SearchResultRow.inlineErrorRow(
+            vehicleError: viewModel.vehicleError,
+            failedVehicleID: viewModel.failedVehicleID,
+            selectionError: selection.error,
+            failedResult: selection.failedResult,
+            onRetryVehicle: { vehicleID in
+                Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+            },
+            onRetrySelect: { result in
+                Task { await select(result) }
+            }
+        )
     }
 
     private var resultCountText: String {
@@ -102,43 +106,28 @@ struct SearchResultsSheetView: View {
             value: "%d results",
             comment: "Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."
         )
-        return String(format: format, viewModel.results.count)
+        // `localizedStringWithFormat`, not `String(format:)`: the latter expands
+        // `%#@count@` but always resolves it against the root plural rule, so the
+        // `few`/`many`/`zero`/`two` forms in the ar, pl, and ru entries could never
+        // be selected. Invisible in English; wrong everywhere with more than two.
+        return String.localizedStringWithFormat(format, viewModel.results.count)
     }
 
     private var rows: [SearchListRow] {
-        viewModel.results.compactMap { result in
-            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
-                // Vehicles need a second request before they can be routed, so the
-                // row shows progress in place instead of navigating immediately.
-                if viewModel.loadingVehicleID == vehicleID {
-                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
-                }
-                return SearchResultRow.row(for: result, application: application) {
-                    Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
-                }
-            }
-
-            return SearchResultRow.row(for: result, application: application) {
+        SearchResultRow.rows(
+            for: viewModel.results,
+            loadingVehicleID: viewModel.loadingVehicleID,
+            application: application,
+            onSelectVehicle: { vehicleID in
+                Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+            },
+            onSelect: { result in
                 Task { await select(result) }
             }
-        }
+        )
     }
 
-    /// Unwinds back to home and opens the result — the SwiftUI equivalent of the UIKit
-    /// path's `exitSearchMode()`.
-    ///
-    /// Resolution comes first so this sheet stays up while the request runs: a failure
-    /// leaves the user on their results rather than dropping them on home, and the
-    /// stacked layer isn't emptied and refilled around a network call.
-    ///
-    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
-    /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
-    /// whichever layer is topmost *at the moment it runs* — racing the SwiftUI
-    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
-    /// deterministically in one step.
     private func select(_ result: Any) async {
-        guard let resolved = await router.resolve(result: result) else { return }
-        coordinator.popToRoot()
-        router.present(resolved)
+        await selection.select(result, coordinator: coordinator)
     }
 }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -15,6 +15,7 @@ import OBAKitCore
 /// the search sheet stays alive beneath with its query intact.
 struct SearchResultsSheetView: View {
     let application: Application
+    let response: SearchResponse
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
@@ -23,6 +24,7 @@ struct SearchResultsSheetView: View {
 
     init(application: Application, response: SearchResponse, router: SearchResultRouter) {
         self.application = application
+        self.response = response
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
     }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -15,7 +15,6 @@ import OBAKitCore
 /// the search sheet stays alive beneath with its query intact.
 struct SearchResultsSheetView: View {
     let application: Application
-    let response: SearchResponse
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
@@ -24,7 +23,6 @@ struct SearchResultsSheetView: View {
 
     init(application: Application, response: SearchResponse, router: SearchResultRouter) {
         self.application = application
-        self.response = response
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
     }
@@ -81,7 +79,14 @@ struct SearchResultsSheetView: View {
                         SearchListRowView(row: SearchListRow(
                             kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
                             title: error.localizedDescription,
-                            icon: .system("exclamationmark.triangle")
+                            subtitle: Strings.retry,
+                            icon: .system("exclamationmark.triangle"),
+                            // `SearchListRowView.errorRow` renders a retry badge and
+                            // enables the row only when there's an action, so a
+                            // failure the user can re-attempt isn't a dead end.
+                            action: viewModel.failedVehicleID.map { vehicleID in
+                                { Task { await viewModel.selectVehicle(vehicleID: vehicleID) } }
+                            }
                         ))
                     }
                 }
@@ -94,7 +99,7 @@ struct SearchResultsSheetView: View {
         let format = OBALoc(
             "search_results_sheet.result_count_fmt",
             value: "%d results",
-            comment: "Header showing how many results a search matched, e.g. '12 results'."
+            comment: "Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."
         )
         return String(format: format, viewModel.results.count)
     }

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -42,6 +42,14 @@ struct SearchSheetView: View {
         .onAppear {
             viewModel.reportSearchOpened()
             isFieldFocused = true
+            // `onDisappear` dismisses the HUD, and the sheet system rebuilds a sheet's
+            // content view without the user going anywhere — see
+            // `MapSearchDisplayModel.owner`. `isSearching` doesn't change across that
+            // rebuild, so `onChange` won't fire and the HUD has to be restored here or
+            // an in-flight search runs with nothing on screen.
+            if viewModel.isSearching {
+                ProgressHUD.show()
+            }
         }
         // The app-wide HUD rather than a spinner of our own: it centres itself over
         // everything, which is what the rest of the app does for an in-flight

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -1,0 +1,115 @@
+//
+//  SearchSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// `AppSheetRoute.search` — search in the same base sheet as home, with a Close
+/// button back to the home sections.
+struct SearchSheetView: View {
+    @StateObject private var viewModel: SearchSheetViewModel
+    @FocusState private var isFieldFocused: Bool
+
+    let placeholder: String
+
+    init(viewModel: @autoclosure @escaping () -> SearchSheetViewModel, placeholder: String) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            statusBanner
+            SearchListView(searchInteractor: viewModel.searchInteractor)
+        }
+        .onAppear {
+            viewModel.reportSearchOpened()
+            isFieldFocused = true
+        }
+        .alert(
+            Strings.clearRecentSearchesConfirmation,
+            isPresented: $viewModel.isConfirmingClearRecents
+        ) {
+            Button(Strings.cancel, role: .cancel) { }
+            Button(Strings.delete, role: .destructive) {
+                viewModel.confirmClearRecentSearches()
+            }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(placeholder, text: Binding(
+                    get: { viewModel.query },
+                    set: { viewModel.updateQuery($0) }
+                ))
+                .focused($isFieldFocused)
+                .submitLabel(.search)
+                .autocorrectionDisabled()
+                // Matches UIKit, where the search bar's search button is unhandled:
+                // Return just dismisses the keyboard; the quick-search rows are the
+                // way to run a search.
+                .onSubmit { isFieldFocused = false }
+
+                if !viewModel.query.isEmpty {
+                    Button {
+                        viewModel.updateQuery("")
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityLabel(OBALoc(
+                        "search_sheet.clear_query",
+                        value: "Clear",
+                        comment: "Accessibility label for the button that clears the search query."
+                    ))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background { Capsule().fill(Color(.tertiarySystemFill)) }
+
+            Button(Strings.close) {
+                isFieldFocused = false
+                viewModel.close()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 16)
+    }
+
+    @ViewBuilder
+    private var statusBanner: some View {
+        if viewModel.isSearching {
+            ProgressView()
+                .padding(.top, 12)
+        } else if let errorMessage = viewModel.errorMessage {
+            Label(errorMessage, systemImage: "exclamationmark.triangle")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.top, 12)
+        } else if viewModel.showsNoResults {
+            Label(
+                OBALoc(
+                    "map_controller.no_search_results_found",
+                    value: "No search results were found.",
+                    comment: "A generic message shown when the user's search query produces no search results."
+                ),
+                systemImage: "magnifyingglass"
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.top, 12)
+        }
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -23,15 +23,46 @@ struct SearchSheetView: View {
         self.placeholder = placeholder
     }
 
+    /// Mirrors `AlertPresenter.show(errorMessage:)`, which the UIKit map uses for
+    /// both search failures and the no-results case: `Strings.error` as the title,
+    /// the message as the body, one dismiss button.
+    private var messageAlert: Binding<Bool> {
+        Binding(
+            get: { viewModel.message != nil },
+            set: { if !$0 { viewModel.dismissMessage() } }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             searchField
-            statusBanner
             SearchListView(searchInteractor: viewModel.searchInteractor)
         }
+        .searchSheetBackground()
         .onAppear {
             viewModel.reportSearchOpened()
             isFieldFocused = true
+        }
+        // The app-wide HUD rather than a spinner of our own: it centres itself over
+        // everything, which is what the rest of the app does for an in-flight
+        // request, and it's already what `SearchManager` shows on the UIKit path.
+        .onChange(of: viewModel.isSearching) { _, isSearching in
+            if isSearching {
+                ProgressHUD.show()
+            } else {
+                ProgressHUD.dismiss()
+            }
+        }
+        // The HUD lives in its own window, so leaving search mid-request would
+        // otherwise strand it on screen with nothing left to dismiss it.
+        .onDisappear { ProgressHUD.dismiss() }
+        // Outcomes go to an alert rather than a banner above the list: the banner
+        // pushed the list down on every failed search, and it sat in the one place
+        // the user is looking while typing.
+        .alert(Strings.error, isPresented: messageAlert, presenting: viewModel.message) { _ in
+            Button(Strings.dismiss, role: .cancel) { }
+        } message: { message in
+            Text(message.text)
         }
         .alert(
             Strings.clearRecentSearchesConfirmation,
@@ -66,8 +97,14 @@ struct SearchSheetView: View {
                         viewModel.updateQuery("")
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
+                            // `Color.secondary`, not the `.secondary` shape style:
+                            // inside a `Button` the latter resolves against the
+                            // button's tint, which rendered a washed-out accent
+                            // colour rather than grey. `.plain` keeps the tint off
+                            // the label for good measure.
+                            .foregroundStyle(Color.secondary)
                     }
+                    .buttonStyle(.plain)
                     .accessibilityLabel(OBALoc(
                         "search_sheet.clear_query",
                         value: "Clear",
@@ -88,28 +125,4 @@ struct SearchSheetView: View {
         .padding(.top, 16)
     }
 
-    @ViewBuilder
-    private var statusBanner: some View {
-        if viewModel.isSearching {
-            ProgressView()
-                .padding(.top, 12)
-        } else if let errorMessage = viewModel.errorMessage {
-            Label(errorMessage, systemImage: "exclamationmark.triangle")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .padding(.top, 12)
-        } else if viewModel.showsNoResults {
-            Label(
-                OBALoc(
-                    "map_controller.no_search_results_found",
-                    value: "No search results were found.",
-                    comment: "A generic message shown when the user's search query produces no search results."
-                ),
-                systemImage: "magnifyingglass"
-            )
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .padding(.top, 12)
-        }
-    }
 }

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -101,6 +101,11 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
     func close() {
         searchTask?.cancel()
         searchTask = nil
+        // A resolving stop or map item has to go too. Without this it lands after the
+        // user has already backed out of search and pushes a detail sheet they
+        // dismissed. The handle is kept rather than cleared so callers can still await
+        // the cancelled task's completion.
+        pendingPresentation?.cancel()
         coordinator.pop()
     }
 
@@ -233,7 +238,12 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
     /// Same order as the single-result path: resolve, then unwind, then present — so
     /// search is only left once there's something to show.
     private func leaveSearchAndPresent(_ result: Any) async {
-        guard let resolved = await router.resolve(result: result) else {
+        let resolved = await router.resolve(result: result)
+        // Cancelling the task doesn't stop the resolve already in flight, so check
+        // before touching the screen: `close()` has already popped search, and
+        // presenting now would hand the rider a sheet they backed out of.
+        guard !Task.isCancelled else { return }
+        guard let resolved else {
             if let error = router.lastError {
                 message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             }

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -11,6 +11,24 @@ import Foundation
 import MapKit
 import OBAKitCore
 
+/// A one-shot search outcome, surfaced by the view as an alert.
+///
+/// Identity is fresh per message, so two identical failures in a row are two
+/// distinct values. A plain `String?` or `Bool` would coalesce when the reset and
+/// the re-set land in the same update pass, silently swallowing the second alert.
+struct SearchSheetMessage: Identifiable, Equatable {
+    enum Kind: Equatable {
+        /// The search ran and matched nothing.
+        case noResults
+        /// The search failed, or could not be attempted.
+        case error
+    }
+
+    let id = UUID()
+    let kind: Kind
+    let text: String
+}
+
 /// Owns a search session: the query, the `SearchInteractor` that turns it into
 /// sections, and the `SearchDelegate` callbacks those sections fire.
 ///
@@ -22,12 +40,7 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     @Published var query: String = ""
 
-    /// Set when a search returns nothing, so the sheet can say so in place rather
-    /// than popping the alert the UIKit path shows.
-    @Published private(set) var showsNoResults = false
-
-    /// Set when resolving a result fails, rendered inline for the same reason.
-    @Published private(set) var errorMessage: String?
+    @Published private(set) var message: SearchSheetMessage?
 
     @Published private(set) var isSearching = false
 
@@ -64,9 +77,14 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     func updateQuery(_ text: String) {
         query = text
-        showsNoResults = false
-        errorMessage = nil
+        message = nil
         searchInteractor.searchModeObjects(text: text)
+    }
+
+    /// Called when the view dismisses the alert, so a repeat of the same failing
+    /// search presents again rather than being swallowed as "no change".
+    func dismissMessage() {
+        message = nil
     }
 
     /// Leaves search and returns the base sheet to home.
@@ -120,15 +138,14 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         application.analytics?.reportSearchQuery(request.query)
 
         isSearching = true
-        showsNoResults = false
-        errorMessage = nil
+        message = nil
         defer { isSearching = false }
 
         let response: SearchResponse?
         do {
             response = try await application.searchManager.fetchResults(for: request)
         } catch {
-            errorMessage = error.localizedDescription
+            message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             return
         }
 
@@ -136,10 +153,10 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         case .unavailable:
             // The query was never sent. Saying "no results" would send the user off
             // rewording a search that never left the device.
-            errorMessage = APIError.noRegionSelected.localizedDescription
+            message = SearchSheetMessage(kind: .error, text: APIError.noRegionSelected.localizedDescription)
 
         case .noResults:
-            showsNoResults = true
+            message = SearchSheetMessage(kind: .noResults, text: Self.noResultsText)
 
         case .disambiguate(let response):
             coordinator.push(.searchResults(response))
@@ -150,10 +167,16 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             coordinator.pop()
             _ = await router.presentSingleResult(from: response)
             if let error = router.lastError {
-                errorMessage = error.localizedDescription
+                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             }
         }
     }
+
+    static let noResultsText = OBALoc(
+        "map_controller.no_search_results_found",
+        value: "No search results were found.",
+        comment: "A generic message shown when the user's search query produces no search results."
+    )
 
     /// The in-flight `router.present(...)` kicked off by a delegate callback.
     /// `SearchDelegate`'s methods are synchronous, so presentation has to be

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -162,13 +162,20 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             coordinator.push(.searchResults(response))
 
         case .single(let response):
+            // Resolve first, leave search second. Popping before the result was
+            // resolved tore this view — and the alert it hosts — down mid-request, so
+            // a failure had nowhere to surface and the user landed on home with no
+            // explanation. It also left the stacked sheet layer empty across the call.
+            guard let resolved = await router.resolveSingleResult(from: response) else {
+                if let error = router.lastError {
+                    message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
+                }
+                return
+            }
             // Leave search before opening the result, so Close on the detail sheet
             // lands back on home rather than on a stale search screen.
             coordinator.pop()
-            _ = await router.presentSingleResult(from: response)
-            if let error = router.lastError {
-                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
-            }
+            router.present(resolved)
         }
     }
 
@@ -185,13 +192,24 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     func showMapItem(_ mapItem: MKMapItem) {
         application.userDataStore.addRecentMapItem(mapItem)
-        coordinator.pop()
-        pendingPresentation = Task { [router] in await router.present(result: mapItem) }
+        pendingPresentation = Task { [weak self] in await self?.leaveSearchAndPresent(mapItem) }
     }
 
     func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) {
+        pendingPresentation = Task { [weak self] in await self?.leaveSearchAndPresent(stop) }
+    }
+
+    /// Same order as the single-result path: resolve, then unwind, then present — so
+    /// search is only left once there's something to show.
+    private func leaveSearchAndPresent(_ result: Any) async {
+        guard let resolved = await router.resolve(result: result) else {
+            if let error = router.lastError {
+                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
+            }
+            return
+        }
         coordinator.pop()
-        pendingPresentation = Task { [router] in await router.present(result: stop) }
+        router.present(resolved)
     }
 
     /// The interactor asks; the view presents the confirmation and calls

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -85,6 +85,35 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         }
     }
 
+    /// What a finished `fetchResults` call means for the screen.
+    ///
+    /// Split out as a pure function because the interesting distinction —
+    /// `nil` (the search never ran) versus an empty result set (it ran and matched
+    /// nothing) — isn't reachable through the test `Application`, which always has a
+    /// region, an API service, and an Obaco service.
+    enum SearchOutcome: Equatable {
+        /// No API service, no Obaco service, or no map rect. The query was never sent.
+        case unavailable
+        /// The search ran and matched nothing.
+        case noResults
+        case single(SearchResponse)
+        case disambiguate(SearchResponse)
+
+        init(response: SearchResponse?) {
+            guard let response else {
+                self = .unavailable
+                return
+            }
+            if response.results.isEmpty {
+                self = .noResults
+            } else if response.results.count == 1 {
+                self = .single(response)
+            } else {
+                self = .disambiguate(response)
+            }
+        }
+    }
+
     /// The awaitable body of `performSearch`, so tests don't have to poll a
     /// fire-and-forget task.
     func performSearchAndWait(request: SearchRequest) async {
@@ -103,22 +132,26 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             return
         }
 
-        guard let response, !response.results.isEmpty else {
+        switch SearchOutcome(response: response) {
+        case .unavailable:
+            // The query was never sent. Saying "no results" would send the user off
+            // rewording a search that never left the device.
+            errorMessage = APIError.noRegionSelected.localizedDescription
+
+        case .noResults:
             showsNoResults = true
-            return
-        }
 
-        guard response.results.count == 1 else {
+        case .disambiguate(let response):
             coordinator.push(.searchResults(response))
-            return
-        }
 
-        // Leave search before opening the result, so Close on the detail sheet lands
-        // back on home rather than on a stale search screen.
-        coordinator.pop()
-        _ = await router.presentSingleResult(from: response)
-        if let error = router.lastError {
-            errorMessage = error.localizedDescription
+        case .single(let response):
+            // Leave search before opening the result, so Close on the detail sheet
+            // lands back on home rather than on a stale search screen.
+            coordinator.pop()
+            _ = await router.presentSingleResult(from: response)
+            if let error = router.lastError {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -1,0 +1,157 @@
+//
+//  SearchSheetViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Owns a search session: the query, the `SearchInteractor` that turns it into
+/// sections, and the `SearchDelegate` callbacks those sections fire.
+///
+/// This is the role `MapFloatingPanelController` plays for the UIKit panel. It's a
+/// class (not view state) because `SearchDelegate` is a class protocol that
+/// `SearchInteractor` holds weakly — the view retains this via `@StateObject`.
+@MainActor
+final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
+
+    @Published var query: String = ""
+
+    /// Set when a search returns nothing, so the sheet can say so in place rather
+    /// than popping the alert the UIKit path shows.
+    @Published private(set) var showsNoResults = false
+
+    /// Set when resolving a result fails, rendered inline for the same reason.
+    @Published private(set) var errorMessage: String?
+
+    @Published private(set) var isSearching = false
+
+    private(set) lazy var searchInteractor = SearchInteractor(application: application, delegate: self)
+
+    private let application: Application
+    private let coordinator: SheetCoordinator<AppSheetRoute>
+    private let router: SearchResultRouter
+    private var searchTask: Task<Void, Never>?
+
+    init(application: Application, coordinator: SheetCoordinator<AppSheetRoute>, router: SearchResultRouter) {
+        self.application = application
+        self.coordinator = coordinator
+        self.router = router
+        super.init()
+    }
+
+    isolated deinit {
+        searchTask?.cancel()
+        pendingPresentation?.cancel()
+    }
+
+    // MARK: - Session
+
+    /// Reported once per entry into search, matching the UIKit panel's
+    /// `inSearchMode` analytics.
+    func reportSearchOpened() {
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/map",
+            label: AnalyticsLabels.searchSelected,
+            value: nil
+        )
+    }
+
+    func updateQuery(_ text: String) {
+        query = text
+        showsNoResults = false
+        errorMessage = nil
+        searchInteractor.searchModeObjects(text: text)
+    }
+
+    /// Leaves search and returns the base sheet to home.
+    func close() {
+        searchTask?.cancel()
+        searchTask = nil
+        coordinator.pop()
+    }
+
+    // MARK: - SearchDelegate
+
+    func performSearch(request: SearchRequest) {
+        searchTask?.cancel()
+        searchTask = Task { [weak self] in
+            await self?.performSearchAndWait(request: request)
+        }
+    }
+
+    /// The awaitable body of `performSearch`, so tests don't have to poll a
+    /// fire-and-forget task.
+    func performSearchAndWait(request: SearchRequest) async {
+        application.analytics?.reportSearchQuery(request.query)
+
+        isSearching = true
+        showsNoResults = false
+        errorMessage = nil
+        defer { isSearching = false }
+
+        let response: SearchResponse?
+        do {
+            response = try await application.searchManager.fetchResults(for: request)
+        } catch {
+            errorMessage = error.localizedDescription
+            return
+        }
+
+        guard let response, !response.results.isEmpty else {
+            showsNoResults = true
+            return
+        }
+
+        guard response.results.count == 1 else {
+            coordinator.push(.searchResults(response))
+            return
+        }
+
+        // Leave search before opening the result, so Close on the detail sheet lands
+        // back on home rather than on a stale search screen.
+        coordinator.pop()
+        _ = await router.presentSingleResult(from: response)
+        if let error = router.lastError {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// The in-flight `router.present(...)` kicked off by a delegate callback.
+    /// `SearchDelegate`'s methods are synchronous, so presentation has to be
+    /// detached — this handle lets tests await it instead of polling.
+    private(set) var pendingPresentation: Task<Void, Never>?
+
+    func showMapItem(_ mapItem: MKMapItem) {
+        application.userDataStore.addRecentMapItem(mapItem)
+        coordinator.pop()
+        pendingPresentation = Task { [router] in await router.present(result: mapItem) }
+    }
+
+    func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) {
+        coordinator.pop()
+        pendingPresentation = Task { [router] in await router.present(result: stop) }
+    }
+
+    /// The interactor asks; the view presents the confirmation and calls
+    /// `confirmClearRecentSearches()` if the user agrees.
+    @Published var isConfirmingClearRecents = false
+
+    func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) {
+        isConfirmingClearRecents = true
+    }
+
+    func confirmClearRecentSearches() {
+        application.userDataStore.deleteAllRecentMapItems()
+        searchInteractor.searchModeObjects(text: query)
+    }
+
+    var isVehicleSearchAvailable: Bool {
+        application.features.obaco == .running
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -65,9 +65,19 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     // MARK: - Session
 
+    /// Guards `reportSearchOpened()`. It lives here rather than on the view because
+    /// the sheet system tears a sheet's content view down and rebuilds it without the
+    /// user going anywhere — see `MapSearchDisplayModel.owner` — so `onAppear` can fire
+    /// more than once per entry into search. This object survives that via
+    /// `@StateObject`, so the flag is accurate no matter how the container behaves.
+    private var hasReportedOpen = false
+
     /// Reported once per entry into search, matching the UIKit panel's
     /// `inSearchMode` analytics.
     func reportSearchOpened() {
+        guard !hasReportedOpen else { return }
+        hasReportedOpen = true
+
         application.analytics?.reportEvent(
             pageURL: "app://localhost/map",
             label: AnalyticsLabels.searchSelected,
@@ -139,17 +149,36 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
         isSearching = true
         message = nil
-        defer { isSearching = false }
+        // Cancelling `searchTask` doesn't stop the request already in flight, so a
+        // superseded search still runs to completion. It must not clear `isSearching`
+        // — the HUD belongs to the search that replaced it, which is still running —
+        // and the `Task.isCancelled` checks below stop it reporting or navigating for
+        // a query the user has already moved on from.
+        defer {
+            if !Task.isCancelled {
+                isSearching = false
+            }
+        }
 
         let response: SearchResponse?
         do {
             response = try await application.searchManager.fetchResults(for: request)
         } catch {
+            guard !Task.isCancelled else { return }
             message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             return
         }
 
-        switch SearchOutcome(response: response) {
+        guard !Task.isCancelled else { return }
+
+        await present(SearchOutcome(response: response))
+    }
+
+    /// What each outcome does to the screen. Split from `performSearchAndWait` so the
+    /// request, its cancellation checks, and the four outcomes stay separately
+    /// readable rather than one long function.
+    private func present(_ outcome: SearchOutcome) async {
+        switch outcome {
         case .unavailable:
             // The query was never sent. Saying "no results" would send the user off
             // rewording a search that never left the device.
@@ -167,11 +196,13 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             // a failure had nowhere to surface and the user landed on home with no
             // explanation. It also left the stacked sheet layer empty across the call.
             guard let resolved = await router.resolveSingleResult(from: response) else {
+                guard !Task.isCancelled else { return }
                 if let error = router.lastError {
                     message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
                 }
                 return
             }
+            guard !Task.isCancelled else { return }
             // Leave search before opening the result, so Close on the detail sheet
             // lands back on home rather than on a stale search screen.
             coordinator.pop()

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import MapKit
 import OBAKitCore
 
 // MARK: - SheetDetentConfiguration
@@ -83,6 +84,10 @@ nonisolated enum AppSheetRoute: SheetRouteable {
     case routePicker
     case currentTrip(route: Route)
     case transitAlert(alertID: String)
+    case searchResults(SearchResponse)
+    case mapItem(MKMapItem)
+    case routeStops(StopsForRoute)
+    case nearbyStops(coordinate: CLLocationCoordinate2D)
 
     case more
     case settings
@@ -122,6 +127,15 @@ nonisolated extension AppSheetRoute {
             return "\(caseName)-\(route.id)"
         case .transitAlert(let alertID):
             return "\(caseName)-\(alertID)"
+        case .searchResults(let response):
+            return "\(caseName)-\(response.request.searchType.rawValue)-\(response.request.query)"
+        case .mapItem(let item):
+            let coordinate = item.placemark.coordinate
+            return "\(caseName)-\(coordinate.latitude)-\(coordinate.longitude)"
+        case .routeStops(let stopsForRoute):
+            return "\(caseName)-\(stopsForRoute.id)"
+        case .nearbyStops(let coordinate):
+            return "\(caseName)-\(coordinate.latitude)-\(coordinate.longitude)"
         }
     }
 
@@ -140,7 +154,7 @@ nonisolated extension AppSheetRoute {
     /// Detail destinations prefer the stacked layer so the base sheet peeks beneath.
     var prefersStacking: Bool {
         switch self {
-        case .stopDetails, .tripPlanner, .tripDetails, .currentTrip, .transitAlert, .more, .nearbyAll, .recentStopsAll, .bookmarksAll, .settings:
+        case .stopDetails, .tripPlanner, .tripDetails, .currentTrip, .transitAlert, .more, .nearbyAll, .recentStopsAll, .bookmarksAll, .settings, .searchResults, .mapItem, .routeStops, .nearbyStops:
             return true
         case .home, .search, .routePicker:
             return false
@@ -218,6 +232,34 @@ nonisolated extension AppSheetRoute {
         case .tripPlanner, .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:
             return SheetDetentConfiguration(
                 detents: [.medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        case .mapItem:
+            // Medium only: the sheet is a detail card over the map, and the map has
+            // to stay visible behind it. Long content scrolls inside the detent.
+            return SheetDetentConfiguration(
+                detents: [.medium],
+                initialDetent: .medium,
+                isDismissDisabled: false
+            )
+        case .routeStops:
+            // Opens at medium so the route polyline stays on screen; the user can
+            // drag to large for the full stop list.
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .medium,
+                isDismissDisabled: false
+            )
+        case .searchResults:
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        case .nearbyStops:
+            return SheetDetentConfiguration(
+                detents: [.large],
                 initialDetent: .large,
                 isDismissDisabled: false
             )

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -38,18 +38,25 @@ final class AppSheetViewFactory {
     let coordinator: SheetCoordinator<AppSheetRoute>
     let searchDisplayModel: MapSearchDisplayModel
 
-    /// `presentingController` has no default on purpose. Every stop-sheet action
-    /// — schedules, bookmarks, the route filter, report-a-problem, the alarm
-    /// picker — resolves through it, so a call site that omitted it would build
-    /// a factory whose sheet renders correctly and then silently ignores every
-    /// button on it.
+    /// Nothing here is defaulted, on purpose, and for two separate reasons.
+    ///
+    /// `presentingController`: every stop-sheet action — schedules, bookmarks,
+    /// the route filter, report-a-problem, the alarm picker — resolves through
+    /// it, so a call site that omitted it would build a factory whose sheet
+    /// renders correctly and then silently ignores every button on it.
+    ///
+    /// `coordinator` and `searchDisplayModel`: they must be the same instances the
+    /// hosting `MapPanelRootView` observes. A factory built with its own private
+    /// copies would push routes onto a coordinator nobody is watching and draw into
+    /// a display model nobody renders — silently, with the search sheet simply
+    /// appearing to do nothing.
     init(
         application: Application,
         onPresentTrip: @escaping (ArrivalDeparture) -> Void,
-        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in },
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void,
         presentingController: @escaping () -> UIViewController?,
-        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
-        searchDisplayModel: MapSearchDisplayModel = MapSearchDisplayModel()
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
@@ -162,7 +169,7 @@ final class AppSheetViewFactory {
     }
 
     func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
-        MapItemSheetView(application: application, mapItem: mapItem)
+        MapItemSheetView(application: application, mapItem: mapItem, displayModel: searchDisplayModel)
     }
 
     /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.
@@ -186,7 +193,7 @@ final class AppSheetViewFactory {
                 coordinator: self.coordinator,
                 router: self.searchResultRouter
             ),
-            placeholder: HomeSheetViewModel(application: self.application).searchPlaceholder
+            placeholder: SearchPlaceholder.text(for: self.application)
         )
     }
 

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -88,9 +88,11 @@ final class AppSheetViewFactory {
         // (the home sheet only knows how to push, not pop), otherwise the
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults:
+             .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
+
+        case .searchResults(let response):
+            searchResultsView(response: response)
 
         case .routeStops(let stopsForRoute):
             routeStopsView(stopsForRoute: stopsForRoute)
@@ -172,6 +174,10 @@ final class AppSheetViewFactory {
 
     func routeStopsView(stopsForRoute: StopsForRoute) -> RouteStopsSheetView {
         RouteStopsSheetView(stopsForRoute: stopsForRoute, displayModel: searchDisplayModel)
+    }
+
+    func searchResultsView(response: SearchResponse) -> SearchResultsSheetView {
+        SearchResultsSheetView(application: application, response: response, router: searchResultRouter)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -169,7 +169,7 @@ final class AppSheetViewFactory {
     }
 
     func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
-        MapItemSheetView(application: application, mapItem: mapItem, displayModel: searchDisplayModel)
+        MapItemSheetView(application: application, mapItem: mapItem)
     }
 
     /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -71,6 +71,7 @@ final class AppSheetViewFactory {
     // MARK: - Dispatcher
 
     @ViewBuilder
+    // swiftlint:disable:next cyclomatic_complexity
     func view(for route: AppSheetRoute) -> some View {
         switch route {
         case .home:
@@ -79,15 +80,13 @@ final class AppSheetViewFactory {
         case .more:
             moreView()
 
+        case .search:
+            searchView()
+
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.
-        //
-        // TODO: `.search` is base-layer and has `isDismissDisabled: true`
-        // — its real view needs to wire up an explicit back affordance
-        // (the home sheet only knows how to push, not pop), otherwise the
-        // route is unreachable once entered.
-        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+        case .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
 
@@ -117,7 +116,7 @@ final class AppSheetViewFactory {
     // MARK: - Per-route view builders
 
     func homeView() -> HomeSheetView {
-        HomeSheetView(viewModel: HomeSheetViewModel())
+        HomeSheetView(viewModel: HomeSheetViewModel(application: self.application))
     }
 
     /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`
@@ -178,6 +177,17 @@ final class AppSheetViewFactory {
 
     func searchResultsView(response: SearchResponse) -> SearchResultsSheetView {
         SearchResultsSheetView(application: application, response: response, router: searchResultRouter)
+    }
+
+    func searchView() -> SearchSheetView {
+        SearchSheetView(
+            viewModel: SearchSheetViewModel(
+                application: self.application,
+                coordinator: self.coordinator,
+                router: self.searchResultRouter
+            ),
+            placeholder: HomeSheetViewModel(application: self.application).searchPlaceholder
+        )
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -68,7 +68,8 @@ final class AppSheetViewFactory {
         // (the home sheet only knows how to push, not pop), otherwise the
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .tripDetails, .transitAlert, .settings:
+             .tripPlanner, .tripDetails, .transitAlert, .settings,
+             .searchResults, .mapItem, .routeStops, .nearbyStops:
             unimplementedView(for: route)
 
         case .stopDetails(let stopID):

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -34,6 +34,10 @@ final class AppSheetViewFactory {
     /// `TripPresentationBridge` does.
     let presentingController: () -> UIViewController?
 
+    let onPresentVehicleTrip: (VehicleStatus) -> Void
+    let coordinator: SheetCoordinator<AppSheetRoute>
+    let searchDisplayModel: MapSearchDisplayModel
+
     /// `presentingController` has no default on purpose. Every stop-sheet action
     /// — schedules, bookmarks, the route filter, report-a-problem, the alarm
     /// picker — resolves through it, so a call site that omitted it would build
@@ -42,12 +46,27 @@ final class AppSheetViewFactory {
     init(
         application: Application,
         onPresentTrip: @escaping (ArrivalDeparture) -> Void,
-        presentingController: @escaping () -> UIViewController?
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in },
+        presentingController: @escaping () -> UIViewController?,
+        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
+        searchDisplayModel: MapSearchDisplayModel = MapSearchDisplayModel()
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
+        self.onPresentVehicleTrip = onPresentVehicleTrip
         self.presentingController = presentingController
+        self.coordinator = coordinator
+        self.searchDisplayModel = searchDisplayModel
     }
+
+    /// Built once and shared: the search sheet and the results sheet must route a
+    /// picked result the same way, and both need the same coordinator instance.
+    private(set) lazy var searchResultRouter = SearchResultRouter(
+        application: application,
+        coordinator: coordinator,
+        displayModel: searchDisplayModel,
+        onPresentVehicleTrip: onPresentVehicleTrip
+    )
 
     // MARK: - Dispatcher
 
@@ -70,8 +89,11 @@ final class AppSheetViewFactory {
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults, .routeStops:
+             .searchResults:
             unimplementedView(for: route)
+
+        case .routeStops(let stopsForRoute):
+            routeStopsView(stopsForRoute: stopsForRoute)
 
         case .mapItem(let mapItem):
             mapItemView(mapItem: mapItem)
@@ -146,6 +168,10 @@ final class AppSheetViewFactory {
     /// Swap this branch's return type once a SwiftUI nearby-stops list lands.
     func nearbyStopsView(coordinate: CLLocationCoordinate2D) -> NearbyStopsSheetHost {
         NearbyStopsSheetHost(application: application, coordinate: coordinate)
+    }
+
+    func routeStopsView(stopsForRoute: StopsForRoute) -> RouteStopsSheetView {
+        RouteStopsSheetView(stopsForRoute: stopsForRoute, displayModel: searchDisplayModel)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import MapKit
 import OBAKitCore
 
 // MARK: - AppSheetViewFactory
@@ -69,8 +70,14 @@ final class AppSheetViewFactory {
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults, .mapItem, .routeStops, .nearbyStops:
+             .searchResults, .routeStops:
             unimplementedView(for: route)
+
+        case .mapItem(let mapItem):
+            mapItemView(mapItem: mapItem)
+
+        case .nearbyStops(let coordinate):
+            nearbyStopsView(coordinate: coordinate)
 
         case .stopDetails(let stopID):
             stopDetailView(stopID: stopID)
@@ -129,6 +136,16 @@ final class AppSheetViewFactory {
             formatters: self.application.formatters,
             onPresentTrip: onPresentTrip
         )
+    }
+
+    func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
+        MapItemSheetView(application: application, mapItem: mapItem)
+    }
+
+    /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.
+    /// Swap this branch's return type once a SwiftUI nearby-stops list lands.
+    func nearbyStopsView(coordinate: CLLocationCoordinate2D) -> NearbyStopsSheetHost {
+        NearbyStopsSheetHost(application: application, coordinate: coordinate)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -25,12 +25,22 @@ public final class MapPanelRootController: UIViewController {
 
     public init(application: Application) {
         let bridge = TripPresentationBridge()
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
         let factory = AppSheetViewFactory(
             application: application,
             onPresentTrip: { [weak bridge] arrival in bridge?.present(arrival) },
-            presentingController: { [weak bridge] in bridge?.topmostController() }
+            onPresentVehicleTrip: { [weak bridge] vehicleStatus in bridge?.present(vehicleStatus: vehicleStatus) },
+            presentingController: { [weak bridge] in bridge?.topmostController() },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
         )
-        let rootView = MapPanelRootView(application: application, factory: factory)
+        let rootView = MapPanelRootView(
+            application: application,
+            factory: factory,
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
+        )
         self.host = UIHostingController(rootView: rootView)
         self.bridge = bridge
         super.init(nibName: nil, bundle: nil)
@@ -87,6 +97,33 @@ public final class MapPanelRootController: UIViewController {
                 return
             }
             let trip = TripViewController(application: application, arrivalDeparture: arrival)
+            presentTripController(trip, application: application, presenter: presenter)
+        }
+
+        func present(vehicleStatus: VehicleStatus) {
+            // As above: `topmostController()` is nil exactly when `host` is.
+            guard let host, let application, let presenter = topmostController() else {
+                Logger.error("TripPresentationBridge: dropping vehicle present — host or application is nil")
+                return
+            }
+
+            guard let convertible = TripConvertible(vehicleStatus: vehicleStatus) else {
+                // Same message the UIKit map shows: the vehicle exists but isn't
+                // assigned to a trip, so there's nothing to display.
+                let message = OBALoc(
+                    "map_controller.vehicle_not_on_trip_error",
+                    value: "The vehicle you chose doesn't appear to be on a trip right now, which means we don't know how to show it to you.",
+                    comment: "This message appears when a searched-for vehicle doesn't have an assigned trip."
+                )
+                Task { await AlertPresenter.show(errorMessage: message, presentingController: host) }
+                return
+            }
+
+            let trip = TripViewController(application: application, tripConvertible: convertible)
+            presentTripController(trip, application: application, presenter: presenter)
+        }
+
+        private func presentTripController(_ trip: TripViewController, application: Application, presenter: UIViewController) {
             // Wrap in our own UINavigationController and modally present from
             // the topmost presented controller, not `host` directly:
             //

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -102,7 +102,7 @@ public final class MapPanelRootController: UIViewController {
 
         func present(vehicleStatus: VehicleStatus) {
             // As above: `topmostController()` is nil exactly when `host` is.
-            guard let host, let application, let presenter = topmostController() else {
+            guard let application, let presenter = topmostController() else {
                 Logger.error("TripPresentationBridge: dropping vehicle present — host or application is nil")
                 return
             }
@@ -115,7 +115,13 @@ public final class MapPanelRootController: UIViewController {
                     value: "The vehicle you chose doesn't appear to be on a trip right now, which means we don't know how to show it to you.",
                     comment: "This message appears when a searched-for vehicle doesn't have an assigned trip."
                 )
-                Task { await AlertPresenter.show(errorMessage: message, presentingController: host) }
+                // `presenter`, not `host`, for the reason spelled out in
+                // `presentTripController` below: UIKit ignores `present` on a
+                // controller that already has a `presentedViewController`, and by the
+                // time we get here the base sheet is still up on `host`. Presenting
+                // from `host` silently drops the alert, leaving the rider on home with
+                // no explanation for why their vehicle search went nowhere.
+                Task { await AlertPresenter.show(errorMessage: message, presentingController: presenter) }
                 return
             }
 

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -83,6 +83,7 @@ struct MapPanelRootView: View {
 
     private let application: Application
     private let factory: AppSheetViewFactory
+    private let viewportRecorder: MapViewportRecorder
 
     init(application: Application, factory: AppSheetViewFactory) {
         _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
@@ -91,6 +92,7 @@ struct MapPanelRootView: View {
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
         self.application = application
         self.factory = factory
+        self.viewportRecorder = MapViewportRecorder(application: application)
 
         // With no location fix, frame the current transit region rather than
         // letting `.automatic` frame the bookmark annotations.
@@ -135,6 +137,7 @@ struct MapPanelRootView: View {
             }
         }
         .onMapCameraChange(frequency: .onEnd) { context in
+            viewportRecorder.record(context.rect)
             visibleRegion = context.region
             visibleMapRectHeight = context.rect.height
             // Keep the "Zoom in for stops" pill in sync with the stop-loading
@@ -431,6 +434,10 @@ extension MapPanelRootView {
             zoomLevel: mapViewModel.zoomLevelForCurrentLocation(),
             mapSize: mapSize
         )
+        // Seed the viewport before the camera animates: `.onMapCameraChange` only
+        // fires on settle, so a search run between launch and the first settle would
+        // otherwise be scoped to a stale rect.
+        viewportRecorder.record(MKMapRect(region))
         withAnimation {
             cameraPosition = .region(region)
         }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -20,6 +20,7 @@ import UIKit
 struct MapPanelRootView: View {
 
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
+    @ObservedObject private var searchDisplay: MapSearchDisplayModel
     @StateObject private var mapViewModel: MapViewModel
     @StateObject private var stopsObserver: MapStopsObserver
 
@@ -85,8 +86,14 @@ struct MapPanelRootView: View {
     private let factory: AppSheetViewFactory
     private let viewportRecorder: MapViewportRecorder
 
-    init(application: Application, factory: AppSheetViewFactory) {
-        _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
+    init(
+        application: Application,
+        factory: AppSheetViewFactory,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel
+    ) {
+        _coordinator = StateObject(wrappedValue: coordinator)
+        _searchDisplay = ObservedObject(wrappedValue: searchDisplayModel)
         _stopsObserver = StateObject(wrappedValue: MapStopsObserver(application: application))
         let initialMapType = MapBaseType(application.mapRegionManager.userSelectedMapType)
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
@@ -125,7 +132,7 @@ struct MapPanelRootView: View {
             }
             // Regular stops show only zoomed in; `renderStops` already excludes
             // bookmarked stops and precomputes labels.
-            if isZoomedInForStops {
+            if isZoomedInForStops, !searchDisplay.suppressesAmbientStops {
                 ForEach(stopsObserver.renderStops) { renderStop in
                     stopAnnotation(
                         for: renderStop.stop,
@@ -135,6 +142,7 @@ struct MapPanelRootView: View {
                     )
                 }
             }
+            searchResultMapContent(for: searchDisplay.display)
         }
         .onMapCameraChange(frequency: .onEnd) { context in
             viewportRecorder.record(context.rect)
@@ -160,6 +168,7 @@ struct MapPanelRootView: View {
             }
             recomputeStopLabels()
             stopsObserver.updateViewport(context.region)
+            guard !searchDisplay.suppressesAmbientStops else { return }
             application.mapRegionManager.scheduleStopsRequest(in: context.region)
         }
         // The map-type toggle changes the label gate (labels only show on the
@@ -174,6 +183,25 @@ struct MapPanelRootView: View {
             guard let id else { return }
             coordinator.push(.stopDetails(stopID: id))
             selectedStopID = nil
+        }
+        .onChange(of: searchDisplay.cameraTarget) { _, target in
+            guard let target else { return }
+            switch target {
+            case .coordinate(let coordinate, let animated):
+                let region = MKCoordinateRegion(
+                    centeredOn: coordinate,
+                    zoomLevel: 16,
+                    mapSize: mapSize
+                )
+                if animated {
+                    withAnimation { cameraPosition = .region(region) }
+                } else {
+                    cameraPosition = .region(region)
+                }
+            case .rect(let rect):
+                withAnimation { cameraPosition = .rect(rect) }
+            }
+            searchDisplay.consumeCameraTarget()
         }
         .mapStyle(mapViewModel.mapType == .standard ? .standard(emphasis: .muted) : .hybrid)
         .safeAreaPadding(.bottom, 180)

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -190,6 +190,15 @@ struct MapPanelRootView: View {
             coordinator.push(.stopDetails(stopID: id))
             selectedStopID = nil
         }
+        // A searched result stays drawn for exactly as long as the sheet that owns it
+        // is on the stack. Watching the stack — rather than clearing from the owning
+        // sheet's `onDisappear` — keeps the drawing alive across the content
+        // teardowns the sheet system performs without dismissing anything, and still
+        // clears on a real exit, including the drag-down the OS routes through
+        // `truncateStacked`.
+        .onChange(of: coordinator.stackedRoutes) { _, _ in
+            searchDisplay.clearIfOwnerAbsent(from: coordinator.routeStack + coordinator.stackedRoutes)
+        }
         .onChange(of: searchDisplay.cameraTarget) { _, target in
             guard let target else { return }
             switch target {

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -142,7 +142,13 @@ struct MapPanelRootView: View {
                     )
                 }
             }
-            searchResultMapContent(for: searchDisplay.display)
+            searchResultMapContent(for: searchDisplay.display) { stop in
+                application.stopIconFactory.buildSquircleIcon(
+                    for: stop,
+                    isBookmarked: false,
+                    traits: UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
+                )
+            }
         }
         .onMapCameraChange(frequency: .onEnd) { context in
             viewportRecorder.record(context.rect)

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -100,6 +100,12 @@ final class MapSearchDisplayModel: ObservableObject {
         ))
     }
 
+    /// Moves the camera without changing what's displayed — used when the user picks
+    /// a stop out of a route's list and the polyline should stay on screen.
+    func focus(coordinate: CLLocationCoordinate2D) {
+        cameraTarget = .coordinate(coordinate, animated: true)
+    }
+
     /// Applies-and-forgets the pending camera move. Called by the view once it has
     /// moved the camera.
     func consumeCameraTarget() {

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -62,6 +62,20 @@ final class MapSearchDisplayModel: ObservableObject {
     @Published private(set) var display: Display = .none
     @Published private(set) var cameraTarget: CameraTarget?
 
+    /// The sheet route this display belongs to, and the thing that decides how long
+    /// it stays on the map.
+    ///
+    /// Lifetime is keyed to the route stack rather than to the owning sheet view's
+    /// `onDisappear`, which is what this originally used. `onDisappear` reads like a
+    /// dismissal signal but isn't one: the floating-sheet system rebuilds a sheet's
+    /// content view for reasons that have nothing to do with the user leaving —
+    /// stacked layers being re-presented, the base sheet's content swapping
+    /// underneath — and each rebuild fired a `clear()` that wiped a route off the map
+    /// seconds after it was drawn, while its sheet sat there still visible.
+    ///
+    /// The route stack is the actual record of what's on screen, so ask it.
+    @Published private(set) var owner: AppSheetRoute?
+
     /// While a route is drawn, the ambient stop pins are hidden and stop loading is
     /// skipped so the route's own stops are the only ones on the map — the SwiftUI
     /// counterpart of the UIKit path's `removeAllAnnotations()` plus
@@ -71,17 +85,20 @@ final class MapSearchDisplayModel: ObservableObject {
         return false
     }
 
-    func show(mapItem: MKMapItem, animated: Bool) {
+    func show(mapItem: MKMapItem, animated: Bool, owner: AppSheetRoute) {
+        self.owner = owner
         display = .mapItem(mapItem)
         cameraTarget = .coordinate(mapItem.placemark.coordinate, animated: animated)
     }
 
-    func show(stop: Stop) {
+    func show(stop: Stop, owner: AppSheetRoute) {
+        self.owner = owner
         display = .stop(stop)
         cameraTarget = .coordinate(stop.coordinate, animated: true)
     }
 
-    func show(stopsForRoute: StopsForRoute) {
+    func show(stopsForRoute: StopsForRoute, owner: AppSheetRoute) {
+        self.owner = owner
         let color = stopsForRoute.route.map { Color(uiColor: $0.color ?? ThemeColors.shared.brand) }
             ?? Color(uiColor: ThemeColors.shared.brand)
 
@@ -112,7 +129,22 @@ final class MapSearchDisplayModel: ObservableObject {
         cameraTarget = nil
     }
 
+    /// Drops the display once the route that owns it is no longer anywhere in the
+    /// sheet stack. Called on every change to that stack.
+    ///
+    /// Deriving the decision from the stack, rather than acting on a dismissal event,
+    /// makes this self-correcting: a route that is popped and immediately re-pushed
+    /// (what a search does while it resolves a result) is still present when this
+    /// runs, so nothing is wiped in the gap.
+    ///
+    /// - Parameter routes: Every route currently on screen — both sheet layers.
+    func clearIfOwnerAbsent(from routes: [AppSheetRoute]) {
+        guard let owner, !routes.contains(owner) else { return }
+        clear()
+    }
+
     func clear() {
+        owner = nil
         display = .none
         cameraTarget = nil
     }

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -1,0 +1,113 @@
+//
+//  MapSearchDisplayModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import SwiftUI
+import OBAKitCore
+
+/// What the SwiftUI map should draw for the current search result, and where the
+/// camera should point.
+///
+/// The UIKit equivalent lives inside `MapRegionManager.searchResponse.didSet`, which
+/// mutates an `MKMapView` directly. The SwiftUI panel has no such view to mutate, so
+/// the same decisions are expressed as state here and rendered by `MapPanelRootView`.
+@MainActor
+final class MapSearchDisplayModel: ObservableObject {
+
+    /// Everything the map builder needs for a displayed route, resolved once so it
+    /// isn't re-derived on every body evaluation. `body` re-runs on unrelated state
+    /// changes — including the continuous sheet-height updates while the sheet is
+    /// dragged — so decoding polylines there would be costly.
+    struct RouteDisplay {
+        let polylines: [MKPolyline]
+        let stops: [Stop]
+        let color: Color
+        let mapRect: MKMapRect
+    }
+
+    enum Display {
+        case none
+        case mapItem(MKMapItem)
+        case route(RouteDisplay)
+        case stop(Stop)
+    }
+
+    /// Where the camera should move next. One-shot: the view applies it and calls
+    /// `consumeCameraTarget()`, so a later unrelated body evaluation can't re-move
+    /// the map out from under the user.
+    enum CameraTarget: Equatable {
+        case coordinate(CLLocationCoordinate2D, animated: Bool)
+        case rect(MKMapRect)
+
+        static func == (lhs: CameraTarget, rhs: CameraTarget) -> Bool {
+            switch (lhs, rhs) {
+            case (.coordinate(let l, let la), .coordinate(let r, let ra)):
+                return l.latitude == r.latitude && l.longitude == r.longitude && la == ra
+            case (.rect(let l), .rect(let r)):
+                return l.origin.x == r.origin.x && l.origin.y == r.origin.y
+                    && l.size.width == r.size.width && l.size.height == r.size.height
+            default:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var display: Display = .none
+    @Published private(set) var cameraTarget: CameraTarget?
+
+    /// While a route is drawn, the ambient stop pins are hidden and stop loading is
+    /// skipped so the route's own stops are the only ones on the map — the SwiftUI
+    /// counterpart of the UIKit path's `removeAllAnnotations()` plus
+    /// `searchResponseOverridesStopLoading()`.
+    var suppressesAmbientStops: Bool {
+        if case .route = display { return true }
+        return false
+    }
+
+    func show(mapItem: MKMapItem, animated: Bool) {
+        display = .mapItem(mapItem)
+        cameraTarget = .coordinate(mapItem.placemark.coordinate, animated: animated)
+    }
+
+    func show(stop: Stop) {
+        display = .stop(stop)
+        cameraTarget = .coordinate(stop.coordinate, animated: true)
+    }
+
+    func show(stopsForRoute: StopsForRoute) {
+        let color = stopsForRoute.route.map { Color(uiColor: $0.color ?? ThemeColors.shared.brand) }
+            ?? Color(uiColor: ThemeColors.shared.brand)
+
+        display = .route(RouteDisplay(
+            polylines: stopsForRoute.polylines,
+            stops: stopsForRoute.stops ?? [],
+            color: color,
+            mapRect: stopsForRoute.mapRect
+        ))
+        // Expand the bounding rect so the route isn't flush against the screen
+        // edges, with extra room at the bottom for the sheet — the SwiftUI
+        // equivalent of the UIKit path's `mapRectThatFits(edgePadding:)`.
+        cameraTarget = .rect(stopsForRoute.mapRect.insetBy(
+            dx: -stopsForRoute.mapRect.size.width * 0.15,
+            dy: -stopsForRoute.mapRect.size.height * 0.30
+        ))
+    }
+
+    /// Applies-and-forgets the pending camera move. Called by the view once it has
+    /// moved the camera.
+    func consumeCameraTarget() {
+        cameraTarget = nil
+    }
+
+    func clear() {
+        display = .none
+        cameraTarget = nil
+    }
+}

--- a/OBAKit/Sheet/Root/MapSearchOverlays.swift
+++ b/OBAKit/Sheet/Root/MapSearchOverlays.swift
@@ -1,0 +1,32 @@
+//
+//  MapSearchOverlays.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// Search-result map content: the route polyline and the searched place marker.
+///
+/// A free function rather than inline map content because `MapPanelRootView.body`
+/// has already exceeded Swift's type-check budget once.
+@MapContentBuilder
+func searchResultMapContent(for display: MapSearchDisplayModel.Display) -> some MapContent {
+    switch display {
+    case .route(let route):
+        ForEach(Array(route.polylines.enumerated()), id: \.offset) { _, polyline in
+            MapPolyline(polyline)
+                .stroke(route.color, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+        }
+    case .mapItem(let item):
+        Marker(item.name ?? "", coordinate: item.placemark.coordinate)
+    case .stop, .none:
+        // Stops are already drawn by the ambient stop layer; nothing extra to add.
+        EmptyMapContent()
+    }
+}

--- a/OBAKit/Sheet/Root/MapSearchOverlays.swift
+++ b/OBAKit/Sheet/Root/MapSearchOverlays.swift
@@ -11,17 +11,36 @@ import SwiftUI
 import MapKit
 import OBAKitCore
 
-/// Search-result map content: the route polyline and the searched place marker.
+/// Search-result map content: the route polyline, the route's own stops, and the
+/// searched place marker.
 ///
 /// A free function rather than inline map content because `MapPanelRootView.body`
 /// has already exceeded Swift's type-check budget once.
+///
+/// - Parameter stopIcon: Builds the pin image for a stop. Passed in rather than
+///   resolved here because the icon depends on `Application.stopIconFactory` and the
+///   current interface style, both of which live on the view.
 @MapContentBuilder
-func searchResultMapContent(for display: MapSearchDisplayModel.Display) -> some MapContent {
+func searchResultMapContent(
+    for display: MapSearchDisplayModel.Display,
+    stopIcon: @escaping (Stop) -> UIImage
+) -> some MapContent {
     switch display {
     case .route(let route):
         ForEach(Array(route.polylines.enumerated()), id: \.offset) { _, polyline in
             MapPolyline(polyline)
                 .stroke(route.color, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+        }
+        // A drawn route suppresses the ambient stop layer, so these are the only
+        // stops on the map — matching the UIKit route search, which replaces the
+        // visible annotations with the route's own. Tagged like ambient stops so
+        // tapping one opens its details.
+        ForEach(route.stops) { stop in
+            Annotation("", coordinate: stop.coordinate) {
+                Image(uiImage: stopIcon(stop))
+                    .accessibilityLabel(Formatters.formattedAccessibilityLabel(stop: stop))
+            }
+            .tag(stop.id)
         }
     case .mapItem(let item):
         Marker(item.name ?? "", coordinate: item.placemark.coordinate)

--- a/OBAKit/Sheet/Root/MapViewportRecorder.swift
+++ b/OBAKit/Sheet/Root/MapViewportRecorder.swift
@@ -1,0 +1,40 @@
+//
+//  MapViewportRecorder.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Records the SwiftUI map panel's settled viewport into
+/// `MapRegionManager.lastVisibleMapRect`.
+///
+/// The UIKit map writes that value from `mapView(_:regionDidChangeAnimated:)`, but
+/// the manager's own `MKMapView` is never installed in the SwiftUI panel, so nothing
+/// here keeps it current. Address and route searches use it *as the region they
+/// query* (`SearchManager.fetchAddress` / `fetchRoute`), and its getter falls back to
+/// the current region's whole service rect rather than `nil` — so a missing write
+/// doesn't fail loudly, it just scopes searches to the wrong area.
+///
+/// A dedicated type rather than a method on `MapViewModel`: that view model
+/// documents itself as containing no MapKit imports so it stays usable from both the
+/// UIKit and SwiftUI hosts.
+@MainActor
+final class MapViewportRecorder {
+
+    private let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    /// Persists `rect` as the panel's last visible viewport.
+    func record(_ rect: MKMapRect) {
+        application.mapRegionManager.lastVisibleMapRect = rect
+    }
+}

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "اختر خطك";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "لا توجد محطات";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "التاريخ";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d نتيجة";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "تعذر فتح نتيجة البحث هذه.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "مسح";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "مصغّرة";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "البحث قريبًا";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "يُرجى التحقق من إعدادات «الأنشطة المباشرة» في تطبيق «الإعدادات».";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "مصغّرة";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "يُرجى التحقق من إعدادات «الأنشطة المباشرة» في تطبيق «الإعدادات».";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "نتائج البحث";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "لا توجد نتائج";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d نتيجة";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "مسح";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "الهيئات المتأثرة";

--- a/OBAKit/Strings/ar.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ar.lproj/Localizable.stringsdict
@@ -50,6 +50,30 @@
 			<string>%d حالة ناجحة</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>لا توجد نتائج</string>
+			<key>one</key>
+			<string>نتيجة واحدة</string>
+			<key>two</key>
+			<string>نتيجتان</string>
+			<key>few</key>
+			<string>%d نتائج</string>
+			<key>many</key>
+			<string>%d نتيجة</string>
+			<key>other</key>
+			<string>%d نتيجة</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -942,6 +942,15 @@
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Search Results";
 
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "No results";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d results";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Clear";
+
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Affected Agencies";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -316,9 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimized";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Search coming soon";
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Please check your Live Activities settings in Settings.";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Select Your Route";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "No stops";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Date";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d results";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "This search result could not be opened.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Clear";

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d successful</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 result</string>
+			<key>other</key>
+			<string>%d results</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Revise los ajustes de Actividades en Vivo en Configuración.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Resultados de Busqueda";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Sin resultados";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Borrar";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agencias Afectadas";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Búsqueda próximamente";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Revise los ajustes de Actividades en Vivo en Configuración.";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Seleccione su Ruta";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Sin paradas";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Fecha";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "No se pudo abrir este resultado de búsqueda.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Borrar";

--- a/OBAKit/Strings/es.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/es.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d exitosos</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 resultado</string>
+			<key>other</key>
+			<string>%d resultados</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Naka-minimize";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Pakisuri ang iyong mga setting ng Live Activities sa Mga Setting.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Mga Resulta ng Paghahanap";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Walang resulta";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d na resulta";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "I-clear";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Mga Apektadong Ahensya";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Piliin ang Iyong Ruta";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Walang mga hintuan";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Petsa";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d na resulta";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Hindi mabuksan ang resultang ito ng paghahanap.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "I-clear";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Naka-minimize";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Paparating na ang paghahanap";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Pakisuri ang iyong mga setting ng Live Activities sa Mga Setting.";

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d na matagumpay</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d resulta</string>
+			<key>other</key>
+			<string>%d na resulta</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Réduit";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Recherche bientôt disponible";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vérifiez vos réglages des activités en direct dans les Réglages.";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Réduit";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vérifiez vos réglages des activités en direct dans les Réglages.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Résultats de recherche";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Aucun résultat";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d résultats";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Effacer";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agences concernées";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Sélectionnez votre ligne";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Aucun arrêt";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Date";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d résultats";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Impossible d'ouvrir ce résultat de recherche.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Effacer";

--- a/OBAKit/Strings/fr.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fr.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d réussites</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d résultat</string>
+			<key>other</key>
+			<string>%d résultats</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizzata";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Controlla le impostazioni delle Attività in tempo reale in Impostazioni.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Risultati della ricerca";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Nessun risultato";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d risultati";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Cancella";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Enti interessati";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizzata";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Ricerca presto disponibile";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Controlla le impostazioni delle Attività in tempo reale in Impostazioni.";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Seleziona la tua linea";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Nessuna fermata";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d risultati";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Impossibile aprire questo risultato di ricerca.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Cancella";

--- a/OBAKit/Strings/it.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/it.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d riusciti</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 risultato</string>
+			<key>other</key>
+			<string>%d risultati</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "최소화됨";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "설정에서 실시간 액티비티 설정을 확인해 주세요.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "검색 결과";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "결과 없음";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "결과 %d개";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "지우기";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "영향을 받는 운영 기관";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "노선 선택";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "정류장 없음";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "날짜";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "결과 %d개";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "이 검색 결과를 열 수 없습니다.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "지우기";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "최소화됨";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "검색 기능 준비 중";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "설정에서 실시간 액티비티 설정을 확인해 주세요.";

--- a/OBAKit/Strings/ko.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ko.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>성공 %d건</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>결과 %d개</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Zminimalizowany";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Wyszukiwanie już wkrótce";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Sprawdź ustawienia Aktywności na żywo w aplikacji Ustawienia.";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Zminimalizowany";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Sprawdź ustawienia Aktywności na żywo w aplikacji Ustawienia.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Wyniki wyszukiwania";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Brak wyników";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d wyników";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Wyczyść";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Dotyczy tych przewoźników";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Wybierz swoją linię";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Brak przystanków";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d wyników";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Nie można otworzyć tego wyniku wyszukiwania.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Wyczyść";

--- a/OBAKit/Strings/pl.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pl.lproj/Localizable.stringsdict
@@ -42,6 +42,26 @@
 			<string>%d udanego zadania</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 wynik</string>
+			<key>few</key>
+			<string>%d wyniki</string>
+			<key>many</key>
+			<string>%d wyników</string>
+			<key>other</key>
+			<string>%d wyniku</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Selecione Sua Linha";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Nenhuma parada";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Não foi possível abrir este resultado de busca.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Limpar";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Verifique os ajustes de Atividades ao Vivo nos Ajustes do sistema.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Resultados da Busca";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Nenhum resultado";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Limpar";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agências Afetadas";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Busca em breve";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Verifique os ajustes de Atividades ao Vivo nos Ajustes do sistema.";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d bem-sucedidas</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 resultado</string>
+			<key>other</key>
+			<string>%d resultados</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Свёрнуто";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Поиск скоро появится";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Проверьте настройки Live-активностей в приложении «Настройки».";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Свёрнуто";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Проверьте настройки Live-активностей в приложении «Настройки».";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Результаты поиска";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Нет результатов";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d результатов";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Очистить";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Затронутые агентства";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Выберите маршрут";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Нет остановок";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Дата";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d результатов";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Не удалось открыть этот результат поиска.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Очистить";

--- a/OBAKit/Strings/ru.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ru.lproj/Localizable.stringsdict
@@ -42,6 +42,26 @@
 			<string>%d успешного переноса</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d результат</string>
+			<key>few</key>
+			<string>%d результата</string>
+			<key>many</key>
+			<string>%d результатов</string>
+			<key>other</key>
+			<string>%d результата</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Thu nhỏ";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Tìm kiếm sắp ra mắt";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vui lòng kiểm tra cài đặt Hoạt động Trực tiếp trong Cài đặt.";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Thu nhỏ";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vui lòng kiểm tra cài đặt Hoạt động Trực tiếp trong Cài đặt.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Kết quả tìm kiếm";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Không có kết quả";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d kết quả";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Xóa";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Đơn vị vận tải bị ảnh hưởng";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Chọn tuyến của bạn";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Không có điểm dừng";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Ngày";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d kết quả";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Không thể mở kết quả tìm kiếm này.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Xóa";

--- a/OBAKit/Strings/vi.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/vi.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d thành công</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d kết quả</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "已最小化";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "搜索功能即将推出";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "请在“设置”中检查“实时活动”的相关设置。";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "已最小化";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "请在“设置”中检查“实时活动”的相关设置。";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "搜索结果";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "无结果";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d 个结果";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "清除";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "受此影响的公交公司";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "选择您的线路";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "无站点";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "日期";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d 个结果";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "无法打开此搜索结果。";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "清除";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d项成功</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个结果</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "最小化";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "請檢查「設定」中的「即時動態」設定。";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "搜尋結果";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "無結果";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d 個結果";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "清除";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "受影響的營運機構";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "最小化";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "搜尋功能即將推出";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "請檢查「設定」中的「即時動態」設定。";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "選擇您的路線";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "無站點";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "日期";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d 個結果";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "無法開啟此搜尋結果。";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "清除";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d 個成功</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個結果</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,7 +8,6 @@
 //
 
 import ActivityKit
-import CoreLocation
 import Combine
 import CoreLocation
 import SwiftUI

--- a/OBAKit/TripPlanning/MapItemView.swift
+++ b/OBAKit/TripPlanning/MapItemView.swift
@@ -41,63 +41,63 @@ public struct MapItemView: View {
 
     public var body: some View {
         VStack(spacing: 0) {
-                headerView
-                    .padding(.top, 20)
-                    .padding(.horizontal)
+            headerView
+                .padding(.top, 20)
+                .padding(.horizontal)
 
-                ScrollView {
-                     VStack(spacing: 20) {
-                        // Action Buttons and Nearby Stops
-                        VStack(spacing: 12) {
-                            actionButtonsRow
-                                .padding(.horizontal)
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Action Buttons and Nearby Stops
+                    VStack(spacing: 12) {
+                        actionButtonsRow
+                            .padding(.horizontal)
 
-                            // Nearby Stops Button - show as full-width only when call/website buttons exist
-                            if viewModel.phoneNumber != nil || viewModel.url != nil {
-                                Button(
-                                    action: {
-                                        viewModel.showNearbyStops()
-                                    },
-                                    label: {
-                                        HStack {
-                                            Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button to view nearby stops"))
-                                                .bold()
-                                            Spacer()
-                                            Image(systemName: "chevron.right")
-                                                .font(.caption)
-                                                .bold()
-                                        }
-                                        .padding()
-                                        .background(Color(uiColor: .secondarySystemBackground))
-                                        .clipShape(.rect(cornerRadius: 12))
+                        // Nearby Stops Button - show as full-width only when call/website buttons exist
+                        if viewModel.phoneNumber != nil || viewModel.url != nil {
+                            Button(
+                                action: {
+                                    viewModel.showNearbyStops()
+                                },
+                                label: {
+                                    HStack {
+                                        Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button to view nearby stops"))
+                                            .bold()
+                                        Spacer()
+                                        Image(systemName: "chevron.right")
+                                            .font(.caption)
+                                            .bold()
                                     }
-                                )
-                                .padding(.horizontal)
-                                .foregroundStyle(.primary)
-                                .accessibilityLabel(OBALoc("map_item_controller.nearby_stops_accessibility", value: "View nearby transit stops", comment: "Accessibility label for nearby stops button"))
-                            }
+                                    .padding()
+                                    .background(Color(uiColor: .secondarySystemBackground))
+                                    .clipShape(.rect(cornerRadius: 12))
+                                }
+                            )
+                            .padding(.horizontal)
+                            .foregroundStyle(.primary)
+                            .accessibilityLabel(OBALoc("map_item_controller.nearby_stops_accessibility", value: "View nearby transit stops", comment: "Accessibility label for nearby stops button"))
                         }
-
-                        if let scene = viewModel.lookAroundScene {
-                            lookAroundSection(scene: scene)
-                        }
-
-                        if viewModel.hasAboutContent {
-                            aboutSection
-                                .padding(.horizontal)
-                        }
-
-                        // Remove Pin button for user-dropped pins
-                        if viewModel.canRemovePin {
-                            removePinSection
-                                .padding(.horizontal)
-                        }
-
-                        Spacer(minLength: 40)
                     }
-                    .padding(.top)
+
+                    if let scene = viewModel.lookAroundScene {
+                        lookAroundSection(scene: scene)
+                    }
+
+                    if viewModel.hasAboutContent {
+                        aboutSection
+                            .padding(.horizontal)
+                    }
+
+                    // Remove Pin button for user-dropped pins
+                    if viewModel.canRemovePin {
+                        removePinSection
+                            .padding(.horizontal)
+                    }
+
+                    Spacer(minLength: 40)
                 }
+                .padding(.top)
             }
+        }
         .lookAroundViewer(
             isPresented: $showLookAroundViewer,
             initialScene: viewModel.lookAroundScene

--- a/OBAKit/TripPlanning/MapItemView.swift
+++ b/OBAKit/TripPlanning/MapItemView.swift
@@ -24,23 +24,23 @@ public struct MapItemView: View {
     /// The view model that manages the data and business logic
     private var viewModel: MapItemViewModel
 
+    /// Whether to show the Share button; the UIKit host shows it, the sheet uses a native ShareLink
+    private let showsShareButton: Bool
+
     /// State for controlling the Look Around viewer presentation
     @State private var showLookAroundViewer = false
 
     /// Initializes a new map item view.
     ///
     /// - Parameter viewModel: The view model containing the map item data and handling user actions
-    public init(viewModel: MapItemViewModel) {
+    /// - Parameter showsShareButton: Whether to show the Share button (default: true for UIKit host)
+    public init(viewModel: MapItemViewModel, showsShareButton: Bool = true) {
         self.viewModel = viewModel
+        self.showsShareButton = showsShareButton
     }
 
     public var body: some View {
-        ZStack {
-            Color.clear
-                .background(.ultraThinMaterial)
-                .ignoresSafeArea(.all)
-
-            VStack(spacing: 0) {
+        VStack(spacing: 0) {
                 headerView
                     .padding(.top, 20)
                     .padding(.horizontal)
@@ -98,7 +98,6 @@ public struct MapItemView: View {
                     .padding(.top)
                 }
             }
-        }
         .lookAroundViewer(
             isPresented: $showLookAroundViewer,
             initialScene: viewModel.lookAroundScene
@@ -130,17 +129,19 @@ public struct MapItemView: View {
 
             HStack(alignment: .top) {
                 // Share Button
-                Button("Share", systemImage: "square.and.arrow.up") {
-                    viewModel.shareLocation()
+                if showsShareButton {
+                    Button("Share", systemImage: "square.and.arrow.up") {
+                        viewModel.shareLocation()
+                    }
+                    .labelStyle(.iconOnly)
+                    .font(.title3)
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(.circle)
+                    .background(.regularMaterial)
+                    .clipShape(.circle)
+                    .accessibilityLabel(OBALoc("map_item_controller.share_button", value: "Share Location", comment: "Accessibility label for share button"))
                 }
-                .labelStyle(.iconOnly)
-                .font(.title3)
-                .foregroundStyle(.primary)
-                .frame(width: 44, height: 44)
-                .contentShape(.circle)
-                .background(.regularMaterial)
-                .clipShape(.circle)
-                .accessibilityLabel(OBALoc("map_item_controller.share_button", value: "Share Location", comment: "Accessibility label for share button"))
 
                 Spacer()
 

--- a/OBAKit/TripPlanning/MapItemViewController.swift
+++ b/OBAKit/TripPlanning/MapItemViewController.swift
@@ -19,19 +19,33 @@ import OBAKitCore
 /// and provides a link to view nearby transit stops.
 ///
 class MapItemViewController: UIViewController, AppContext {
-    private let makeViewModel: (MapItemViewController) -> MapItemViewModel
-    private var viewModel: MapItemViewModel!
+    let application: Application
 
-    var application: Application { viewModel.application }
+    private let mapItem: MKMapItem
+    private weak var modalDelegate: ModalDelegate?
+    private let removePinHandler: (() -> Void)?
+    private let planTripHandler: () -> Void
 
     /// The hosting controller that embeds the SwiftUI view
     private var hostingController: UIHostingController<AnyView>?
 
-    /// The view model needs `MapItemActions` bound to *this* controller as their
-    /// presenter, which doesn't exist until after `super.init`. The caller supplies
-    /// a builder instead of a finished view model, and it runs in `viewDidLoad`.
-    init(makeViewModel: @escaping (MapItemViewController) -> MapItemViewModel) {
-        self.makeViewModel = makeViewModel
+    /// The view model, built in `viewDidLoad` because `MapItemActions.uiKit` needs
+    /// this controller as its presenter — which isn't available until after
+    /// `super.init`.
+    private var viewModel: MapItemViewModel?
+
+    init(
+        application: Application,
+        mapItem: MKMapItem,
+        delegate: ModalDelegate?,
+        removePinHandler: (() -> Void)? = nil,
+        planTripHandler: @escaping () -> Void
+    ) {
+        self.application = application
+        self.mapItem = mapItem
+        self.modalDelegate = delegate
+        self.removePinHandler = removePinHandler
+        self.planTripHandler = planTripHandler
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -40,7 +54,14 @@ class MapItemViewController: UIViewController, AppContext {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        viewModel = makeViewModel(self)
+        let viewModel = MapItemViewModel(
+            mapItem: mapItem,
+            application: application,
+            actions: .uiKit(presenter: self, delegate: modalDelegate, application: application),
+            removePinHandler: removePinHandler,
+            planTripHandler: planTripHandler
+        )
+        self.viewModel = viewModel
 
         view.backgroundColor = .clear
 
@@ -52,7 +73,7 @@ class MapItemViewController: UIViewController, AppContext {
         background.pinToSuperview(.edges)
 
         let mapItemView = MapItemView(viewModel: viewModel, showsShareButton: true)
-            .environment(\.coreApplication, viewModel.application)
+            .environment(\.coreApplication, application)
 
         let hostingController = UIHostingController(rootView: AnyView(mapItemView))
         hostingController.view.backgroundColor = .clear

--- a/OBAKit/TripPlanning/MapItemViewController.swift
+++ b/OBAKit/TripPlanning/MapItemViewController.swift
@@ -19,18 +19,19 @@ import OBAKitCore
 /// and provides a link to view nearby transit stops.
 ///
 class MapItemViewController: UIViewController, AppContext {
-    var application: Application {
-        viewModel.application
-    }
+    private let makeViewModel: (MapItemViewController) -> MapItemViewModel
+    private var viewModel: MapItemViewModel!
+
+    var application: Application { viewModel.application }
 
     /// The hosting controller that embeds the SwiftUI view
     private var hostingController: UIHostingController<AnyView>?
 
-    /// The view model that manages the business logic
-    private let viewModel: MapItemViewModel
-
-    init(_ viewModel: MapItemViewModel) {
-        self.viewModel = viewModel
+    /// The view model needs `MapItemActions` bound to *this* controller as their
+    /// presenter, which doesn't exist until after `super.init`. The caller supplies
+    /// a builder instead of a finished view model, and it runs in `viewDidLoad`.
+    init(makeViewModel: @escaping (MapItemViewController) -> MapItemViewModel) {
+        self.makeViewModel = makeViewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -39,11 +40,18 @@ class MapItemViewController: UIViewController, AppContext {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        viewModel = makeViewModel(self)
+
         view.backgroundColor = .clear
 
-        viewModel.setPresentingViewController(self)
+        // The blurred surface used to live inside `MapItemView`. It's panel chrome,
+        // not content — and inside a SwiftUI sheet it fights the sheet's own
+        // material — so the UIKit host owns it now.
+        let background = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+        view.addSubview(background)
+        background.pinToSuperview(.edges)
 
-        let mapItemView = MapItemView(viewModel: viewModel)
+        let mapItemView = MapItemView(viewModel: viewModel, showsShareButton: true)
             .environment(\.coreApplication, viewModel.application)
 
         let hostingController = UIHostingController(rootView: AnyView(mapItemView))

--- a/OBAKit/TripPlanning/MapItemViewModel.swift
+++ b/OBAKit/TripPlanning/MapItemViewModel.swift
@@ -13,6 +13,69 @@ import Contacts
 import SafariServices
 import OBAKitCore
 
+/// The presentation-dependent half of the map-item screen, injected so the same
+/// view model drives both the UIKit floating panel and the SwiftUI sheet.
+///
+/// Everything else the screen does — opening Maps, dialing a phone number — is
+/// app-level and needs no presenter.
+@MainActor
+public struct MapItemActions {
+    public var openWebsite: (URL) -> Void
+    public var showNearbyStops: (CLLocationCoordinate2D) -> Void
+    public var dismiss: () -> Void
+    /// Only the UIKit host uses this — the sheet renders a native `ShareLink` from
+    /// `MapItemViewModel.shareURL` instead and passes a no-op here.
+    public var share: (URL) -> Void
+
+    public init(
+        openWebsite: @escaping (URL) -> Void,
+        showNearbyStops: @escaping (CLLocationCoordinate2D) -> Void,
+        dismiss: @escaping () -> Void,
+        share: @escaping (URL) -> Void = { _ in }
+    ) {
+        self.openWebsite = openWebsite
+        self.showNearbyStops = showNearbyStops
+        self.dismiss = dismiss
+        self.share = share
+    }
+
+    /// Reproduces the pre-sheet behavior: an in-app Safari controller and a pushed
+    /// `NearbyStopsViewController`, both presented from `presenter`, dismissal via
+    /// the modal delegate.
+    public static func uiKit(
+        presenter: UIViewController,
+        delegate: ModalDelegate?,
+        application: Application
+    ) -> MapItemActions {
+        MapItemActions(
+            openWebsite: { [weak presenter] url in
+                guard let presenter else { return }
+                application.viewRouter.present(SFSafariViewController(url: url), from: presenter)
+            },
+            showNearbyStops: { [weak presenter] coordinate in
+                guard let presenter else { return }
+                let nearbyStops = NearbyStopsViewController(coordinate: coordinate, application: application)
+                application.viewRouter.navigate(to: nearbyStops, from: presenter)
+            },
+            dismiss: { [weak presenter, weak delegate] in
+                guard let presenter else { return }
+                delegate?.dismissModalController(presenter)
+            },
+            share: { [weak presenter] url in
+                guard let presenter else { return }
+                let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                // iPad support, unchanged from the previous `shareLocation()` body.
+                if let popover = activityController.popoverPresentationController {
+                    popover.sourceView = presenter.view
+                    popover.sourceRect = CGRect(x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0)
+                    popover.permittedArrowDirections = []
+                }
+                presenter.present(activityController, animated: true)
+            }
+        )
+    }
+}
+
 /// A view model that manages the data and business logic for displaying map item information.
 ///
 /// This view model extracts and formats data from an `MKMapItem` and handles user interactions
@@ -34,11 +97,8 @@ public class MapItemViewModel {
     /// Optional handler for removing a user-dropped pin
     let removePinHandler: (() -> Void)?
 
-    /// Delegate for handling modal dismissal
-    weak var delegate: ModalDelegate?
-
-    /// The presenting view controller for navigation actions
-    private weak var presentingViewController: UIViewController?
+    /// Presentation-dependent actions injected at init time
+    private let actions: MapItemActions
 
     /// The name/title of the location
     var title: String
@@ -79,13 +139,13 @@ public class MapItemViewModel {
     /// - Parameters:
     ///   - mapItem: The map item containing location information
     ///   - application: The OBA application instance
-    ///   - delegate: Optional delegate for handling modal dismissal
+    ///   - actions: Injected actions for presentation-dependent operations
     ///   - removePinHandler: Optional handler called when user wants to remove a dropped pin
     ///   - planTripHandler: Handler called when user wants to plan a trip
-    public init(mapItem: MKMapItem, application: Application, delegate: ModalDelegate?, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
+    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
         self.mapItem = mapItem
         self.application = application
-        self.delegate = delegate
+        self.actions = actions
         self.removePinHandler = removePinHandler
         self.planTripHandler = planTripHandler
 
@@ -146,15 +206,6 @@ public class MapItemViewModel {
         }
     }
 
-    /// Sets the presenting view controller for navigation actions.
-    ///
-    /// This must be called before any navigation actions (like showing nearby stops or opening URLs)
-    /// to ensure proper view controller presentation.
-    ///
-    /// - Parameter viewController: The view controller that will present navigation actions
-    func setPresentingViewController(_ viewController: UIViewController) {
-        self.presentingViewController = viewController
-    }
 
     /// Opens the location in the Maps app.
     ///
@@ -172,28 +223,15 @@ public class MapItemViewModel {
         application.open(url, options: [:], completionHandler: nil)
     }
 
-    /// Opens the location's website in a Safari view controller.
-    ///
-    /// This presents an in-app Safari browser with the location's website.
-    /// Does nothing if no URL is available or if the presenting view controller hasn't been set.
+    /// Opens the location's website through the injected action.
     func openURL() {
-        guard let url = url else { return }
-        guard let presenter = presentingViewController else { return }
-        let safari = SFSafariViewController(url: url)
-        application.viewRouter.present(safari, from: presenter)
+        guard let url else { return }
+        actions.openWebsite(url)
     }
 
-    /// Navigates to the nearby stops view controller.
-    ///
-    /// This pushes a new view controller showing transit stops near the location.
-    /// Does nothing if the presenting view controller hasn't been set.
+    /// Shows nearby stops through the injected action.
     func showNearbyStops() {
-        guard let presenter = presentingViewController else { return }
-        let nearbyStops = NearbyStopsViewController(
-            coordinate: mapItem.placemark.coordinate,
-            application: application
-        )
-        application.viewRouter.navigate(to: nearbyStops, from: presenter)
+        actions.showNearbyStops(mapItem.placemark.coordinate)
     }
 
     /// Plans a trip from/to this location.
@@ -209,31 +247,21 @@ public class MapItemViewModel {
         removePinHandler?()
     }
 
-    /// Dismisses the view by calling the delegate's dismissModalController method.
-    ///
-    /// This properly dismisses the FloatingPanel that contains the MapItemViewController.
+    /// Dismisses the view through the injected action.
     func dismissView() {
-        guard let presenter = presentingViewController else { return }
-        delegate?.dismissModalController(presenter)
+        actions.dismiss()
     }
 
-    /// Uses the MapKit Place ID when available to generate a stable "Place Link" URL,
-    /// falling back to query + coordinates when the place identity is not available.
+    /// The Apple Maps link for this place. Exposed so the SwiftUI sheet can use a
+    /// native `ShareLink`; the UIKit path still routes through `shareLocation()`.
+    var shareURL: URL? {
+        appleMapsShareURL(for: mapItem)
+    }
+
+    /// Shares the location through the injected action.
     func shareLocation() {
-        guard let presenter = presentingViewController else { return }
-        guard let url = appleMapsShareURL(for: mapItem) else { return }
-
-        let activityItems: [Any] = [url]
-        let activityController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-
-        // iPad support
-        if let popover = activityController.popoverPresentationController {
-            popover.sourceView = presenter.view
-            popover.sourceRect = CGRect(x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-
-        presenter.present(activityController, animated: true)
+        guard let shareURL else { return }
+        actions.share(shareURL)
     }
 
     /// Generates an Apple Maps share URL using the Place ID when available,

--- a/OBAKit/TripPlanning/MapItemViewModel.swift
+++ b/OBAKit/TripPlanning/MapItemViewModel.swift
@@ -92,7 +92,10 @@ public class MapItemViewModel {
     /// The OBA application instance for accessing services and navigation
     let application: Application
 
-    let planTripHandler: () -> Void
+    /// `nil` on surfaces that have no trip-planner destination to hand off to.
+    /// Gates `showPlanTripButton`, so those surfaces don't render a button that
+    /// does nothing when tapped.
+    let planTripHandler: (() -> Void)?
 
     /// Optional handler for removing a user-dropped pin
     let removePinHandler: (() -> Void)?
@@ -141,8 +144,9 @@ public class MapItemViewModel {
     ///   - application: The OBA application instance
     ///   - actions: Injected actions for presentation-dependent operations
     ///   - removePinHandler: Optional handler called when user wants to remove a dropped pin
-    ///   - planTripHandler: Handler called when user wants to plan a trip
-    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
+    ///   - planTripHandler: Handler called when user wants to plan a trip, or `nil`
+    ///     to hide the Plan Trip button entirely
+    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: (() -> Void)?) {
         self.mapItem = mapItem
         self.application = application
         self.actions = actions
@@ -155,7 +159,7 @@ public class MapItemViewModel {
             self.formattedAddress = CNPostalAddressFormatter.string(from: address, style: .mailingAddress)
         }
 
-        self.showPlanTripButton = application.features.tripPlanning == .running
+        self.showPlanTripButton = application.features.tripPlanning == .running && planTripHandler != nil
         self.phoneNumber = mapItem.phoneNumber
         self.url = mapItem.url
 
@@ -206,7 +210,6 @@ public class MapItemViewModel {
         }
     }
 
-
     /// Opens the location in the Maps app.
     ///
     /// This launches the system Maps application and displays the location.
@@ -237,7 +240,7 @@ public class MapItemViewModel {
     /// Plans a trip from/to this location.
     ///
     func planTrip() {
-        planTripHandler()
+        planTripHandler?()
     }
 
     /// Removes the user-dropped pin and dismisses the view.

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -159,7 +159,16 @@ class Fixtures {
             "agencyId": "test_agency",
             "id": id,
             "shortName": "1",
-            "type": 3
+            "type": 3,
+            "agency": [
+                "id": "test_agency",
+                "name": "Test Agency",
+                "lang": "en",
+                "phone": "555-0000",
+                "privateService": false,
+                "timezone": "America/Los_Angeles",
+                "url": "https://example.com"
+            ]
         ]
         return try dictionaryToModel(type: Route.self, dictionary: dictionary)
     }

--- a/OBAKitTests/Helpers/Mocks/GatedDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/GatedDataLoader.swift
@@ -1,0 +1,87 @@
+//
+//  GatedDataLoader.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Wraps a `MockDataLoader` and holds a request open until the test lets it go, so
+/// state that exists only *while* a request is in flight — a row's loading id, an
+/// in-progress flag — can be observed rather than inferred from what's left behind
+/// afterwards.
+///
+/// `CountingDataLoader` yields once so concurrent tasks interleave; this one blocks
+/// until told otherwise, which is what an assertion made mid-request needs to be
+/// deterministic rather than a race against a mock that answers instantly.
+// @unchecked Sendable: all mutable state is guarded by `lock`.
+// `nonisolated` for the same reason `MockDataLoader` is: `data(for:)` runs on
+// whatever task issued the request, not on the test target's default main actor.
+nonisolated final class GatedDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
+
+    private let inner: MockDataLoader
+    private let lock = NSLock()
+
+    private var hasArrived = false
+    private var arrivalContinuation: CheckedContinuation<Void, Never>?
+
+    private var isReleased = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(_ inner: MockDataLoader) {
+        self.inner = inner
+    }
+
+    /// Suspends until a request reaches the loader — i.e. until the code under test
+    /// has run everything it does before awaiting the network.
+    func waitForRequest() async {
+        await withCheckedContinuation { continuation in
+            let alreadyArrived = lock.withLock { () -> Bool in
+                if hasArrived { return true }
+                arrivalContinuation = continuation
+                return false
+            }
+            // Resumed outside the lock: `resume()` can run the waiter inline, and a
+            // waiter that comes straight back here would deadlock on a held lock.
+            if alreadyArrived { continuation.resume() }
+        }
+    }
+
+    /// Lets the held request run to completion.
+    func releaseRequest() {
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            isReleased = true
+            defer { releaseContinuation = nil }
+            return releaseContinuation
+        }
+        continuation?.resume()
+    }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        inner.dataTask(with: request, completionHandler: completionHandler)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let arrival = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            hasArrived = true
+            defer { arrivalContinuation = nil }
+            return arrivalContinuation
+        }
+        arrival?.resume()
+
+        await withCheckedContinuation { continuation in
+            let alreadyReleased = lock.withLock { () -> Bool in
+                if isReleased { return true }
+                releaseContinuation = continuation
+                return false
+            }
+            if alreadyReleased { continuation.resume() }
+        }
+
+        return try await inner.data(for: request)
+    }
+}

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -70,13 +70,22 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     /// `recordedRequestURLsLock` because real callers fan out across multiple
     /// concurrent tasks (e.g. `AgencyAlertsStore.update()`'s alerts task group).
     private var _recordedRequestURLs = [URL]()
+    private var _recordedRequests = [URLRequest]()
     private let recordedRequestURLsLock = NSLock()
     var recordedRequestURLs: [URL] {
         recordedRequestURLsLock.withLock { _recordedRequestURLs }
     }
-    private func recordRequest(_ url: URL?) {
+    var requests: [URLRequest] {
+        recordedRequestURLsLock.withLock { _recordedRequests }
+    }
+    private func recordRequest(_ url: URL?, request: URLRequest? = nil) {
         guard let url else { return }
-        recordedRequestURLsLock.withLock { _recordedRequestURLs.append(url) }
+        recordedRequestURLsLock.withLock {
+            _recordedRequestURLs.append(url)
+            if let request {
+                _recordedRequests.append(request)
+            }
+        }
     }
 
     /// Clears recorded request URLs. Useful in tests that need to ignore the
@@ -93,7 +102,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        recordRequest(request.url)
+        recordRequest(request.url, request: request)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }
@@ -121,7 +130,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
             throw URLError(.cancelled)
         }
 
-        recordRequest(request.url)
+        recordRequest(request.url, request: request)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -70,22 +70,13 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     /// `recordedRequestURLsLock` because real callers fan out across multiple
     /// concurrent tasks (e.g. `AgencyAlertsStore.update()`'s alerts task group).
     private var _recordedRequestURLs = [URL]()
-    private var _recordedRequests = [URLRequest]()
     private let recordedRequestURLsLock = NSLock()
     var recordedRequestURLs: [URL] {
         recordedRequestURLsLock.withLock { _recordedRequestURLs }
     }
-    var requests: [URLRequest] {
-        recordedRequestURLsLock.withLock { _recordedRequests }
-    }
-    private func recordRequest(_ url: URL?, request: URLRequest? = nil) {
+    private func recordRequest(_ url: URL?) {
         guard let url else { return }
-        recordedRequestURLsLock.withLock {
-            _recordedRequestURLs.append(url)
-            if let request {
-                _recordedRequests.append(request)
-            }
-        }
+        recordedRequestURLsLock.withLock { _recordedRequestURLs.append(url) }
     }
 
     /// Clears recorded request URLs. Useful in tests that need to ignore the
@@ -102,7 +93,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        recordRequest(request.url, request: request)
+        recordRequest(request.url)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }
@@ -130,7 +121,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
             throw URLError(.cancelled)
         }
 
-        recordRequest(request.url, request: request)
+        recordRequest(request.url)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }

--- a/OBAKitTests/Search/SearchInteractorTests.swift
+++ b/OBAKitTests/Search/SearchInteractorTests.swift
@@ -1,0 +1,126 @@
+//
+//  SearchInteractorTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// What the search list offers for a given query.
+@Suite(.serialized)
+final class SearchInteractorTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    /// `SearchInteractor` holds its delegate weakly, so the suite keeps it alive.
+    private var delegate: StubDelegate!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private final class StubDelegate: NSObject, SearchDelegate {
+        func performSearch(request: SearchRequest) { }
+        func showMapItem(_ mapItem: MKMapItem) { }
+        func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) { }
+        func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) { }
+        var isVehicleSearchAvailable: Bool { false }
+    }
+
+    @MainActor
+    private func makeInteractor() -> (SearchInteractor, Application) {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stub = StubDelegate()
+        delegate = stub
+        return (SearchInteractor(application: application, delegate: stub), application)
+    }
+
+    // MARK: - Empty query
+
+    /// The empty query offers recent *searches* and nothing else — matching the UIKit
+    /// panel, which has never surfaced recent stops here.
+    @Test @MainActor
+    func `An empty query shows recent searches only`() throws {
+        let (interactor, application) = makeInteractor()
+
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+        application.userDataStore.addRecentMapItem(item)
+
+        // Present, and deliberately not offered on an empty query.
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: "")
+
+        #expect(interactor.sections.map(\.id) == [.recentMapItems])
+    }
+
+    /// No recent searches means no sections at all, so the view falls through to its
+    /// empty state. Recent stops are *not* used as a stand-in.
+    @Test @MainActor
+    func `An empty query with no recent searches shows nothing`() throws {
+        let (interactor, application) = makeInteractor()
+        application.userDataStore.deleteAllRecentMapItems()
+
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: "")
+
+        #expect(interactor.sections.isEmpty)
+    }
+
+    // MARK: - Recent stops
+
+    /// Recent stops are matched against a typed query, which is the only place they
+    /// appear.
+    @Test @MainActor
+    func `A query matches recent stops by name`() throws {
+        let (interactor, application) = makeInteractor()
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: stop.name)
+
+        let section = try #require(interactor.sections.first { $0.id == .recentStops })
+        #expect(section.content.map(\.title) == [stop.name])
+    }
+
+    /// Recent-stop rows render in a `ForEach`, and stop names repeat across the two
+    /// directions of a corner — the row id has to come from the stop, not the title,
+    /// or a query matching both drops one of them.
+    @Test @MainActor
+    func `Recent stops sharing a name get distinct row ids`() throws {
+        let (interactor, application) = makeInteractor()
+
+        let stops = try Fixtures.loadSomeStops()
+        let sharedName = try #require(
+            Dictionary(grouping: stops, by: \.name).first { $0.value.count > 1 }?.value,
+            "Fixture no longer contains two stops sharing a name; pick another fixture."
+        )
+        for stop in sharedName {
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        interactor.searchModeObjects(text: try #require(sharedName.first).name)
+
+        let section = try #require(interactor.sections.first { $0.id == .recentStops })
+        #expect(section.content.count == sharedName.count)
+        #expect(Set(section.content.map(\.id)).count == section.content.count)
+    }
+}

--- a/OBAKitTests/Search/SearchManagerTests.swift
+++ b/OBAKitTests/Search/SearchManagerTests.swift
@@ -1,0 +1,140 @@
+//
+//  SearchManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// `fetchResults` is the returning entry point the SwiftUI panel consumes. These
+/// tests pin its output per search type; `search(request:)`'s publishing behavior for
+/// the UIKit path is covered separately at the end.
+@Suite(.serialized)
+final class SearchManagerTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Stubs
+
+    private func stubStopsForLocation(dataLoader: MockDataLoader) {
+        let data = Fixtures.loadData(file: "stops_for_location_seattle.json")
+        dataLoader.mock(data: data) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+    }
+
+    private func stubRoutesForLocation(dataLoader: MockDataLoader) {
+        let data = Fixtures.loadData(file: "routes_for_location_query.json")
+        dataLoader.mock(data: data) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+    }
+
+    // MARK: - Stop number
+
+    @Test @MainActor
+    func `Fetch results for a stop number returns the matching stops`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubStopsForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        let request = SearchRequest(query: "1_75403", type: .stopNumber)
+        let response = try #require(await manager.fetchResults(for: request))
+
+        #expect(response.request === request)
+        #expect(response.results.isEmpty == false)
+        #expect(response.results.allSatisfy { $0 is Stop })
+    }
+
+    // MARK: - Route
+
+    @Test @MainActor
+    func `Fetch results for a route returns the matching routes`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRoutesForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        let request = SearchRequest(query: "44", type: .route)
+        let response = try #require(await manager.fetchResults(for: request))
+
+        #expect(response.results.allSatisfy { $0 is Route })
+    }
+
+    // MARK: - Errors are thrown, not swallowed
+
+    @Test @MainActor
+    func `Fetch results throws when the route request fails`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
+        }
+    }
+
+    // MARK: - The search region comes from lastVisibleMapRect
+
+    @Test @MainActor
+    func `Route search queries the recorded viewport`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRoutesForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        // A small rect near Seattle; the request's lat/lon must land inside it.
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            latitudinalMeters: 2_000,
+            longitudinalMeters: 2_000
+        )
+        application.mapRegionManager.lastVisibleMapRect = MKMapRect(region)
+
+        let manager = SearchManager(application: application)
+        _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
+
+        let sent = try #require(dataLoader.requests.first { $0.url?.path.contains("routes-for-location") ?? false })
+        let url = try #require(sent.url)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let lat = try #require(components.queryItems?.first { $0.name == "lat" }?.value.flatMap(Double.init))
+        let lon = try #require(components.queryItems?.first { $0.name == "lon" }?.value.flatMap(Double.init))
+
+        #expect(abs(lat - 47.6) < 0.05)
+        #expect(abs(lon - (-122.3)) < 0.05)
+    }
+
+    // MARK: - The UIKit path still publishes
+
+    @Test @MainActor
+    func `Search publishes the response to the region manager`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubStopsForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        await manager.search(request: SearchRequest(query: "1_75403", type: .stopNumber))
+
+        #expect(application.mapRegionManager.searchResponse != nil)
+    }
+}

--- a/OBAKitTests/Search/SearchManagerTests.swift
+++ b/OBAKitTests/Search/SearchManagerTests.swift
@@ -100,7 +100,17 @@ final class SearchManagerTests: OBATestCase {
     @Test @MainActor
     func `Route search queries the recorded viewport`() async throws {
         let dataLoader = MockDataLoader(testName: name)
-        stubRoutesForLocation(dataLoader: dataLoader)
+        let capturedRequest = SendableBox<URLRequest?>(nil)
+
+        let data = Fixtures.loadData(file: "routes_for_location_query.json")
+        dataLoader.mock(data: data) { request in
+            if request.url?.path.contains("/api/where/routes-for-location.json") ?? false {
+                capturedRequest.value = request
+                return true
+            }
+            return false
+        }
+
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
         // A small rect near Seattle; the request's lat/lon must land inside it.
@@ -114,7 +124,7 @@ final class SearchManagerTests: OBATestCase {
         let manager = SearchManager(application: application)
         _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
 
-        let sent = try #require(dataLoader.requests.first { $0.url?.path.contains("routes-for-location") ?? false })
+        let sent = try #require(capturedRequest.value)
         let url = try #require(sent.url)
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let lat = try #require(components.queryItems?.first { $0.name == "lat" }?.value.flatMap(Double.init))

--- a/OBAKitTests/Search/SearchResultRouterTests.swift
+++ b/OBAKitTests/Search/SearchResultRouterTests.swift
@@ -1,0 +1,124 @@
+//
+//  SearchResultRouterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Turning one search result into a map display plus a sheet route.
+@Suite(.serialized)
+final class SearchResultRouterTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeRouter(
+        dataLoader: MockDataLoader,
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in }
+    ) -> (SearchResultRouter, SheetCoordinator<AppSheetRoute>, MapSearchDisplayModel) {
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: onPresentVehicleTrip
+        )
+        return (router, coordinator, displayModel)
+    }
+
+    @Test @MainActor
+    func `A stop result pushes stop details and centers the map`() async throws {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        await router.present(result: stop)
+
+        #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
+        if case .stop = displayModel.display {} else {
+            Issue.record("Expected the stop to be displayed on the map")
+        }
+    }
+
+    @Test @MainActor
+    func `A map item result pushes the map item sheet and centers the map`() async {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        await router.present(result: item)
+
+        #expect(coordinator.stackedRoutes.contains(.mapItem(item)))
+        if case .mapItem = displayModel.display {} else {
+            Issue.record("Expected the map item to be displayed on the map")
+        }
+    }
+
+    /// A `Route` isn't renderable on its own — it has to be resolved into
+    /// `StopsForRoute` first, which is where the polyline and stop list come from.
+    @Test @MainActor
+    func `A route result resolves stops for route then pushes the route stops sheet`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+        #expect(displayModel.suppressesAmbientStops == true)
+        #expect(router.lastError == nil)
+    }
+
+    @Test @MainActor
+    func `A failed route resolution records the error and pushes nothing`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, _) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(coordinator.stackedRoutes.isEmpty)
+        #expect(router.lastError != nil)
+    }
+
+    @Test @MainActor
+    func `Presenting a single result returns false when the response holds several`() async throws {
+        let (router, coordinator, _) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let stops = try Fixtures.loadSomeStops()
+        let response = SearchResponse(
+            request: SearchRequest(query: "1", type: .stopNumber),
+            results: Array(stops.prefix(3)),
+            boundingRegion: nil,
+            error: nil
+        )
+
+        let handled = await router.presentSingleResult(from: response)
+
+        #expect(handled == false)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+}

--- a/OBAKitTests/Search/SearchResultRouterTests.swift
+++ b/OBAKitTests/Search/SearchResultRouterTests.swift
@@ -90,6 +90,37 @@ final class SearchResultRouterTests: OBATestCase {
         #expect(router.lastError == nil)
     }
 
+    /// The map display is cleared when its owning route leaves the sheet stack, so
+    /// the route recorded as the owner has to be the very one that got pushed. If
+    /// the two drift, the display is either wiped while its sheet is still up or
+    /// stranded on the map after it goes away.
+    @Test @MainActor
+    func `The recorded display owner is the route that was pushed`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
+    /// Stops and map items own their displays too — the map-item sheet no longer
+    /// clears the marker from its own `onDisappear`.
+    @Test @MainActor
+    func `A map item result owns its display`() async {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        await router.present(result: item)
+
+        #expect(displayModel.owner == .mapItem(item))
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
     @Test @MainActor
     func `A failed route resolution records the error and pushes nothing`() async throws {
         let dataLoader = MockDataLoader(testName: name)
@@ -105,8 +136,66 @@ final class SearchResultRouterTests: OBATestCase {
         #expect(router.lastError != nil)
     }
 
+    // MARK: - Resolve / present split
+
+    /// Resolving performs the network work but touches nothing on screen, so callers
+    /// can keep their own UI up (and report a failure there) before committing to the
+    /// navigation.
     @Test @MainActor
-    func `Presenting a single result returns false when the response holds several`() async throws {
+    func `Resolving leaves the sheet stack and the map untouched`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let resolved = await router.resolve(result: route)
+
+        #expect(resolved != nil)
+        #expect(coordinator.stackedRoutes.isEmpty)
+        #expect(displayModel.owner == nil)
+        if case .none = displayModel.display {} else {
+            Issue.record("Resolving must not draw anything, got \(displayModel.display)")
+        }
+    }
+
+    /// Drawing and pushing happen in one synchronous step, so the stacked layer never
+    /// sits empty between them.
+    @Test @MainActor
+    func `Presenting a resolution draws it and pushes its sheet together`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+        let resolved = try #require(await router.resolve(result: route))
+
+        router.present(resolved)
+
+        #expect(displayModel.suppressesAmbientStops == true)
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
+    @Test @MainActor
+    func `A failed resolution yields nothing and records the error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, _) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let resolved = await router.resolve(result: route)
+
+        #expect(resolved == nil)
+        #expect(router.lastError != nil)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    @Test @MainActor
+    func `Resolving a single result returns nil when the response holds several`() async throws {
         let (router, coordinator, _) = makeRouter(dataLoader: MockDataLoader(testName: name))
         let stops = try Fixtures.loadSomeStops()
         let response = SearchResponse(
@@ -116,9 +205,9 @@ final class SearchResultRouterTests: OBATestCase {
             error: nil
         )
 
-        let handled = await router.presentSingleResult(from: response)
+        let resolved = await router.resolveSingleResult(from: response)
 
-        #expect(handled == false)
+        #expect(resolved == nil)
         #expect(coordinator.stackedRoutes.isEmpty)
     }
 }

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -82,4 +82,44 @@ final class SearchResultRowTests: OBATestCase {
 
         #expect(selected == true)
     }
+
+    // MARK: - Row identity
+
+    /// The disambiguation list renders through `ForEach`, so ids have to be unique.
+    /// Stop names are not: the two directions of a corner share one, and the Seattle
+    /// fixture has six such pairs among 26 stops. Deriving ids from titles collided
+    /// in exactly the case this list exists to handle.
+    @Test @MainActor
+    func `Stops sharing a name still get distinct row ids`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stops = try Fixtures.loadSomeStops()
+
+        let duplicatedName = try #require(
+            Dictionary(grouping: stops, by: \.name).first { $0.value.count > 1 }?.value,
+            "Fixture no longer contains two stops sharing a name; pick another fixture."
+        )
+
+        let rows = duplicatedName.compactMap {
+            SearchResultRow.row(for: $0, application: application, onSelect: { })
+        }
+
+        #expect(rows.count == duplicatedName.count)
+        #expect(Set(rows.map(\.id)).count == rows.count)
+    }
+
+    @Test @MainActor
+    func `Routes sharing a short name still get distinct row ids`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        // Two agencies can both run a route called "1".
+        let first = try Fixtures.createRoute(id: "1_44")
+        let second = try Fixtures.createRoute(id: "2_44")
+
+        let rows = [first, second].compactMap {
+            SearchResultRow.row(for: $0, application: application, onSelect: { })
+        }
+
+        #expect(rows.count == 2)
+        #expect(rows[0].title == rows[1].title)
+        #expect(rows[0].id != rows[1].id)
+    }
 }

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -1,0 +1,85 @@
+//
+//  SearchResultRowTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Row mapping for the disambiguation sheet: one row per result type, reusing the
+/// same row model as the search list so the two screens look alike.
+@Suite(.serialized)
+final class SearchResultRowTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @Test @MainActor
+    func `A stop result becomes a titled row`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let row = try #require(SearchResultRow.row(for: stop, application: application, onSelect: { }))
+
+        #expect(row.title == stop.name)
+        #expect(row.accessory == .disclosureIndicator)
+    }
+
+    @Test @MainActor
+    func `A route result shows its short name and agency`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let row = try #require(SearchResultRow.row(for: route, application: application, onSelect: { }))
+
+        #expect(row.title == route.shortName)
+        #expect(row.subtitle?.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func `A map item result shows the place name`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
+        let item = MKMapItem(placemark: placemark)
+        item.name = "Pike Place Market"
+
+        let row = try #require(SearchResultRow.row(for: item, application: application, onSelect: { }))
+
+        #expect(row.title == "Pike Place Market")
+    }
+
+    @Test @MainActor
+    func `An unknown result type produces no row`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+
+        #expect(SearchResultRow.row(for: "just a string", application: application, onSelect: { }) == nil)
+    }
+
+    @Test @MainActor
+    func `Selecting a row invokes its handler`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var selected = false
+
+        let row = try #require(SearchResultRow.row(for: stop, application: application, onSelect: { selected = true }))
+        row.action?()
+
+        #expect(selected == true)
+    }
+}

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -1,0 +1,116 @@
+//
+//  SearchSheetViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The search session: what `MapFloatingPanelController` does for the UIKit panel.
+@Suite(.serialized)
+final class SearchSheetViewModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(dataLoader: MockDataLoader) -> (SearchSheetViewModel, Application, SheetCoordinator<AppSheetRoute>) {
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: { _ in }
+        )
+        let viewModel = SearchSheetViewModel(application: application, coordinator: coordinator, router: router)
+        return (viewModel, application, coordinator)
+    }
+
+    @Test @MainActor
+    func `Typing rebuilds the interactor sections`() {
+        let (viewModel, _, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+
+        viewModel.updateQuery("cap hill")
+
+        #expect(viewModel.searchInteractor.sections.isEmpty == false)
+    }
+
+    /// Quick-search rows are only offered for vehicles when Obaco is running, which
+    /// is what `isVehicleSearchAvailable` gates.
+    @Test @MainActor
+    func `Vehicle search availability mirrors the obaco feature`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+
+        #expect(viewModel.isVehicleSearchAvailable == (application.features.obaco == .running))
+    }
+
+    @Test @MainActor
+    func `Showing a stop pops search and pushes stop details`() async throws {
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        viewModel.searchInteractor(viewModel.searchInteractor, showStop: stop)
+        // `SearchDelegate` is synchronous, so presentation runs in a detached task.
+        await viewModel.pendingPresentation?.value
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
+    }
+
+    @Test @MainActor
+    func `Showing a map item records it as a recent search`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+
+        viewModel.showMapItem(item)
+
+        #expect(application.userDataStore.recentMapItems.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func `Clearing recent searches empties the store and rebuilds sections`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+        application.userDataStore.addRecentMapItem(item)
+
+        viewModel.confirmClearRecentSearches()
+
+        #expect(application.userDataStore.recentMapItems.isEmpty)
+    }
+
+    /// A search that matches nothing reports inline rather than popping an alert.
+    @Test @MainActor
+    func `A search with no results sets the no results message`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
+
+        #expect(viewModel.showsNoResults == true)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+}

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -77,12 +77,16 @@ final class SearchSheetViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Showing a map item records it as a recent search`() {
+    func `Showing a map item records it as a recent search`() async {
         let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
         item.name = "Pike Place Market"
 
         viewModel.showMapItem(item)
+        // The detached presentation task pops search and pushes the map item. The
+        // suite is `.serialized`, so leaving it in flight lets it land during the
+        // next test.
+        await viewModel.pendingPresentation?.value
 
         #expect(application.userDataStore.recentMapItems.isEmpty == false)
     }
@@ -199,6 +203,74 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.message?.kind == .error)
         #expect(coordinator.currentRoute == .search, "Search must stay up to show the failure")
         #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Vehicle search
+
+    /// The vehicle exists; its *details* request is what failed. `fetchVehicleID` used
+    /// to swallow that and hand back an empty response, which classifies as
+    /// `.noResults` — telling the user their query matched nothing and sending them
+    /// off rewording a search that was fine. It has to read as the failure it is.
+    @Test @MainActor
+    func `A failed vehicle details fetch reports an error rather than no results`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let vehicles = #"[{"id": "1", "name": "Metro Transit", "vehicle_id": "1_4351"}]"#
+        dataLoader.mock(data: Data(vehicles.utf8)) { request in
+            request.url?.path.contains("/api/v1/regions/") ?? false
+        }
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/vehicle/") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "4351", type: .vehicleID))
+
+        #expect(viewModel.message?.kind == .error)
+        #expect(viewModel.message?.text != SearchSheetViewModel.noResultsText)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Superseded searches
+
+    /// Cancelling `searchTask` doesn't stop the request already in flight, so a
+    /// superseded search runs to completion. It must not report, navigate, or clear
+    /// `isSearching` — that flag belongs to the search that replaced it, and clearing
+    /// it dismisses the progress HUD while the newer search is still running.
+    @Test @MainActor
+    func `A cancelled search neither reports nor navigates`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        let search = Task { await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route)) }
+        search.cancel()
+        await search.value
+
+        #expect(viewModel.message == nil, "A search the user abandoned must not raise an alert")
+        #expect(viewModel.isSearching, "Clearing this would dismiss the HUD out from under the newer search")
+        #expect(coordinator.currentRoute == .search)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Analytics
+
+    /// The sheet system tears a sheet's content view down and rebuilds it without the
+    /// user going anywhere, so `onAppear` can fire more than once per entry into
+    /// search. The event is documented as once per entry.
+    @Test @MainActor
+    func `Reporting search opened more than once counts once`() throws {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let analytics = try #require(application.analytics as? AnalyticsMock)
+
+        viewModel.reportSearchOpened()
+        viewModel.reportSearchOpened()
+        viewModel.reportSearchOpened()
+
+        let opens = analytics.reportedEvents.filter { $0.label == AnalyticsLabels.searchSelected }
+        #expect(opens.count == 1)
     }
 
     // MARK: - Outcome classification

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -154,6 +154,53 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.message == nil)
     }
 
+    // MARK: - Single-result sequencing
+
+    /// A single result is resolved *before* search is left, so the sheet stack never
+    /// sits empty across the network call and the user isn't dropped on home while a
+    /// request is still in flight.
+    @Test @MainActor
+    func `A single result leaves search only once it resolves`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes-for-location-10.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        dataLoader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "10", type: .route))
+
+        #expect(viewModel.message == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+    }
+
+    /// The regression: search used to be popped *before* the route was resolved, so a
+    /// failure set `message` on a view model whose view — and whose alert — had
+    /// already been torn down. The user landed on home with no explanation. Search has
+    /// to stay up so it can report the failure.
+    @Test @MainActor
+    func `A single result that fails to resolve keeps search up and reports the error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes-for-location-10.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "10", type: .route))
+
+        #expect(viewModel.message?.kind == .error)
+        #expect(coordinator.currentRoute == .search, "Search must stay up to show the failure")
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
     // MARK: - Outcome classification
 
     /// A `nil` response means the search never ran (no API service, no Obaco service,

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -76,6 +76,22 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
     }
 
+    /// Closing search has to take a resolving presentation with it. Otherwise it
+    /// lands afterwards and hands the rider a detail sheet they already backed out of.
+    @Test @MainActor
+    func `Closing search cancels an in-flight presentation`() async throws {
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        viewModel.searchInteractor(viewModel.searchInteractor, showStop: stop)
+        viewModel.close()
+        await viewModel.pendingPresentation?.value
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
     @Test @MainActor
     func `Showing a map item records it as a recent search`() async {
         let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -113,4 +113,43 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.showsNoResults == true)
         #expect(coordinator.stackedRoutes.isEmpty)
     }
+
+    // MARK: - Outcome classification
+
+    /// A `nil` response means the search never ran (no API service, no Obaco service,
+    /// no map rect) — a different thing from a query that ran and matched nothing.
+    /// Reporting the first as "no results" would send the user off rewording a query
+    /// that never left the device.
+    ///
+    /// Asserted against the pure classifier because the `nil` case can't be produced
+    /// through the test `Application`, which always has a region, an API service, and
+    /// an Obaco service.
+    @Test @MainActor
+    func `A nil response is unavailable rather than no results`() {
+        #expect(SearchSheetViewModel.SearchOutcome(response: nil) == .unavailable)
+    }
+
+    @Test @MainActor
+    func `An empty response is no results`() {
+        let response = SearchResponse(
+            request: SearchRequest(query: "zzzz", type: .route),
+            results: [],
+            boundingRegion: nil,
+            error: nil
+        )
+
+        #expect(SearchSheetViewModel.SearchOutcome(response: response) == .noResults)
+    }
+
+    @Test @MainActor
+    func `One result routes straight through and several disambiguate`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let request = SearchRequest(query: "1", type: .stopNumber)
+
+        let one = SearchResponse(request: request, results: Array(stops.prefix(1)), boundingRegion: nil, error: nil)
+        let many = SearchResponse(request: request, results: Array(stops.prefix(3)), boundingRegion: nil, error: nil)
+
+        #expect(SearchSheetViewModel.SearchOutcome(response: one) == .single(one))
+        #expect(SearchSheetViewModel.SearchOutcome(response: many) == .disambiguate(many))
+    }
 }

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -99,9 +99,10 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(application.userDataStore.recentMapItems.isEmpty)
     }
 
-    /// A search that matches nothing reports inline rather than popping an alert.
+    /// A search that matches nothing raises a message, which the view turns into the
+    /// same alert the UIKit path shows.
     @Test @MainActor
-    func `A search with no results sets the no results message`() async throws {
+    func `A search with no results raises a no results message`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
             request.url?.path.contains("/api/where/routes-for-location.json") ?? false
@@ -110,8 +111,47 @@ final class SearchSheetViewModelTests: OBATestCase {
 
         await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
 
-        #expect(viewModel.showsNoResults == true)
+        #expect(viewModel.message?.kind == .noResults)
         #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    /// The message carries a fresh identity per occurrence, so repeating a search
+    /// that fails the same way twice raises two distinct values — otherwise, once
+    /// the alert had been dismissed, the second failure would look like no change
+    /// and never present.
+    @Test @MainActor
+    func `Repeating a failed search raises a distinct message each time`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, _) = makeViewModel(dataLoader: dataLoader)
+        let request = SearchRequest(query: "zzzz", type: .route)
+
+        await viewModel.performSearchAndWait(request: request)
+        let first = try #require(viewModel.message)
+
+        await viewModel.performSearchAndWait(request: request)
+        let second = try #require(viewModel.message)
+
+        #expect(first.text == second.text)
+        #expect(first != second)
+    }
+
+    @Test @MainActor
+    func `Typing clears a pending message`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, _) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
+        #expect(viewModel.message != nil)
+
+        viewModel.updateQuery("cap hill")
+
+        #expect(viewModel.message == nil)
     }
 
     // MARK: - Outcome classification

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -322,4 +322,96 @@ final class SearchViewModelTests: OBATestCase {
         #expect(vm.loadingVehicleID == nil)
         #expect(vm.vehicleError != nil)
     }
+
+    /// `loadingVehicleID` is the only thing driving the in-row progress indicator, so
+    /// asserting it's nil afterwards isn't enough — a version that never set it at all
+    /// would pass that. Observed while the request is held open.
+    @Test @MainActor
+    func `Loading vehicle id names the vehicle being fetched while the request is in flight`() async {
+        let loader = GatedDataLoader(makeSuccessLoader())
+        let config = APIServiceConfiguration(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL)
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: RESTAPIService(config, dataLoader: loader)
+        )
+
+        let lookup = Task { await vm.selectVehicle(vehicleID: vehicleID) }
+        await loader.waitForRequest()
+
+        #expect(vm.loadingVehicleID == vehicleID)
+
+        loader.releaseRequest()
+        await lookup.value
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
+
+    // MARK: - Vehicle retry affordance
+
+    @Test @MainActor
+    func `Failed vehicle id is nil before any request`() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        #expect(vm.failedVehicleID == nil)
+    }
+
+    /// `failedVehicleID` is the user's only escape from a failed lookup: it's what
+    /// lets the inline error row offer a retry rather than dead-ending them.
+    @Test @MainActor
+    func `Failed vehicle id names the vehicle whose lookup failed`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+        #expect(vm.vehicleError != nil)
+    }
+
+    @Test @MainActor
+    func `Failed vehicle id is set when the vehicle is not on any trip`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeKeyNotFoundLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+        #expect((vm.vehicleError as? SearchError) == .noTripsAvailable)
+    }
+
+    /// The misconfiguration path bails before `loadingVehicleID` is ever set, so it
+    /// has to name the vehicle on its own or the error row loses its retry.
+    @Test @MainActor
+    func `Failed vehicle id is set when there is no api service`() async {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+    }
+
+    /// A retry that succeeds has to clear it, or the error row outlives the error.
+    @Test @MainActor
+    func `Failed vehicle id is cleared by a successful retry`() async {
+        let loader = makeNetworkErrorLoader()
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: loader)
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+        #expect(vm.failedVehicleID == vehicleID)
+
+        loader.removeMappedResponses()
+        loader.mock(URLString: vehicleURLString, with: Fixtures.loadData(file: "api_where_vehicle_1_4351.json"))
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
 }

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -286,4 +286,40 @@ final class SearchViewModelTests: OBATestCase {
         #expect(vm.vehicleError == nil)
         #expect(vm.vehicleSearchResponse != nil)
     }
+
+    // MARK: - Row-level loading state
+
+    @Test @MainActor
+    func `Loading vehicle id is nil before any request`() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        #expect(vm.loadingVehicleID == nil)
+    }
+
+    /// The results sheet shows progress on the tapped row, so the id has to be
+    /// observable while the request is in flight and cleared afterwards.
+    @Test @MainActor
+    func `Loading vehicle id is cleared once the request finishes`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeSuccessLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
+
+    @Test @MainActor
+    func `Loading vehicle id is cleared after a failure`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleError != nil)
+    }
 }

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Testing
+import MapKit
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -223,6 +224,70 @@ final class AppSheetRouteTests {
         #expect(sheetRoute1.hashValue == sheetRoute2.hashValue)
     }
 
+    // MARK: - Search result routes
+
+    @Test func `Id embeds map item coordinates`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        #expect(AppSheetRoute.mapItem(item).id == "mapItem-47.6--122.3")
+    }
+
+    @Test func `Id embeds the route id for route stops`() throws {
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        #expect(AppSheetRoute.routeStops(stopsForRoute).id == "routeStops-\(stopsForRoute.id)")
+    }
+
+    @Test func `Id embeds the query and type for search results`() {
+        let request = SearchRequest(query: "44", type: .route)
+        let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        #expect(AppSheetRoute.searchResults(response).id == "searchResults-\(SearchType.route.rawValue)-44")
+    }
+
+    @Test func `Id embeds nearby stops coordinates`() {
+        let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+        #expect(AppSheetRoute.nearbyStops(coordinate: coordinate).id == "nearbyStops-47.6--122.3")
+    }
+
+    @Test func `Search result routes prefer stacking`() throws {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let response = SearchResponse(request: SearchRequest(query: "q", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        #expect(AppSheetRoute.mapItem(item).prefersStacking == true)
+        #expect(AppSheetRoute.routeStops(stopsForRoute).prefersStacking == true)
+        #expect(AppSheetRoute.searchResults(response).prefersStacking == true)
+        #expect(AppSheetRoute.nearbyStops(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)).prefersStacking == true)
+    }
+
+    @Test func `Map item route offers only the medium detent`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let config = AppSheetRoute.mapItem(item).detentConfiguration
+
+        #expect(config.detents == [.medium])
+        #expect(config.initialDetent == .medium)
+    }
+
+    @Test func `Route stops route opens at medium so the polyline stays visible`() throws {
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let config = AppSheetRoute.routeStops(stopsForRoute).detentConfiguration
+
+        #expect(config.detents == [.medium, .large])
+        #expect(config.initialDetent == .medium)
+    }
+
+    /// `SheetCoordinator.push` preconditions on this for every stacked route: the OS
+    /// owns drag-down on that layer, and locking dismissal would leave
+    /// `stackedEntries` pointing at a sheet that is no longer on screen.
+    @Test func `Stacked search routes allow interactive dismissal`() throws {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let response = SearchResponse(request: SearchRequest(query: "q", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        #expect(AppSheetRoute.mapItem(item).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.routeStops(stopsForRoute).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.searchResults(response).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.nearbyStops(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)).detentConfiguration.isDismissDisabled == false)
+    }
+
     // MARK: - Exhaustiveness guard
 
     /// Adding a new `AppSheetRoute` case must fail to compile here, forcing
@@ -231,7 +296,8 @@ final class AppSheetRouteTests {
         switch route {
         case .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .stopDetails, .tripPlanner, .tripDetails, .routePicker,
-             .currentTrip, .transitAlert, .more, .settings:
+             .currentTrip, .transitAlert, .more, .settings,
+             .searchResults, .mapItem, .routeStops, .nearbyStops:
             break
         }
     }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -33,13 +33,30 @@ final class AppSheetViewFactoryTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
+    /// The coordinator and display model are required dependencies, so every test
+    /// builds the factory the same way the app does.
+    @MainActor
+    private func makeFactory(
+        application: Application,
+        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
+        displayModel: MapSearchDisplayModel = MapSearchDisplayModel()
+    ) -> AppSheetViewFactory {
+        AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in },
+            onPresentVehicleTrip: { _ in },
+            presentingController: { nil },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
+        )
+    }
+
     @Test @MainActor
     func `More view returns more sheet host forwarding application`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let host = factory.moreView()
+        let host = makeFactory(application: application).moreView()
 
         // Reference identity: the factory must forward its own `Application`
         // into the host, not construct a new one or drop it. `MoreSheetHost`'s
@@ -54,8 +71,7 @@ final class AppSheetViewFactoryTests: OBATestCase {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let view = factory.stopDetailView(stopID: "1_10914")
+        let view = makeFactory(application: application).stopDetailView(stopID: "1_10914")
 
         #expect(view.stopID == "1_10914")
     }
@@ -71,8 +87,7 @@ final class AppSheetViewFactoryTests: OBATestCase {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let view = factory.stopDetailView(stopID: "1_10914")
+        let view = makeFactory(application: application).stopDetailView(stopID: "1_10914")
 
         #expect(view.makePresenter().application === application)
         #expect(view.makeViewModel().stopID == "1_10914")
@@ -83,40 +98,55 @@ final class AppSheetViewFactoryTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Route stops view returns route stops sheet view forwarding the stops for route`() {
+    func `Route stops view returns route stops sheet view forwarding the stops for route`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
-        let stopsForRoute = try! Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
-        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+        let view = makeFactory(application: application).routeStopsView(stopsForRoute: stopsForRoute)
 
         #expect(view.stopsForRoute.route.id == stopsForRoute.route.id)
     }
 
+    /// The route-stops sheet clears the map on dismissal, so it has to be handed the
+    /// same display model the map renders — not a private one.
     @Test @MainActor
-    func `Search results view returns search results sheet view forwarding the response`() {
+    func `Route stops view forwards the shared display model`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let displayModel = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        let factory = makeFactory(application: application, displayModel: displayModel)
+        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+
+        #expect(view.displayModel === displayModel)
+    }
+
+    /// Both search surfaces have to route a picked result through the *same* router,
+    /// or the two screens can drift on what "opening a result" means.
+    @Test @MainActor
+    func `Search results view is handed the factory's shared router`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
         let request = SearchRequest(query: "test", type: .stopNumber)
         let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = makeFactory(application: application)
         let view = factory.searchResultsView(response: response)
 
-        #expect(view.response.request.query == response.request.query)
+        #expect(view.router === factory.searchResultRouter)
+        #expect(view.application === application)
     }
 
     @Test @MainActor
-    func `Search view returns search sheet view forwarding the application`() {
+    func `Search view returns search sheet view forwarding the placeholder`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
-        let view = factory.searchView()
+        let view = makeFactory(application: application).searchView()
 
-        // SearchSheetView's viewModel is internal state via @StateObject, so we verify
-        // indirectly by checking that the view rendered successfully with the placeholder
+        #expect(view.placeholder == SearchPlaceholder.text(for: application))
         #expect(!view.placeholder.isEmpty)
     }
 }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -81,4 +81,42 @@ final class AppSheetViewFactoryTests: OBATestCase {
         #expect(view.formatters === application.formatters)
         #expect(view.userDefaults === application.userDefaults)
     }
+
+    @Test @MainActor
+    func `Route stops view returns route stops sheet view forwarding the stops for route`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stopsForRoute = try! Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+
+        #expect(view.stopsForRoute.route.id == stopsForRoute.route.id)
+    }
+
+    @Test @MainActor
+    func `Search results view returns search results sheet view forwarding the response`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let request = SearchRequest(query: "test", type: .stopNumber)
+        let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.searchResultsView(response: response)
+
+        #expect(view.response.request.query == response.request.query)
+    }
+
+    @Test @MainActor
+    func `Search view returns search sheet view forwarding the application`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.searchView()
+
+        // SearchSheetView's viewModel is internal state via @StateObject, so we verify
+        // indirectly by checking that the view rendered successfully with the placeholder
+        #expect(!view.placeholder.isEmpty)
+    }
 }

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -32,14 +32,14 @@ final class MapItemSheetViewTests: OBATestCase {
     }
 
     @MainActor
-    private func makeFactory(application: Application, displayModel: MapSearchDisplayModel = MapSearchDisplayModel()) -> AppSheetViewFactory {
+    private func makeFactory(application: Application) -> AppSheetViewFactory {
         AppSheetViewFactory(
             application: application,
             onPresentTrip: { _ in },
             onPresentVehicleTrip: { _ in },
             presentingController: { nil },
             coordinator: SheetCoordinator(root: .home),
-            searchDisplayModel: displayModel
+            searchDisplayModel: MapSearchDisplayModel()
         )
     }
 
@@ -127,17 +127,13 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let displayModel = MapSearchDisplayModel()
-        let factory = makeFactory(application: application, displayModel: displayModel)
+        let factory = makeFactory(application: application)
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
 
         #expect(view.application === application)
         #expect(view.mapItem === item)
-        // The sheet clears the map marker when it goes away, so it needs the same
-        // display model the map renders.
-        #expect(view.displayModel === displayModel)
     }
 
     @Test @MainActor

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -90,7 +90,7 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
@@ -102,7 +102,7 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a nearby stops host for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
         let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
 
         let host = factory.nearbyStopsView(coordinate: coordinate)

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -1,0 +1,113 @@
+//
+//  MapItemSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import UIKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The map-item sheet's wiring: injected actions and the share URL the native
+/// `ShareLink` uses.
+@Suite(.serialized)
+final class MapItemSheetViewTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(actions: MapItemActions) -> MapItemViewModel {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = "Pike Place Market"
+        return MapItemViewModel(
+            mapItem: mapItem,
+            application: application,
+            actions: actions,
+            removePinHandler: nil,
+            planTripHandler: {}
+        )
+    }
+
+    @Test @MainActor
+    func `Dismissing routes through the injected action`() {
+        var dismissed = false
+        let viewModel = makeViewModel(actions: MapItemActions(
+            openWebsite: { _ in },
+            showNearbyStops: { _ in },
+            dismiss: { dismissed = true }
+        ))
+
+        viewModel.dismissView()
+
+        #expect(dismissed == true)
+    }
+
+    @Test @MainActor
+    func `Nearby stops routes through the injected action with the item coordinate`() {
+        var received: CLLocationCoordinate2D?
+        let viewModel = makeViewModel(actions: MapItemActions(
+            openWebsite: { _ in },
+            showNearbyStops: { received = $0 },
+            dismiss: { }
+        ))
+
+        viewModel.showNearbyStops()
+
+        let coordinate = try? #require(received)
+        #expect(coordinate?.latitude == 47.6)
+    }
+
+    /// The sheet header uses a native `ShareLink`, so the view model exposes the URL
+    /// rather than presenting a `UIActivityViewController` itself.
+    @Test @MainActor
+    func `Share URL falls back to a query and coordinates link`() throws {
+        let viewModel = makeViewModel(actions: MapItemActions(openWebsite: { _ in }, showNearbyStops: { _ in }, dismiss: { }))
+
+        let url = try #require(viewModel.shareURL)
+
+        #expect(url.absoluteString.contains("maps.apple.com"))
+        #expect(url.absoluteString.contains("47.6"))
+    }
+
+    @Test @MainActor
+    func `Factory builds a map item sheet for the route`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        let view = factory.mapItemView(mapItem: item)
+
+        #expect(view.application === application)
+        #expect(view.mapItem === item)
+    }
+
+    @Test @MainActor
+    func `Factory builds a nearby stops host for the route`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+
+        let host = factory.nearbyStopsView(coordinate: coordinate)
+
+        #expect(host.application === application)
+        #expect(host.coordinate.latitude == coordinate.latitude)
+    }
+}

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -32,7 +32,19 @@ final class MapItemSheetViewTests: OBATestCase {
     }
 
     @MainActor
-    private func makeViewModel(actions: MapItemActions) -> MapItemViewModel {
+    private func makeFactory(application: Application, displayModel: MapSearchDisplayModel = MapSearchDisplayModel()) -> AppSheetViewFactory {
+        AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in },
+            onPresentVehicleTrip: { _ in },
+            presentingController: { nil },
+            coordinator: SheetCoordinator(root: .home),
+            searchDisplayModel: displayModel
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(actions: MapItemActions, planTripHandler: (() -> Void)? = {}) -> MapItemViewModel {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
         let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
         let mapItem = MKMapItem(placemark: placemark)
@@ -42,9 +54,11 @@ final class MapItemSheetViewTests: OBATestCase {
             application: application,
             actions: actions,
             removePinHandler: nil,
-            planTripHandler: {}
+            planTripHandler: planTripHandler
         )
     }
+
+    private static let noopActions = MapItemActions(openWebsite: { _ in }, showNearbyStops: { _ in }, dismiss: { })
 
     @Test @MainActor
     func `Dismissing routes through the injected action`() {
@@ -87,22 +101,49 @@ final class MapItemSheetViewTests: OBATestCase {
         #expect(url.absoluteString.contains("47.6"))
     }
 
+    /// The sheet has no trip-planner destination to hand off to, so it passes a `nil`
+    /// handler — which must hide the button rather than render one that no-ops.
+    @Test @MainActor
+    func `A nil plan trip handler hides the plan trip button`() {
+        let viewModel = makeViewModel(actions: Self.noopActions, planTripHandler: nil)
+
+        #expect(viewModel.showPlanTripButton == false)
+
+        // Tapping it anyway (the button is gone, but the method is reachable) must
+        // not trap on a force-unwrapped handler.
+        viewModel.planTrip()
+    }
+
+    @Test @MainActor
+    func `A supplied plan trip handler is invoked`() {
+        var planned = false
+        let viewModel = makeViewModel(actions: Self.noopActions, planTripHandler: { planned = true })
+
+        viewModel.planTrip()
+
+        #expect(planned == true)
+    }
+
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
+        let displayModel = MapSearchDisplayModel()
+        let factory = makeFactory(application: application, displayModel: displayModel)
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
 
         #expect(view.application === application)
         #expect(view.mapItem === item)
+        // The sheet clears the map marker when it goes away, so it needs the same
+        // display model the map renders.
+        #expect(view.displayModel === displayModel)
     }
 
     @Test @MainActor
     func `Factory builds a nearby stops host for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
+        let factory = makeFactory(application: application)
         let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
 
         let host = factory.nearbyStopsView(coordinate: coordinate)

--- a/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
@@ -33,9 +33,14 @@ final class MapSearchDisplayModelTests {
         }
     }
 
+    private func loadStopsForRoute() throws -> StopsForRoute {
+        try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+    }
+
     @Test func `Showing a map item targets its coordinate`() throws {
+        let item = makeMapItem()
         let model = MapSearchDisplayModel()
-        model.show(mapItem: makeMapItem(), animated: true)
+        model.show(mapItem: item, animated: true, owner: .mapItem(item))
 
         guard case .mapItem = model.display else {
             Issue.record("Expected .mapItem, got \(model.display)")
@@ -51,9 +56,9 @@ final class MapSearchDisplayModelTests {
 
     @Test func `Showing a route targets its bounding rect and suppresses ambient stops`() throws {
         let model = MapSearchDisplayModel()
-        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let stopsForRoute = try loadStopsForRoute()
 
-        model.show(stopsForRoute: stopsForRoute)
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
 
         #expect(model.suppressesAmbientStops == true)
         guard case .route(let display) = model.display else {
@@ -70,8 +75,9 @@ final class MapSearchDisplayModelTests {
     /// The camera target is one-shot: the view applies it and consumes it, so an
     /// unrelated body evaluation later can't yank the map back.
     @Test func `Consuming the camera target clears it without clearing the display`() {
+        let item = makeMapItem()
         let model = MapSearchDisplayModel()
-        model.show(mapItem: makeMapItem(), animated: false)
+        model.show(mapItem: item, animated: false, owner: .mapItem(item))
 
         model.consumeCameraTarget()
 
@@ -81,17 +87,86 @@ final class MapSearchDisplayModelTests {
         }
     }
 
-    @Test func `Clearing resets display and camera target`() throws {
+    @Test func `Clearing resets display, camera target, and owner`() throws {
         let model = MapSearchDisplayModel()
-        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
-        model.show(stopsForRoute: stopsForRoute)
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
 
         model.clear()
 
         #expect(model.cameraTarget == nil)
+        #expect(model.owner == nil)
         #expect(model.suppressesAmbientStops == false)
         if case .none = model.display {} else {
             Issue.record("Expected .none after clear")
+        }
+    }
+
+    // MARK: - Ownership
+
+    @Test func `Showing a result records the sheet route that owns it`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        #expect(model.owner == .routeStops(stopsForRoute))
+    }
+
+    /// The regression this ownership rule exists for: the route sheet's view can be
+    /// torn down and rebuilt by the sheet system without the sheet being dismissed.
+    /// Keying the polyline's lifetime to the view's `onDisappear` wiped the route off
+    /// the map seconds after it was drawn; keying it to the route stack does not.
+    @Test func `The display survives while its owning route is still on the stack`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home, .routeStops(stopsForRoute)])
+
+        #expect(model.suppressesAmbientStops == true)
+        if case .route = model.display {} else {
+            Issue.record("Expected the route to survive, got \(model.display)")
+        }
+    }
+
+    /// Tapping a stop out of the route's list stacks `.stopDetails` over the route
+    /// sheet rather than replacing it, so the polyline has to stay drawn beneath.
+    @Test func `Stacking stop details over the route keeps the route drawn`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        let stopID = try #require(stopsForRoute.stops?.first?.id)
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home, .routeStops(stopsForRoute), .stopDetails(stopID: stopID)])
+
+        if case .route = model.display {} else {
+            Issue.record("Expected the route to survive, got \(model.display)")
+        }
+    }
+
+    @Test func `The display clears once its owning route leaves the stack`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home])
+
+        #expect(model.owner == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none once the owning route was popped")
+        }
+    }
+
+    @Test func `Checking ownership with nothing displayed is a no-op`() {
+        let model = MapSearchDisplayModel()
+
+        model.clearIfOwnerAbsent(from: [])
+
+        #expect(model.owner == nil)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none")
         }
     }
 }

--- a/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  MapSearchDisplayModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Map-side state for a displayed search result: what to draw and where to point
+/// the camera.
+@MainActor
+@Suite(.serialized)
+final class MapSearchDisplayModelTests {
+
+    private func makeMapItem(latitude: Double = 47.6, longitude: Double = -122.3) -> MKMapItem {
+        MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude)))
+    }
+
+    @Test func `Starts with nothing displayed`() {
+        let model = MapSearchDisplayModel()
+
+        #expect(model.cameraTarget == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none, got \(model.display)")
+        }
+    }
+
+    @Test func `Showing a map item targets its coordinate`() throws {
+        let model = MapSearchDisplayModel()
+        model.show(mapItem: makeMapItem(), animated: true)
+
+        guard case .mapItem = model.display else {
+            Issue.record("Expected .mapItem, got \(model.display)")
+            return
+        }
+        guard case .coordinate(let coordinate, let animated) = try #require(model.cameraTarget) else {
+            Issue.record("Expected a coordinate target")
+            return
+        }
+        #expect(coordinate.latitude == 47.6)
+        #expect(animated == true)
+    }
+
+    @Test func `Showing a route targets its bounding rect and suppresses ambient stops`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        model.show(stopsForRoute: stopsForRoute)
+
+        #expect(model.suppressesAmbientStops == true)
+        guard case .route(let display) = model.display else {
+            Issue.record("Expected .route, got \(model.display)")
+            return
+        }
+        #expect(display.polylines.isEmpty == false)
+        guard case .rect = try #require(model.cameraTarget) else {
+            Issue.record("Expected a rect target")
+            return
+        }
+    }
+
+    /// The camera target is one-shot: the view applies it and consumes it, so an
+    /// unrelated body evaluation later can't yank the map back.
+    @Test func `Consuming the camera target clears it without clearing the display`() {
+        let model = MapSearchDisplayModel()
+        model.show(mapItem: makeMapItem(), animated: false)
+
+        model.consumeCameraTarget()
+
+        #expect(model.cameraTarget == nil)
+        if case .mapItem = model.display {} else {
+            Issue.record("Consuming the camera target must not clear the display")
+        }
+    }
+
+    @Test func `Clearing resets display and camera target`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        model.show(stopsForRoute: stopsForRoute)
+
+        model.clear()
+
+        #expect(model.cameraTarget == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none after clear")
+        }
+    }
+}

--- a/OBAKitTests/Sheet/MapViewportRecorderTests.swift
+++ b/OBAKitTests/Sheet/MapViewportRecorderTests.swift
@@ -1,0 +1,64 @@
+//
+//  MapViewportRecorderTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The SwiftUI panel's only writer of `MapRegionManager.lastVisibleMapRect`.
+@Suite(.serialized)
+final class MapViewportRecorderTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @Test @MainActor
+    func `Record persists the rect as the last visible map rect`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let recorder = MapViewportRecorder(application: application)
+        let rect = MKMapRect(
+            origin: MKMapPoint(x: 42_000_000, y: 91_000_000),
+            size: MKMapSize(width: 250_000, height: 180_000)
+        )
+
+        recorder.record(rect)
+
+        let stored = try #require(application.mapRegionManager.lastVisibleMapRect)
+        #expect(stored.origin.x == rect.origin.x)
+        #expect(stored.origin.y == rect.origin.y)
+        #expect(stored.size.width == rect.size.width)
+        #expect(stored.size.height == rect.size.height)
+    }
+
+    @Test @MainActor
+    func `Record overwrites a previously stored rect`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let recorder = MapViewportRecorder(application: application)
+        let first = MKMapRect(origin: MKMapPoint(x: 1, y: 2), size: MKMapSize(width: 3, height: 4))
+        let second = MKMapRect(origin: MKMapPoint(x: 10, y: 20), size: MKMapSize(width: 30, height: 40))
+
+        recorder.record(first)
+        recorder.record(second)
+
+        let stored = try #require(application.mapRegionManager.lastVisibleMapRect)
+        #expect(stored.origin.x == second.origin.x)
+        #expect(stored.size.width == second.size.width)
+    }
+}

--- a/OBAKitTests/Sheet/RouteStopsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/RouteStopsSheetViewTests.swift
@@ -1,0 +1,63 @@
+//
+//  RouteStopsSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Row mapping for the route-stops sheet, asserted without a view host.
+@MainActor
+@Suite(.serialized)
+final class RouteStopsSheetViewTests {
+
+    private func loadStopsForRoute() throws -> StopsForRoute {
+        try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+    }
+
+    @Test func `Rows carry each stop name and id`() throws {
+        let stopsForRoute = try loadStopsForRoute()
+        let rows = RouteStopsRow.rows(from: stopsForRoute)
+
+        #expect(rows.count == (stopsForRoute.stops ?? []).count)
+        let first = try #require(rows.first)
+        let firstStop = try #require(stopsForRoute.stops?.first)
+        #expect(first.title == firstStop.name)
+        #expect(first.stopID == firstStop.id)
+    }
+
+    /// `RouteStopsViewController` renders the adjective form of the stop's cardinal
+    /// direction as its subtitle; the SwiftUI rows must match.
+    @Test func `Rows use the adjective form of the stop direction`() throws {
+        let stopsForRoute = try loadStopsForRoute()
+        let rows = RouteStopsRow.rows(from: stopsForRoute)
+        let firstStop = try #require(stopsForRoute.stops?.first)
+
+        let expected = Formatters.adjectiveFormOfCardinalDirection(firstStop.direction) ?? ""
+        #expect(rows.first?.subtitle == expected)
+    }
+
+    /// `StopsForRoute.stops` is an implicitly-unwrapped optional populated by
+    /// `HasReferences`. `RouteStopsViewController` force-unwraps it; the sheet must
+    /// not.
+    @Test func `Rows are empty when stops have not been resolved`() throws {
+        let stopsForRoute = try Fixtures.dictionaryToModel(
+            type: StopsForRoute.self,
+            dictionary: [
+                "routeId": "1_44",
+                "polylines": [],
+                "stopIds": [],
+                "stopGroupings": []
+            ]
+        )
+
+        #expect(RouteStopsRow.rows(from: stopsForRoute).isEmpty)
+    }
+}

--- a/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
@@ -328,7 +328,14 @@ final class SearchResultsSheetViewTests: OBATestCase {
         await selection.select(route, coordinator: coordinator)
         #expect(selection.error != nil)
 
+        // replaceMappedResponses replaces the *entire* table, so re-register the
+        // regions/agencies mocks that the Application's background tasks rely on.
+        // Dropping them lets the regions refresh land on an unmocked URL, and
+        // MockDataLoader's fatalError takes the whole test host down — attributed to
+        // whichever test happened to be in flight, not this one.
         dataLoader.replaceMappedResponses { loader in
+            stubRegions(dataLoader: loader)
+            stubAgenciesWithCoverage(dataLoader: loader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
             loader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
                 request.url?.path.contains("/api/where/stops-for-route") ?? false
             }

--- a/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
@@ -1,0 +1,344 @@
+//
+//  SearchResultsSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Everything the disambiguation sheet decides: which rows it builds, which failure
+/// it surfaces inline, and the order in which selecting a row resolves, unwinds, and
+/// presents. Asserted against the extracted pieces rather than a view host, the same
+/// way `RouteStopsSheetViewTests` does.
+@Suite(.serialized)
+final class SearchResultsSheetViewTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeApplication(dataLoader: MockDataLoader) -> Application {
+        buildApplication(queue: queue, dataLoader: dataLoader)
+    }
+
+    @MainActor
+    private func makeSelection(
+        dataLoader: MockDataLoader
+    ) -> (SearchResultsSelection, SheetCoordinator<AppSheetRoute>, MapSearchDisplayModel) {
+        let application = makeApplication(dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: { _ in }
+        )
+        return (SearchResultsSelection(router: router), coordinator, displayModel)
+    }
+
+    private func makeVehicle(id: String?, agency: String = "Metro Transit") throws -> AgencyVehicle {
+        var dictionary: [String: Any] = ["id": "1", "name": agency]
+        if let id { dictionary["vehicle_id"] = id }
+        return try Fixtures.dictionaryToModel(type: AgencyVehicle.self, dictionary: dictionary)
+    }
+
+    // MARK: - Row mapping
+
+    @Test @MainActor
+    func `Rows carry one entry per result, keyed by the model's id`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let stops = try Array(Fixtures.loadSomeStops().prefix(3))
+
+        let rows = SearchResultRow.rows(
+            for: stops,
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.count == 3)
+        #expect(rows.map(\.title) == stops.map(\.name))
+        // Row identity comes from the stop id, not the title: two stops on opposite
+        // sides of one corner share a name, which is exactly the case a
+        // disambiguation list exists to handle.
+        #expect(Set(rows.map(\.id)).count == 3)
+        for (row, stop) in zip(rows, stops) {
+            #expect(row.id.contains(stop.id))
+        }
+    }
+
+    /// A vehicle needs a second request before it can be routed, so its row shows
+    /// progress in place instead of navigating immediately.
+    @Test @MainActor
+    func `The vehicle being fetched becomes a loading row and the others stay tappable`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let vehicles = [try makeVehicle(id: "1_1156"), try makeVehicle(id: "1_1157")]
+
+        let rows = SearchResultRow.rows(
+            for: vehicles,
+            loadingVehicleID: "1_1156",
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.count == 2)
+        if case .loading = rows[0].kind {} else {
+            Issue.record("The vehicle being fetched should render as a loading row")
+        }
+        #expect(rows[0].action == nil)
+
+        if case .loading = rows[1].kind {
+            Issue.record("Only the vehicle being fetched should render as a loading row")
+        }
+        #expect(rows[1].action != nil)
+    }
+
+    @Test @MainActor
+    func `A tapped vehicle row selects by vehicle id rather than by result`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let vehicle = try makeVehicle(id: "1_1156")
+        var selectedVehicleID: String?
+        var selectedResults = 0
+
+        let rows = SearchResultRow.rows(
+            for: [vehicle],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { selectedVehicleID = $0 },
+            onSelect: { _ in selectedResults += 1 }
+        )
+        rows.first?.action?()
+
+        #expect(selectedVehicleID == "1_1156")
+        #expect(selectedResults == 0)
+    }
+
+    /// `AgencyVehicle.vehicleID` is optional, and a vehicle with no id can neither be
+    /// fetched nor routed.
+    @Test @MainActor
+    func `A vehicle with no id produces no row`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+
+        let rows = SearchResultRow.rows(
+            for: [try makeVehicle(id: nil)],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.isEmpty)
+    }
+
+    @Test @MainActor
+    func `A tapped non-vehicle row selects the result itself`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var selected: Stop?
+
+        let rows = SearchResultRow.rows(
+            for: [stop],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { selected = $0 as? Stop }
+        )
+        rows.first?.action?()
+
+        #expect(selected === stop)
+    }
+
+    // MARK: - Inline error row
+
+    @Test @MainActor
+    func `No failure produces no error row`() {
+        #expect(SearchResultRow.inlineErrorRow(
+            vehicleError: nil,
+            failedVehicleID: nil,
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ) == nil)
+    }
+
+    @Test @MainActor
+    func `A vehicle failure offers a retry for that vehicle`() throws {
+        var retried: String?
+
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: "1_1156",
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { retried = $0 },
+            onRetrySelect: { _ in }
+        ))
+        row.action?()
+
+        #expect(row.title == SearchError.noTripsAvailable.localizedDescription)
+        #expect(retried == "1_1156")
+    }
+
+    /// `selectVehicle` reports a missing API service without ever naming a vehicle, so
+    /// there's nothing to retry — the row still has to say what went wrong.
+    @Test @MainActor
+    func `A vehicle failure with no vehicle id has no retry action`() throws {
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: nil,
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ))
+
+        #expect(row.action == nil)
+    }
+
+    /// The regression this sheet shipped with: a failed resolve was dropped on the
+    /// floor, so the tapped row simply did nothing — no error, no spinner, no
+    /// navigation. It has to reach the same inline row a vehicle failure does.
+    @Test @MainActor
+    func `A failed resolve produces an error row that retries the same result`() throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var retried: Stop?
+
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: nil,
+            failedVehicleID: nil,
+            selectionError: UnstructuredError("boom"),
+            failedResult: stop,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { retried = $0 as? Stop }
+        ))
+        row.action?()
+
+        #expect(row.title == UnstructuredError("boom").localizedDescription)
+        #expect(retried === stop)
+    }
+
+    /// Only one row is ever shown. A vehicle failure is the more specific of the two,
+    /// and `selectVehicle` clears its own error before retrying, so it wins.
+    @Test @MainActor
+    func `A vehicle failure takes precedence over a resolve failure`() throws {
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: "1_1156",
+            selectionError: UnstructuredError("boom"),
+            failedResult: "anything",
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ))
+
+        #expect(row.title == SearchError.noTripsAvailable.localizedDescription)
+    }
+
+    // MARK: - Selecting a row
+
+    /// Resolve, then unwind, then present — and `popToRoot()` rather than a `pop()`
+    /// per layer, because both the stacked results sheet and the `.search` route
+    /// beneath it have to come off.
+    @Test @MainActor
+    func `Selecting a result unwinds to root and presents it`() async throws {
+        let (selection, coordinator, displayModel) = makeSelection(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        coordinator.push(.searchResults(SearchResponse(
+            request: SearchRequest(query: "1", type: .stopNumber),
+            results: [stop],
+            boundingRegion: nil,
+            error: nil
+        )))
+
+        await selection.select(stop, coordinator: coordinator)
+
+        #expect(selection.error == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes == [.stopDetails(stopID: stop.id)])
+        #expect(displayModel.owner == .stopDetails(stopID: stop.id))
+    }
+
+    /// The Critical: `stops-for-route` fails, so there is nothing to show. The sheet
+    /// has to stay up and say so rather than leave the row silently dead.
+    @Test @MainActor
+    func `A failed resolve keeps the sheet up and records the error and the result`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (selection, coordinator, _) = makeSelection(dataLoader: dataLoader)
+        coordinator.push(.search)
+        let route = try Fixtures.createRoute(id: "1_100002")
+
+        await selection.select(route, coordinator: coordinator)
+
+        #expect(selection.error != nil)
+        #expect((selection.failedResult as? Route) === route)
+        #expect(coordinator.currentRoute == .search, "The results sheet must stay up to show the failure")
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    /// `SearchResultRouter.resolve` returns nil with no `lastError` for a result type
+    /// it doesn't handle. That's a programming error rather than anything the user
+    /// did, but the row still can't be a no-op.
+    @Test @MainActor
+    func `An unhandled result type still reports an error`() async {
+        let (selection, coordinator, _) = makeSelection(dataLoader: MockDataLoader(testName: name))
+
+        await selection.select("not a search result", coordinator: coordinator)
+
+        #expect(selection.error?.localizedDescription == SearchResultsSelection.unresolvableText)
+        #expect(selection.failedResult != nil)
+    }
+
+    /// Retrying has to clear the previous failure, or the error row outlives the
+    /// error and the sheet reports a failure that no longer happened.
+    @Test @MainActor
+    func `A successful retry clears the recorded failure`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (selection, coordinator, _) = makeSelection(dataLoader: dataLoader)
+        coordinator.push(.search)
+        let route = try Fixtures.createRoute(id: "1_100002")
+
+        await selection.select(route, coordinator: coordinator)
+        #expect(selection.error != nil)
+
+        dataLoader.replaceMappedResponses { loader in
+            loader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
+                request.url?.path.contains("/api/where/stops-for-route") ?? false
+            }
+        }
+
+        await selection.select(route, coordinator: coordinator)
+
+        #expect(selection.error == nil)
+        #expect(selection.failedResult == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+    }
+}

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Testing
+import MapKit
 @testable import OBAKit
 
 /// Behavior tests for `SheetCoordinator`'s content-swap and stacked navigation,
@@ -238,5 +239,33 @@ final class SheetCoordinatorTests {
 
         coordinator.push(.tripPlanner) // stacked — must not alter currentDetents
         #expect(coordinator.currentDetents == AppSheetRoute.search.detentConfiguration.detents)
+    }
+
+    // MARK: - Search navigation shape
+
+    /// Search content-swaps the base sheet; disambiguation stacks *over* it, so the
+    /// search screen stays alive underneath and its query survives a Close.
+    @Test func `Search results stack over the search route rather than replacing it`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let response = SearchResponse(request: SearchRequest(query: "44", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        coordinator.push(.search)
+        coordinator.push(.searchResults(response))
+
+        #expect(coordinator.currentRoute == .search)
+        #expect(coordinator.stackedRoutes.count == 1)
+    }
+
+    /// Picking a result unwinds search before opening the detail, so Close on the
+    /// detail lands on home — not on a stale search screen.
+    @Test func `Popping search after a result leaves home beneath the detail sheet`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+
+        coordinator.push(.search)
+        coordinator.pop()
+        coordinator.push(.stopDetails(stopID: "1_75403"))
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes == [.stopDetails(stopID: "1_75403")])
     }
 }

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -21,7 +21,12 @@ import Testing
 final class LocalizationTests {
 
     /// Keys whose plural forms come from `Localizable.stringsdict` rather than
-    /// `Localizable.strings`. Every one of these is called with `String(format:)` and a count.
+    /// `Localizable.strings`. Each is called with a count.
+    ///
+    /// Note that `String(format:)` expands `%#@…@` but always resolves it against the root
+    /// plural rule, so only `one`/`other` are ever reachable through it — the call site has to
+    /// use `String.localizedStringWithFormat` for a locale's `few`/`many`/`zero`/`two` entries
+    /// to mean anything. Nothing here can catch that; it's a call-site property.
     private static let pluralKeys: Set<String> = [
         "stop_page.service_alerts.summary_fmt",
         "stop_page.service_alerts.show_all_fmt",
@@ -30,7 +35,8 @@ final class LocalizationTests {
         "stop_controller.transfer_show_earlier_departures_fmt",
         "stop_page.empty.no_departures_fmt",
         "data_migration_bulletin.report_summary_number_of_failures",
-        "data_migration_bulletin.report_summary_number_of_successes"
+        "data_migration_bulletin.report_summary_number_of_successes",
+        "search_results_sheet.result_count_fmt"
     ]
 
     /// `%@`, `%d`, `%1$@`, `%2$d`, … and the escaped `%%`.


### PR DESCRIPTION
# Native search for the SwiftUI map panel

Brings search to the map-panel experience (`OBAUseMapPanelExperience`) as native SwiftUI, replacing the roles `MapFloatingPanelController`, `SearchResultsController`, and `RouteStopsViewController` play on the UIKit map. The classic UIKit path is untouched — both surfaces work, and the panel is still behind its feature flag.

## What's included

**Search session.** `SearchSheetView` / `SearchSheetViewModel` open search in the home sheet with a Close button back to the home sections. Reuses the existing `SearchInteractor` for quick-search, recents, bookmarks, and placemark rows; adds `SearchManager.fetchResults` so results can be awaited directly instead of arriving through `MapRegionManager.searchResponse`.

**One routing path for results.** `SearchResultRouter` turns a result into a map display plus a sheet route, shared by the single-result path and the disambiguation list so the two can't drift on what "opening a result" means. A `Route` is resolved into `StopsForRoute` before anything is drawn.

**Results drawn on the map.** `MapSearchDisplayModel` holds what the SwiftUI `Map` should draw and where the camera should point; `MapSearchOverlays` renders route polylines, the route's own stops, and searched place markers. A drawn route suppresses the ambient stop layer, matching the UIKit path's `removeAllAnnotations()` + `searchResponseOverridesStopLoading()`.

**New sheets.** `searchResults` (disambiguation, with inline vehicle progress and a retryable error row), `mapItem` (reuses `MapItemView` with sheet-native actions), `routeStops` (replaces `RouteStopsViewController`, opens at medium so the route stays visible), and `nearbyStops` (bridges the existing controller).

**Viewport scoping.** `MapViewportRecorder` records the SwiftUI map's visible rect so address and route searches are scoped to what the user is looking at.

Plus the new strings across all locales, including per-locale plural forms for the result count.

## Notable decisions

**A drawn result's lifetime is keyed to the sheet stack, not to a view's lifecycle.** Clearing the map from the owning sheet's `onDisappear` looked right but wasn't: the floating-sheet system rebuilds a sheet's content view without the user leaving, and each rebuild wiped the route off the map seconds after it was drawn while the sheet stayed visible. The display now records its owning route and is dropped when that route leaves the stack — which still covers a real exit, including the drag-down the OS routes through `truncateStacked`.

**Results are resolved before the sheet stack is unwound.** Popping first left the stacked layer empty across a network call, and set the failure message on a search view model whose view — and whose alert — had already been torn down, so a route that failed to resolve dropped the user on home with no explanation. Resolve, then unwind and push in one synchronous step.

## Verification

- Full `OBAKitTests` suite passes on iPhone 16 / iOS 26, with one pre-existing unrelated failure (`RentalFormatTests.rangeFallbackUsesAbbreviatedUnits` compares `MKDistanceFormatter`'s abbreviated and spelled-out output, which are identical under a metric host locale).
- SwiftLint clean.
- New unit coverage for the router, the search view model, the display model's ownership rule, the sheet-route factory, and row mapping.
- Manually exercised on the simulator: route search opens the stops sheet and the drawn result stays put.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive search for stops, routes, map items, and vehicles.
  * Added search results, route stops, nearby stops, and map-item sheets with navigation and map integration.
  * Added vehicle loading, retry, and inline error states.
  * Added dynamic, region-aware search placeholders and improved map camera behavior.
* **Bug Fixes**
  * Prevented duplicate search rows from sharing identifiers.
  * Improved route-stop handling for unresolved or empty results.
* **Accessibility & Localization**
  * Added translated search states, result counts, query-clearing labels, and accessibility actions across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->