### PR TITLE
Refresh stop-page arrival filter after a Settings change

### DIFF
--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -158,6 +158,7 @@ class StopViewModel: ObservableObject {
     /// Cache for trip-panel approach timelines, invalidated on each refresh.
 
     private var alarmFiredCancellable: AnyCancellable?
+    private var userDefaultsCancellable: AnyCancellable?
 
     // MARK: - Init Context
 
@@ -222,6 +223,14 @@ class StopViewModel: ObservableObject {
             .publisher(for: .alarmFired)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.rebuildAlarmIndex() }
+
+        // Settings is presented modally from More, so this VM can outlive a
+        // filter change. Re-read the persisted value; skip the write path so
+        // we don't echo defaults back at ourselves (#1273).
+        userDefaultsCancellable = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification, object: environment.userDefaults)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.syncArrivalDepartureFilterFromDefaults() }
     }
 
     /// Backward-compatible entry point for existing callers that pass `Application` directly.
@@ -511,6 +520,16 @@ class StopViewModel: ObservableObject {
         guard filter != arrivalDepartureFilter else { return }
         arrivalDepartureFilter = filter
         environment.setArrivalDepartureFilter(filter)
+    }
+
+    /// Re-reads the persisted arrival/departure filter after an external write
+    /// (Settings). No-op when the published value already matches — this is the
+    /// hot path for `UserDefaults.didChangeNotification` fan-out.
+    private func syncArrivalDepartureFilterFromDefaults() {
+        let persisted = environment.effectiveArrivalDepartureFilter
+        if persisted != arrivalDepartureFilter {
+            arrivalDepartureFilter = persisted
+        }
     }
 
     /// `true` when the user has never saved preferences for this stop, so the

--- a/OBAKit/ViewModels/StopViewModelEnvironment.swift
+++ b/OBAKit/ViewModels/StopViewModelEnvironment.swift
@@ -50,6 +50,10 @@ protocol StopViewModelEnvironment: AnyObject {
     /// Persists the rider's arrival/departure filter choice.
     func setArrivalDepartureFilter(_ filter: ArrivalDepartureFilter)
 
+    /// The defaults store Settings writes. Used to observe filter changes made
+    /// while this stop page is already on screen (#1273).
+    var userDefaults: UserDefaults { get }
+
     // MARK: - Scalar extractions (avoid concrete service types in the protocol)
 
     /// `locationService.currentLocation`
@@ -152,6 +156,8 @@ final class PreviewStopViewModelEnvironment: StopViewModelEnvironment {
     func setArrivalDepartureFilter(_ filter: ArrivalDepartureFilter) {
         effectiveArrivalDepartureFilter = filter
     }
+
+    let userDefaults = UserDefaults(suiteName: "StopViewModelPreview")!
 
     var currentUserLocation: CLLocation? { nil }
     var shouldRequestDonations: Bool { false }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -347,6 +347,27 @@ final class StopViewModelTests: OBATestCase {
         #expect(app.effectiveArrivalDepartureFilter == .estimatedOnly)
     }
 
+    /// Settings writes the same defaults key without going through this view
+    /// model. An already-open stop page must pick that up so its Departure Type
+    /// menu and filtered list don't stay on the value from `init` (#1273).
+    @Test @MainActor
+    func `Arrival departure filter syncs from an external Settings change`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        #expect(viewModel.arrivalDepartureFilter == .all)
+
+        // Settings' write path — not `updateArrivalDepartureFilter`.
+        app.setArrivalDepartureFilter(.estimatedOnly)
+
+        // `UserDefaults.didChangeNotification` fan-out is `receive(on: main)`,
+        // so give the runloop a few hops to deliver.
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(viewModel.arrivalDepartureFilter == .estimatedOnly)
+    }
+
     // MARK: - $stop re-emit guard
 
     /// `$stop` must not re-emit across refreshes when the underlying value is unchanged.

--- a/docs/superpowers/specs/2026-08-14-stale-stop-filter-design.md
+++ b/docs/superpowers/specs/2026-08-14-stale-stop-filter-design.md
@@ -1,0 +1,36 @@
+# Stop page stale arrival/departure filter after Settings
+
+**Date:** 2026-08-14
+**Status:** Approved for implementation
+**Issue:** #1273
+
+## Goal
+
+An already-open stop page keeps showing the arrival/departure filter it seeded in `init`, including a stale checkmark in its own Departure Type menu, after the rider changes the same setting in Settings (modal, More tab). Fresh navigation is already correct.
+
+## Approach
+
+Mirror `MapViewModel`'s `UserDefaults.didChangeNotification` subscription.
+
+On each notification (same `UserDefaults` instance as Settings writes):
+
+1. Read `environment.effectiveArrivalDepartureFilter`.
+2. If it differs from the published `arrivalDepartureFilter`, assign the published property.
+3. Do **not** call `setArrivalDepartureFilter` from this path — that would write defaults again.
+4. Do **not** refetch arrivals. The list already filters in the view from the published value.
+
+Unrelated defaults writes are a no-op via the equality guard, same as `MapViewModel.syncMapTypeFromRegionManager`.
+
+## Protocol
+
+Add `var userDefaults: UserDefaults { get }` to `StopViewModelEnvironment` so the subscription can target the same store Settings uses. `Application` already has this property. The preview stub uses its existing suite defaults.
+
+Do not add a test-only handler or extra publisher.
+
+## Tests
+
+A `StopViewModel` constructed with `.all`, then `application.setArrivalDepartureFilter(.estimatedOnly)` (Settings' write path, not `updateArrivalDepartureFilter`), must publish `.estimatedOnly` after the notification hops to the main actor (`Task.yield` loop, same as `MapViewModelTests`).
+
+That test is green on `main` today only if someone already subscribed — it must fail before the production change.
+
+Do not load `StopPageViewController.view`.


### PR DESCRIPTION
## Summary
- `StopViewModel` seeded `arrivalDepartureFilter` once in `init`. Settings is modal from More, so an already-open stop kept a stale list and a stale Departure Type checkmark.
- Subscribe to `UserDefaults.didChangeNotification` on the same store Settings writes, same pattern as `MapViewModel` map-type sync. Equality-guarded; does not write defaults or refetch.
- Design notes: `docs/superpowers/specs/2026-08-14-stale-stop-filter-design.md`.

Closes #1273.

## Test plan
- [x] `StopViewModelTests` on iPhone 17 Pro simulator, including `Arrival departure filter syncs from an external Settings change` — writes via `application.setArrivalDepartureFilter` (Settings' path), not `updateArrivalDepartureFilter`
- [ ] Open a stop, switch More → Settings → Arrival/Departure filter, return to the stop without popping it: list and menu checkmark match the new value
- [ ] Changing the filter from the stop's own menu still persists and still updates the list