### PR TITLE
Address arrival/departure filter follow-ups

### DIFF
--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -146,6 +146,7 @@ These are parameters specified in your app's `project.yml` file that customizes 
     RESTServerAPIKey: org.onebusaway.iphone
     RegionsServerBaseAddress: https://regions.onebusaway.org
     RegionsServerAPIPath: /regions-v3.json
+    DefaultArrivalDepartureFilter: all
 
 ### Regions
 
@@ -158,3 +159,15 @@ There are three parameters that are associated with regions:
 The regions JSON file that you will specify with the `BundledRegionsFileName` parameter is required so that the app can show the user a list of available regions as soon as the application launches, without having to worry about having an internet connection. However, that list will eventually/inevitably become out of date, and so the app will also regularly download the remote copy of the regions file to make sure that changes (names, features, new regions, deleted regions) are handled.
 
 If you choose to leave out `RegionsServerBaseAddress` and `RegionsServerAPIPath`, then your app will rely solely on the bundled regions file for all regions that your application will know about. It is _highly_ recommended that you provide a regions server URL and path, but it is not strictly required.
+
+### Arrival and Departure Display
+
+* `DefaultArrivalDepartureFilter` - Optional. Defaults to `all`.
+
+Stop pages can hide departures that lack real-time data, or hide the real-time ones and show only the schedule. This parameter picks which of those a fresh install starts with:
+
+* `all` - Show every departure. This is the behavior you get if you omit the parameter, and the right choice for most agencies.
+* `estimatedOnly` - Show only departures the server has real-time data for. Worth considering if your feed's scheduled times are unreliable enough that riders are better off not seeing them.
+* `scheduledOnly` - Show only departures without real-time data.
+
+This is a starting value, not a lock: riders can change it in Settings under Arrival & Departure Display, or from the Departure Type menu on any stop page, and their choice is remembered from then on. An unrecognized value is ignored and treated as `all`.

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -176,13 +176,13 @@ class SettingsViewController: FormViewController {
         store.walkingSpeedMetersPerSecond = decision.speed
     }
 
