### PR TITLE
Distinguish unreachable-server copy from bad stop data

### DIFF
--- a/OBAKit/Controls/ListView/Rows/EmptyData/OBAEmptyDataSetItem.swift
+++ b/OBAKit/Controls/ListView/Rows/EmptyData/OBAEmptyDataSetItem.swift
@@ -66,6 +66,8 @@ nonisolated struct EmptyDataSetItem: OBAListViewItem {
                 icon = UIImage(systemName: "questionmark.square.dashed")
             case .serverError, .serverUnavailable:
                 icon = UIImage(systemName: "server.rack")
+            case .invalidResponseData:
+                icon = UIImage(systemName: "exclamationmark.triangle")
             case .surveyServiceNotConfigured:
                 icon = UIImage(systemName: "doc.text.magnifyingglass")
             case .noRegionSelected:

--- a/OBAKit/Controls/ListView/Rows/EmptyData/OBAListViewEmptyDataViewModel.swift
+++ b/OBAKit/Controls/ListView/Rows/EmptyData/OBAListViewEmptyDataViewModel.swift
@@ -55,6 +55,8 @@ extension OBAListView {
                     icon = UIImage(systemName: "questionmark.square.dashed")
                 case .serverError, .serverUnavailable:
                     icon = UIImage(systemName: "server.rack")
+                case .invalidResponseData:
+                    icon = UIImage(systemName: "exclamationmark.triangle")
                 case .surveyServiceNotConfigured:
                     icon = UIImage(systemName: "doc.text.magnifyingglass")
                 case .noRegionSelected:

--- a/OBAKit/Controls/SwiftUI/ErrorView.swift
+++ b/OBAKit/Controls/SwiftUI/ErrorView.swift
@@ -51,6 +51,8 @@ struct ErrorView: View {
             return "wifi.slash"
         case .serverError, .serverUnavailable:
             return "server.rack"
+        case .invalidResponseData:
+            return "exclamationmark.triangle"
         case .captivePortal:
             return "lock.shield"
         default:

--- a/OBAKitCore/Network/ErrorClassifier.swift
+++ b/OBAKitCore/Network/ErrorClassifier.swift
@@ -30,7 +30,7 @@ public enum ErrorClassifier {
         // Already-classified errors pass through unchanged.
         if let apiError = error as? APIError {
             switch apiError {
-            case .serverError, .serverUnavailable, .cellularDataRestricted:
+            case .serverError, .serverUnavailable, .invalidResponseData, .cellularDataRestricted:
                 return apiError
             default:
                 return classifyAPIError(apiError, regionName: regionName, isCellularDataRestricted: isCellularDataRestricted)
@@ -45,7 +45,7 @@ public enum ErrorClassifier {
 
         // DecodingErrors surface raw Swift messages like
         // "The data couldn't be read because it is missing."
-        // Replace with a server-problem message.
+        // That is bad payload, not an unreachable host (#1276).
         if error is DecodingError {
             return classifyDecodingError(error, regionName: regionName)
         }
@@ -112,13 +112,13 @@ public enum ErrorClassifier {
         guard let regionName else {
             let message = OBALoc(
                 "api_error.decoding_failure",
-                value: "The server returned unexpected data. This usually means the server is experiencing problems. Please try again shortly.",
-                comment: "An error shown when the server returns data the app can't understand, indicating a likely server-side issue."
+                value: "The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.",
+                comment: "An error shown when the server returns a body the app cannot decode and no region name is available to specialize the copy."
             )
             return UnstructuredError(message)
         }
 
-        return APIError.serverUnavailable(regionName: regionName, statusCode: nil)
+        return APIError.invalidResponseData(regionName: regionName)
     }
 
     // MARK: - Helpers

--- a/OBAKitCore/Network/Operations/NetworkOperation.swift
+++ b/OBAKitCore/Network/Operations/NetworkOperation.swift
@@ -28,6 +28,10 @@ public enum APIError: Error, LocalizedError {
     /// The regional server is down or unreachable (502, 503, 504, or timeout).
     case serverUnavailable(regionName: String, statusCode: Int?)
 
+    /// The regional server returned a body this app cannot decode. Distinct from
+    /// `.serverUnavailable`: the host responded, the payload is unusable (#1276).
+    case invalidResponseData(regionName: String)
+
     /// Survey service is not configured or survey base URL is missing.
     case surveyServiceNotConfigured
 
@@ -107,8 +111,15 @@ public enum APIError: Error, LocalizedError {
         case .serverUnavailable(let regionName, _):
             let fmt = OBALoc(
                 "api_error.server_unavailable_fmt",
-                value: "The server for %@ appears to be down right now, so %@ isn't able to show transit information for this region. The app should start working again once the server is back up.",
-                comment: "An error shown when the regional transit server is unavailable. The first substituted value is the region name, the second is the app name."
+                value: "Unable to reach the server for %@. %@ can't show transit information for this region right now. The server may be down, or a VPN or firewall may be blocking it.",
+                comment: "An error shown when the regional transit server cannot be reached. Mentions VPN because riders often hit this with a working phone on a filtered network. The first substituted value is the region name, the second is the app name."
+            )
+            return String(format: fmt, regionName, Bundle.main.appName)
+        case .invalidResponseData(let regionName):
+            let fmt = OBALoc(
+                "api_error.invalid_response_data_fmt",
+                value: "The server for %@ returned data this app can't read. That's usually a problem with the stop or agency feed, not with %@. Try again shortly.",
+                comment: "An error shown when the regional server returned a body the app cannot decode. Distinct from a down server. The first substituted value is the region name, the second is the app name."
             )
             return String(format: fmt, regionName, Bundle.main.appName)
         case .surveyServiceNotConfigured:

--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "كان من المتوقع استلام بيانات %1$@ من الخادم، ولكننا استلمنا %2$@ بدلًا من ذلك.";
 
+"api_error.invalid_response_data_fmt" = "أرجع خادم %1$@ بيانات لا يستطيع هذا التطبيق قراءتها. عادةً ما تكون هذه مشكلة في المحطة أو تغذية الوكالة، وليست مشكلة في %2$@. يُرجى المحاولة مرة أخرى بعد قليل.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "تعذّر الاتصال بالإنترنت أو بالخادم. يُرجى التحقق من اتصالك بالشبكة والمحاولة مرة أخرى.";
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -5,10 +5,12 @@
 "api_error.cellular_data_restricted_fmt" = "%1$@ is not currently allowed to access cellular data. To fix this, go to Settings > Cellular and enable cellular data for %2$@, or connect to a WiFi network.";
 
 /* An error shown when the server returns data the app can't understand, indicating a likely server-side issue. */
-"api_error.decoding_failure" = "The server returned unexpected data. This usually means the server is experiencing problems. Please try again shortly.";
+"api_error.decoding_failure" = "The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.";
 
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Expected to receive %1$@ data from the server, but we received %2$@ instead.";
+
+"api_error.invalid_response_data_fmt" = "The server for %1$@ returned data this app can't read. That's usually a problem with the stop or agency feed, not with %2$@. Try again shortly.";
 
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Unable to connect to the Internet or the server. Please check your network connection and try again.";
@@ -29,7 +31,7 @@
 "api_error.server_error_fmt" = "The server for %@ encountered an error while handling your request. Please try again.";
 
 /* An error shown when the regional transit server is unavailable. The first substituted value is the region name, the second is the app name. */
-"api_error.server_unavailable_fmt" = "The server for %1$@ appears to be down right now, so %2$@ isn't able to show transit information for this region. The app should start working again once the server is back up.";
+"api_error.server_unavailable_fmt" = "Unable to reach the server for %1$@. %2$@ can't show transit information for this region right now. The server may be down, or a VPN or firewall may be blocking it.";
 
 /* An error message that tells the user that surveys are not available. */
 "api_error.survey_service_not_configured" = "Survey service is not available in this region.";

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Se esperaba recibir %1$@ datos del servidor, pero recibimos %2$@ en su lugar.";
 
+"api_error.invalid_response_data_fmt" = "El servidor de %1$@ devolvió datos que esta aplicación no puede leer. Suele ser un problema con la parada o el feed de la agencia, no con %2$@. Inténtelo de nuevo en unos momentos.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "No fue posible conectarse a Internet o al servidor. Por favor verifique su conexión de red e intenténtelo nuevamente. ";
 

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Inaasahan naming makatanggap ng %1$@ na data mula sa server, pero %2$@ ang natanggap namin.";
 
+"api_error.invalid_response_data_fmt" = "Nagbalik ang server para sa %1$@ ng data na hindi mabasa ng app na ito. Kadalasan ay problema ito sa stop o agency feed, hindi sa %2$@. Pakisubukang muli sa ilang sandali.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Hindi makakonekta sa Internet o sa server. Pakisuri ang iyong koneksyon sa network at subukang muli.";
 

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Nous attendions des données %1$@ du serveur, mais nous avons reçu %2$@ à la place.";
 
+"api_error.invalid_response_data_fmt" = "Le serveur de la région %1$@ a renvoyé des données que cette app ne peut pas lire. Il s'agit généralement d'un problème lié à l'arrêt ou au flux de l'agence, et non à %2$@. Réessayez dans quelques instants.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Impossible de se connecter à Internet ou au serveur. Veuillez vérifier votre connexion réseau et réessayer.";
 

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Si sarebbero dovuti ricevere %1$@ dati dal server, invece ne sono stati ricevuti %2$@.";
 
+"api_error.invalid_response_data_fmt" = "Il server di %1$@ ha restituito dati che questa app non può leggere. Di solito è un problema con la fermata o il feed dell'agenzia, non con %2$@. Riprova tra poco.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Impossibile connettersi a Internet o al server. Controlla la connessione e riprova.";
 

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "서버에서 %1$@ 데이터를 받을 것으로 예상했지만 %2$@ 데이터를 받았습니다.";
 
+"api_error.invalid_response_data_fmt" = "%1$@ 서버가 이 앱에서 읽을 수 없는 데이터를 반환했습니다. 보통 정류장 또는 기관 피드 문제이며 %2$@의 문제는 아닙니다. 잠시 후 다시 시도해 주세요.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "인터넷 또는 서버에 연결할 수 없습니다. 네트워크 연결을 확인한 후 다시 시도해 주세요.";
 

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Spodziewano się otrzymać %1$@ danych z serwera, ale otrzymano %2$@ w zamian.";
 
+"api_error.invalid_response_data_fmt" = "Serwer regionu %1$@ zwrócił dane, których ta aplikacja nie potrafi odczytać. Zwykle oznacza to problem z przystankiem lub feedem agencji, a nie z aplikacją %2$@. Spróbuj ponownie za chwilę.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Nie można połączyć się z Internetem lub serwerem. Sprawdź połączenie sieciowe i spróbuj ponownie.";
 

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Esperávamos receber dados %1$@ do servidor, mas recebemos %2$@.";
 
+"api_error.invalid_response_data_fmt" = "O servidor de %1$@ retornou dados que este app não consegue ler. Geralmente isso indica um problema na parada ou no feed da agência, não no %2$@. Tente novamente em instantes.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Não foi possível conectar à internet ou ao servidor. Verifique sua conexão de rede e tente novamente.";
 

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "От сервера ожидались данные типа %1$@, но вместо этого получены %2$@.";
 
+"api_error.invalid_response_data_fmt" = "Сервер региона %1$@ вернул данные, которые это приложение не может прочитать. Обычно это проблема остановки или фида агентства, а не приложения %2$@. Повторите попытку чуть позже.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Не удаётся подключиться к интернету или серверу. Проверьте сетевое подключение и повторите попытку.";
 

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Dự kiến nhận dữ liệu %1$@ từ máy chủ, nhưng chúng tôi lại nhận được %2$@.";
 
+"api_error.invalid_response_data_fmt" = "Máy chủ của %1$@ trả về dữ liệu mà ứng dụng này không đọc được. Đây thường là vấn đề với điểm dừng hoặc nguồn dữ liệu của cơ quan, không phải với %2$@. Vui lòng thử lại sau ít phút.";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "Không thể kết nối với Internet hoặc máy chủ. Vui lòng kiểm tra kết nối mạng của bạn và thử lại.";
 

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "预计从服务器收到%1$@数据，但收到了%2$@。";
 
+"api_error.invalid_response_data_fmt" = "%1$@的服务器返回了此应用无法读取的数据。这通常是站点或机构数据源的问题，而不是%2$@的问题。请稍后重试。";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "无法连接到互联网或者服务器。请检查网络连接后重试。";
 

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -10,6 +10,8 @@
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "預期從伺服器收到 %1$@ 資料，但實際收到的是 %2$@。";
 
+"api_error.invalid_response_data_fmt" = "%1$@ 的伺服器回傳了此 App 無法讀取的資料。這通常是站點或機構資料源的問題，而非 %2$@ 的問題。請稍後再試。";
+
 /* An error that tells the user that the network connection isn't working. */
 "api_error.network_failure" = "無法連線至網際網路或伺服器。請檢查您的網路連線後再試一次。";
 

--- a/OBAKitTests/Networking/ErrorClassifierTests.swift
+++ b/OBAKitTests/Networking/ErrorClassifierTests.swift
@@ -291,7 +291,7 @@ final class ErrorClassifierTests {
 
     // MARK: - DecodingError Classification
 
-    @Test func `Classify decoding error with region name becomes server unavailable`() {
+    @Test func `Classify decoding error with region name becomes invalid response data`() {
         let decodingError = DecodingError.keyNotFound(
             AnyCodingKey(stringValue: "data")!,
             DecodingError.Context(codingPath: [], debugDescription: "No value associated with key")
@@ -304,11 +304,12 @@ final class ErrorClassifierTests {
         }
 
         switch apiError {
-        case .serverUnavailable(let regionName, let statusCode):
+        case .invalidResponseData(let regionName):
             #expect(regionName == "San Diego")
-            #expect(statusCode == nil)
+        case .serverUnavailable:
+            Issue.record("DecodingError must not be classified as an unreachable server")
         default:
-            Issue.record("Expected .serverUnavailable, got \(apiError)")
+            Issue.record("Expected .invalidResponseData, got \(apiError)")
         }
     }
 
@@ -320,7 +321,8 @@ final class ErrorClassifierTests {
 
         let description = result.localizedDescription
         #expect(!description.contains("couldn't be read"))
-        #expect(description.contains("server"))
+        #expect(description.contains("feed"))
+        #expect(!description.contains("experiencing problems"))
     }
 
     // MARK: - NSURLError Classification
@@ -447,6 +449,23 @@ final class ErrorClassifierTests {
         }
     }
 
+    @Test func `Classify invalid response data passes through`() {
+        let error = APIError.invalidResponseData(regionName: "Puget Sound")
+        let result = ErrorClassifier.classify(error, regionName: "Tampa")
+
+        guard let apiError = result as? APIError else {
+            Issue.record("Expected APIError, got \(type(of: result))")
+            return
+        }
+
+        switch apiError {
+        case .invalidResponseData(let regionName):
+            #expect(regionName == "Puget Sound")
+        default:
+            Issue.record("Expected .invalidResponseData to pass through, got \(apiError)")
+        }
+    }
+
     @Test func `Classify cellular data restricted passes through`() {
         let error = APIError.cellularDataRestricted
         let result = ErrorClassifier.classify(error, regionName: "Puget Sound")
@@ -482,7 +501,19 @@ final class ErrorClassifierTests {
         let description = error.localizedDescription
 
         #expect(description.contains("Puget Sound"))
-        #expect(description.contains("down"))
+        #expect(description.contains("Unable to reach"))
+        #expect(description.contains("VPN"))
+        #expect(!description.contains("appears to be down right now"))
+    }
+
+    @Test func `Invalid response data error description does not claim the server is down`() {
+        let error = APIError.invalidResponseData(regionName: "San Diego")
+        let description = error.localizedDescription
+
+        #expect(description.contains("San Diego"))
+        #expect(description.contains("can't read"))
+        #expect(!description.contains("down"))
+        #expect(!description.contains("VPN"))
     }
 
     @Test func `Cellular data restricted error description mentions settings`() {

--- a/docs/superpowers/specs/2026-08-14-error-copy-reachability-design.md
+++ b/docs/superpowers/specs/2026-08-14-error-copy-reachability-design.md
@@ -52,4 +52,4 @@ Empty-state / error icons treat `.invalidResponseData` like other “bad payload
 
 ## Locales
 
-Update `OBALoc` defaults and `en.lproj`. Other locales keep the previous `.serverUnavailable` wording until translated; the new key falls back to the English `value:` via `OBALoc`.
+Update `OBALoc` defaults and `en.lproj`. Add `api_error.invalid_response_data_fmt` to every `OBAKitCore` locale — `LocalizationTests` requires key parity, so a missing key fails CI instead of falling back. Existing `server_unavailable_fmt` / `decoding_failure` translations stay until a translator revises them; they still have the key.

--- a/docs/superpowers/specs/2026-08-14-error-copy-reachability-design.md
+++ b/docs/superpowers/specs/2026-08-14-error-copy-reachability-design.md
@@ -1,0 +1,55 @@
+# Unreachable server vs bad stop data — error copy
+
+**Date:** 2026-08-14
+**Status:** Approved for implementation
+**Issues:** #1281, #1276
+
+## Goal
+
+Riders currently see “the server appears to be down” for two different failures: the regional host is unreachable (timeout / connection / 502–504), and the host returned a body this app cannot decode. The first is often a VPN or firewall; the second is bad stop/agency data. They need distinct copy.
+
+## Non-goals
+
+- No new report-a-problem CTA. The issue text for #1276 asks riders to “let us know”; wiring that is a separate product change.
+- No change to which HTTP status codes map to `.serverUnavailable` vs `.serverError`.
+- No VPN detection. We mention VPN as one possible cause, not as a diagnosed cause.
+
+## Classification
+
+| Raw error | Today | After |
+|---|---|---|
+| Timeout / cannot connect / cannot find host / 502–504 | `.serverUnavailable` | unchanged |
+| `DecodingError` with a region name | `.serverUnavailable` | **`.invalidResponseData(regionName:)`** |
+| `DecodingError` with no region | `UnstructuredError` (decoding_failure) | same case, copy no longer says “server experiencing problems” |
+
+Empty HTTP 200 stays `APIError.requestNotFound` (see #1268). Do not fold it into either of these cases.
+
+## Copy (English)
+
+`.serverUnavailable` — keep it short, do not claim the server *is* down:
+
+> Unable to reach the server for {region}. {app} can't show transit information for this region right now. The server may be down, or a VPN or firewall may be blocking it.
+
+`.invalidResponseData`:
+
+> The server for {region} returned data this app can't read. That's usually a problem with the stop or agency feed, not with {app}. Try again shortly.
+
+No-region decoding fallback:
+
+> The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.
+
+## UI
+
+Empty-state / error icons treat `.invalidResponseData` like other “bad payload” errors (`exclamationmark.triangle` / `bolt.horizontal.circle`), not `server.rack`. That is the visual distinction #1276 is after.
+
+## Tests
+
+- Existing `Classify decoding error with region name becomes server unavailable` must fail on `main` once rewritten to expect `.invalidResponseData`.
+- `.serverUnavailable` description still includes the region name; it also mentions VPN.
+- `.invalidResponseData` description includes the region and does not say the server is down.
+- Timeout / 502–504 still classify as `.serverUnavailable`.
+- Do not load stop-page views.
+
+## Locales
+
+Update `OBALoc` defaults and `en.lproj`. Other locales keep the previous `.serverUnavailable` wording until translated; the new key falls back to the English `value:` via `OBALoc`.


### PR DESCRIPTION
## Summary
- Unreachable regional hosts (timeout / cannot connect / 502–504) still use `.serverUnavailable`, but the English copy no longer asserts the server *is* down. It says we cannot reach it, and mentions a VPN or firewall as one possible cause (#1281).
- `DecodingError` is no longer classified as `.serverUnavailable`. It becomes `.invalidResponseData`, with copy that names a bad stop/agency feed (#1276). Empty HTTP 200 is unchanged (`requestNotFound`, see #1268).
- Empty-state icons use `exclamationmark.triangle` for bad payload, not `server.rack`.
- Design notes: `docs/superpowers/specs/2026-08-14-error-copy-reachability-design.md`.

Closes #1281. Closes #1276.

## Test plan
- [x] `ErrorClassifierTests` — 30 tests on iPhone 17 Pro simulator, including:
  - DecodingError + region → `.invalidResponseData`, not `.serverUnavailable`
  - `.serverUnavailable` description contains `Unable to reach` and `VPN`
  - `.invalidResponseData` description does not contain `down` or `VPN`
  - timeout / 502–504 still `.serverUnavailable`
- [ ] Dark/light: trigger a real unreachable-host alert and confirm the VPN sentence
- [ ] Bad JSON at a stop shows the feed copy, not “server is down”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when transit data cannot be read.
  * Distinguishes invalid response data from unavailable servers.
  * Updated error screens with a warning icon and clearer retry guidance.
* **Localization**
  * Added translated invalid-data error messages across supported languages.
* **Documentation**
  * Documented error classification, messaging, icon treatment, and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->