### PR TITLE
Stop advertising an unsupported bundle-ID override in scripts/setup

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -49,7 +49,7 @@ fi
 if [[ -f "Apps/${APP}/local.yml" ]]; then
   ok "Local overrides: Apps/${APP}/local.yml (gitignored)"
 else
-  say "  · No Apps/${APP}/local.yml yet. Copy Apps/${APP}/local.yml.example to override DEVELOPMENT_TEAM / bundle ID without editing the shared project.yml."
+  say "  · No Apps/${APP}/local.yml yet. Copy Apps/${APP}/local.yml.example to override DEVELOPMENT_TEAM without editing the shared project.yml. PRODUCT_BUNDLE_IDENTIFIER is not supported there — see local.yml.example."
 fi
 
 say ""


### PR DESCRIPTION
## Summary
- `scripts/setup` told contributors they could override the bundle ID via `Apps/<App>/local.yml`. `generate_project` only splices `DEVELOPMENT_TEAM`, and `local.yml.example` already says `PRODUCT_BUNDLE_IDENTIFIER` is not supported there.
- The missing-file hint now matches those two sources.

Closes #1282.

## Test plan
- [x] Diff: the new sentence names `DEVELOPMENT_TEAM` only and points at `local.yml.example` for the bundle-ID rule
- [ ] `scripts/setup OneBusAway` with no `local.yml` prints the corrected hint