-    // MARK: - Arrival Display Section
+    // MARK: - Arrival & Departure Display Section
 
     private let arrivalFilterTag = "arrivalDepartureFilter"
 
     private lazy var arrivalDisplaySection: Section = {
         let section = Section(
-            OBALoc("settings_controller.arrival_display_section.title", value: "Arrival Display", comment: "Settings section title for controlling which arrivals/departures are shown")
+            OBALoc("settings_controller.arrival_display_section.title", value: "Arrival & Departure Display", comment: "Settings section title for controlling which arrivals/departures are shown")
         )
 
         section <<< AlertRow<ArrivalDepartureFilter> {

--- a/OBAKit/Stops/StopPage/StopPageToolbar.swift
+++ b/OBAKit/Stops/StopPage/StopPageToolbar.swift
@@ -126,6 +126,11 @@ struct StopPageToolbar: View {
                     filtered: true
                 )
             } label: {
+                // Route filter only. Unlike the pushed presentation — where this
+                // glyph sits on the bar button that *contains* both filters, and so
+                // fills for either — here the two are sibling submenus. Filling this
+                // one for a Departure Type change would point at the wrong filter,
+                // so each submenu carries its own state instead.
                 Label(
                     Strings.filter,
                     systemImage: isFilterOn ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle"
@@ -149,7 +154,7 @@ struct StopPageToolbar: View {
             } label: {
                 Label(
                     OBALoc("stop_controller.arrival_filter.menu_title", value: "Departure Type", comment: "Title for the menu that filters departures by data type"),
-                    systemImage: "antenna.radiowaves.left.and.right"
+                    systemImage: Icons.departureTypeSymbolName(isActive: activeDepartureFilter != .all)
                 )
             }
 

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -660,8 +660,14 @@ private extension StopPageViewController {
         // The titles double as the VoiceOver labels for these image-only bar
         // buttons, so they must be localized, human-readable strings — the
         // filter's on/off state rides in `accessibilityValue` rather than
-        // being baked into the label. The glyph fills for either filter: hidden
-        // routes or a non-default Departure Type both mean rows are being held back.
+        // being baked into the label.
+        //
+        // This glyph fills for either filter: the bar button owns `filterMenu()`,
+        // which contains both the route section and the Departure Type submenu, so
+        // hidden routes or a non-default Departure Type both mean rows are being
+        // held back and either should show up here. The sheet presentation's
+        // toolbar deliberately does *not* mirror this — see `StopPageToolbar`,
+        // where the two filters are siblings and each carries its own state.
         let filterIsOn = (viewModel.stopPreferences.hasHiddenRoutes && viewModel.isListFiltered)
             || viewModel.arrivalDepartureFilter != .all
         let filterButtonImage = UIImage(systemName: filterIsOn ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
@@ -702,11 +708,12 @@ private extension StopPageViewController {
 
         if let stop = viewModel.stop {
             if stop.routes.count > 1 {
-                if viewModel.isListFiltered && viewModel.stopPreferences.hasHiddenRoutes {
-                    showFiltered.image = UIImage(systemName: "checkmark")
-                } else {
-                    showAll.image = UIImage(systemName: "checkmark")
-                }
+                // `state`, not a checkmark image: it draws the same checkmark but
+                // is also what VoiceOver reads as "selected". An image is
+                // decoration the accessibility layer never announces.
+                let routesAreFiltered = viewModel.isListFiltered && viewModel.stopPreferences.hasHiddenRoutes
+                showFiltered.state = routesAreFiltered ? .on : .off
+                showAll.state = routesAreFiltered ? .off : .on
 
                 routeChildren.append(showFiltered)
             }
@@ -727,12 +734,12 @@ private extension StopPageViewController {
             let action = UIAction(title: filter.displayTitle) { [unowned self] _ in
                 self.viewModel.updateArrivalDepartureFilter(filter)
             }
-            if filter == currentFilter { action.image = UIImage(systemName: "checkmark") }
+            action.state = filter == currentFilter ? .on : .off
             return action
         }
 
         let menuTitle = OBALoc("stop_controller.arrival_filter.menu_title", value: "Departure Type", comment: "Title for the menu that filters departures by data type")
-        return UIMenu(title: menuTitle, image: UIImage(systemName: "antenna.radiowaves.left.and.right"), children: actions)
+        return UIMenu(title: menuTitle, image: Icons.departureType(isActive: currentFilter != .all), children: actions)
     }
 
     func fileMenu() -> UIMenu {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -348,11 +348,12 @@ public class StopViewController: UIViewController,
         var children = [showAll]
 
         if stop.routes.count > 1 {
-            if viewModel.isListFiltered && viewModel.stopPreferences.hasHiddenRoutes {
-                showFiltered.image = UIImage(systemName: "checkmark")
-            } else {
-                showAll.image = UIImage(systemName: "checkmark")
-            }
+            // `state`, not a checkmark image: it draws the same checkmark but is
+            // also what VoiceOver reads as "selected". An image is decoration the
+            // accessibility layer never announces.
+            let routesAreFiltered = viewModel.isListFiltered && viewModel.stopPreferences.hasHiddenRoutes
+            showFiltered.state = routesAreFiltered ? .on : .off
+            showAll.state = routesAreFiltered ? .off : .on
 
             children.append(showFiltered)
         }
@@ -435,10 +436,8 @@ public class StopViewController: UIViewController,
             self.viewModel.updateSortType(.route)
         }
 
-        switch currentSort {
-        case .time:  sortByTime.image =  Icons.checkmark
-        case .route: sortByRoute.image = Icons.checkmark
-        }
+        sortByTime.state = currentSort == .time ? .on : .off
+        sortByRoute.state = currentSort == .route ? .on : .off
 
         let sortMenuTitle = OBALoc("stop_preferences_controller.sorting_section.header_title", value: "Sort By", comment: "Title of the Sorting section")
         return UIMenu(title: sortMenuTitle, image: Icons.sort, children: [sortByTime, sortByRoute])
@@ -458,12 +457,12 @@ public class StopViewController: UIViewController,
                 self.viewModel.updateArrivalDepartureFilter(filter)
                 self.dataDidReload()
             }
-            if filter == currentFilter { action.image = Icons.checkmark }
+            action.state = filter == currentFilter ? .on : .off
             return action
         }
 
         let menuTitle = OBALoc("stop_controller.arrival_filter.menu_title", value: "Departure Type", comment: "Title for the menu that filters departures by data type")
-        return UIMenu(title: menuTitle, image: Icons.departureType, children: actions)
+        return UIMenu(title: menuTitle, image: Icons.departureType(isActive: currentFilter != .all), children: actions)
     }
 
     fileprivate func helpMenu() -> UIMenu {
@@ -725,14 +724,19 @@ public class StopViewController: UIViewController,
                 sections.append(arrivalFilterNoResultsSection())
             } else {
                 let pastDeps = filtered.filter { $0.arrivalDepartureMinutes < 0 }
-                let upcomingDeps = filtered.filter { $0.arrivalDepartureMinutes >= 0 }
-
                 if !pastDeps.isEmpty {
                     sections.append(sectionForPastDepartures(groupRoute: nil, arrDeps: pastDeps))
                 }
-                // Always append upcoming section (even if empty) to display load more and walk times
-                sections.append(sectionForGroup(groupRoute: nil, arrDeps: upcomingDeps))
             }
+
+            // Always append the upcoming section, even when it is empty and even
+            // behind the filter's empty state, because it carries Load More —
+            // the one control that can resolve a filtered-empty stop, since
+            // widening the window is how a real-time departure appears when the
+            // loaded window holds only scheduled ones. (The walk-time row rides
+            // along here too, but suppresses itself on an empty list.)
+            let upcomingDeps = filtered.filter { $0.arrivalDepartureMinutes >= 0 }
+            sections.append(sectionForGroup(groupRoute: nil, arrDeps: upcomingDeps))
 
         } else {
             let plausible = stopArrivals.arrivalsAndDepartures.filteringImplausibleDates()

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -982,7 +982,7 @@
 "settings_controller.alerts_section.display_test_alerts" = "Display test alerts";
 
 /* Settings section title for controlling which arrivals/departures are shown */
-"settings_controller.arrival_display_section.title" = "Arrival Display";
+"settings_controller.arrival_display_section.title" = "Arrival & Departure Display";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Show Departures";

--- a/OBAKit/Theme/Icons.swift
+++ b/OBAKit/Theme/Icons.swift
@@ -179,9 +179,23 @@ nonisolated class Icons: NSObject {
         imageNamed("header")
     }
 
+    /// The symbol name behind ``departureType(isActive:)``, for the SwiftUI stop
+    /// page — `Label(_:systemImage:)` takes a name, not a `UIImage`, and both
+    /// presentations have to show the same glyph.
+    public class func departureTypeSymbolName(isActive: Bool) -> String {
+        isActive
+            ? "antenna.radiowaves.left.and.right.circle.fill"
+            : "antenna.radiowaves.left.and.right.circle"
+    }
+
     /// An icon for the departure-type filter menu (antenna radiowaves).
-    public class var departureType: UIImage {
-        systemImage(named: "antenna.radiowaves.left.and.right")
+    ///
+    /// Fills when a non-default filter is applied, the same filled/unfilled pair
+    /// the route filter uses. In the sheet presentation the two filters are
+    /// sibling submenus, so each one has to carry its own state — neither glyph
+    /// can stand in for the other.
+    public class func departureType(isActive: Bool) -> UIImage {
+        systemImage(named: departureTypeSymbolName(isActive: isActive))
     }
 
     /// An icon for the sort-order menu (up/down arrows).

--- a/OBAKitTests/Application/IconsTests.swift
+++ b/OBAKitTests/Application/IconsTests.swift
@@ -1,0 +1,38 @@
+//
+//  IconsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import UIKit
+import Testing
+@testable import OBAKit
+
+/// `Icons` force-unwraps `UIImage(systemName:)`, so a symbol name that doesn't
+/// resolve on the running OS is a crash the first time the icon is drawn rather
+/// than a build failure. These pin the departure-type pair.
+@Suite
+struct IconsTests {
+
+    /// Asserts on the names rather than the rendered images: two `UIImage`s built
+    /// from different symbols are not usefully comparable (symbol images carry no
+    /// bitmap to diff, and identity says nothing), while the names are exactly the
+    /// contract the two stop pages share.
+    @Test func `Departure type symbol differs by state`() {
+        #expect(Icons.departureTypeSymbolName(isActive: false) != Icons.departureTypeSymbolName(isActive: true))
+    }
+
+    @Test func `Departure type symbols resolve on this OS`() {
+        // The names must resolve, or `departureType(isActive:)` traps on unwrap.
+        #expect(UIImage(systemName: Icons.departureTypeSymbolName(isActive: false)) != nil)
+        #expect(UIImage(systemName: Icons.departureTypeSymbolName(isActive: true)) != nil)
+
+        // And the force-unwrapping accessor itself must survive both states.
+        #expect(Icons.departureType(isActive: false).size != .zero)
+        #expect(Icons.departureType(isActive: true).size != .zero)
+    }
+}

--- a/OBAKitTests/Stops/ArrivalFilterEmptyStateTests.swift
+++ b/OBAKitTests/Stops/ArrivalFilterEmptyStateTests.swift
@@ -1,0 +1,103 @@
+//
+//  ArrivalFilterEmptyStateTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+@testable import OBAKit
+@testable import OBAKitCore
+import Foundation
+import Testing
+import UIKit
+
+/// When the Departure Type filter hides every departure, the stop page shows an
+/// explanatory empty state — but it must not take Load More down with it. Load
+/// More is the only control that can resolve this particular empty state, since
+/// widening the time window is how a real-time departure surfaces at a stop whose
+/// loaded window holds nothing but scheduled ones.
+@MainActor
+@Suite(.serialized)
+final class ArrivalFilterEmptyStateTests: OBATestCase {
+
+    /// Every departure in this fixture is scheduled — zero `predicted` entries —
+    /// so `.estimatedOnly` reliably empties the list while the unfiltered list
+    /// stays populated. That is exactly the branch under test.
+    private let stopID = "1_10020"
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    /// `MockDataLoader` fatal-errors on any unstubbed request, so every endpoint the
+    /// stop page touches on load has to be mocked here — arrivals, surveys, and
+    /// agency alerts, on top of the regions/agencies pair `buildApplication` adds.
+    private func makeApplication() -> Application {
+        let dataLoader = MockDataLoader(testName: name)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals_and_departures_for_stop_1_10020_no_realtime.json")) { request in
+            request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let emptySurveys = Data(#"{"surveys":[],"region":{"id":1,"name":"Puget Sound"}}"#.utf8)
+        dataLoader.mock(data: emptySurveys) { request in
+            request.url?.path.contains("/surveys.json") ?? false
+        }
+
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        return buildApplication(queue: queue, dataLoader: dataLoader)
+    }
+
+    /// Builds the legacy stop page with `filter` already applied. The filter has to
+    /// be set before the controller exists: its view model seeds the value at init.
+    private func loadedController(filter: ArrivalDepartureFilter) async -> StopViewController {
+        let application = makeApplication()
+        application.setArrivalDepartureFilter(filter)
+
+        let controller = StopViewController(application: application, stopID: stopID)
+        controller.loadViewIfNeeded()
+        await controller.viewModel.refresh()
+
+        return controller
+    }
+
+    private func sectionIDs(of controller: StopViewController) -> [String] {
+        controller.items(for: OBAListView()).map(\.id)
+    }
+
+    // MARK: - Tests
+
+    /// The regression: the empty state used to *replace* the trailing section
+    /// rather than accompany it, silently removing Load More.
+    @Test func `Filtered-empty stop keeps its Load More section`() async {
+        let controller = await loadedController(filter: .estimatedOnly)
+        let ids = sectionIDs(of: controller)
+
+        #expect(ids.contains(StopViewController.ListSections.emptyData.sectionID))
+        #expect(ids.contains(StopViewController.ListSections.arrivalDepartures(suffix: "all").sectionID))
+    }
+
+    /// Guards the fixture's own premise. If the data ever gains a real-time
+    /// departure, the test above would pass for the wrong reason — the list would
+    /// never have been emptied by the filter at all.
+    @Test func `Unfiltered stop shows departures and no empty state`() async {
+        let controller = await loadedController(filter: .all)
+        let ids = sectionIDs(of: controller)
+
+        #expect(!ids.contains(StopViewController.ListSections.emptyData.sectionID))
+        #expect(ids.contains(StopViewController.ListSections.arrivalDepartures(suffix: "all").sectionID))
+    }
+}

--- a/OBAKitTests/Stops/StopPage/DepartureFilterMenuTests.swift
+++ b/OBAKitTests/Stops/StopPage/DepartureFilterMenuTests.swift
@@ -1,0 +1,96 @@
+//
+//  DepartureFilterMenuTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+@testable import OBAKit
+@testable import OBAKitCore
+import Foundation
+import Testing
+import UIKit
+
+/// Selection in the Departure Type menu has to ride on `UIAction.state`. A
+/// checkmark image renders identically, which is why this regressed once already
+/// — but VoiceOver only announces the former, so the image version leaves the
+/// menu unreadable to anyone not looking at it.
+@MainActor
+@Suite(.serialized)
+final class DepartureFilterMenuTests: OBATestCase {
+
+    private var queue: OperationQueue!
+    private var application: Application!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        userDefaults.set(true, forKey: FeatureFlags.useNewStopPageKey)
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    /// Walks the pushed presentation's bar-button menus to the Departure Type
+    /// submenu. Identified by the filter titles it contains rather than by
+    /// position, so reordering the bar items doesn't quietly void these tests.
+    private func departureTypeMenu() throws -> UIMenu {
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let controller = StopPageViewController(application: application, stop: stop)
+        controller.loadViewIfNeeded()
+
+        let barItems = try #require(controller.navigationItem.rightBarButtonItems)
+        let submenus = barItems.compactMap(\.menu).flatMap { $0.children.compactMap { $0 as? UIMenu } }
+
+        return try #require(submenus.first { submenu in
+            submenu.children.contains { $0.title == ArrivalDepartureFilter.all.displayTitle }
+        })
+    }
+
+    private func selectedTitles(in menu: UIMenu) -> [String] {
+        menu.children.compactMap { $0 as? UIAction }.filter { $0.state == .on }.map(\.title)
+    }
+
+    // MARK: - Selection state
+
+    @Test func `Active filter is the only one marked selected`() throws {
+        application.setArrivalDepartureFilter(.estimatedOnly)
+
+        let menu = try departureTypeMenu()
+
+        #expect(selectedTitles(in: menu) == [ArrivalDepartureFilter.estimatedOnly.displayTitle])
+    }
+
+    @Test func `Selecting a different filter moves the selection`() throws {
+        application.setArrivalDepartureFilter(.scheduledOnly)
+
+        let menu = try departureTypeMenu()
+
+        #expect(selectedTitles(in: menu) == [ArrivalDepartureFilter.scheduledOnly.displayTitle])
+    }
+
+    /// An unset preference resolves to the configured default, so the menu still
+    /// marks a row rather than reading as "nothing is applied".
+    @Test func `Default filter is selected when nothing is saved`() throws {
+        #expect(application.effectiveArrivalDepartureFilter == .all)
+
+        let menu = try departureTypeMenu()
+
+        #expect(selectedTitles(in: menu) == [ArrivalDepartureFilter.all.displayTitle])
+    }
+
+    /// Every filter has a row, so none of them can become unreachable.
+    @Test func `Menu offers every filter`() throws {
+        let menu = try departureTypeMenu()
+
+        let titles = menu.children.compactMap { $0 as? UIAction }.map(\.title)
+        #expect(titles == ArrivalDepartureFilter.allCases.map(\.displayTitle))
+    }
+}


### PR DESCRIPTION
Description:

Closes #1274 — all five follow-ups, one commit each concern.

1. **English copy** — `en.lproj` and the inline `OBALoc` value both now say "Arrival & Departure Display". They have to move together or `genstrings` reverts the strings file.
2. **VoiceOver** — selection rides on `UIAction.state` instead of a checkmark image, across all five menus in both stop pages (as you guessed, fixing one meant fixing the convention).
3. **Docs** — `DefaultArrivalDepartureFilter` documented in `WhiteLabel.md`.
4. **Sheet glyph** — kept your reasoning: the route-filter glyph stays route-only because there the two are siblings. Instead each submenu carries its own state, so Departure Type gets a filled/unfilled pair matching the route filter's. That also tells you *which* filter is on when you open the funnel in the pushed presentation.
5. **Load More** — not intentional, restored. It's the one control that can resolve a filtered-empty stop, since widening the window is how a real-time departure appears when the loaded window holds only scheduled ones.

Tests cover the three behavioral changes: menu selection state, the restored section, and the symbol pair (`Icons` force-unwraps `UIImage(systemName:)`).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for configuring default arrival and departure filters.
  * Improved stop-page filtering menus with clear selected-state indicators.
  * Added dynamic icons to show whether departure-type filtering is active.
  * Renamed the settings label to “Arrival & Departure Display.”

* **Bug Fixes**
  * Improved filtered stop results, including empty states and past-departure ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->