### PR TITLE
Remove duplicate CoreLocation import

### DIFF
--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,7 +8,6 @@
 //
 
 import ActivityKit
-import CoreLocation
 import Combine
 import CoreLocation
 import SwiftUI


### PR DESCRIPTION
`main` currently has `import CoreLocation` twice in `TripPageViewController.swift`:

```swift
import ActivityKit
import CoreLocation
import Combine
import CoreLocation
import SwiftUI
import OBAKitCore
```

Fallout from tonight's merges. #1260, #1264, and #1265 each added the import after `import ActivityKit`; #1262 added the same import after `import Combine`. Because the insertion points differed, git merged them as two independent additions rather than collapsing them into one.

Swift accepts a redundant import, so nothing is broken and CI stayed green — but `duplicate_imports` isn't in `.swiftlint.yml`'s `disabled_rules`, and `scripts/swiftlint.sh` skips in CI, so this would only ever show up in a local lint run.

Keeps the copy after `Combine`, which leaves the system frameworks alphabetized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a redundant internal import.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->