### PR TITLE
Home sheet sections for the SwiftUI map panel

### DIFF
--- a/OBAKit/Bookmarks/BookmarkCardView.swift
+++ b/OBAKit/Bookmarks/BookmarkCardView.swift
@@ -50,7 +50,7 @@ struct BookmarkCardView: View {
         .onAppear { flashIfNeeded() }
         .onChange(of: row.highlightedTripIDs) { flashIfNeeded() }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(formatters.accessibilityLabel(for: row))
+        .accessibilityLabel(row.accessibilityLabel(base: formatters.accessibilityLabel(for: row)))
         .accessibilityValue(formatters.accessibilityValue(for: row) ?? "")
         .accessibilityAddTraits([.isButton, .updatesFrequently])
     }
@@ -102,10 +102,15 @@ struct BookmarkCardView: View {
     }
 
     private var nameText: some View {
-        Text(row.name)
-            .font(.headline.weight(.heavy))
-            .foregroundStyle(.primary)
-            .lineLimit(isAccessibilitySize ? nil : 2)
+        HStack(spacing: 4) {
+            if row.isPinned {
+                BookmarkPinIndicator()
+            }
+            Text(row.name)
+                .font(.headline.weight(.heavy))
+                .foregroundStyle(.primary)
+                .lineLimit(isAccessibilitySize ? nil : 2)
+        }
     }
 
     @ViewBuilder
@@ -265,10 +270,15 @@ struct StopBookmarkRow: View {
                     in: RoundedRectangle(cornerRadius: 48 * badgeScale * 0.28, style: .continuous)
                 )
             VStack(alignment: .leading, spacing: 3) {
-                Text(row.name)
-                    .font(.headline.weight(.heavy))
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
+                HStack(spacing: 4) {
+                    if row.isPinned {
+                        BookmarkPinIndicator()
+                    }
+                    Text(row.name)
+                        .font(.headline.weight(.heavy))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                }
                 if let subtitle = row.routesSubtitle {
                     Text(subtitle)
                         .font(.footnote)
@@ -279,7 +289,7 @@ struct StopBookmarkRow: View {
             Spacer(minLength: 0)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(formatters.accessibilityLabel(for: row))
+        .accessibilityLabel(row.accessibilityLabel(base: formatters.accessibilityLabel(for: row)))
         .accessibilityAddTraits(.isButton)
     }
 }

--- a/OBAKit/Bookmarks/BookmarkPinning.swift
+++ b/OBAKit/Bookmarks/BookmarkPinning.swift
@@ -1,0 +1,85 @@
+//
+//  BookmarkPinning.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+// MARK: - Menu item
+
+/// The pin/unpin context-menu item, shared by the Bookmarks tab and the home
+/// sheet's bookmarks section.
+///
+/// Defined once so both surfaces show the same verb and glyph — a user who pins
+/// from the tab and unpins from the home sheet shouldn't meet two vocabularies
+/// for one piece of state.
+struct BookmarkPinButton: View {
+    let isPinned: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            if isPinned {
+                Label(Strings.unpinBookmark, systemImage: "pin.slash")
+            } else {
+                Label(Strings.pinBookmark, systemImage: "pin")
+            }
+        }
+    }
+}
+
+// MARK: - Row indicator
+
+/// The glyph marking a pinned bookmark in a list row.
+///
+/// `accessibilityHidden` on purpose: both bookmark cells flatten themselves with
+/// `.accessibilityElement(children: .ignore)` and build one label, so the pinned
+/// state is announced through `BookmarkRowViewModel.accessibilityLabel(base:)`
+/// instead of as a stray element.
+struct BookmarkPinIndicator: View {
+    var body: some View {
+        Image(systemName: "pin.fill")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Accessibility
+
+extension BookmarkRowViewModel {
+    /// `base` with the pinned state appended, for cells that collapse themselves
+    /// into a single accessibility element.
+    func accessibilityLabel(base: String) -> String {
+        guard isPinned else { return base }
+        return "\(base), \(Strings.pinnedBookmarkAccessibilityLabel)"
+    }
+}
+
+// MARK: - Strings
+
+extension Strings {
+
+    static let pinBookmark = OBALoc(
+        "bookmarks_controller.context_menu.pin",
+        value: "Pin",
+        comment: "Context menu action that pins a bookmark to the top of the home sheet's bookmarks section."
+    )
+
+    static let unpinBookmark = OBALoc(
+        "bookmarks_controller.context_menu.unpin",
+        value: "Unpin",
+        comment: "Context menu action that removes a bookmark's pin, returning it to the normal ordering."
+    )
+
+    static let pinnedBookmarkAccessibilityLabel = OBALoc(
+        "bookmarks_controller.pinned.a11y_label",
+        value: "Pinned",
+        comment: "VoiceOver suffix announcing that a bookmark row is pinned."
+    )
+}

--- a/OBAKit/Bookmarks/BookmarkRowViewModel.swift
+++ b/OBAKit/Bookmarks/BookmarkRowViewModel.swift
@@ -35,6 +35,12 @@ struct BookmarkRowViewModel: Identifiable, Equatable {
     let stopID: StopID
     let isTripBookmark: Bool
     let isFavorite: Bool
+
+    /// Whether the user pinned this bookmark to the top of the home sheet's
+    /// bookmarks section. Carried into the row so the cell can show the glyph and
+    /// the context menu can offer the right verb.
+    let isPinned: Bool
+
     let routeShortName: String?
 
     /// Upcoming arrival/departures for a trip bookmark. Empty until data lands,
@@ -61,6 +67,7 @@ struct BookmarkRowViewModel: Identifiable, Equatable {
         self.stopID = bookmark.stopID
         self.isTripBookmark = bookmark.isTripBookmark
         self.isFavorite = bookmark.isFavorite
+        self.isPinned = bookmark.isPinned
         self.routeShortName = bookmark.routeShortName
         // Self-enforce "always empty for whole-stop bookmarks" rather than
         // trusting the caller.
@@ -76,6 +83,7 @@ struct BookmarkRowViewModel: Identifiable, Equatable {
         lhs.stopID == rhs.stopID &&
         lhs.isTripBookmark == rhs.isTripBookmark &&
         lhs.isFavorite == rhs.isFavorite &&
+        lhs.isPinned == rhs.isPinned &&
         lhs.routeShortName == rhs.routeShortName &&
         lhs.arrivalDepartures == rhs.arrivalDepartures &&
         lhs.hasLoadedArrivalData == rhs.hasLoadedArrivalData &&

--- a/OBAKit/Bookmarks/BookmarksListView.swift
+++ b/OBAKit/Bookmarks/BookmarksListView.swift
@@ -23,6 +23,9 @@ struct BookmarksNavigationHandler {
     let deleteBookmark: (Bookmark) -> Void
     /// Starts a Live Activity tracking the bookmark on the Lock Screen.
     let trackBookmark: (Bookmark) -> Void
+    /// Pins or unpins the bookmark (row context menu). Pinning affects the home
+    /// sheet's bookmarks section only; this tab's ordering is unchanged.
+    let togglePin: (Bookmark) -> Void
     /// Whether the system allows starting Live Activities; gates the Track item.
     let liveActivitiesEnabled: () -> Bool
     /// Drives pull-to-refresh: kicks off a batch, returns when it completes,
@@ -150,6 +153,10 @@ struct BookmarksListView: View {
                     systemImage: "waveform.circle.fill"
                 )
             }
+        }
+
+        BookmarkPinButton(isPinned: row.isPinned) {
+            navigation.togglePin(row.bookmark)
         }
 
         Button {

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -96,6 +96,7 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
         editBookmark: { _ in assertionFailure("placeholder navigation handler invoked") },
         deleteBookmark: { _ in assertionFailure("placeholder navigation handler invoked") },
         trackBookmark: { _ in assertionFailure("placeholder navigation handler invoked") },
+        togglePin: { _ in assertionFailure("placeholder navigation handler invoked") },
         liveActivitiesEnabled: {
             assertionFailure("placeholder navigation handler invoked")
             return false
@@ -116,6 +117,10 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
             editBookmark: { [weak self] bookmark in self?.editBookmark(bookmark) },
             deleteBookmark: { [weak self] bookmark in self?.deleteBookmark(bookmark) },
             trackBookmark: { [weak self] bookmark in self?.startLiveActivity(for: bookmark) },
+            togglePin: { [weak self] bookmark in
+                guard let self else { return }
+                self.application.userDataStore.setPinned(!bookmark.isPinned, for: bookmark)
+            },
             liveActivitiesEnabled: { ActivityAuthorizationInfo().areActivitiesEnabled },
             refresh: { [weak self] in
                 guard let self else { return }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1210,23 +1210,18 @@ class MapViewController: UIViewController,
 
         self.floatingPanel.move(to: .tip, animated: true)
 
-        let mapItemController = MapItemViewController { [weak self] controller in
-            guard let self else {
-                fatalError("MapItemViewController outlived its presenting MapViewController")
+        let mapItemController = MapItemViewController(
+            application: application,
+            mapItem: mapItem,
+            delegate: self,
+            removePinHandler: removePinHandler,
+            planTripHandler: { [weak self] in
+                guard let self else { return }
+                self.dismissExistingMapItemController(animated: true)
+                self.showTripPlanner(destination: mapItem)
+                self.semiModalPanel?.move(to: .tip, animated: false)
             }
-            return MapItemViewModel(
-                mapItem: mapItem,
-                application: self.application,
-                actions: .uiKit(presenter: controller, delegate: self, application: self.application),
-                removePinHandler: removePinHandler,
-                planTripHandler: { [weak self] in
-                    guard let self else { return }
-                    self.dismissExistingMapItemController(animated: true)
-                    self.showTripPlanner(destination: mapItem)
-                    self.semiModalPanel?.move(to: .tip, animated: false)
-                }
-            )
-        }
+        )
         let semiModal = createSemiModalPanel(childController: mapItemController)
         semiModal.addPanel(toParent: self)
         self.semiModalMapItemController = semiModal

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1208,17 +1208,25 @@ class MapViewController: UIViewController,
             removePinHandler = nil
         }
 
-        let viewModel = MapItemViewModel(mapItem: mapItem, application: application, delegate: self, removePinHandler: removePinHandler) { [weak self] in
-            guard let self else { return }
-
-            self.dismissExistingMapItemController(animated: true)
-            self.showTripPlanner(destination: mapItem)
-            self.semiModalPanel?.move(to: .tip, animated: false)
-        }
-
         self.floatingPanel.move(to: .tip, animated: true)
 
-        let mapItemController = MapItemViewController(viewModel)
+        let mapItemController = MapItemViewController { [weak self] controller in
+            guard let self else {
+                fatalError("MapItemViewController outlived its presenting MapViewController")
+            }
+            return MapItemViewModel(
+                mapItem: mapItem,
+                application: self.application,
+                actions: .uiKit(presenter: controller, delegate: self, application: self.application),
+                removePinHandler: removePinHandler,
+                planTripHandler: { [weak self] in
+                    guard let self else { return }
+                    self.dismissExistingMapItemController(animated: true)
+                    self.showTripPlanner(destination: mapItem)
+                    self.semiModalPanel?.move(to: .tip, animated: false)
+                }
+            )
+        }
         let semiModal = createSemiModalPanel(childController: mapItemController)
         semiModal.addPanel(toParent: self)
         self.semiModalMapItemController = semiModal

--- a/OBAKit/Mapping/NearbyStopsListViewController.swift
+++ b/OBAKit/Mapping/NearbyStopsListViewController.swift
@@ -39,7 +39,7 @@ class NearbyStopsListViewController: UIViewController, UICollectionViewDelegate,
             case .alert:
                 return Strings.serviceAlerts
             case .nearbyStops:
-                return OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller.")
+                return Strings.nearbyStops
             }
         }
     }

--- a/OBAKit/Recent/RecentStopsViewModel.swift
+++ b/OBAKit/Recent/RecentStopsViewModel.swift
@@ -41,9 +41,7 @@ final class RecentStopsViewModel: ObservableObject {
         }
         // Region resolved — re-arm the warn so a *later* region loss is still observable.
         didWarnNilRegion = false
-        recentStops = application.userDataStore.recentStops.filter {
-            $0.regionIdentifier == currentRegion.regionIdentifier
-        }
+        recentStops = application.userDataStore.recentStops(in: currentRegion)
     }
 
     func deleteAllRecentStops() {

--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -124,7 +124,7 @@ class SearchInteractor: NSObject {
     // MARK: - Bookmarks
     private func buildBookmarksSection(searchText: String) -> SearchListSection? {
         let bookmarks = userDataStore.findBookmarks(matching: searchText).map { bookmark in
-            SearchListRow(kind: .bookmark, title: bookmark.name, accessory: .disclosureIndicator) { [weak self] in
+            SearchListRow(kind: .bookmark(id: bookmark.id.uuidString), title: bookmark.name, accessory: .disclosureIndicator) { [weak self] in
                 guard let self else { return }
                 self.delegate?.searchInteractor(self, showStop: bookmark.stop)
             }

--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -108,7 +108,7 @@ class SearchInteractor: NSObject {
     // MARK: - Recent Stops
     private func buildRecentStopsSection(searchText: String) -> SearchListSection? {
         let recentStops = userDataStore.findRecentStops(matching: searchText).map { stop in
-            SearchListRow(kind: .recentStop, title: stop.name, accessory: .disclosureIndicator) { [weak self] in
+            SearchListRow(kind: .recentStop(id: stop.id), title: stop.name, accessory: .disclosureIndicator) { [weak self] in
                 guard let self else { return }
                 self.delegate?.searchInteractor(self, showStop: stop)
             }

--- a/OBAKit/Search/SearchInteractor.swift
+++ b/OBAKit/Search/SearchInteractor.swift
@@ -136,7 +136,7 @@ class SearchInteractor: NSObject {
 
         return .init(
             id: .bookmarks,
-            title: OBALoc("search_controller.bookmarks.header", value: "Bookmarks", comment: "Title of the Bookmarks search header"),
+            title: Strings.bookmarks,
             content: bookmarks
         )
     }

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -143,9 +143,14 @@ extension SearchListRow {
 
 extension SearchListRow {
 
-    /// The standard stop row: stop glyph, name, and a "distance • direction"
-    /// subtitle. Shared by the search results sheet and the home sheet's nearby
-    /// and recent sections so all three render stops identically.
+    /// The standard `SearchListRow` for a stop: stop glyph, name, and a
+    /// "distance • direction" subtitle.
+    ///
+    /// Used by the search results sheet (`SearchResultRow`). The home sheet's
+    /// nearby and recent sections deliberately do **not** use this — they render
+    /// `HomeStopRow`, which uses the squircle transport glyph to match the
+    /// bookmark cards it sits beside. Keep this in step with the search list's
+    /// placemark rows, not with the home sheet.
     ///
     /// `kind` is a parameter rather than fixed because the caller owns row
     /// identity — the same stop can legitimately appear in two sections at once.

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -17,7 +17,10 @@ struct SearchListRow: Identifiable {
 
     enum Kind {
         case quickSearch(SearchType)
-        case recentStop
+        /// Carries the stop's id for the same reason `searchResult` does: recent
+        /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
+        /// corner share a name.
+        case recentStop(id: String)
         case bookmark
         case placemark(MKMapItem)
         /// A row in a disambiguation list. Carries the underlying model's id
@@ -40,8 +43,8 @@ struct SearchListRow: Identifiable {
             switch self {
             case .quickSearch(let type):
                 return "quickSearch-\(type.rawValue)"
-            case .recentStop:
-                return "recentStop"
+            case .recentStop(let id):
+                return "recentStop-\(id)"
             case .bookmark:
                 return "bookmark"
             case .placemark(let item):

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -8,6 +8,7 @@
 import Foundation
 import MapKit
 import UIKit
+import OBAKitCore
 
 struct SearchListRow: Identifiable {
     enum Accessory {
@@ -21,6 +22,9 @@ struct SearchListRow: Identifiable {
         /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
         /// corner share a name.
         case recentStop(id: String)
+        /// Carries the stop's id for the same reason `recentStop` does: two
+        /// stops on opposite sides of a corner share a name.
+        case nearbyStop(id: String)
         /// Carries the bookmark's id for the same reason `recentStop` does: a
         /// bookmark's default name is its stop's name, so two bookmarks on
         /// opposite sides of one street would otherwise share a row id.
@@ -48,6 +52,8 @@ struct SearchListRow: Identifiable {
                 return "quickSearch-\(type.rawValue)"
             case .recentStop(let id):
                 return "recentStop-\(id)"
+            case .nearbyStop(let id):
+                return "nearbyStop-\(id)"
             case .bookmark(let id):
                 return "bookmark-\(id)"
             case .placemark(let item):
@@ -135,5 +141,51 @@ extension SearchListRow {
             return .system(poi.symbolName)
         }
         return .system("mappin")
+    }
+}
+
+// MARK: - Stop Row Building
+
+extension SearchListRow {
+
+    /// The standard stop row: stop glyph, name, and a "distance • direction"
+    /// subtitle. Shared by the search results sheet and the home sheet's nearby
+    /// and recent sections so all three render stops identically.
+    ///
+    /// `kind` is a parameter rather than fixed because the caller owns row
+    /// identity — the same stop can legitimately appear in two sections at once.
+    @MainActor
+    static func stop(
+        _ stop: Stop,
+        application: Application,
+        kind: Kind,
+        onSelect: @escaping () -> Void
+    ) -> SearchListRow {
+        SearchListRow(
+            kind: kind,
+            title: stop.name,
+            subtitle: stopSubtitle(application, stop),
+            icon: .uiImage(Icons.stop),
+            accessory: .disclosureIndicator,
+            action: onSelect
+        )
+    }
+
+    /// Direction plus distance from the user, mirroring what the placemark rows
+    /// in the search list already show. Distance is dropped when there's no fix.
+    @MainActor
+    static func stopSubtitle(_ application: Application, _ stop: Stop) -> String? {
+        var parts: [String] = []
+
+        if let currentLocation = application.locationService.currentLocation {
+            let distance = currentLocation.distance(from: stop.location)
+            parts.append(application.formatters.distanceFormatter.string(fromDistance: distance))
+        }
+
+        if let direction = Formatters.adjectiveFormOfCardinalDirection(stop.direction), !direction.isEmpty {
+            parts.append(direction)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " • ")
     }
 }

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -20,6 +20,12 @@ struct SearchListRow: Identifiable {
         case recentStop
         case bookmark
         case placemark(MKMapItem)
+        /// A row in a disambiguation list. Carries the underlying model's id
+        /// because titles are not identity — two stops on opposite sides of the
+        /// same corner share a name, and two agencies can both run a route "1".
+        /// Deriving the row id from the title alone collides in exactly the case
+        /// a disambiguation list exists to handle.
+        case searchResult(id: String)
         case clearRecents
         case loading
         case noResults
@@ -41,6 +47,8 @@ struct SearchListRow: Identifiable {
             case .placemark(let item):
                 let coord = item.placemark.coordinate
                 return "placemark-\(coord.latitude)-\(coord.longitude)"
+            case .searchResult(let id):
+                return "searchResult-\(id)"
             case .clearRecents:
                 return "clearRecents"
             case .loading:

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -21,7 +21,10 @@ struct SearchListRow: Identifiable {
         /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
         /// corner share a name.
         case recentStop(id: String)
-        case bookmark
+        /// Carries the bookmark's id for the same reason `recentStop` does: a
+        /// bookmark's default name is its stop's name, so two bookmarks on
+        /// opposite sides of one street would otherwise share a row id.
+        case bookmark(id: String)
         case placemark(MKMapItem)
         /// A row in a disambiguation list. Carries the underlying model's id
         /// because titles are not identity — two stops on opposite sides of the
@@ -45,8 +48,8 @@ struct SearchListRow: Identifiable {
                 return "quickSearch-\(type.rawValue)"
             case .recentStop(let id):
                 return "recentStop-\(id)"
-            case .bookmark:
-                return "bookmark"
+            case .bookmark(let id):
+                return "bookmark-\(id)"
             case .placemark(let item):
                 let coord = item.placemark.coordinate
                 return "placemark-\(coord.latitude)-\(coord.longitude)"

--- a/OBAKit/Search/SearchList/Models/SearchListRow.swift
+++ b/OBAKit/Search/SearchList/Models/SearchListRow.swift
@@ -22,9 +22,6 @@ struct SearchListRow: Identifiable {
         /// stops are rendered in a `ForEach`, and two stops on opposite sides of a
         /// corner share a name.
         case recentStop(id: String)
-        /// Carries the stop's id for the same reason `recentStop` does: two
-        /// stops on opposite sides of a corner share a name.
-        case nearbyStop(id: String)
         /// Carries the bookmark's id for the same reason `recentStop` does: a
         /// bookmark's default name is its stop's name, so two bookmarks on
         /// opposite sides of one street would otherwise share a row id.
@@ -52,8 +49,6 @@ struct SearchListRow: Identifiable {
                 return "quickSearch-\(type.rawValue)"
             case .recentStop(let id):
                 return "recentStop-\(id)"
-            case .nearbyStop(let id):
-                return "nearbyStop-\(id)"
             case .bookmark(let id):
                 return "bookmark-\(id)"
             case .placemark(let item):

--- a/OBAKit/Search/SearchList/SearchListRowView.swift
+++ b/OBAKit/Search/SearchList/SearchListRowView.swift
@@ -23,7 +23,7 @@ struct SearchListRowView: View {
             errorRow
         case .clearRecents:
             clearRecentsRow
-        case .quickSearch, .recentStop, .bookmark, .placemark, .searchResult:
+        case .quickSearch, .recentStop, .nearbyStop, .bookmark, .placemark, .searchResult:
             actionRow
         }
     }
@@ -135,7 +135,7 @@ struct SearchListRowView: View {
             switch row.kind {
             case .placemark:
                 badgedIcon(icon, size: 32, imagePadding: 14)
-            case .quickSearch, .recentStop, .bookmark, .searchResult:
+            case .quickSearch, .recentStop, .nearbyStop, .bookmark, .searchResult:
                 badgedIcon(icon, size: 24, imagePadding: 8)
             case .error:
                 plainIcon(icon, size: 20, tint: .orange)

--- a/OBAKit/Search/SearchList/SearchListRowView.swift
+++ b/OBAKit/Search/SearchList/SearchListRowView.swift
@@ -23,7 +23,7 @@ struct SearchListRowView: View {
             errorRow
         case .clearRecents:
             clearRecentsRow
-        case .quickSearch, .recentStop, .nearbyStop, .bookmark, .placemark, .searchResult:
+        case .quickSearch, .recentStop, .bookmark, .placemark, .searchResult:
             actionRow
         }
     }
@@ -135,7 +135,7 @@ struct SearchListRowView: View {
             switch row.kind {
             case .placemark:
                 badgedIcon(icon, size: 32, imagePadding: 14)
-            case .quickSearch, .recentStop, .nearbyStop, .bookmark, .searchResult:
+            case .quickSearch, .recentStop, .bookmark, .searchResult:
                 badgedIcon(icon, size: 24, imagePadding: 8)
             case .error:
                 plainIcon(icon, size: 20, tint: .orange)

--- a/OBAKit/Search/SearchList/SearchListRowView.swift
+++ b/OBAKit/Search/SearchList/SearchListRowView.swift
@@ -23,7 +23,7 @@ struct SearchListRowView: View {
             errorRow
         case .clearRecents:
             clearRecentsRow
-        case .quickSearch, .recentStop, .bookmark, .placemark:
+        case .quickSearch, .recentStop, .bookmark, .placemark, .searchResult:
             actionRow
         }
     }
@@ -135,7 +135,7 @@ struct SearchListRowView: View {
             switch row.kind {
             case .placemark:
                 badgedIcon(icon, size: 32, imagePadding: 14)
-            case .quickSearch, .recentStop, .bookmark:
+            case .quickSearch, .recentStop, .bookmark, .searchResult:
                 badgedIcon(icon, size: 24, imagePadding: 8)
             case .error:
                 plainIcon(icon, size: 20, tint: .orange)

--- a/OBAKit/Search/SearchList/SearchListView.swift
+++ b/OBAKit/Search/SearchList/SearchListView.swift
@@ -24,6 +24,40 @@ struct SearchListView: View {
     }
 }
 
+// MARK: - Shared list chrome
+
+extension View {
+    /// The list treatment shared by every search surface: inset-grouped cards on no
+    /// background of the list's own.
+    ///
+    /// Pairs with `searchSheetBackground()` on the enclosing sheet — hiding the
+    /// list's background only works if something behind it supplies the contrast the
+    /// cards need.
+    func searchListChrome() -> some View {
+        self
+            .listStyle(.insetGrouped)
+            .scrollDismissesKeyboard(.interactively)
+            .scrollContentBackground(.hidden)
+            .contentMargins(.horizontal, 8, for: .scrollContent)
+            .background(.clear)
+    }
+
+    /// Grouped background for a sheet hosting a search list.
+    ///
+    /// Sheets default to `systemBackground`, and `insetGrouped` rows are filled with
+    /// `secondarySystemGroupedBackground` — the same colour in light mode. The cards
+    /// are drawn, but they're white on white, so the rows read as plain text with no
+    /// list edges at all. Painting the sheet with `systemGroupedBackground` is what
+    /// a grouped list normally sits on and gives the cards their contrast back.
+    ///
+    /// Applied to the whole sheet rather than left to the `List`'s own background so
+    /// the colour runs edge to edge, instead of starting below the search field and
+    /// leaving the header two-tone.
+    func searchSheetBackground() -> some View {
+        presentationBackground(Color(.systemGroupedBackground))
+    }
+}
+
 // MARK: - SearchListContentView
 
 private struct SearchListContentView: View {
@@ -43,11 +77,7 @@ private struct SearchListContentView: View {
                 }
             }
         }
-        .listStyle(.insetGrouped)
-        .scrollDismissesKeyboard(.interactively)
-        .scrollContentBackground(.hidden)
-        .contentMargins(.horizontal, 8, for: .scrollContent)
-        .background(.clear)
+        .searchListChrome()
     }
 }
 

--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -95,6 +95,11 @@ public class SearchManager: NSObject {
     ///   - `.route` / `.vehicleID` show an alert only; publishing an empty response
     ///     would additionally trigger the "No search results were found" alert via
     ///     `notifyDelegatesNoSearchResults`, double-alerting the user.
+    ///
+    /// A failed vehicle *details* fetch used to be the one exception, alerting and
+    /// publishing an empty error response from inside `fetchVehicleID` — i.e. the
+    /// double alert the `.vehicleID` rule above exists to avoid. It now propagates
+    /// like every other failure and lands in the same branch.
     public func search(request: SearchRequest) async {
         if request.searchType == .vehicleID {
             ProgressHUD.show()
@@ -182,16 +187,15 @@ public class SearchManager: NSObject {
             return SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
         }
 
-        do {
-            let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
-            return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
-        } catch {
-            // Preserved from `processSearchResults`: this inner failure alerted and
-            // published an empty error response rather than propagating. Kept as-is
-            // so the UIKit path is unchanged; revisit when the SwiftUI panel is the
-            // only surface.
-            await application.displayError(error)
-            return SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-        }
+        // Propagated, not swallowed. `processSearchResults` used to alert here and
+        // return an empty error response, which put a *failed* lookup and a query
+        // that genuinely matched nothing into the same shape — fine while
+        // `MapRegionManager` was the only consumer, wrong now that `fetchResults` is
+        // also the SwiftUI entry point and classifies purely on `results`. Letting it
+        // throw sends it to the `.vehicleID` branch of `search(request:)`, which is
+        // where every other vehicle-search failure is already alerted, and lets the
+        // SwiftUI sheet report it as the error it is.
+        let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
+        return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
     }
 }

--- a/OBAKit/Search/SearchRequest.swift
+++ b/OBAKit/Search/SearchRequest.swift
@@ -84,119 +84,114 @@ public class SearchManager: NSObject {
         self.application = application
     }
 
+    // MARK: - Publishing entry point (UIKit)
+
+    /// Performs `request` and publishes the result through `MapRegionManager`, which
+    /// fans out to `MapRegionDelegate`. Error handling deliberately differs per
+    /// search type — that asymmetry is pre-existing behavior the UIKit map depends
+    /// on, not an oversight:
+    ///   - `.address` publishes an error response and shows no alert.
+    ///   - `.stopNumber` shows an alert *and* publishes an error response.
+    ///   - `.route` / `.vehicleID` show an alert only; publishing an empty response
+    ///     would additionally trigger the "No search results were found" alert via
+    ///     `notifyDelegatesNoSearchResults`, double-alerting the user.
     public func search(request: SearchRequest) async {
+        if request.searchType == .vehicleID {
+            ProgressHUD.show()
+        }
+        defer {
+            if request.searchType == .vehicleID {
+                ProgressHUD.dismiss()
+            }
+        }
+
+        do {
+            guard let response = try await fetchResults(for: request) else { return }
+            application.mapRegionManager.searchResponse = response
+        } catch {
+            switch request.searchType {
+            case .address:
+                application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
+            case .stopNumber:
+                await application.displayError(error)
+                application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
+            case .route, .vehicleID:
+                await application.displayError(error)
+            }
+        }
+    }
+
+    // MARK: - Returning entry point (SwiftUI)
+
+    /// Performs `request` and returns the response instead of publishing it.
+    ///
+    /// Returns `nil` when the search could not run at all — no API service, no
+    /// Obaco service, or no map rect — mirroring the `guard … else { return }`
+    /// bail-outs the publishing path has always had.
+    func fetchResults(for request: SearchRequest) async throws -> SearchResponse? {
         switch request.searchType {
-        case .address:    await searchAddress(request: request)
-        case .route:      await searchRoute(request: request)
-        case .stopNumber: searchStopNumber(request: request)
-        case .vehicleID:  await searchVehicleID(request: request)
+        case .address:    return try await fetchAddress(request: request)
+        case .route:      return try await fetchRoute(request: request)
+        case .stopNumber: return try await fetchStopNumber(request: request)
+        case .vehicleID:  return try await fetchVehicleID(request: request)
         }
     }
 
-    private func searchAddress(request: SearchRequest) async {
+    private func fetchAddress(request: SearchRequest) async throws -> SearchResponse? {
         guard
             let apiService = application.apiService,
             let mapRect = application.mapRegionManager.lastVisibleMapRect
-        else {
-            return
-        }
+        else { return nil }
 
-        let searchResponse: SearchResponse
-        do {
-            let results = try await apiService.getPlacemarks(query: request.query, region: MKCoordinateRegion(mapRect))
-            searchResponse = SearchResponse(request: request, results: results.mapItems, boundingRegion: results.boundingRegion, error: nil)
-        } catch {
-            searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-        }
-
-        await MainActor.run {
-            self.application.mapRegionManager.searchResponse = searchResponse
-        }
+        let results = try await apiService.getPlacemarks(query: request.query, region: MKCoordinateRegion(mapRect))
+        return SearchResponse(request: request, results: results.mapItems, boundingRegion: results.boundingRegion, error: nil)
     }
 
-    private func searchRoute(request: SearchRequest) async {
+    private func fetchRoute(request: SearchRequest) async throws -> SearchResponse? {
         guard
             let apiService = application.apiService,
             let mapRect = application.mapRegionManager.lastVisibleMapRect
-        else {
-            return
-        }
+        else { return nil }
 
-        do {
-            let response = try await apiService.getRoute(query: request.query, region: CLCircularRegion(mapRect: mapRect))
-            await MainActor.run {
-                self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
-            }
-        } catch {
-            await self.application.displayError(error)
-        }
+        let response = try await apiService.getRoute(query: request.query, region: CLCircularRegion(mapRect: mapRect))
+        return SearchResponse(request: request, results: response.list, boundingRegion: nil, error: nil)
     }
 
-    private func searchStopNumber(request: SearchRequest) {
-        guard let apiService = application.apiService else {
-            return
-        }
+    private func fetchStopNumber(request: SearchRequest) async throws -> SearchResponse? {
+        guard
+            let apiService = application.apiService,
+            let serviceRect = application.regionsService.currentRegion?.serviceRect
+        else { return nil }
 
-        let region = CLCircularRegion(mapRect: application.regionsService.currentRegion!.serviceRect)
-
-        Task(priority: .userInitiated) {
-            do {
-                let stops = try await apiService.getStops(circularRegion: region, query: request.query).list
-                await MainActor.run {
-                    self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: stops, boundingRegion: nil, error: nil)
-                }
-            } catch {
-                await self.application.displayError(error)
-                await MainActor.run {
-                    self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-                }
-            }
-        }
+        let stops = try await apiService.getStops(circularRegion: CLCircularRegion(mapRect: serviceRect), query: request.query).list
+        return SearchResponse(request: request, results: stops, boundingRegion: nil, error: nil)
     }
 
-    private func searchVehicleID(request: SearchRequest) async {
-        guard let obacoService = application.obacoService else { return }
+    private func fetchVehicleID(request: SearchRequest) async throws -> SearchResponse? {
+        guard let obacoService = application.obacoService else { return nil }
 
-        ProgressHUD.show()
+        let matchingVehicles = try await obacoService.getVehicles(matching: request.query)
 
-        do {
-            let vehicles = try await obacoService.getVehicles(matching: request.query)
-            self.processSearchResults(request: request, matchingVehicles: vehicles)
-        } catch {
-            await self.application.displayError(error)
-        }
-
-        ProgressHUD.dismiss()
-    }
-
-    private func processSearchResults(request: SearchRequest, matchingVehicles: [AgencyVehicle]) {
-        guard let apiService = application.apiService else { return }
+        guard let apiService = application.apiService else { return nil }
 
         if matchingVehicles.count > 1 {
-            // Show a disambiguation UI.
-            application.mapRegionManager.searchResponse = SearchResponse(request: request, results: matchingVehicles, boundingRegion: nil, error: nil)
-            return
+            return SearchResponse(request: request, results: matchingVehicles, boundingRegion: nil, error: nil)
         }
 
-        if matchingVehicles.count == 1, let vehicleID = matchingVehicles.first?.vehicleID {
-            // One result. Find that vehicle and show it.
-            Task(priority: .userInitiated) {
-                do {
-                    let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
-                    await MainActor.run {
-                        self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
-                    }
-                } catch {
-                    await self.application.displayError(error)
-                    await MainActor.run {
-                        self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
-                    }
-                }
+        guard matchingVehicles.count == 1, let vehicleID = matchingVehicles.first?.vehicleID else {
+            return SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        }
 
-            }
-        } else {
-            // No results :(
-            self.application.mapRegionManager.searchResponse = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        do {
+            let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
+            return SearchResponse(request: request, results: [vehicle], boundingRegion: nil, error: nil)
+        } catch {
+            // Preserved from `processSearchResults`: this inner failure alerted and
+            // published an empty error response rather than propagating. Kept as-is
+            // so the UIKit path is unchanged; revisit when the SwiftUI panel is the
+            // only surface.
+            await application.displayError(error)
+            return SearchResponse(request: request, results: [], boundingRegion: nil, error: error)
         }
     }
 }

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -15,13 +15,16 @@ final class SearchViewModel: ObservableObject {
 
     @Published private(set) var vehicleSearchResponse: SearchResponse?
     @Published private(set) var vehicleError: Error?
+    /// The vehicle whose details are being fetched, or `nil` when idle. Published so
+    /// the results sheet can show progress on the tapped row — the UIKit controller
+    /// showed none at all.
+    @Published private(set) var loadingVehicleID: String?
 
     let subtitle: String
     let results: [Any]
 
     private let searchResponse: SearchResponse
     private let apiService: RESTAPIService?
-    private var isLoading = false
 
     convenience init(searchResponse: SearchResponse, application: Application) {
         self.init(searchResponse: searchResponse, apiService: application.apiService)
@@ -39,7 +42,7 @@ final class SearchViewModel: ObservableObject {
     }
 
     func selectVehicle(vehicleID: String) async {
-        guard !isLoading else { return }
+        guard loadingVehicleID == nil else { return }
         guard let apiService else {
             // Misconfiguration (no API service available). Surface it through the same
             // error channel as a request failure so the screen doesn't silently no-op.
@@ -50,10 +53,10 @@ final class SearchViewModel: ObservableObject {
             ))
             return
         }
-        isLoading = true
+        loadingVehicleID = vehicleID
         vehicleError = nil
         vehicleSearchResponse = nil
-        defer { isLoading = false }
+        defer { loadingVehicleID = nil }
         do {
             let vehicle = try await apiService.getVehicle(vehicleID: vehicleID).entry
             vehicleSearchResponse = SearchResponse(response: searchResponse, substituteResult: vehicle)

--- a/OBAKit/Search/SearchViewModel.swift
+++ b/OBAKit/Search/SearchViewModel.swift
@@ -20,6 +20,10 @@ final class SearchViewModel: ObservableObject {
     /// showed none at all.
     @Published private(set) var loadingVehicleID: String?
 
+    /// The vehicle whose lookup produced `vehicleError`, so the inline error row can
+    /// offer a retry rather than dead-ending the user.
+    @Published private(set) var failedVehicleID: String?
+
     let subtitle: String
     let results: [Any]
 
@@ -46,6 +50,7 @@ final class SearchViewModel: ObservableObject {
         guard let apiService else {
             // Misconfiguration (no API service available). Surface it through the same
             // error channel as a request failure so the screen doesn't silently no-op.
+            failedVehicleID = vehicleID
             vehicleError = UnstructuredError(OBALoc(
                 "search_results_controller.no_api_service_error",
                 value: "No transit data service is available. Please choose a region in Settings.",
@@ -55,6 +60,7 @@ final class SearchViewModel: ObservableObject {
         }
         loadingVehicleID = vehicleID
         vehicleError = nil
+        failedVehicleID = nil
         vehicleSearchResponse = nil
         defer { loadingVehicleID = nil }
         do {
@@ -64,9 +70,11 @@ final class SearchViewModel: ObservableObject {
             // VehicleStatus requires `tripId`; its absence means the vehicle isn't on
             // any trip right now. Any *other* missing key signals a real decode failure
             // (renamed field, malformed payload) and should surface as-is.
+            failedVehicleID = vehicleID
             vehicleError = SearchError.noTripsAvailable
         } catch {
             Logger.error("selectVehicle decode failure: \(error)")
+            failedVehicleID = vehicleID
             vehicleError = error
         }
     }

--- a/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
@@ -52,11 +52,16 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
 
         // `.bookmarksDidChange` may be posted off the main actor, so hop rather
         // than assume isolation. This mirrors the pattern in `MapStopsObserver`.
+        //
+        // Scoped to this application's own store rather than `object: nil`:
+        // `UserDefaultsStore` is the only poster and always posts `object: self`,
+        // so narrowing costs nothing in the app and keeps a concurrently-running
+        // test suite's store from driving this model.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(bookmarksDidChange),
             name: .bookmarksDidChange,
-            object: nil
+            object: application.userDataStore
         )
     }
 
@@ -66,17 +71,39 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
 
     /// Re-reads which bookmarks belong on screen and rebuilds the rows.
     ///
-    /// `findBookmarks(in:)` returns raw persisted order — only `bookmarksInGroup`
-    /// sorts — so the sort here is what makes the four shown match the user's
-    /// Manage Bookmarks ordering.
+    /// Every pinned bookmark is shown, then unpinned ones fill up to `limit`.
+    /// `limit` is therefore a *floor* on the section's size, not a cap: pinning
+    /// is the user saying "always keep this one here", so a pin is never squeezed
+    /// out by a newer bookmark. With nothing pinned this is just the `limit`
+    /// most recent.
+    ///
+    /// Within each half, most-recently-created first — a bookmark the user just
+    /// made should be visible. `sortOrder` can't do that job: `UserDataStore.add`
+    /// appends a new bookmark to the end of its group, so ordering by it puts the
+    /// newest one *last*, past the cut. It's also renumbered per group, so its
+    /// values aren't comparable across groups at all. It still breaks ties,
+    /// ascending: bookmarks stored before `dateCreated` existed all decode as
+    /// `.distantPast`, and among those the user's own Manage Bookmarks order is
+    /// the best signal left.
     func refreshSelection() {
-        selection = Array(
-            application.userDataStore
-                .findBookmarks(in: application.currentRegion)
-                .sorted { $0.sortOrder < $1.sortOrder }
-                .prefix(limit)
-        )
+        let all = application.userDataStore
+            .findBookmarks(in: application.currentRegion)
+            .sorted(by: Self.isOrderedBefore)
+
+        let pinned = all.filter(\.isPinned)
+        let unpinned = all.filter { !$0.isPinned }
+
+        selection = pinned + unpinned.prefix(max(0, limit - pinned.count))
         rebuildRows()
+    }
+
+    /// Newest first, with the user's manual order breaking same-date ties.
+    /// `static` so the ordering can be asserted directly in tests.
+    static func isOrderedBefore(_ lhs: Bookmark, _ rhs: Bookmark) -> Bool {
+        if lhs.dateCreated != rhs.dateCreated {
+            return lhs.dateCreated > rhs.dateCreated
+        }
+        return lhs.sortOrder < rhs.sortOrder
     }
 
     // MARK: - Bookmarks
@@ -84,10 +111,14 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
     /// `.bookmarksDidChange` may be posted off the main actor, so hop rather
     /// than assume isolation. Selector-based observation is auto-removed on
     /// dealloc, so no token/deinit needed.
+    ///
+    /// Goes straight to `loadIfNeeded()`, which re-reads the selection itself.
+    /// Calling `refreshSelection()` first would update `selection` *before*
+    /// `loadIfNeeded()` snapshots it, so the newly bookmarked stop would never
+    /// register as a selection change and its arrivals would never be fetched.
     @objc
     private nonisolated func bookmarksDidChange() {
         Task { @MainActor [weak self] in
-            self?.refreshSelection()
             self?.loadIfNeeded()
         }
     }
@@ -115,6 +146,15 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
         lastFetchedRegionID = regionID
         loader.loadData()
         return true
+    }
+
+    /// Flips `bookmark`'s pinned state.
+    ///
+    /// No local refresh: the store posts `.bookmarksDidChange`, which this model
+    /// already observes, so the reorder arrives through the same path as any
+    /// other bookmark edit rather than a second one that could drift from it.
+    func togglePin(_ bookmark: Bookmark) {
+        application.userDataStore.setPinned(!bookmark.isPinned, for: bookmark)
     }
 
     // MARK: - Row Building

--- a/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
@@ -1,0 +1,125 @@
+//
+//  HomeBookmarksSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The home sheet's bookmarks preview: the first few bookmarks by the user's
+/// own ordering, with live arrivals for those few only.
+///
+/// Reuses `BookmarkDataLoader` — the same loader the Bookmarks tab uses — but
+/// scoped to the displayed bookmarks and with auto-refresh off, so this screen
+/// costs at most `limit` requests per activation and installs no polling timer.
+///
+/// Subclasses `NSObject` to adopt `BookmarkDataDelegate`.
+@MainActor
+final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataDelegate {
+
+    @Published private(set) var rows: [BookmarkRowViewModel] = []
+
+    /// The bookmarks a fetch is scoped to. Read by the loader's provider.
+    private(set) var selection: [Bookmark] = []
+
+    private let application: Application
+    private let limit: Int
+    private var loader: BookmarkDataLoader!
+
+    private var lastFetchDate: Date?
+    private var lastFetchedRegionID: Int?
+
+    init(application: Application, limit: Int = HomeSheetSection.itemLimit) {
+        self.application = application
+        self.limit = limit
+        super.init()
+
+        // The provider reads `selection` at fetch time rather than capturing a
+        // snapshot, so `refreshSelection()` before a load is enough to rescope
+        // the next batch.
+        self.loader = BookmarkDataLoader(
+            application: application,
+            delegate: self,
+            bookmarkProvider: { [weak self] in self?.selection ?? [] },
+            autoRefreshes: false
+        )
+
+        refreshSelection()
+    }
+
+    isolated deinit {
+        loader?.cancelUpdates()
+    }
+
+    /// Re-reads which bookmarks belong on screen and rebuilds the rows.
+    ///
+    /// `findBookmarks(in:)` returns raw persisted order — only `bookmarksInGroup`
+    /// sorts — so the sort here is what makes the four shown match the user's
+    /// Manage Bookmarks ordering.
+    func refreshSelection() {
+        selection = Array(
+            application.userDataStore
+                .findBookmarks(in: application.currentRegion)
+                .sorted { $0.sortOrder < $1.sortOrder }
+                .prefix(limit)
+        )
+        rebuildRows()
+    }
+
+    /// Fetches arrivals for the current selection, but only when something has
+    /// actually changed: the data is stale, the region moved, or the displayed
+    /// bookmarks differ. Returns whether a fetch was started.
+    ///
+    /// The sheet system tears sheet content down and rebuilds it without the
+    /// user navigating anywhere, so activation can fire repeatedly per visit —
+    /// this gate is what keeps that from becoming repeated network traffic.
+    @discardableResult
+    func loadIfNeeded(now: Date = Date(), staleAfter: TimeInterval = 30) -> Bool {
+        let previousIDs = selection.map(\.id)
+        refreshSelection()
+
+        let regionID = application.currentRegion?.regionIdentifier
+        let selectionChanged = previousIDs != selection.map(\.id)
+        let regionChanged = regionID != lastFetchedRegionID
+        let isStale = lastFetchDate.map { now.timeIntervalSince($0) > staleAfter } ?? true
+
+        guard selectionChanged || regionChanged || isStale else { return false }
+
+        lastFetchDate = now
+        lastFetchedRegionID = regionID
+        loader.loadData()
+        return true
+    }
+
+    // MARK: - Row Building
+
+    /// Rebuilds the row snapshots from the loader's current arrival data.
+    ///
+    /// `highlightedTripIDs` is always empty: the flash-on-change affordance
+    /// belongs to the polling Bookmarks tab, and nothing polls here.
+    private func rebuildRows() {
+        rows = selection.map { bookmark in
+            BookmarkRowViewModel(
+                bookmark: bookmark,
+                arrivalDepartures: arrivalDepartures(for: bookmark),
+                highlightedTripIDs: [],
+                hasLoadedArrivalData: loader.hasFetchedData(forStopID: bookmark.stopID)
+            )
+        }
+    }
+
+    private func arrivalDepartures(for bookmark: Bookmark) -> [ArrivalDeparture] {
+        guard let key = TripBookmarkKey(bookmark: bookmark) else { return [] }
+        return loader.dataForKey(key)
+    }
+
+    // MARK: - BookmarkDataDelegate
+
+    func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {
+        rebuildRows()
+    }
+}

--- a/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
@@ -28,7 +28,16 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
 
     private let application: Application
     private let limit: Int
-    private var loader: BookmarkDataLoader!
+
+    /// The loader driving this section's arrivals.
+    ///
+    /// Deliberately `internal`, not `private`: nothing in the app reaches it, and
+    /// it exists so `HomeSectionModelTests` can drive a real batch to completion
+    /// and assert what this model does with the outcome — in particular the
+    /// failed-batch retry path below, which can't be observed from the outside
+    /// otherwise. `@testable import` reaches it; the framework's public surface
+    /// doesn't grow for a test.
+    private(set) var loader: BookmarkDataLoader!
 
     private var lastFetchDate: Date?
     private var lastFetchedRegionID: Int?
@@ -163,8 +172,13 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
     ///
     /// `highlightedTripIDs` is always empty: the flash-on-change affordance
     /// belongs to the polling Bookmarks tab, and nothing polls here.
+    ///
+    /// Guarded against a no-op write for the same reason
+    /// `HomeRecentStopsSectionModel.reload()` is: this runs on every activation
+    /// and on every loader update, and `BookmarkRowViewModel` is `Equatable`, so
+    /// an unchanged rebuild can be dropped rather than republished.
     private func rebuildRows() {
-        rows = selection.map { bookmark in
+        let rebuilt = selection.map { bookmark in
             BookmarkRowViewModel(
                 bookmark: bookmark,
                 arrivalDepartures: arrivalDepartures(for: bookmark),
@@ -172,6 +186,8 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
                 hasLoadedArrivalData: loader.hasFetchedData(forStopID: bookmark.stopID)
             )
         }
+        guard rebuilt != rows else { return }
+        rows = rebuilt
     }
 
     private func arrivalDepartures(for bookmark: Bookmark) -> [ArrivalDeparture] {
@@ -183,5 +199,23 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
 
     func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {
         rebuildRows()
+    }
+
+    /// Clears the staleness stamp when a batch finishes having failed, so the
+    /// next activation retries instead of being gated out.
+    ///
+    /// `loadIfNeeded()` stamps `lastFetchDate` *before* the batch resolves — it
+    /// has to, or two activations in the same run loop would both fetch. That
+    /// stamp is only meaningful if the batch succeeded: without this, a failed
+    /// batch left the rows stuck in their "Loading…" state for the rest of the
+    /// staleness window, and this sheet has neither the polling timer nor the
+    /// pull-to-refresh that bail the Bookmarks tab out of the same situation.
+    ///
+    /// `lastFetchedRegionID` is deliberately left alone: `isStale` is enough to
+    /// reopen the gate, and clearing the region too would make the next
+    /// successful fetch look like a region change to any future caller.
+    func dataLoader(_ dataLoader: BookmarkDataLoader, isLoadingChanged isLoading: Bool) {
+        guard !isLoading, dataLoader.lastBatchHadError else { return }
+        lastFetchDate = nil
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift
@@ -49,6 +49,15 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
         )
 
         refreshSelection()
+
+        // `.bookmarksDidChange` may be posted off the main actor, so hop rather
+        // than assume isolation. This mirrors the pattern in `MapStopsObserver`.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(bookmarksDidChange),
+            name: .bookmarksDidChange,
+            object: nil
+        )
     }
 
     isolated deinit {
@@ -68,6 +77,19 @@ final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataD
                 .prefix(limit)
         )
         rebuildRows()
+    }
+
+    // MARK: - Bookmarks
+
+    /// `.bookmarksDidChange` may be posted off the main actor, so hop rather
+    /// than assume isolation. Selector-based observation is auto-removed on
+    /// dealloc, so no token/deinit needed.
+    @objc
+    private nonisolated func bookmarksDidChange() {
+        Task { @MainActor [weak self] in
+            self?.refreshSelection()
+            self?.loadIfNeeded()
+        }
     }
 
     /// Fetches arrivals for the current selection, but only when something has

--- a/OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift
@@ -1,0 +1,55 @@
+//
+//  HomeNearbyStopsSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Combine
+import CoreLocation
+import OBAKitCore
+
+/// The home sheet's nearby-stops preview: the few stops closest to the map's
+/// center.
+///
+/// Reads `MapStopsObserver` rather than subscribing to `MapRegionManager`
+/// itself. The observer is already that manager's subscriber, and a second
+/// delegate would redo the accumulate-and-prune work on every map settle for
+/// the sake of four rows. This costs no network requests at all — it re-slices
+/// stops the map has already loaded.
+@MainActor
+final class HomeNearbyStopsSectionModel: ObservableObject {
+
+    @Published private(set) var stops: [Stop] = []
+
+    private let observer: MapStopsObserver
+    private let limit: Int
+    private var cancellables = Set<AnyCancellable>()
+
+    init(observer: MapStopsObserver, limit: Int = HomeSheetSection.itemLimit) {
+        self.observer = observer
+        self.limit = limit
+
+        observer.$stops
+            .combineLatest(observer.$viewportCenter)
+            .sink { [weak self] stops, center in
+                self?.rebuild(stops: stops, center: center)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// `combineLatest` emits on subscribe, so the initial state is set by the
+    /// sink above rather than duplicated here.
+    private func rebuild(stops: [Stop], center: CLLocationCoordinate2D?) {
+        guard let center else {
+            // No settle yet. The observer's id ordering is arbitrary but stable,
+            // which beats rendering an empty section for the frame or two before
+            // the first camera settle lands.
+            self.stops = Array(stops.prefix(limit))
+            return
+        }
+        self.stops = Stop.nearest(stops, to: center, limit: limit)
+    }
+}

--- a/OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift
@@ -1,0 +1,41 @@
+//
+//  HomeRecentStopsSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The home sheet's recent-stops preview.
+///
+/// Backed entirely by `UserDataStore`, so it costs no network requests. Recents
+/// are already stored most-recently-used first, so there is nothing to sort.
+@MainActor
+final class HomeRecentStopsSectionModel: ObservableObject {
+
+    @Published private(set) var stops: [Stop] = []
+
+    private let application: Application
+    private let limit: Int
+
+    init(application: Application, limit: Int = HomeSheetSection.itemLimit) {
+        self.application = application
+        self.limit = limit
+        reload()
+    }
+
+    /// Re-reads the store. Called on activation and on region change — a
+    /// region switch changes which recents are current, and the store posts no
+    /// notification for it.
+    func reload() {
+        stops = Array(
+            application.userDataStore
+                .recentStops(in: application.currentRegion)
+                .prefix(limit)
+        )
+    }
+}

--- a/OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift
@@ -31,11 +31,18 @@ final class HomeRecentStopsSectionModel: ObservableObject {
     /// Re-reads the store. Called on activation and on region change — a
     /// region switch changes which recents are current, and the store posts no
     /// notification for it.
+    ///
+    /// Guarded against a no-op write: `activate()` runs on every sheet
+    /// re-appearance and the store usually hasn't changed, so an unconditional
+    /// assignment would fire `objectWillChange` — and through the view model's
+    /// forwarding, a whole home-sheet body evaluation — for nothing.
     func reload() {
-        stops = Array(
+        let reloaded = Array(
             application.userDataStore
                 .recentStops(in: application.currentRegion)
                 .prefix(limit)
         )
+        guard reloaded != stops else { return }
+        stops = reloaded
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
@@ -25,7 +25,8 @@ struct HomeSectionHeader: View {
         Button(action: onSeeAll) {
             HStack(spacing: 8) {
                 Text(title)
-                    .font(.headline)
+                    .font(.title2)
+                    .fontWeight(.bold)
                     .foregroundStyle(.primary)
                 Spacer()
                 Image(systemName: "chevron.right")

--- a/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
@@ -32,6 +32,7 @@ struct HomeSectionHeader: View {
                     .font(.footnote)
                     .fontWeight(.semibold)
                     .foregroundStyle(brandColor)
+                    .accessibilityHidden(true)
             }
             .contentShape(.rect)
         }
@@ -42,7 +43,6 @@ struct HomeSectionHeader: View {
             value: "Shows all items in this section.",
             comment: "VoiceOver hint for a home sheet section header, which opens that section's full list."
         ))
-        .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
@@ -27,7 +27,8 @@ struct HomeSectionHeader: View {
                 Text(title)
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundStyle(.primary)
+                    // Use explicit .label color instead of .primary, which would be remapped to secondary by the List's muted treatment
+                    .foregroundStyle(Color(uiColor: .label))
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(.footnote)

--- a/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
@@ -1,0 +1,54 @@
+//
+//  HomeSectionHeader.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// A home sheet section header: title on the left, chevron on the right, the
+/// whole row acting as one button into that section's full index.
+///
+/// One button rather than a label plus a separate chevron button, so the tap
+/// target matches what the row looks like and VoiceOver reads one element.
+struct HomeSectionHeader: View {
+    let title: String
+    let onSeeAll: () -> Void
+
+    private let brandColor = Color(uiColor: ThemeColors.shared.brand)
+
+    var body: some View {
+        Button(action: onSeeAll) {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(brandColor)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityHint(OBALoc(
+            "home_sheet.section_header.a11y_hint",
+            value: "Shows all items in this section.",
+            comment: "VoiceOver hint for a home sheet section header, which opens that section's full list."
+        ))
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+#if DEBUG
+#Preview {
+    HomeSectionHeader(title: "Nearby Stops") { }
+        .padding()
+}
+#endif

--- a/OBAKit/Sheet/Content/Home/HomeSheetSection.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetSection.swift
@@ -1,0 +1,26 @@
+//
+//  HomeSheetSection.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// The home sheet's content sections, in the order they render.
+///
+/// Order is fixed: an empty earlier section is omitted, never replaced by a
+/// later one. Declared as its own type — rather than inline in the view model —
+/// so each section model can reference `itemLimit` without depending on the
+/// view model that composes them.
+enum HomeSheetSection: Hashable {
+    case nearby
+    case recent
+    case bookmarks
+
+    /// How many items each section previews before the header's chevron takes
+    /// over. Defined once so the three sections can't drift apart.
+    static let itemLimit = 4
+}

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -14,6 +14,10 @@ struct HomeSheetView: View {
     @StateObject private var viewModel: HomeSheetViewModel
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
 
+    /// Tracks whether the stacked routes were non-empty on the last observation,
+    /// so we can detect the transition to empty and re-activate.
+    @State private var wasStackedRoutesNonEmpty = false
+
     /// Needed by `SearchListRow.stop(...)` for distance formatting. Passed in
     /// rather than read from the environment: there is no `Application`
     /// environment key in this codebase, and adding one for a single consumer
@@ -48,6 +52,16 @@ struct HomeSheetView: View {
         .ignoresSafeArea(.container, edges: .bottom)
         .task {
             viewModel.activate()
+        }
+        .onChange(of: coordinator.stackedRoutes) { _, routes in
+            // When a stacked sheet is dismissed and the stack transitions to empty,
+            // re-activate the home sheet. This is the moment the user returns to it,
+            // and when a new recent stop may have been added.
+            let isStackedRoutesNonEmpty = !routes.isEmpty
+            if wasStackedRoutesNonEmpty && !isStackedRoutesNonEmpty {
+                viewModel.activate()
+            }
+            wasStackedRoutesNonEmpty = isStackedRoutesNonEmpty
         }
     }
 

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,15 +31,22 @@ struct HomeSheetView: View {
                 .padding(.top, 16)
                 .padding(.bottom, 12)
 
-            if viewModel.visibleSections.isEmpty {
-                emptyState
-            } else {
+            if !viewModel.visibleSections.isEmpty {
                 List {
                     ForEach(viewModel.visibleSections, id: \.self) { section in
                         sectionContent(for: section)
                     }
                 }
+                // Applied to the `List`, matching `BookmarksListView`, rather than
+                // to the bookmarks `Section` alone.
+                .environment(\.obaFormatters, application.formatters)
                 .searchListChrome()
+            } else if viewModel.hasLoadedInitialContent {
+                emptyState
+            } else {
+                // Pre-first-settle: nearby hasn't had its chance yet, so "empty"
+                // isn't a fact. Hold the space rather than flash a wrong answer.
+                Spacer()
             }
         }
         .searchSheetBackground()
@@ -102,7 +109,6 @@ struct HomeSheetView: View {
 
         case .bookmarks:
             bookmarksSection
-                .environment(\.obaFormatters, application.formatters)
         }
     }
 

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -14,18 +14,41 @@ struct HomeSheetView: View {
     @StateObject private var viewModel: HomeSheetViewModel
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
 
-    init(viewModel: @autoclosure @escaping () -> HomeSheetViewModel) {
+    /// Needed by `SearchListRow.stop(...)` for distance formatting. Passed in
+    /// rather than read from the environment: there is no `Application`
+    /// environment key in this codebase, and adding one for a single consumer
+    /// would be a wider change than this task warrants. `obaFormatters` (used by
+    /// the bookmark rows below) does exist, and is injected from here.
+    private let application: Application
+
+    init(
+        application: Application,
+        viewModel: @autoclosure @escaping () -> HomeSheetViewModel
+    ) {
+        self.application = application
         _viewModel = StateObject(wrappedValue: viewModel())
     }
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 20) {
                 searchBarRow
                     .padding(.top, 16)
+
+                if viewModel.visibleSections.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(viewModel.visibleSections, id: \.self) { section in
+                        sectionView(for: section)
+                    }
+                }
             }
+            .padding(.bottom, 24)
         }
         .ignoresSafeArea(.container, edges: .bottom)
+        .task {
+            viewModel.activate()
+        }
     }
 
     // MARK: - Search Bar
@@ -50,4 +73,98 @@ struct HomeSheetView: View {
         .padding(.horizontal, 12)
     }
 
+    // MARK: - Sections
+
+    @ViewBuilder
+    private func sectionView(for section: HomeSheetSection) -> some View {
+        switch section {
+        case .nearby:
+            stopSection(
+                title: Strings.nearbyStops,
+                stops: viewModel.nearby.stops,
+                destination: .nearbyAll,
+                kind: { .nearbyStop(id: $0.id) }
+            )
+        case .recent:
+            stopSection(
+                title: Strings.recentStops,
+                stops: viewModel.recent.stops,
+                destination: .recentStopsAll,
+                kind: { .recentStop(id: $0.id) }
+            )
+        case .bookmarks:
+            bookmarksSection
+        }
+    }
+
+    /// Nearby and Recent render identically — same row builder, same layout —
+    /// and differ only in title, data, destination, and row kind.
+    private func stopSection(
+        title: String,
+        stops: [Stop],
+        destination: AppSheetRoute,
+        kind: @escaping (Stop) -> SearchListRow.Kind
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HomeSectionHeader(title: title) {
+                coordinator.push(destination)
+            }
+            ForEach(stops, id: \.id) { stop in
+                SearchListRowView(
+                    row: SearchListRow.stop(
+                        stop,
+                        application: application,
+                        kind: kind(stop),
+                        onSelect: { coordinator.push(.stopDetails(stopID: stop.id)) }
+                    )
+                )
+            }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private var bookmarksSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HomeSectionHeader(title: Strings.bookmarks) {
+                coordinator.push(.bookmarksAll)
+            }
+            ForEach(viewModel.bookmarks.rows) { row in
+                Group {
+                    if row.isTripBookmark {
+                        BookmarkCardView(row: row)
+                    } else {
+                        StopBookmarkRow(row: row)
+                    }
+                }
+                .contentShape(.rect)
+                .onTapGesture {
+                    coordinator.push(.stopDetails(stopID: row.stopID))
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .environment(\.obaFormatters, application.formatters)
+    }
+
+    /// Shown only when all three sections are empty — a first launch, or a map
+    /// parked at region-level zoom with no saved data. Reuses the nearby
+    /// controller's copy, minus its "Search Wider Area" button: that drives
+    /// `MapRegionManager.preferredLoadDataRegionFudgeFactor` and a timed reset
+    /// the SwiftUI path has no equivalent plumbing for.
+    private var emptyState: some View {
+        EmptyStateView(
+            title: OBALoc(
+                "nearby_controller.empty_set.title",
+                value: "No Nearby Stops",
+                comment: "Title for the empty set indicator on the Nearby controller"
+            ),
+            description: OBALoc(
+                "nearby_controller.empty_set.body",
+                value: "Zoom out or pan around to find some stops.",
+                comment: "Body for the empty set indicator on the Nearby controller."
+            ),
+            systemImage: "mappin.slash"
+        )
+        .padding(.top, 40)
+    }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -26,21 +26,23 @@ struct HomeSheetView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                searchBarRow
-                    .padding(.top, 16)
+        VStack(spacing: 0) {
+            searchBarRow
+                .padding(.top, 16)
+                .padding(.bottom, 12)
 
-                if viewModel.visibleSections.isEmpty {
-                    emptyState
-                } else {
+            if viewModel.visibleSections.isEmpty {
+                emptyState
+            } else {
+                List {
                     ForEach(viewModel.visibleSections, id: \.self) { section in
-                        sectionView(for: section)
+                        sectionContent(for: section)
                     }
                 }
+                .searchListChrome()
             }
-            .padding(.bottom, 24)
         }
+        .searchSheetBackground()
         .ignoresSafeArea(.container, edges: .bottom)
         .task {
             viewModel.activate()
@@ -82,66 +84,59 @@ struct HomeSheetView: View {
     // MARK: - Sections
 
     @ViewBuilder
-    private func sectionView(for section: HomeSheetSection) -> some View {
+    private func sectionContent(for section: HomeSheetSection) -> some View {
         switch section {
         case .nearby:
-            stopSection(
-                title: Strings.nearbyStops,
-                stops: viewModel.nearby.stops,
-                destination: .nearbyAll
-            )
-        case .recent:
-            stopSection(
-                title: Strings.recentStops,
-                stops: viewModel.recent.stops,
-                destination: .recentStopsAll
-            )
-        case .bookmarks:
-            bookmarksSection
-        }
-    }
-
-    /// Nearby and Recent render identically — same row builder, same layout —
-    /// and differ only in title, data, and destination.
-    private func stopSection(
-        title: String,
-        stops: [Stop],
-        destination: AppSheetRoute
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HomeSectionHeader(title: title) {
-                coordinator.push(destination)
-            }
-            ForEach(stops, id: \.id) { stop in
-                HomeStopRow(stop: stop) {
-                    coordinator.push(.stopDetails(stopID: stop.id))
-                }
-            }
-        }
-        .padding(.horizontal, 12)
-    }
-
-    private var bookmarksSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HomeSectionHeader(title: Strings.bookmarks) {
-                coordinator.push(.bookmarksAll)
-            }
-            ForEach(viewModel.bookmarks.rows) { row in
-                Group {
-                    if row.isTripBookmark {
-                        BookmarkCardView(row: row)
-                    } else {
-                        StopBookmarkRow(row: row)
+            Section {
+                ForEach(viewModel.nearby.stops, id: \.id) { stop in
+                    HomeStopRow(stop: stop) {
+                        coordinator.push(.stopDetails(stopID: stop.id))
                     }
                 }
-                .contentShape(.rect)
-                .onTapGesture {
-                    coordinator.push(.stopDetails(stopID: row.stopID))
+            } header: {
+                HomeSectionHeader(title: Strings.nearbyStops) {
+                    coordinator.push(.nearbyAll)
                 }
             }
+            .textCase(nil)
+
+        case .recent:
+            Section {
+                ForEach(viewModel.recent.stops, id: \.id) { stop in
+                    HomeStopRow(stop: stop) {
+                        coordinator.push(.stopDetails(stopID: stop.id))
+                    }
+                }
+            } header: {
+                HomeSectionHeader(title: Strings.recentStops) {
+                    coordinator.push(.recentStopsAll)
+                }
+            }
+            .textCase(nil)
+
+        case .bookmarks:
+            Section {
+                ForEach(viewModel.bookmarks.rows) { row in
+                    Group {
+                        if row.isTripBookmark {
+                            BookmarkCardView(row: row)
+                        } else {
+                            StopBookmarkRow(row: row)
+                        }
+                    }
+                    .contentShape(.rect)
+                    .onTapGesture {
+                        coordinator.push(.stopDetails(stopID: row.stopID))
+                    }
+                }
+            } header: {
+                HomeSectionHeader(title: Strings.bookmarks) {
+                    coordinator.push(.bookmarksAll)
+                }
+            }
+            .textCase(nil)
+            .environment(\.obaFormatters, application.formatters)
         }
-        .padding(.horizontal, 12)
-        .environment(\.obaFormatters, application.formatters)
     }
 
     /// Shown only when all three sections are empty — a first launch, or a map

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -14,10 +14,6 @@ struct HomeSheetView: View {
     @StateObject private var viewModel: HomeSheetViewModel
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
 
-    /// Tracks whether the stacked routes were non-empty on the last observation,
-    /// so we can detect the transition to empty and re-activate.
-    @State private var wasStackedRoutesNonEmpty = false
-
     /// Needed by `SearchListRow.stop(...)` for distance formatting. Passed in
     /// rather than read from the environment: there is no `Application`
     /// environment key in this codebase, and adding one for a single consumer
@@ -53,15 +49,15 @@ struct HomeSheetView: View {
         .task {
             viewModel.activate()
         }
-        .onChange(of: coordinator.stackedRoutes) { _, routes in
-            // When a stacked sheet is dismissed and the stack transitions to empty,
-            // re-activate the home sheet. This is the moment the user returns to it,
-            // and when a new recent stop may have been added.
-            let isStackedRoutesNonEmpty = !routes.isEmpty
-            if wasStackedRoutesNonEmpty && !isStackedRoutesNonEmpty {
+        .onChange(of: coordinator.stackedRoutes) { previousRoutes, routes in
+            // Re-activate when the stacked layer transitions to empty — the moment the
+            // user returns to the home sheet, and when a recent stop may have been added.
+            // Derived from `onChange`'s previous value rather than tracked in `@State`:
+            // the sheet system can rebuild this view's content while a stacked sheet is
+            // open, which would re-seed a stored flag and silently skip the next refresh.
+            if !previousRoutes.isEmpty && routes.isEmpty {
                 viewModel.activate()
             }
-            wasStackedRoutesNonEmpty = isStackedRoutesNonEmpty
         }
     }
 

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -14,11 +14,7 @@ struct HomeSheetView: View {
     @StateObject private var viewModel: HomeSheetViewModel
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
 
-    /// Needed by `SearchListRow.stop(...)` for distance formatting. Passed in
-    /// rather than read from the environment: there is no `Application`
-    /// environment key in this codebase, and adding one for a single consumer
-    /// would be a wider change than this task warrants. `obaFormatters` (used by
-    /// the bookmark rows below) does exist, and is injected from here.
+    /// Used by the bookmark rows to format distances.
     private let application: Application
 
     init(
@@ -92,15 +88,13 @@ struct HomeSheetView: View {
             stopSection(
                 title: Strings.nearbyStops,
                 stops: viewModel.nearby.stops,
-                destination: .nearbyAll,
-                kind: { .nearbyStop(id: $0.id) }
+                destination: .nearbyAll
             )
         case .recent:
             stopSection(
                 title: Strings.recentStops,
                 stops: viewModel.recent.stops,
-                destination: .recentStopsAll,
-                kind: { .recentStop(id: $0.id) }
+                destination: .recentStopsAll
             )
         case .bookmarks:
             bookmarksSection
@@ -108,26 +102,20 @@ struct HomeSheetView: View {
     }
 
     /// Nearby and Recent render identically — same row builder, same layout —
-    /// and differ only in title, data, destination, and row kind.
+    /// and differ only in title, data, and destination.
     private func stopSection(
         title: String,
         stops: [Stop],
-        destination: AppSheetRoute,
-        kind: @escaping (Stop) -> SearchListRow.Kind
+        destination: AppSheetRoute
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HomeSectionHeader(title: title) {
                 coordinator.push(destination)
             }
             ForEach(stops, id: \.id) { stop in
-                SearchListRowView(
-                    row: SearchListRow.stop(
-                        stop,
-                        application: application,
-                        kind: kind(stop),
-                        onSelect: { coordinator.push(.stopDetails(stopID: stop.id)) }
-                    )
-                )
+                HomeStopRow(stop: stop) {
+                    coordinator.push(.stopDetails(stopID: stop.id))
+                }
             }
         }
         .padding(.horizontal, 12)

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -87,74 +87,100 @@ struct HomeSheetView: View {
     private func sectionContent(for section: HomeSheetSection) -> some View {
         switch section {
         case .nearby:
-            Section {
-                ForEach(viewModel.nearby.stops, id: \.id) { stop in
-                    HomeStopRow(stop: stop) {
-                        coordinator.push(.stopDetails(stopID: stop.id))
-                    }
-                }
-            } header: {
-                HomeSectionHeader(title: Strings.nearbyStops) {
-                    coordinator.push(.nearbyAll)
-                }
-            }
-            .textCase(nil)
+            stopSection(
+                stops: viewModel.nearby.stops,
+                title: Strings.nearbyStops,
+                seeAll: .nearbyAll
+            )
 
         case .recent:
-            Section {
-                ForEach(viewModel.recent.stops, id: \.id) { stop in
-                    HomeStopRow(stop: stop) {
-                        coordinator.push(.stopDetails(stopID: stop.id))
-                    }
-                }
-            } header: {
-                HomeSectionHeader(title: Strings.recentStops) {
-                    coordinator.push(.recentStopsAll)
-                }
-            }
-            .textCase(nil)
+            stopSection(
+                stops: viewModel.recent.stops,
+                title: Strings.recentStops,
+                seeAll: .recentStopsAll
+            )
 
         case .bookmarks:
-            Section {
-                ForEach(viewModel.bookmarks.rows) { row in
-                    Group {
-                        if row.isTripBookmark {
-                            BookmarkCardView(row: row)
-                        } else {
-                            StopBookmarkRow(row: row)
-                        }
-                    }
-                    .contentShape(.rect)
-                    .onTapGesture {
-                        coordinator.push(.stopDetails(stopID: row.stopID))
-                    }
-                }
-            } header: {
-                HomeSectionHeader(title: Strings.bookmarks) {
-                    coordinator.push(.bookmarksAll)
-                }
-            }
-            .textCase(nil)
-            .environment(\.obaFormatters, application.formatters)
+            bookmarksSection
+                .environment(\.obaFormatters, application.formatters)
         }
     }
 
-    /// Shown only when all three sections are empty — a first launch, or a map
-    /// parked at region-level zoom with no saved data. Reuses the nearby
-    /// controller's copy, minus its "Search Wider Area" button: that drives
-    /// `MapRegionManager.preferredLoadDataRegionFudgeFactor` and a timed reset
-    /// the SwiftUI path has no equivalent plumbing for.
+    /// The nearby and recent sections: same row and header shape, different
+    /// source and destination.
+    private func stopSection(
+        stops: [Stop],
+        title: String,
+        seeAll: AppSheetRoute
+    ) -> some View {
+        Section {
+            ForEach(stops, id: \.id) { stop in
+                HomeStopRow(stop: stop) {
+                    coordinator.push(.stopDetails(stopID: stop.id))
+                }
+            }
+        } header: {
+            HomeSectionHeader(title: title) {
+                coordinator.push(seeAll)
+            }
+        }
+        .textCase(nil)
+    }
+
+    /// Bookmark rows reuse the Bookmarks tab's cells as-is, so the two surfaces
+    /// can't drift apart visually.
+    private var bookmarksSection: some View {
+        Section {
+            ForEach(viewModel.bookmarks.rows) { row in
+                Group {
+                    if row.isTripBookmark {
+                        BookmarkCardView(row: row)
+                    } else {
+                        StopBookmarkRow(row: row)
+                    }
+                }
+                .contentShape(.rect)
+                .onTapGesture {
+                    coordinator.push(.stopDetails(stopID: row.stopID))
+                }
+                .contextMenu {
+                    // Pinning is reachable from the row it affects, not only from
+                    // the Bookmarks tab — this section is where the result shows.
+                    BookmarkPinButton(isPinned: row.isPinned) {
+                        viewModel.bookmarks.togglePin(row.bookmark)
+                    }
+                }
+            }
+        } header: {
+            HomeSectionHeader(title: Strings.bookmarks) {
+                coordinator.push(.bookmarksAll)
+            }
+        }
+        .textCase(nil)
+    }
+
+    /// Shown only when all three sections are empty at once — a first launch, or
+    /// a map parked at region-level zoom with nothing saved.
+    ///
+    /// Has its own copy rather than reusing the nearby controller's: two of the
+    /// three sections have nothing to do with the map, so "Zoom out or pan around
+    /// to find some stops" would be advice that can't fix what the user is
+    /// actually missing.
+    ///
+    /// Deliberately omits the nearby controller's "Search Wider Area" button: that
+    /// drives `MapRegionManager.preferredLoadDataRegionFudgeFactor` and a timed
+    /// reset the SwiftUI path has no equivalent plumbing for.
     private var emptyState: some View {
         EmptyStateView(
             title: OBALoc(
-                "nearby_controller.empty_set.title",
-                value: "No Nearby Stops",
-                comment: "Title for the empty set indicator on the Nearby controller"
+                "home_sheet.empty_set.title",
+                value: "Nothing Here Yet",
+                comment: "Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks."
             ),
             description: OBALoc(
-                "nearby_controller.empty_set.body",
-                value: "Zoom out or pan around to find some stops.",
-                comment: "Body for the empty set indicator on the Nearby controller."
+                "home_sheet.empty_set.body",
+                value: "Nearby stops, stops you've viewed, and your bookmarks will show up here.",
+                comment: "Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks."
             ),
             systemImage: "mappin.slash"
         )

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -31,32 +31,23 @@ struct HomeSheetView: View {
     // MARK: - Search Bar
 
     private var searchBarRow: some View {
-        // Non-interactive while the `.search` route lacks a real view with a
-        // back affordance — a tap would otherwise animate to the largest detent
-        // and strand the user there (the route is base-layer with
-        // `isDismissDisabled: true`). Rendered as an `HStack` (not a disabled
-        // `Button`) so the shape communicates "not actionable yet" honestly to
-        // both readers and assistive tech — VoiceOver announces it as static
-        // text rather than a disabled button.
-        HStack(spacing: 12) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            Text(OBALoc(
-                "home_sheet.search_bar.coming_soon",
-                value: "Search coming soon",
-                comment: "Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented."
-            ))
-                .foregroundStyle(.secondary)
-            Spacer()
+        Button {
+            coordinator.push(.search)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                Text(viewModel.searchPlaceholder)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background { Capsule().fill(Color(.tertiarySystemFill)) }
+            .contentShape(.capsule)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background {
-            Capsule()
-                .fill(Color(.tertiarySystemFill))
-        }
+        .buttonStyle(.plain)
         .padding(.horizontal, 12)
-        .accessibilityElement(children: .combine)
     }
 
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -17,27 +17,32 @@ import OBAKitCore
 // `@StateObject` + `@autoclosure` plumbing is already in place and the
 // next reader sees the intended shape rather than an unexplained empty type.
 @MainActor
-final class HomeSheetViewModel: ObservableObject {
+final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelegate {
     // TODO: Populate from `RESTAPIService` / `LocationService` once the
     // home sheet renders nearby stops.
     @Published private(set) var nearbyStops: [Stop] = []
+
+    /// Published rather than computed so a region change repaints the search bar.
+    /// The UIKit panel gets this from its own `RegionsServiceDelegate` callback
+    /// (`MapFloatingPanelController.regionsService(_:updatedRegion:)`); a plain
+    /// computed property would leave the placeholder naming the old region until
+    /// something unrelated happened to invalidate the view.
+    @Published private(set) var searchPlaceholder: String
 
     private let application: Application
 
     init(application: Application) {
         self.application = application
+        self.searchPlaceholder = SearchPlaceholder.text(for: application)
+        super.init()
+
+        // `RegionsService` holds delegates weakly, so there's nothing to unregister.
+        application.regionsService.addDelegate(self)
     }
 
-    /// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
-    var searchPlaceholder: String {
-        guard let region = application.regionsService.currentRegion else { return "" }
-        if application.features.tripPlanning == .running {
-            return OBALoc(
-                "map_floating_panel.where_are_you_going",
-                value: "Where are you going?",
-                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
-            )
-        }
-        return Formatters.searchPlaceholderText(region: region)
+    // MARK: - RegionsServiceDelegate
+
+    func regionsService(_ service: RegionsService, updatedRegion region: Region) {
+        searchPlaceholder = SearchPlaceholder.text(for: application)
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -21,4 +21,23 @@ final class HomeSheetViewModel: ObservableObject {
     // TODO: Populate from `RESTAPIService` / `LocationService` once the
     // home sheet renders nearby stops.
     @Published private(set) var nearbyStops: [Stop] = []
+
+    private let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    /// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
+    var searchPlaceholder: String {
+        guard let region = application.regionsService.currentRegion else { return "" }
+        if application.features.tripPlanning == .running {
+            return OBALoc(
+                "map_floating_panel.where_are_you_going",
+                value: "Where are you going?",
+                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
+            )
+        }
+        return Formatters.searchPlaceholderText(region: region)
+    }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -36,6 +36,16 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
     /// sections are dropped entirely — header included.
     @Published private(set) var visibleSections: [HomeSheetSection] = []
 
+    /// Whether the sheet knows enough to say the three sections are genuinely
+    /// empty. False until the map's first camera settle.
+    ///
+    /// Recents and bookmarks are read from the store synchronously in the
+    /// section models' initializers, so they're already accurate at first body
+    /// evaluation. Nearby isn't: it's empty until the map settles. Without this
+    /// gate, a cold open with nothing saved paints "Nothing Here Yet" for a frame
+    /// or two before the nearby stops arrive and replace it.
+    @Published private(set) var hasLoadedInitialContent = false
+
     private let application: Application
     private var cancellables = Set<AnyCancellable>()
 
@@ -72,6 +82,16 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
         .sink { [weak self] _ in self?.objectWillChange.send() }
         .store(in: &cancellables)
 
+        // Latched in the observer, so this fires at most once with `true` — and
+        // fires immediately with `true` when the sheet is rebuilt against an
+        // observer that has already settled.
+        stopsObserver.$hasSettledOnce
+            .sink { [weak self] hasSettled in
+                guard let self, hasSettled, !self.hasLoadedInitialContent else { return }
+                self.hasLoadedInitialContent = true
+            }
+            .store(in: &cancellables)
+
         // Recompute the visible set whenever any child's content changes. The
         // children publish values, not the section list, so this is the single
         // place the order and the omission rule live.
@@ -89,8 +109,10 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
 
     /// Called when the sheet's content appears. Idempotent: the sheet system
     /// tears content down and rebuilds it without the user navigating anywhere,
-    /// so this can fire several times per visit. The store reads are cheap and
-    /// unconditional; only the bookmark fetch is gated.
+    /// so this can fire several times per visit. Every step here is a no-op when
+    /// nothing changed: the store reads are cheap and their results are only
+    /// published when they differ, and the bookmark fetch is gated on staleness,
+    /// region, and selection.
     func activate() {
         recent.reload()
         bookmarks.loadIfNeeded()

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -7,20 +7,23 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import Combine
 import MapKit
 import OBAKitCore
 
 // MARK: - HomeSheetViewModel
 
-// Owns the home sheet's reactive content state. Empty today beyond a stub
-// for the nearby-stops snapshot — kept here so `HomeSheetView`'s
-// `@StateObject` + `@autoclosure` plumbing is already in place and the
-// next reader sees the intended shape rather than an unexplained empty type.
+/// Owns the home sheet's reactive content state: the search bar's placeholder
+/// and the three preview sections.
+///
+/// Composes three child section models rather than talking to the data sources
+/// itself, so each section's rules stay separately readable and testable.
 @MainActor
 final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelegate {
-    // TODO: Populate from `RESTAPIService` / `LocationService` once the
-    // home sheet renders nearby stops.
-    @Published private(set) var nearbyStops: [Stop] = []
+
+    let nearby: HomeNearbyStopsSectionModel
+    let recent: HomeRecentStopsSectionModel
+    let bookmarks: HomeBookmarksSectionModel
 
     /// Published rather than computed so a region change repaints the search bar.
     /// The UIKit panel gets this from its own `RegionsServiceDelegate` callback
@@ -29,20 +32,64 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
     /// something unrelated happened to invalidate the view.
     @Published private(set) var searchPlaceholder: String
 
-    private let application: Application
+    /// Sections that currently have something to show, in render order. Empty
+    /// sections are dropped entirely — header included.
+    @Published private(set) var visibleSections: [HomeSheetSection] = []
 
-    init(application: Application) {
+    private let application: Application
+    private var cancellables = Set<AnyCancellable>()
+
+    init(application: Application, stopsObserver: MapStopsObserver) {
         self.application = application
         self.searchPlaceholder = SearchPlaceholder.text(for: application)
+        self.nearby = HomeNearbyStopsSectionModel(observer: stopsObserver)
+        self.recent = HomeRecentStopsSectionModel(application: application)
+        self.bookmarks = HomeBookmarksSectionModel(application: application)
         super.init()
 
         // `RegionsService` holds delegates weakly, so there's nothing to unregister.
         application.regionsService.addDelegate(self)
+
+        // Recompute the visible set whenever any child's content changes. The
+        // children publish values, not the section list, so this is the single
+        // place the order and the omission rule live.
+        nearby.$stops
+            .combineLatest(recent.$stops, bookmarks.$rows)
+            .sink { [weak self] nearbyStops, recentStops, bookmarkRows in
+                self?.updateVisibleSections(
+                    hasNearby: !nearbyStops.isEmpty,
+                    hasRecent: !recentStops.isEmpty,
+                    hasBookmarks: !bookmarkRows.isEmpty
+                )
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Called when the sheet's content appears. Idempotent: the sheet system
+    /// tears content down and rebuilds it without the user navigating anywhere,
+    /// so this can fire several times per visit. The store reads are cheap and
+    /// unconditional; only the bookmark fetch is gated.
+    func activate() {
+        recent.reload()
+        bookmarks.loadIfNeeded()
+    }
+
+    private func updateVisibleSections(hasNearby: Bool, hasRecent: Bool, hasBookmarks: Bool) {
+        var sections: [HomeSheetSection] = []
+        if hasNearby { sections.append(.nearby) }
+        if hasRecent { sections.append(.recent) }
+        if hasBookmarks { sections.append(.bookmarks) }
+        guard sections != visibleSections else { return }
+        visibleSections = sections
     }
 
     // MARK: - RegionsServiceDelegate
 
     func regionsService(_ service: RegionsService, updatedRegion region: Region) {
         searchPlaceholder = SearchPlaceholder.text(for: application)
+        // Which recents and bookmarks are "current" changed, and neither store
+        // posts a notification for it.
+        recent.reload()
+        bookmarks.loadIfNeeded()
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -50,6 +50,28 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
         // `RegionsService` holds delegates weakly, so there's nothing to unregister.
         application.regionsService.addDelegate(self)
 
+        // Republish the children's changes as our own.
+        //
+        // `HomeSheetView` is handed this object and reads section content through
+        // it (`viewModel.recent.stops`). SwiftUI subscribes to the object a view
+        // is given and never to nested `ObservableObject`s reached through it, so
+        // without this a child's `@Published` write updates the model and leaves
+        // the sheet rendering stale rows. `visibleSections` below can't stand in
+        // for it: it's guarded against no-op writes, so a stop viewed while the
+        // Recent section is already on screen would publish nothing at all.
+        //
+        // Forwarding `objectWillChange` rather than the specific publishers used
+        // below so a `@Published` added to a section model later is covered
+        // automatically. Delivery is synchronous on the child's `willSet`, which
+        // is the timing SwiftUI wants.
+        Publishers.MergeMany(
+            nearby.objectWillChange,
+            recent.objectWillChange,
+            bookmarks.objectWillChange
+        )
+        .sink { [weak self] _ in self?.objectWillChange.send() }
+        .store(in: &cancellables)
+
         // Recompute the visible set whenever any child's content changes. The
         // children publish values, not the section list, so this is the single
         // place the order and the omission rule live.

--- a/OBAKit/Sheet/Content/Home/HomeStopRow.swift
+++ b/OBAKit/Sheet/Content/Home/HomeStopRow.swift
@@ -21,8 +21,13 @@ struct HomeStopRow: View {
 
     private let brandColor = Color(uiColor: ThemeColors.shared.brand)
 
+    /// Name, direction, routes, and stop ID — the same label the map pins use.
+    ///
+    /// Not `stop.name` joined with `stop.subtitle`: `subtitle` comes from `Stop`'s
+    /// `MKAnnotation` conformance and embeds a newline between the stop code and
+    /// the route list, which VoiceOver reads verbatim.
     private var accessibilityLabelText: String {
-        [stop.name, stop.subtitle].compactMap { $0 }.joined(separator: ", ")
+        Formatters.formattedAccessibilityLabel(stop: stop)
     }
 
     var body: some View {

--- a/OBAKit/Sheet/Content/Home/HomeStopRow.swift
+++ b/OBAKit/Sheet/Content/Home/HomeStopRow.swift
@@ -1,0 +1,63 @@
+//
+//  HomeStopRow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// A stop row for the home sheet's nearby and recent sections.
+///
+/// Mirrors the UIKit `StopRowItem` appearance: untinted squircle transport icon,
+/// stop name in title3 bold, subtitle in body, and a trailing chevron.
+struct HomeStopRow: View {
+    let stop: Stop
+    let onSelect: () -> Void
+
+    private let brandColor = Color(uiColor: ThemeColors.shared.brand)
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 12) {
+                // Untinted squircle icon, matching StopRowItem exactly
+                Image(uiImage: Icons.squircleTransportIcon(for: stop.prioritizedRouteTypeForDisplay))
+                    .frame(width: Icons.squircleIconSize, height: Icons.squircleIconSize)
+
+                // Title and subtitle stack
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(stop.name)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    if let subtitle = stop.subtitle {
+                        Text(subtitle)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                // Trailing chevron
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(brandColor)
+                    .accessibilityHidden(true)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement()
+        .accessibilityLabel(stop.name)
+        .accessibilityHint(stop.subtitle ?? "")
+        .accessibilityAddTraits(.isButton)
+    }
+}

--- a/OBAKit/Sheet/Content/Home/HomeStopRow.swift
+++ b/OBAKit/Sheet/Content/Home/HomeStopRow.swift
@@ -20,6 +20,10 @@ struct HomeStopRow: View {
 
     private let brandColor = Color(uiColor: ThemeColors.shared.brand)
 
+    private var accessibilityLabelText: String {
+        [stop.name, stop.subtitle].compactMap { $0 }.joined(separator: ", ")
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 12) {
@@ -33,13 +37,13 @@ struct HomeStopRow: View {
                         .font(.title3)
                         .fontWeight(.bold)
                         .foregroundStyle(.primary)
-                        .lineLimit(1)
+                        .lineLimit(2)
 
                     if let subtitle = stop.subtitle {
                         Text(subtitle)
                             .font(.body)
                             .foregroundStyle(.primary)
-                            .lineLimit(1)
+                            .lineLimit(2)
                     }
                 }
 
@@ -56,8 +60,7 @@ struct HomeStopRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement()
-        .accessibilityLabel(stop.name)
-        .accessibilityHint(stop.subtitle ?? "")
+        .accessibilityLabel(accessibilityLabelText)
         .accessibilityAddTraits(.isButton)
     }
 }

--- a/OBAKit/Sheet/Content/Home/HomeStopRow.swift
+++ b/OBAKit/Sheet/Content/Home/HomeStopRow.swift
@@ -12,8 +12,9 @@ import OBAKitCore
 
 /// A stop row for the home sheet's nearby and recent sections.
 ///
-/// Mirrors the UIKit `StopRowItem` appearance: untinted squircle transport icon,
-/// stop name in title3 bold, subtitle in body, and a trailing chevron.
+/// Uses headline heavy for stop name and footnote secondary for subtitle,
+/// matching the bookmark card rows. Includes an untinted squircle transport icon
+/// and a trailing chevron.
 struct HomeStopRow: View {
     let stop: Stop
     let onSelect: () -> Void
@@ -34,15 +35,14 @@ struct HomeStopRow: View {
                 // Title and subtitle stack
                 VStack(alignment: .leading, spacing: 0) {
                     Text(stop.name)
-                        .font(.title3)
-                        .fontWeight(.bold)
+                        .font(.headline.weight(.heavy))
                         .foregroundStyle(.primary)
                         .lineLimit(2)
 
                     if let subtitle = stop.subtitle {
                         Text(subtitle)
-                            .font(.body)
-                            .foregroundStyle(.primary)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
                             .lineLimit(2)
                     }
                 }

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -17,10 +17,13 @@ import OBAKitCore
 /// Wraps the shared `MapItemView` with sheet-native actions: Close pops the stacked
 /// sheet, Nearby Stops pushes its own route, and the website opens in a local Safari
 /// sheet rather than being presented from a view controller.
+///
+/// The searched place marker is drawn by `MapPanelRootView`, which drops it when this
+/// route leaves the sheet stack — the sheet doesn't clear the map itself. See
+/// `MapSearchDisplayModel.owner`.
 struct MapItemSheetView: View {
     let application: Application
     let mapItem: MKMapItem
-    let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
@@ -67,10 +70,6 @@ struct MapItemSheetView: View {
                 planTripHandler: nil
             )
         }
-        // The searched place marker belongs to this sheet. Pushing `.nearbyStops`
-        // from a row *stacks* over this sheet rather than dismissing it, so this
-        // only fires on a real exit.
-        .onDisappear { displayModel.clear() }
         .sheet(item: $website) { link in
             SafariSheetView(url: link.url)
         }

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -1,0 +1,72 @@
+//
+//  MapItemSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// `AppSheetRoute.mapItem` — the place-detail card, at the medium detent so the map
+/// stays visible behind it.
+///
+/// Wraps the shared `MapItemView` with sheet-native actions: Close pops the stacked
+/// sheet, Nearby Stops pushes its own route, and the website opens in a local Safari
+/// sheet rather than being presented from a view controller.
+struct MapItemSheetView: View {
+    let application: Application
+    let mapItem: MKMapItem
+
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var websiteURL: URL?
+    @State private var viewModel: MapItemViewModel?
+
+    var body: some View {
+        Group {
+            if let viewModel {
+                VStack(spacing: 0) {
+                    MapItemView(viewModel: viewModel, showsShareButton: false)
+                }
+                .overlay(alignment: .topTrailing) {
+                    if let shareURL = viewModel.shareURL {
+                        ShareLink(item: shareURL)
+                            .labelStyle(.iconOnly)
+                            .padding()
+                    }
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .onAppear {
+            guard viewModel == nil else { return }
+            viewModel = MapItemViewModel(
+                mapItem: mapItem,
+                application: application,
+                actions: MapItemActions(
+                    openWebsite: { websiteURL = $0 },
+                    showNearbyStops: { coordinator.push(.nearbyStops(coordinate: $0)) },
+                    dismiss: { dismiss() }
+                ),
+                removePinHandler: nil,
+                // Trip planning has no SwiftUI route yet: the button renders for
+                // layout parity and does nothing. Wire this up when the trip
+                // planner lands on this surface.
+                planTripHandler: { }
+            )
+        }
+        .sheet(item: $websiteURL) { url in
+            SafariSheetView(url: url)
+        }
+    }
+}
+
+extension URL: @retroactive Identifiable {
+    public var id: String { absoluteString }
+}

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -20,53 +20,69 @@ import OBAKitCore
 struct MapItemSheetView: View {
     let application: Application
     let mapItem: MKMapItem
+    let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
 
-    @State private var websiteURL: URL?
+    @State private var website: WebsiteLink?
     @State private var viewModel: MapItemViewModel?
 
     var body: some View {
         Group {
             if let viewModel {
-                VStack(spacing: 0) {
-                    MapItemView(viewModel: viewModel, showsShareButton: false)
-                }
-                .overlay(alignment: .topTrailing) {
-                    if let shareURL = viewModel.shareURL {
-                        ShareLink(item: shareURL)
-                            .labelStyle(.iconOnly)
-                            .padding()
+                MapItemView(viewModel: viewModel, showsShareButton: false)
+                    // Top-*leading*, matching where `MapItemView` puts Share in the
+                    // UIKit host. `.topTrailing` would land on top of that view's
+                    // own Close button and swallow its taps.
+                    .overlay(alignment: .topLeading) {
+                        if let shareURL = viewModel.shareURL {
+                            ShareLink(item: shareURL)
+                                .labelStyle(.iconOnly)
+                                .padding()
+                        }
                     }
-                }
             } else {
                 Color.clear
             }
         }
+        // Built here rather than in `init`: `MapItemViewModel.init` kicks off a Look
+        // Around scene request, and `@State`'s initial value would be re-evaluated on
+        // every body pass of the sheet container — one network request per detent
+        // drag frame.
         .onAppear {
             guard viewModel == nil else { return }
             viewModel = MapItemViewModel(
                 mapItem: mapItem,
                 application: application,
                 actions: MapItemActions(
-                    openWebsite: { websiteURL = $0 },
+                    openWebsite: { website = WebsiteLink(url: $0) },
                     showNearbyStops: { coordinator.push(.nearbyStops(coordinate: $0)) },
                     dismiss: { dismiss() }
                 ),
                 removePinHandler: nil,
-                // Trip planning has no SwiftUI route yet: the button renders for
-                // layout parity and does nothing. Wire this up when the trip
-                // planner lands on this surface.
-                planTripHandler: { }
+                // No trip-planner route on this surface yet. `nil` hides the button
+                // rather than rendering one that does nothing; wire it up when the
+                // trip planner lands here.
+                planTripHandler: nil
             )
         }
-        .sheet(item: $websiteURL) { url in
-            SafariSheetView(url: url)
+        // The searched place marker belongs to this sheet. Pushing `.nearbyStops`
+        // from a row *stacks* over this sheet rather than dismissing it, so this
+        // only fires on a real exit.
+        .onDisappear { displayModel.clear() }
+        .sheet(item: $website) { link in
+            SafariSheetView(url: link.url)
         }
     }
 }
 
-extension URL: @retroactive Identifiable {
-    public var id: String { absoluteString }
+/// `.sheet(item:)` needs an `Identifiable` payload. A local wrapper rather than a
+/// retroactive `Identifiable` conformance on `URL` — protocol conformances aren't
+/// access-controlled, so conforming a Foundation type here would make it OBAKit's
+/// answer for every consumer of the framework and collide with any other module
+/// (or a future Foundation version) that declares the same thing.
+private struct WebsiteLink: Identifiable {
+    let url: URL
+    var id: String { url.absoluteString }
 }

--- a/OBAKit/Sheet/Content/Search/NearbyStopsSheetHost.swift
+++ b/OBAKit/Sheet/Content/Search/NearbyStopsSheetHost.swift
@@ -1,0 +1,43 @@
+//
+//  NearbyStopsSheetHost.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import UIKit
+import MapKit
+import OBAKitCore
+
+/// UIKit wiring wrapper for `AppSheetRoute.nearbyStops`, mirroring
+/// `StopDetailSheetHost`. Replace with a native list when one exists.
+struct NearbyStopsSheetHost: UIViewControllerRepresentable {
+    let application: Application
+    let coordinate: CLLocationCoordinate2D
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let dismiss = context.environment.dismiss
+        return Self.makeNavigationController(application: application, coordinate: coordinate, onClose: { dismiss() })
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+
+    /// Factory seam mirroring `StopDetailSheetHost`, so tests can drive the wiring
+    /// without a `UIHostingController`.
+    static func makeNavigationController(
+        application: Application,
+        coordinate: CLLocationCoordinate2D,
+        onClose: @escaping () -> Void
+    ) -> UINavigationController {
+        let controller = NearbyStopsViewController(coordinate: coordinate, application: application)
+        let closeButton = UIBarButtonItem(primaryAction: UIAction(title: Strings.close) { _ in onClose() })
+        for state: UIControl.State in [.normal, .highlighted] {
+            closeButton.setTitleTextAttributes([.foregroundColor: UIColor.label], for: state)
+        }
+        controller.navigationItem.leftBarButtonItem = closeButton
+        return UINavigationController(rootViewController: controller)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -56,6 +56,44 @@ struct RouteStopsSheetView: View {
 
     var body: some View {
         NavigationStack {
+            content
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        VStack(spacing: 0) {
+                            Text(stopsForRoute.route?.shortName ?? "")
+                                .font(.headline)
+                            if let subtitle = routeSubtitle {
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { dismiss() }
+                    }
+                }
+        }
+        .searchSheetBackground()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if rows.isEmpty {
+            // `RouteStopsRow.rows(from:)` yields nothing for an unresolved payload.
+            // Say so, rather than showing a blank list the user can only read as a
+            // broken screen — the same treatment `SearchResultsSheetView` gives its
+            // empty case.
+            EmptyStateView(
+                title: OBALoc(
+                    "route_stops_sheet.empty.title",
+                    value: "No stops",
+                    comment: "Title shown when a route's stop list could not be loaded or is empty."
+                ),
+                systemImage: AppSymbol.error
+            )
+        } else {
             List(rows) { row in
                 Button {
                     // Keep the map in step with the list — something the UIKit
@@ -83,25 +121,7 @@ struct RouteStopsSheetView: View {
                 .buttonStyle(.plain)
             }
             .searchListChrome()
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    VStack(spacing: 0) {
-                        Text(stopsForRoute.route?.shortName ?? "")
-                            .font(.headline)
-                        if let subtitle = routeSubtitle {
-                            Text(subtitle)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(Strings.close) { dismiss() }
-                }
-            }
         }
-        .searchSheetBackground()
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -1,0 +1,104 @@
+//
+//  RouteStopsSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// One row of the route-stops list. A plain value so the mapping — including the
+/// direction formatting and the unresolved-stops case — is testable without a view.
+struct RouteStopsRow: Identifiable {
+    let stopID: Stop.ID
+    let title: String
+    let subtitle: String
+    let coordinate: CLLocationCoordinate2D
+
+    var id: Stop.ID { stopID }
+
+    /// `StopsForRoute.stops` is an implicitly-unwrapped optional filled in by
+    /// `HasReferences`; an unresolved payload yields no rows rather than a crash.
+    static func rows(from stopsForRoute: StopsForRoute) -> [RouteStopsRow] {
+        (stopsForRoute.stops ?? []).map { stop in
+            RouteStopsRow(
+                stopID: stop.id,
+                title: stop.name,
+                subtitle: Formatters.adjectiveFormOfCardinalDirection(stop.direction) ?? "",
+                coordinate: stop.coordinate
+            )
+        }
+    }
+}
+
+/// `AppSheetRoute.routeStops` — the stop list for a searched route, opening at the
+/// medium detent so the polyline stays on screen. Native replacement for
+/// `RouteStopsViewController`.
+struct RouteStopsSheetView: View {
+    let stopsForRoute: StopsForRoute
+    let displayModel: MapSearchDisplayModel
+
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    private var rows: [RouteStopsRow] { RouteStopsRow.rows(from: stopsForRoute) }
+
+    var body: some View {
+        NavigationStack {
+            List(rows) { row in
+                Button {
+                    // Keep the map in step with the list — something the UIKit
+                    // controller can't do, since it has no handle on the map.
+                    displayModel.focus(coordinate: row.coordinate)
+                    coordinator.push(.stopDetails(stopID: row.stopID))
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.title)
+                            if !row.subtitle.isEmpty {
+                                Text(row.subtitle)
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color(uiColor: ThemeColors.shared.brand))
+                    }
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+            .navigationTitle(stopsForRoute.route?.shortName ?? "")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    VStack(spacing: 0) {
+                        Text(stopsForRoute.route?.shortName ?? "")
+                            .font(.headline)
+                        if let subtitle = routeSubtitle {
+                            Text(subtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(Strings.close) { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var routeSubtitle: String? {
+        guard let route = stopsForRoute.route else { return nil }
+        return route.longName ?? route.agency.name
+    }
+}

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -76,7 +76,6 @@ struct RouteStopsSheetView: View {
                 .buttonStyle(.plain)
             }
             .listStyle(.plain)
-            .navigationTitle(stopsForRoute.route?.shortName ?? "")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -95,6 +94,12 @@ struct RouteStopsSheetView: View {
                 }
             }
         }
+        // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
+        // also gates the ambient stop layer, so leaving it set after the sheet goes
+        // away would strand the map with a dismissed route drawn on it and no stop
+        // pins at all. Pushing `.stopDetails` from a row *stacks* over this sheet
+        // rather than dismissing it, so this only fires on a real exit.
+        .onDisappear { displayModel.clear() }
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -75,7 +75,7 @@ struct RouteStopsSheetView: View {
                 }
                 .buttonStyle(.plain)
             }
-            .listStyle(.plain)
+            .searchListChrome()
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -94,6 +94,7 @@ struct RouteStopsSheetView: View {
                 }
             }
         }
+        .searchSheetBackground()
         // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
         // also gates the ambient stop layer, so leaving it set after the sheet goes
         // away would strand the map with a dismissed route drawn on it and no stop

--- a/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/RouteStopsSheetView.swift
@@ -38,8 +38,15 @@ struct RouteStopsRow: Identifiable {
 /// `AppSheetRoute.routeStops` — the stop list for a searched route, opening at the
 /// medium detent so the polyline stays on screen. Native replacement for
 /// `RouteStopsViewController`.
+///
+/// The polyline itself is drawn by `MapPanelRootView` and dropped when this route
+/// leaves the sheet stack — the sheet doesn't clear the map on its own way out. See
+/// `MapSearchDisplayModel.owner`.
 struct RouteStopsSheetView: View {
     let stopsForRoute: StopsForRoute
+
+    /// Only used to pan the map alongside the list; the drawn route's lifetime is
+    /// not this view's business.
     let displayModel: MapSearchDisplayModel
 
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
@@ -95,12 +102,6 @@ struct RouteStopsSheetView: View {
             }
         }
         .searchSheetBackground()
-        // The route polyline belongs to this sheet. `MapSearchDisplayModel.display`
-        // also gates the ambient stop layer, so leaving it set after the sheet goes
-        // away would strand the map with a dismissed route drawn on it and no stop
-        // pins at all. Pushing `.stopDetails` from a row *stacks* over this sheet
-        // rather than dismissing it, so this only fires on a real exit.
-        .onDisappear { displayModel.clear() }
     }
 
     private var routeSubtitle: String? {

--- a/OBAKit/Sheet/Content/Search/SafariSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SafariSheetView.swift
@@ -1,0 +1,23 @@
+//
+//  SafariSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import SafariServices
+
+/// In-app browser for SwiftUI sheets, matching the UIKit path's
+/// `SFSafariViewController` presentation.
+struct SafariSheetView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) { }
+}

--- a/OBAKit/Sheet/Content/Search/SearchPlaceholder.swift
+++ b/OBAKit/Sheet/Content/Search/SearchPlaceholder.swift
@@ -1,0 +1,35 @@
+//
+//  SearchPlaceholder.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The search field's placeholder copy, shared by the home sheet's search bar and
+/// the search sheet's field so the text doesn't change when the user taps through.
+///
+/// Mirrors `MapFloatingPanelController.updateSearchBarPlaceholderText()`.
+enum SearchPlaceholder {
+
+    /// Empty when no region is selected, matching the UIKit panel, which sets the
+    /// search bar's placeholder to `nil` in that case.
+    @MainActor
+    static func text(for application: Application) -> String {
+        guard let region = application.regionsService.currentRegion else { return "" }
+
+        if application.features.tripPlanning == .running {
+            return OBALoc(
+                "map_floating_panel.where_are_you_going",
+                value: "Where are you going?",
+                comment: "Search bar placeholder on the map floating panel when the trip planner is enabled."
+            )
+        }
+
+        return Formatters.searchPlaceholderText(region: region)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -1,0 +1,109 @@
+//
+//  SearchResultRouter.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Turns a single search result into a map display plus a sheet route.
+///
+/// Shared by `SearchSheetViewModel` (single-result searches) and
+/// `SearchResultsSheetView` (a row picked out of a disambiguation list), so the two
+/// can't drift on what "opening a result" means.
+///
+/// The UIKit equivalent is split across `MapRegionManager.searchResponse.didSet` and
+/// `MapViewController.mapRegionManager(_:showSearchResult:)`.
+@MainActor
+final class SearchResultRouter {
+
+    private let application: Application
+    private let coordinator: SheetCoordinator<AppSheetRoute>
+    private let displayModel: MapSearchDisplayModel
+    private let onPresentVehicleTrip: (VehicleStatus) -> Void
+
+    /// Set when resolving a result fails, so the presenting screen can render the
+    /// failure inline instead of popping a modal over the sheet.
+    private(set) var lastError: Error?
+
+    init(
+        application: Application,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        displayModel: MapSearchDisplayModel,
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void
+    ) {
+        self.application = application
+        self.coordinator = coordinator
+        self.displayModel = displayModel
+        self.onPresentVehicleTrip = onPresentVehicleTrip
+    }
+
+    /// Routes `response` when it holds exactly one result. Returns `false` when it
+    /// doesn't, leaving the decision (disambiguate, or report no results) to the
+    /// caller.
+    func presentSingleResult(from response: SearchResponse) async -> Bool {
+        guard response.results.count == 1, let result = response.results.first else {
+            return false
+        }
+        await present(result: result)
+        return true
+    }
+
+    func present(result: Any) async {
+        lastError = nil
+
+        switch result {
+        case let stop as Stop:
+            displayModel.show(stop: stop)
+            coordinator.push(.stopDetails(stopID: stop.id))
+
+        case let mapItem as MKMapItem:
+            // Matches the UIKit rule: only animate the recenter for nearby
+            // destinations, so a cross-region jump doesn't fly the camera across
+            // the map.
+            let animated = isWithinAnimationRange(mapItem.placemark.coordinate)
+            displayModel.show(mapItem: mapItem, animated: animated)
+            coordinator.push(.mapItem(mapItem))
+
+        case let route as Route:
+            await presentRoute(route)
+
+        case let stopsForRoute as StopsForRoute:
+            displayModel.show(stopsForRoute: stopsForRoute)
+            coordinator.push(.routeStops(stopsForRoute))
+
+        case let vehicle as VehicleStatus:
+            onPresentVehicleTrip(vehicle)
+
+        default:
+            Logger.error("SearchResultRouter: unhandled result type \(type(of: result))")
+        }
+    }
+
+    /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
+    /// and stop list — before anything can be drawn or listed.
+    private func presentRoute(_ route: Route) async {
+        guard let apiService = application.apiService else { return }
+
+        do {
+            let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry
+            displayModel.show(stopsForRoute: stopsForRoute)
+            coordinator.push(.routeStops(stopsForRoute))
+        } catch {
+            Logger.error("SearchResultRouter: failed to load stops for route \(route.id): \(error)")
+            lastError = error
+        }
+    }
+
+    private static let animationDistanceThreshold: CLLocationDistance = 1609 // roughly a mile
+
+    private func isWithinAnimationRange(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        guard let currentLocation = application.locationService.currentLocation else { return false }
+        return coordinate.distance(from: currentLocation.coordinate) <= Self.animationDistanceThreshold
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -43,67 +43,112 @@ final class SearchResultRouter {
         self.onPresentVehicleTrip = onPresentVehicleTrip
     }
 
-    /// Routes `response` when it holds exactly one result. Returns `false` when it
-    /// doesn't, leaving the decision (disambiguate, or report no results) to the
-    /// caller.
-    func presentSingleResult(from response: SearchResponse) async -> Bool {
-        guard response.results.count == 1, let result = response.results.first else {
-            return false
-        }
-        await present(result: result)
-        return true
+    /// A search result that has been resolved into everything needed to show it, with
+    /// any network work already done.
+    ///
+    /// Separating this from `present(_:)` lets a caller finish the slow part while its
+    /// own screen is still up — so a failure can be reported where the user is looking,
+    /// and the sheet stack isn't torn down around an in-flight request.
+    enum Resolved {
+        case stop(Stop)
+        case mapItem(MKMapItem, animated: Bool)
+        case route(StopsForRoute)
+        /// Handed to the trip bridge rather than a sheet, so it has no sheet route.
+        case vehicle(VehicleStatus)
     }
 
-    func present(result: Any) async {
+    /// Resolves the single result in `response`. Returns `nil` when the response holds
+    /// anything other than exactly one result, leaving that decision (disambiguate, or
+    /// report no results) to the caller.
+    func resolveSingleResult(from response: SearchResponse) async -> Resolved? {
+        guard response.results.count == 1, let result = response.results.first else {
+            return nil
+        }
+        return await resolve(result: result)
+    }
+
+    /// Turns a raw search result into a `Resolved`, performing whatever network work
+    /// the result needs. Records `lastError` and returns `nil` when it can't be
+    /// resolved. Touches neither the map nor the sheet stack.
+    func resolve(result: Any) async -> Resolved? {
         lastError = nil
 
         switch result {
         case let stop as Stop:
-            displayModel.show(stop: stop)
-            coordinator.push(.stopDetails(stopID: stop.id))
+            return .stop(stop)
 
         case let mapItem as MKMapItem:
             // Matches the UIKit rule: only animate the recenter for nearby
             // destinations, so a cross-region jump doesn't fly the camera across
             // the map.
-            let animated = isWithinAnimationRange(mapItem.placemark.coordinate)
-            displayModel.show(mapItem: mapItem, animated: animated)
-            coordinator.push(.mapItem(mapItem))
+            return .mapItem(mapItem, animated: isWithinAnimationRange(mapItem.placemark.coordinate))
 
         case let route as Route:
-            await presentRoute(route)
+            return await resolveRoute(route)
 
         case let stopsForRoute as StopsForRoute:
-            displayModel.show(stopsForRoute: stopsForRoute)
-            coordinator.push(.routeStops(stopsForRoute))
+            return .route(stopsForRoute)
 
         case let vehicle as VehicleStatus:
-            onPresentVehicleTrip(vehicle)
+            return .vehicle(vehicle)
 
         default:
             Logger.error("SearchResultRouter: unhandled result type \(type(of: result))")
+            return nil
         }
+    }
+
+    /// Draws the result and opens its sheet in one synchronous step, so the stacked
+    /// layer never sits empty between the two.
+    ///
+    /// Each display is handed the same route value that gets pushed: the display lives
+    /// exactly as long as its sheet route is on the stack, so the two must not drift.
+    func present(_ resolved: Resolved) {
+        switch resolved {
+        case .stop(let stop):
+            let route = AppSheetRoute.stopDetails(stopID: stop.id)
+            displayModel.show(stop: stop, owner: route)
+            coordinator.push(route)
+
+        case .mapItem(let mapItem, let animated):
+            let route = AppSheetRoute.mapItem(mapItem)
+            displayModel.show(mapItem: mapItem, animated: animated, owner: route)
+            coordinator.push(route)
+
+        case .route(let stopsForRoute):
+            let route = AppSheetRoute.routeStops(stopsForRoute)
+            displayModel.show(stopsForRoute: stopsForRoute, owner: route)
+            coordinator.push(route)
+
+        case .vehicle(let vehicle):
+            onPresentVehicleTrip(vehicle)
+        }
+    }
+
+    /// Resolve-and-present for callers with nothing to unwind first.
+    func present(result: Any) async {
+        guard let resolved = await resolve(result: result) else { return }
+        present(resolved)
     }
 
     /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
     /// and stop list — before anything can be drawn or listed.
-    private func presentRoute(_ route: Route) async {
+    private func resolveRoute(_ route: Route) async -> Resolved? {
         guard let apiService = application.apiService else {
             // Every other failure here records `lastError` so the presenting screen
             // can say something. Returning silently would leave the caller reading
             // "succeeded, nothing happened" and the tapped row doing nothing.
             Logger.error("SearchResultRouter: no API service; cannot resolve route \(route.id).")
             lastError = APIError.noRegionSelected
-            return
+            return nil
         }
 
         do {
-            let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry
-            displayModel.show(stopsForRoute: stopsForRoute)
-            coordinator.push(.routeStops(stopsForRoute))
+            return .route(try await apiService.getStopsForRoute(routeID: route.id).entry)
         } catch {
             Logger.error("SearchResultRouter: failed to load stops for route \(route.id): \(error)")
             lastError = error
+            return nil
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRouter.swift
@@ -88,7 +88,14 @@ final class SearchResultRouter {
     /// A `Route` carries no geometry. Resolve it into `StopsForRoute` — the polyline
     /// and stop list — before anything can be drawn or listed.
     private func presentRoute(_ route: Route) async {
-        guard let apiService = application.apiService else { return }
+        guard let apiService = application.apiService else {
+            // Every other failure here records `lastError` so the presenting screen
+            // can say something. Returning silently would leave the caller reading
+            // "succeeded, nothing happened" and the tapped row doing nothing.
+            Logger.error("SearchResultRouter: no API service; cannot resolve route \(route.id).")
+            lastError = APIError.noRegionSelected
+            return
+        }
 
         do {
             let stopsForRoute = try await apiService.getStopsForRoute(routeID: route.id).entry

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -1,0 +1,83 @@
+//
+//  SearchResultRow.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Builds `SearchListRow`s for disambiguation results, so the results sheet renders
+/// through the same row view as the search list above it.
+enum SearchResultRow {
+
+    static func row(for result: Any, application: Application, onSelect: @escaping () -> Void) -> SearchListRow? {
+        switch result {
+        case let stop as Stop:
+            return SearchListRow(
+                kind: .recentStop,
+                title: stop.name,
+                subtitle: stopSubtitle(application, stop),
+                icon: .uiImage(Icons.stop),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let route as Route:
+            return SearchListRow(
+                kind: .quickSearch(.route),
+                title: route.shortName,
+                subtitle: route.longName ?? route.agency.name,
+                icon: .uiImage(Icons.route),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let mapItem as MKMapItem:
+            guard let title = mapItem.name ?? mapItem.placemark.title, !title.isEmpty else { return nil }
+            return SearchListRow(
+                kind: .placemark(mapItem),
+                title: title,
+                subtitle: SearchListRow.subtitleForMapItem(application, mapItem),
+                icon: SearchListRow.systemImageForMapItem(mapItem),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        case let vehicle as AgencyVehicle:
+            guard let vehicleID = vehicle.vehicleID else { return nil }
+            return SearchListRow(
+                kind: .quickSearch(.vehicleID),
+                title: vehicleID,
+                subtitle: vehicle.agencyName,
+                icon: .uiImage(Icons.busTransport),
+                accessory: .disclosureIndicator,
+                action: onSelect
+            )
+
+        default:
+            return nil
+        }
+    }
+
+    /// Direction plus distance from the user, mirroring what the placemark rows in
+    /// the search list already show. Distance is dropped when there's no fix.
+    private static func stopSubtitle(_ application: Application, _ stop: Stop) -> String? {
+        var parts: [String] = []
+
+        if let currentLocation = application.locationService.currentLocation {
+            let distance = currentLocation.distance(from: CLLocation(latitude: stop.coordinate.latitude, longitude: stop.coordinate.longitude))
+            parts.append(application.formatters.distanceFormatter.string(fromDistance: distance))
+        }
+
+        if let direction = Formatters.adjectiveFormOfCardinalDirection(stop.direction), !direction.isEmpty {
+            parts.append(direction)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " • ")
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -90,13 +90,11 @@ enum SearchResultRow {
     static func row(for result: Any, application: Application, onSelect: @escaping () -> Void) -> SearchListRow? {
         switch result {
         case let stop as Stop:
-            return SearchListRow(
+            return SearchListRow.stop(
+                stop,
+                application: application,
                 kind: .searchResult(id: stop.id),
-                title: stop.name,
-                subtitle: stopSubtitle(application, stop),
-                icon: .uiImage(Icons.stop),
-                accessory: .disclosureIndicator,
-                action: onSelect
+                onSelect: onSelect
             )
 
         case let route as Route:
@@ -136,20 +134,4 @@ enum SearchResultRow {
         }
     }
 
-    /// Direction plus distance from the user, mirroring what the placemark rows in
-    /// the search list already show. Distance is dropped when there's no fix.
-    private static func stopSubtitle(_ application: Application, _ stop: Stop) -> String? {
-        var parts: [String] = []
-
-        if let currentLocation = application.locationService.currentLocation {
-            let distance = currentLocation.distance(from: CLLocation(latitude: stop.coordinate.latitude, longitude: stop.coordinate.longitude))
-            parts.append(application.formatters.distanceFormatter.string(fromDistance: distance))
-        }
-
-        if let direction = Formatters.adjectiveFormOfCardinalDirection(stop.direction), !direction.isEmpty {
-            parts.append(direction)
-        }
-
-        return parts.isEmpty ? nil : parts.joined(separator: " • ")
-    }
 }

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -19,7 +19,7 @@ enum SearchResultRow {
         switch result {
         case let stop as Stop:
             return SearchListRow(
-                kind: .recentStop,
+                kind: .searchResult(id: stop.id),
                 title: stop.name,
                 subtitle: stopSubtitle(application, stop),
                 icon: .uiImage(Icons.stop),
@@ -29,7 +29,7 @@ enum SearchResultRow {
 
         case let route as Route:
             return SearchListRow(
-                kind: .quickSearch(.route),
+                kind: .searchResult(id: route.id),
                 title: route.shortName,
                 subtitle: route.longName ?? route.agency.name,
                 icon: .uiImage(Icons.route),
@@ -51,7 +51,7 @@ enum SearchResultRow {
         case let vehicle as AgencyVehicle:
             guard let vehicleID = vehicle.vehicleID else { return nil }
             return SearchListRow(
-                kind: .quickSearch(.vehicleID),
+                kind: .searchResult(id: vehicleID),
                 title: vehicleID,
                 subtitle: vehicle.agencyName,
                 icon: .uiImage(Icons.busTransport),

--- a/OBAKit/Sheet/Content/Search/SearchResultRow.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultRow.swift
@@ -15,6 +15,78 @@ import OBAKitCore
 /// through the same row view as the search list above it.
 enum SearchResultRow {
 
+    /// The whole disambiguation list, including the in-place progress swap for a
+    /// vehicle whose details are being fetched. A static function rather than a
+    /// computed property on the view so the mapping can be asserted without a view
+    /// host — the same shape `RouteStopsRow.rows(from:)` uses.
+    static func rows(
+        for results: [Any],
+        loadingVehicleID: String?,
+        application: Application,
+        onSelectVehicle: @escaping (String) -> Void,
+        onSelect: @escaping (Any) -> Void
+    ) -> [SearchListRow] {
+        results.compactMap { result in
+            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
+                // Vehicles need a second request before they can be routed, so the
+                // row shows progress in place instead of navigating immediately.
+                if loadingVehicleID == vehicleID {
+                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
+                }
+                return row(for: result, application: application) { onSelectVehicle(vehicleID) }
+            }
+
+            return row(for: result, application: application) { onSelect(result) }
+        }
+    }
+
+    /// The one inline error row the results sheet shows, from either of the two things
+    /// that can fail there: looking a vehicle's details up, or resolving any other
+    /// tapped row. A failed resolve used to be dropped on the floor, which left the
+    /// tapped row doing nothing at all with no explanation.
+    ///
+    /// Rendered inline rather than as a modal alert: the sheet is already the user's
+    /// context, and a bulletin over it hides what failed. `SearchListRowView.errorRow`
+    /// shows a retry badge and enables the row only when there's an action, so a
+    /// failure the user can re-attempt isn't a dead end.
+    ///
+    /// Static, and taking the state rather than reading it, so the choice of which
+    /// failure wins and whether a retry is offered is assertable without a view host.
+    static func inlineErrorRow(
+        vehicleError: Error?,
+        failedVehicleID: String?,
+        selectionError: Error?,
+        failedResult: Any?,
+        onRetryVehicle: @escaping (String) -> Void,
+        onRetrySelect: @escaping (Any) -> Void
+    ) -> SearchListRow? {
+        if let vehicleError {
+            return errorRow(
+                message: vehicleError.localizedDescription,
+                retry: failedVehicleID.map { vehicleID in { onRetryVehicle(vehicleID) } }
+            )
+        }
+
+        if let selectionError {
+            return errorRow(
+                message: selectionError.localizedDescription,
+                retry: failedResult.map { result in { onRetrySelect(result) } }
+            )
+        }
+
+        return nil
+    }
+
+    private static func errorRow(message: String, retry: (() -> Void)?) -> SearchListRow {
+        SearchListRow(
+            kind: .error(message, systemImage: AppSymbol.error),
+            title: message,
+            subtitle: Strings.retry,
+            icon: .system(AppSymbol.error),
+            action: retry
+        )
+    }
+
     static func row(for result: Any, application: Application, onSelect: @escaping () -> Void) -> SearchListRow? {
         switch result {
         case let stop as Stop:

--- a/OBAKit/Sheet/Content/Search/SearchResultsSelection.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSelection.swift
@@ -1,0 +1,71 @@
+//
+//  SearchResultsSelection.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Opening a row picked out of a disambiguation list, plus whatever failure that
+/// left behind.
+///
+/// A separate object rather than `@State` on `SearchResultsSheetView` so the two
+/// things worth pinning — the resolve/unwind/present ordering, and the fact that a
+/// failed resolve is reported instead of dropped — can be asserted without a view
+/// host. `SearchSheetViewModel` plays the same role for the search sheet.
+@MainActor
+final class SearchResultsSelection: ObservableObject {
+
+    /// Set when `select(_:coordinator:)` could not resolve a result, so the sheet can
+    /// render the failure inline rather than leaving the tapped row doing nothing.
+    @Published private(set) var error: Error?
+
+    /// The result the failure belongs to, kept so the inline error row can offer a
+    /// retry instead of dead-ending the user.
+    @Published private(set) var failedResult: Any?
+
+    private let router: SearchResultRouter
+
+    init(router: SearchResultRouter) {
+        self.router = router
+    }
+
+    /// Unwinds back to home and opens `result` — the SwiftUI equivalent of the UIKit
+    /// path's `exitSearchMode()`.
+    ///
+    /// Resolution comes first so the results sheet stays up while the request runs: a
+    /// failure leaves the user on their results rather than dropping them on home, and
+    /// the stacked layer isn't emptied and refilled around a network call.
+    ///
+    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
+    /// (the stacked results sheet and the `.search` route beneath it), and `pop()` acts
+    /// on whichever layer is topmost *at the moment it runs* — racing the SwiftUI
+    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
+    /// deterministically in one step.
+    func select(_ result: Any, coordinator: SheetCoordinator<AppSheetRoute>) async {
+        error = nil
+        failedResult = nil
+
+        guard let resolved = await router.resolve(result: result) else {
+            // `router.lastError` is nil only for a result type `resolve` doesn't
+            // handle, which is a programming error rather than anything the user did
+            // — but the row still has to say *something*, or tapping it is a no-op.
+            error = router.lastError ?? UnstructuredError(Self.unresolvableText)
+            failedResult = result
+            return
+        }
+
+        coordinator.popToRoot()
+        router.present(resolved)
+    }
+
+    static let unresolvableText = OBALoc(
+        "search_results_sheet.unresolvable_result",
+        value: "This search result could not be opened.",
+        comment: "Error shown when a tapped search result cannot be turned into something to display."
+    )
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -42,6 +42,7 @@ struct SearchResultsSheetView: View {
                     }
                 }
         }
+        .searchSheetBackground()
         .onChange(of: viewModel.vehicleSearchResponse) { _, response in
             guard let result = response?.results.first else { return }
             Task { await select(result) }
@@ -91,7 +92,7 @@ struct SearchResultsSheetView: View {
                     }
                 }
             }
-            .listStyle(.insetGrouped)
+            .searchListChrome()
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -124,8 +124,12 @@ struct SearchResultsSheetView: View {
         }
     }
 
-    /// Unwinds back to home before opening the result — the SwiftUI equivalent of
-    /// the UIKit path's `exitSearchMode()`.
+    /// Unwinds back to home and opens the result — the SwiftUI equivalent of the UIKit
+    /// path's `exitSearchMode()`.
+    ///
+    /// Resolution comes first so this sheet stays up while the request runs: a failure
+    /// leaves the user on their results rather than dropping them on home, and the
+    /// stacked layer isn't emptied and refilled around a network call.
     ///
     /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
     /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
@@ -133,7 +137,8 @@ struct SearchResultsSheetView: View {
     /// binding write that `dismiss()` triggers. `popToRoot()` clears both
     /// deterministically in one step.
     private func select(_ result: Any) async {
+        guard let resolved = await router.resolve(result: result) else { return }
         coordinator.popToRoot()
-        await router.present(result: result)
+        router.present(resolved)
     }
 }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -1,0 +1,131 @@
+//
+//  SearchResultsSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// `AppSheetRoute.searchResults` — disambiguation for a search that matched several
+/// things. Native replacement for `SearchResultsController`, on the stacked layer so
+/// the search sheet stays alive beneath with its query intact.
+struct SearchResultsSheetView: View {
+    let application: Application
+    let router: SearchResultRouter
+
+    @StateObject private var viewModel: SearchViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+    @Environment(\.dismiss) private var dismiss
+
+    init(application: Application, response: SearchResponse, router: SearchResultRouter) {
+        self.application = application
+        self.router = router
+        _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(OBALoc(
+                    "search_results_controller.title",
+                    value: "Search Results",
+                    comment: "The title of the Search Results controller."
+                )))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { dismiss() }
+                    }
+                }
+        }
+        .onChange(of: viewModel.vehicleSearchResponse) { _, response in
+            guard let result = response?.results.first else { return }
+            Task { await select(result) }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.results.isEmpty {
+            EmptyStateView(
+                title: OBALoc(
+                    "search_results_sheet.empty.title",
+                    value: "No results",
+                    comment: "Title shown when a disambiguation sheet has no results to show."
+                ),
+                systemImage: AppSymbol.error
+            )
+        } else {
+            List {
+                Section {
+                    ForEach(rows) { row in
+                        SearchListRowView(row: row)
+                    }
+                } header: {
+                    // "12 results · Route 44" — the count is the enhancement over
+                    // `SearchResultsController`, which showed the subtitle alone.
+                    Text("\(resultCountText) · \(viewModel.subtitle)")
+                        .font(.headline)
+                }
+
+                if let error = viewModel.vehicleError {
+                    // Inline rather than a modal alert: the sheet is already the
+                    // user's context, and a bulletin over it hides what failed.
+                    Section {
+                        SearchListRowView(row: SearchListRow(
+                            kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
+                            title: error.localizedDescription,
+                            icon: .system("exclamationmark.triangle")
+                        ))
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+    }
+
+    private var resultCountText: String {
+        let format = OBALoc(
+            "search_results_sheet.result_count_fmt",
+            value: "%d results",
+            comment: "Header showing how many results a search matched, e.g. '12 results'."
+        )
+        return String(format: format, viewModel.results.count)
+    }
+
+    private var rows: [SearchListRow] {
+        viewModel.results.compactMap { result in
+            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
+                // Vehicles need a second request before they can be routed, so the
+                // row shows progress in place instead of navigating immediately.
+                if viewModel.loadingVehicleID == vehicleID {
+                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
+                }
+                return SearchResultRow.row(for: result, application: application) {
+                    Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+                }
+            }
+
+            return SearchResultRow.row(for: result, application: application) {
+                Task { await select(result) }
+            }
+        }
+    }
+
+    /// Unwinds back to home before opening the result — the SwiftUI equivalent of
+    /// the UIKit path's `exitSearchMode()`.
+    ///
+    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
+    /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
+    /// whichever layer is topmost *at the moment it runs* — racing the SwiftUI
+    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
+    /// deterministically in one step.
+    private func select(_ result: Any) async {
+        coordinator.popToRoot()
+        await router.present(result: result)
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -18,6 +18,7 @@ struct SearchResultsSheetView: View {
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
+    @StateObject private var selection: SearchResultsSelection
     @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
 
@@ -25,6 +26,7 @@ struct SearchResultsSheetView: View {
         self.application = application
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
+        _selection = StateObject(wrappedValue: SearchResultsSelection(router: router))
     }
 
     var body: some View {
@@ -73,27 +75,29 @@ struct SearchResultsSheetView: View {
                         .font(.headline)
                 }
 
-                if let error = viewModel.vehicleError {
-                    // Inline rather than a modal alert: the sheet is already the
-                    // user's context, and a bulletin over it hides what failed.
+                if let errorRow {
                     Section {
-                        SearchListRowView(row: SearchListRow(
-                            kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
-                            title: error.localizedDescription,
-                            subtitle: Strings.retry,
-                            icon: .system("exclamationmark.triangle"),
-                            // `SearchListRowView.errorRow` renders a retry badge and
-                            // enables the row only when there's an action, so a
-                            // failure the user can re-attempt isn't a dead end.
-                            action: viewModel.failedVehicleID.map { vehicleID in
-                                { Task { await viewModel.selectVehicle(vehicleID: vehicleID) } }
-                            }
-                        ))
+                        SearchListRowView(row: errorRow)
                     }
                 }
             }
             .searchListChrome()
         }
+    }
+
+    private var errorRow: SearchListRow? {
+        SearchResultRow.inlineErrorRow(
+            vehicleError: viewModel.vehicleError,
+            failedVehicleID: viewModel.failedVehicleID,
+            selectionError: selection.error,
+            failedResult: selection.failedResult,
+            onRetryVehicle: { vehicleID in
+                Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+            },
+            onRetrySelect: { result in
+                Task { await select(result) }
+            }
+        )
     }
 
     private var resultCountText: String {
@@ -102,43 +106,28 @@ struct SearchResultsSheetView: View {
             value: "%d results",
             comment: "Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."
         )
-        return String(format: format, viewModel.results.count)
+        // `localizedStringWithFormat`, not `String(format:)`: the latter expands
+        // `%#@count@` but always resolves it against the root plural rule, so the
+        // `few`/`many`/`zero`/`two` forms in the ar, pl, and ru entries could never
+        // be selected. Invisible in English; wrong everywhere with more than two.
+        return String.localizedStringWithFormat(format, viewModel.results.count)
     }
 
     private var rows: [SearchListRow] {
-        viewModel.results.compactMap { result in
-            if let vehicle = result as? AgencyVehicle, let vehicleID = vehicle.vehicleID {
-                // Vehicles need a second request before they can be routed, so the
-                // row shows progress in place instead of navigating immediately.
-                if viewModel.loadingVehicleID == vehicleID {
-                    return SearchListRow(kind: .loading, title: vehicleID, icon: .system("bus"))
-                }
-                return SearchResultRow.row(for: result, application: application) {
-                    Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
-                }
-            }
-
-            return SearchResultRow.row(for: result, application: application) {
+        SearchResultRow.rows(
+            for: viewModel.results,
+            loadingVehicleID: viewModel.loadingVehicleID,
+            application: application,
+            onSelectVehicle: { vehicleID in
+                Task { await viewModel.selectVehicle(vehicleID: vehicleID) }
+            },
+            onSelect: { result in
                 Task { await select(result) }
             }
-        }
+        )
     }
 
-    /// Unwinds back to home and opens the result — the SwiftUI equivalent of the UIKit
-    /// path's `exitSearchMode()`.
-    ///
-    /// Resolution comes first so this sheet stays up while the request runs: a failure
-    /// leaves the user on their results rather than dropping them on home, and the
-    /// stacked layer isn't emptied and refilled around a network call.
-    ///
-    /// `popToRoot()` rather than `dismiss()` + `pop()`: two layers have to come off
-    /// (this stacked sheet and the `.search` route beneath it), and `pop()` acts on
-    /// whichever layer is topmost *at the moment it runs* — racing the SwiftUI
-    /// binding write that `dismiss()` triggers. `popToRoot()` clears both
-    /// deterministically in one step.
     private func select(_ result: Any) async {
-        guard let resolved = await router.resolve(result: result) else { return }
-        coordinator.popToRoot()
-        router.present(resolved)
+        await selection.select(result, coordinator: coordinator)
     }
 }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -15,6 +15,7 @@ import OBAKitCore
 /// the search sheet stays alive beneath with its query intact.
 struct SearchResultsSheetView: View {
     let application: Application
+    let response: SearchResponse
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
@@ -23,6 +24,7 @@ struct SearchResultsSheetView: View {
 
     init(application: Application, response: SearchResponse, router: SearchResultRouter) {
         self.application = application
+        self.response = response
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
     }

--- a/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchResultsSheetView.swift
@@ -15,7 +15,6 @@ import OBAKitCore
 /// the search sheet stays alive beneath with its query intact.
 struct SearchResultsSheetView: View {
     let application: Application
-    let response: SearchResponse
     let router: SearchResultRouter
 
     @StateObject private var viewModel: SearchViewModel
@@ -24,7 +23,6 @@ struct SearchResultsSheetView: View {
 
     init(application: Application, response: SearchResponse, router: SearchResultRouter) {
         self.application = application
-        self.response = response
         self.router = router
         _viewModel = StateObject(wrappedValue: SearchViewModel(searchResponse: response, application: application))
     }
@@ -81,7 +79,14 @@ struct SearchResultsSheetView: View {
                         SearchListRowView(row: SearchListRow(
                             kind: .error(error.localizedDescription, systemImage: "exclamationmark.triangle"),
                             title: error.localizedDescription,
-                            icon: .system("exclamationmark.triangle")
+                            subtitle: Strings.retry,
+                            icon: .system("exclamationmark.triangle"),
+                            // `SearchListRowView.errorRow` renders a retry badge and
+                            // enables the row only when there's an action, so a
+                            // failure the user can re-attempt isn't a dead end.
+                            action: viewModel.failedVehicleID.map { vehicleID in
+                                { Task { await viewModel.selectVehicle(vehicleID: vehicleID) } }
+                            }
                         ))
                     }
                 }
@@ -94,7 +99,7 @@ struct SearchResultsSheetView: View {
         let format = OBALoc(
             "search_results_sheet.result_count_fmt",
             value: "%d results",
-            comment: "Header showing how many results a search matched, e.g. '12 results'."
+            comment: "Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."
         )
         return String(format: format, viewModel.results.count)
     }

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -42,6 +42,14 @@ struct SearchSheetView: View {
         .onAppear {
             viewModel.reportSearchOpened()
             isFieldFocused = true
+            // `onDisappear` dismisses the HUD, and the sheet system rebuilds a sheet's
+            // content view without the user going anywhere — see
+            // `MapSearchDisplayModel.owner`. `isSearching` doesn't change across that
+            // rebuild, so `onChange` won't fire and the HUD has to be restored here or
+            // an in-flight search runs with nothing on screen.
+            if viewModel.isSearching {
+                ProgressHUD.show()
+            }
         }
         // The app-wide HUD rather than a spinner of our own: it centres itself over
         // everything, which is what the rest of the app does for an in-flight

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -1,0 +1,115 @@
+//
+//  SearchSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// `AppSheetRoute.search` — search in the same base sheet as home, with a Close
+/// button back to the home sections.
+struct SearchSheetView: View {
+    @StateObject private var viewModel: SearchSheetViewModel
+    @FocusState private var isFieldFocused: Bool
+
+    let placeholder: String
+
+    init(viewModel: @autoclosure @escaping () -> SearchSheetViewModel, placeholder: String) {
+        _viewModel = StateObject(wrappedValue: viewModel())
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            statusBanner
+            SearchListView(searchInteractor: viewModel.searchInteractor)
+        }
+        .onAppear {
+            viewModel.reportSearchOpened()
+            isFieldFocused = true
+        }
+        .alert(
+            Strings.clearRecentSearchesConfirmation,
+            isPresented: $viewModel.isConfirmingClearRecents
+        ) {
+            Button(Strings.cancel, role: .cancel) { }
+            Button(Strings.delete, role: .destructive) {
+                viewModel.confirmClearRecentSearches()
+            }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(placeholder, text: Binding(
+                    get: { viewModel.query },
+                    set: { viewModel.updateQuery($0) }
+                ))
+                .focused($isFieldFocused)
+                .submitLabel(.search)
+                .autocorrectionDisabled()
+                // Matches UIKit, where the search bar's search button is unhandled:
+                // Return just dismisses the keyboard; the quick-search rows are the
+                // way to run a search.
+                .onSubmit { isFieldFocused = false }
+
+                if !viewModel.query.isEmpty {
+                    Button {
+                        viewModel.updateQuery("")
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityLabel(OBALoc(
+                        "search_sheet.clear_query",
+                        value: "Clear",
+                        comment: "Accessibility label for the button that clears the search query."
+                    ))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background { Capsule().fill(Color(.tertiarySystemFill)) }
+
+            Button(Strings.close) {
+                isFieldFocused = false
+                viewModel.close()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 16)
+    }
+
+    @ViewBuilder
+    private var statusBanner: some View {
+        if viewModel.isSearching {
+            ProgressView()
+                .padding(.top, 12)
+        } else if let errorMessage = viewModel.errorMessage {
+            Label(errorMessage, systemImage: "exclamationmark.triangle")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.top, 12)
+        } else if viewModel.showsNoResults {
+            Label(
+                OBALoc(
+                    "map_controller.no_search_results_found",
+                    value: "No search results were found.",
+                    comment: "A generic message shown when the user's search query produces no search results."
+                ),
+                systemImage: "magnifyingglass"
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.top, 12)
+        }
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetView.swift
@@ -23,15 +23,46 @@ struct SearchSheetView: View {
         self.placeholder = placeholder
     }
 
+    /// Mirrors `AlertPresenter.show(errorMessage:)`, which the UIKit map uses for
+    /// both search failures and the no-results case: `Strings.error` as the title,
+    /// the message as the body, one dismiss button.
+    private var messageAlert: Binding<Bool> {
+        Binding(
+            get: { viewModel.message != nil },
+            set: { if !$0 { viewModel.dismissMessage() } }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             searchField
-            statusBanner
             SearchListView(searchInteractor: viewModel.searchInteractor)
         }
+        .searchSheetBackground()
         .onAppear {
             viewModel.reportSearchOpened()
             isFieldFocused = true
+        }
+        // The app-wide HUD rather than a spinner of our own: it centres itself over
+        // everything, which is what the rest of the app does for an in-flight
+        // request, and it's already what `SearchManager` shows on the UIKit path.
+        .onChange(of: viewModel.isSearching) { _, isSearching in
+            if isSearching {
+                ProgressHUD.show()
+            } else {
+                ProgressHUD.dismiss()
+            }
+        }
+        // The HUD lives in its own window, so leaving search mid-request would
+        // otherwise strand it on screen with nothing left to dismiss it.
+        .onDisappear { ProgressHUD.dismiss() }
+        // Outcomes go to an alert rather than a banner above the list: the banner
+        // pushed the list down on every failed search, and it sat in the one place
+        // the user is looking while typing.
+        .alert(Strings.error, isPresented: messageAlert, presenting: viewModel.message) { _ in
+            Button(Strings.dismiss, role: .cancel) { }
+        } message: { message in
+            Text(message.text)
         }
         .alert(
             Strings.clearRecentSearchesConfirmation,
@@ -66,8 +97,14 @@ struct SearchSheetView: View {
                         viewModel.updateQuery("")
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
+                            // `Color.secondary`, not the `.secondary` shape style:
+                            // inside a `Button` the latter resolves against the
+                            // button's tint, which rendered a washed-out accent
+                            // colour rather than grey. `.plain` keeps the tint off
+                            // the label for good measure.
+                            .foregroundStyle(Color.secondary)
                     }
+                    .buttonStyle(.plain)
                     .accessibilityLabel(OBALoc(
                         "search_sheet.clear_query",
                         value: "Clear",
@@ -88,28 +125,4 @@ struct SearchSheetView: View {
         .padding(.top, 16)
     }
 
-    @ViewBuilder
-    private var statusBanner: some View {
-        if viewModel.isSearching {
-            ProgressView()
-                .padding(.top, 12)
-        } else if let errorMessage = viewModel.errorMessage {
-            Label(errorMessage, systemImage: "exclamationmark.triangle")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .padding(.top, 12)
-        } else if viewModel.showsNoResults {
-            Label(
-                OBALoc(
-                    "map_controller.no_search_results_found",
-                    value: "No search results were found.",
-                    comment: "A generic message shown when the user's search query produces no search results."
-                ),
-                systemImage: "magnifyingglass"
-            )
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .padding(.top, 12)
-        }
-    }
 }

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -101,6 +101,11 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
     func close() {
         searchTask?.cancel()
         searchTask = nil
+        // A resolving stop or map item has to go too. Without this it lands after the
+        // user has already backed out of search and pushes a detail sheet they
+        // dismissed. The handle is kept rather than cleared so callers can still await
+        // the cancelled task's completion.
+        pendingPresentation?.cancel()
         coordinator.pop()
     }
 
@@ -233,7 +238,12 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
     /// Same order as the single-result path: resolve, then unwind, then present — so
     /// search is only left once there's something to show.
     private func leaveSearchAndPresent(_ result: Any) async {
-        guard let resolved = await router.resolve(result: result) else {
+        let resolved = await router.resolve(result: result)
+        // Cancelling the task doesn't stop the resolve already in flight, so check
+        // before touching the screen: `close()` has already popped search, and
+        // presenting now would hand the rider a sheet they backed out of.
+        guard !Task.isCancelled else { return }
+        guard let resolved else {
             if let error = router.lastError {
                 message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             }

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -11,6 +11,24 @@ import Foundation
 import MapKit
 import OBAKitCore
 
+/// A one-shot search outcome, surfaced by the view as an alert.
+///
+/// Identity is fresh per message, so two identical failures in a row are two
+/// distinct values. A plain `String?` or `Bool` would coalesce when the reset and
+/// the re-set land in the same update pass, silently swallowing the second alert.
+struct SearchSheetMessage: Identifiable, Equatable {
+    enum Kind: Equatable {
+        /// The search ran and matched nothing.
+        case noResults
+        /// The search failed, or could not be attempted.
+        case error
+    }
+
+    let id = UUID()
+    let kind: Kind
+    let text: String
+}
+
 /// Owns a search session: the query, the `SearchInteractor` that turns it into
 /// sections, and the `SearchDelegate` callbacks those sections fire.
 ///
@@ -22,12 +40,7 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     @Published var query: String = ""
 
-    /// Set when a search returns nothing, so the sheet can say so in place rather
-    /// than popping the alert the UIKit path shows.
-    @Published private(set) var showsNoResults = false
-
-    /// Set when resolving a result fails, rendered inline for the same reason.
-    @Published private(set) var errorMessage: String?
+    @Published private(set) var message: SearchSheetMessage?
 
     @Published private(set) var isSearching = false
 
@@ -64,9 +77,14 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     func updateQuery(_ text: String) {
         query = text
-        showsNoResults = false
-        errorMessage = nil
+        message = nil
         searchInteractor.searchModeObjects(text: text)
+    }
+
+    /// Called when the view dismisses the alert, so a repeat of the same failing
+    /// search presents again rather than being swallowed as "no change".
+    func dismissMessage() {
+        message = nil
     }
 
     /// Leaves search and returns the base sheet to home.
@@ -120,15 +138,14 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         application.analytics?.reportSearchQuery(request.query)
 
         isSearching = true
-        showsNoResults = false
-        errorMessage = nil
+        message = nil
         defer { isSearching = false }
 
         let response: SearchResponse?
         do {
             response = try await application.searchManager.fetchResults(for: request)
         } catch {
-            errorMessage = error.localizedDescription
+            message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             return
         }
 
@@ -136,10 +153,10 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         case .unavailable:
             // The query was never sent. Saying "no results" would send the user off
             // rewording a search that never left the device.
-            errorMessage = APIError.noRegionSelected.localizedDescription
+            message = SearchSheetMessage(kind: .error, text: APIError.noRegionSelected.localizedDescription)
 
         case .noResults:
-            showsNoResults = true
+            message = SearchSheetMessage(kind: .noResults, text: Self.noResultsText)
 
         case .disambiguate(let response):
             coordinator.push(.searchResults(response))
@@ -150,10 +167,16 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             coordinator.pop()
             _ = await router.presentSingleResult(from: response)
             if let error = router.lastError {
-                errorMessage = error.localizedDescription
+                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             }
         }
     }
+
+    static let noResultsText = OBALoc(
+        "map_controller.no_search_results_found",
+        value: "No search results were found.",
+        comment: "A generic message shown when the user's search query produces no search results."
+    )
 
     /// The in-flight `router.present(...)` kicked off by a delegate callback.
     /// `SearchDelegate`'s methods are synchronous, so presentation has to be

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -162,13 +162,20 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             coordinator.push(.searchResults(response))
 
         case .single(let response):
+            // Resolve first, leave search second. Popping before the result was
+            // resolved tore this view — and the alert it hosts — down mid-request, so
+            // a failure had nowhere to surface and the user landed on home with no
+            // explanation. It also left the stacked sheet layer empty across the call.
+            guard let resolved = await router.resolveSingleResult(from: response) else {
+                if let error = router.lastError {
+                    message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
+                }
+                return
+            }
             // Leave search before opening the result, so Close on the detail sheet
             // lands back on home rather than on a stale search screen.
             coordinator.pop()
-            _ = await router.presentSingleResult(from: response)
-            if let error = router.lastError {
-                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
-            }
+            router.present(resolved)
         }
     }
 
@@ -185,13 +192,24 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     func showMapItem(_ mapItem: MKMapItem) {
         application.userDataStore.addRecentMapItem(mapItem)
-        coordinator.pop()
-        pendingPresentation = Task { [router] in await router.present(result: mapItem) }
+        pendingPresentation = Task { [weak self] in await self?.leaveSearchAndPresent(mapItem) }
     }
 
     func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) {
+        pendingPresentation = Task { [weak self] in await self?.leaveSearchAndPresent(stop) }
+    }
+
+    /// Same order as the single-result path: resolve, then unwind, then present — so
+    /// search is only left once there's something to show.
+    private func leaveSearchAndPresent(_ result: Any) async {
+        guard let resolved = await router.resolve(result: result) else {
+            if let error = router.lastError {
+                message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
+            }
+            return
+        }
         coordinator.pop()
-        pendingPresentation = Task { [router] in await router.present(result: stop) }
+        router.present(resolved)
     }
 
     /// The interactor asks; the view presents the confirmation and calls

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -85,6 +85,35 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
         }
     }
 
+    /// What a finished `fetchResults` call means for the screen.
+    ///
+    /// Split out as a pure function because the interesting distinction —
+    /// `nil` (the search never ran) versus an empty result set (it ran and matched
+    /// nothing) — isn't reachable through the test `Application`, which always has a
+    /// region, an API service, and an Obaco service.
+    enum SearchOutcome: Equatable {
+        /// No API service, no Obaco service, or no map rect. The query was never sent.
+        case unavailable
+        /// The search ran and matched nothing.
+        case noResults
+        case single(SearchResponse)
+        case disambiguate(SearchResponse)
+
+        init(response: SearchResponse?) {
+            guard let response else {
+                self = .unavailable
+                return
+            }
+            if response.results.isEmpty {
+                self = .noResults
+            } else if response.results.count == 1 {
+                self = .single(response)
+            } else {
+                self = .disambiguate(response)
+            }
+        }
+    }
+
     /// The awaitable body of `performSearch`, so tests don't have to poll a
     /// fire-and-forget task.
     func performSearchAndWait(request: SearchRequest) async {
@@ -103,22 +132,26 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             return
         }
 
-        guard let response, !response.results.isEmpty else {
+        switch SearchOutcome(response: response) {
+        case .unavailable:
+            // The query was never sent. Saying "no results" would send the user off
+            // rewording a search that never left the device.
+            errorMessage = APIError.noRegionSelected.localizedDescription
+
+        case .noResults:
             showsNoResults = true
-            return
-        }
 
-        guard response.results.count == 1 else {
+        case .disambiguate(let response):
             coordinator.push(.searchResults(response))
-            return
-        }
 
-        // Leave search before opening the result, so Close on the detail sheet lands
-        // back on home rather than on a stale search screen.
-        coordinator.pop()
-        _ = await router.presentSingleResult(from: response)
-        if let error = router.lastError {
-            errorMessage = error.localizedDescription
+        case .single(let response):
+            // Leave search before opening the result, so Close on the detail sheet
+            // lands back on home rather than on a stale search screen.
+            coordinator.pop()
+            _ = await router.presentSingleResult(from: response)
+            if let error = router.lastError {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -1,0 +1,157 @@
+//
+//  SearchSheetViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Owns a search session: the query, the `SearchInteractor` that turns it into
+/// sections, and the `SearchDelegate` callbacks those sections fire.
+///
+/// This is the role `MapFloatingPanelController` plays for the UIKit panel. It's a
+/// class (not view state) because `SearchDelegate` is a class protocol that
+/// `SearchInteractor` holds weakly — the view retains this via `@StateObject`.
+@MainActor
+final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
+
+    @Published var query: String = ""
+
+    /// Set when a search returns nothing, so the sheet can say so in place rather
+    /// than popping the alert the UIKit path shows.
+    @Published private(set) var showsNoResults = false
+
+    /// Set when resolving a result fails, rendered inline for the same reason.
+    @Published private(set) var errorMessage: String?
+
+    @Published private(set) var isSearching = false
+
+    private(set) lazy var searchInteractor = SearchInteractor(application: application, delegate: self)
+
+    private let application: Application
+    private let coordinator: SheetCoordinator<AppSheetRoute>
+    private let router: SearchResultRouter
+    private var searchTask: Task<Void, Never>?
+
+    init(application: Application, coordinator: SheetCoordinator<AppSheetRoute>, router: SearchResultRouter) {
+        self.application = application
+        self.coordinator = coordinator
+        self.router = router
+        super.init()
+    }
+
+    isolated deinit {
+        searchTask?.cancel()
+        pendingPresentation?.cancel()
+    }
+
+    // MARK: - Session
+
+    /// Reported once per entry into search, matching the UIKit panel's
+    /// `inSearchMode` analytics.
+    func reportSearchOpened() {
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/map",
+            label: AnalyticsLabels.searchSelected,
+            value: nil
+        )
+    }
+
+    func updateQuery(_ text: String) {
+        query = text
+        showsNoResults = false
+        errorMessage = nil
+        searchInteractor.searchModeObjects(text: text)
+    }
+
+    /// Leaves search and returns the base sheet to home.
+    func close() {
+        searchTask?.cancel()
+        searchTask = nil
+        coordinator.pop()
+    }
+
+    // MARK: - SearchDelegate
+
+    func performSearch(request: SearchRequest) {
+        searchTask?.cancel()
+        searchTask = Task { [weak self] in
+            await self?.performSearchAndWait(request: request)
+        }
+    }
+
+    /// The awaitable body of `performSearch`, so tests don't have to poll a
+    /// fire-and-forget task.
+    func performSearchAndWait(request: SearchRequest) async {
+        application.analytics?.reportSearchQuery(request.query)
+
+        isSearching = true
+        showsNoResults = false
+        errorMessage = nil
+        defer { isSearching = false }
+
+        let response: SearchResponse?
+        do {
+            response = try await application.searchManager.fetchResults(for: request)
+        } catch {
+            errorMessage = error.localizedDescription
+            return
+        }
+
+        guard let response, !response.results.isEmpty else {
+            showsNoResults = true
+            return
+        }
+
+        guard response.results.count == 1 else {
+            coordinator.push(.searchResults(response))
+            return
+        }
+
+        // Leave search before opening the result, so Close on the detail sheet lands
+        // back on home rather than on a stale search screen.
+        coordinator.pop()
+        _ = await router.presentSingleResult(from: response)
+        if let error = router.lastError {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// The in-flight `router.present(...)` kicked off by a delegate callback.
+    /// `SearchDelegate`'s methods are synchronous, so presentation has to be
+    /// detached — this handle lets tests await it instead of polling.
+    private(set) var pendingPresentation: Task<Void, Never>?
+
+    func showMapItem(_ mapItem: MKMapItem) {
+        application.userDataStore.addRecentMapItem(mapItem)
+        coordinator.pop()
+        pendingPresentation = Task { [router] in await router.present(result: mapItem) }
+    }
+
+    func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) {
+        coordinator.pop()
+        pendingPresentation = Task { [router] in await router.present(result: stop) }
+    }
+
+    /// The interactor asks; the view presents the confirmation and calls
+    /// `confirmClearRecentSearches()` if the user agrees.
+    @Published var isConfirmingClearRecents = false
+
+    func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) {
+        isConfirmingClearRecents = true
+    }
+
+    func confirmClearRecentSearches() {
+        application.userDataStore.deleteAllRecentMapItems()
+        searchInteractor.searchModeObjects(text: query)
+    }
+
+    var isVehicleSearchAvailable: Bool {
+        application.features.obaco == .running
+    }
+}

--- a/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Search/SearchSheetViewModel.swift
@@ -65,9 +65,19 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
     // MARK: - Session
 
+    /// Guards `reportSearchOpened()`. It lives here rather than on the view because
+    /// the sheet system tears a sheet's content view down and rebuilds it without the
+    /// user going anywhere — see `MapSearchDisplayModel.owner` — so `onAppear` can fire
+    /// more than once per entry into search. This object survives that via
+    /// `@StateObject`, so the flag is accurate no matter how the container behaves.
+    private var hasReportedOpen = false
+
     /// Reported once per entry into search, matching the UIKit panel's
     /// `inSearchMode` analytics.
     func reportSearchOpened() {
+        guard !hasReportedOpen else { return }
+        hasReportedOpen = true
+
         application.analytics?.reportEvent(
             pageURL: "app://localhost/map",
             label: AnalyticsLabels.searchSelected,
@@ -139,17 +149,36 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
 
         isSearching = true
         message = nil
-        defer { isSearching = false }
+        // Cancelling `searchTask` doesn't stop the request already in flight, so a
+        // superseded search still runs to completion. It must not clear `isSearching`
+        // — the HUD belongs to the search that replaced it, which is still running —
+        // and the `Task.isCancelled` checks below stop it reporting or navigating for
+        // a query the user has already moved on from.
+        defer {
+            if !Task.isCancelled {
+                isSearching = false
+            }
+        }
 
         let response: SearchResponse?
         do {
             response = try await application.searchManager.fetchResults(for: request)
         } catch {
+            guard !Task.isCancelled else { return }
             message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
             return
         }
 
-        switch SearchOutcome(response: response) {
+        guard !Task.isCancelled else { return }
+
+        await present(SearchOutcome(response: response))
+    }
+
+    /// What each outcome does to the screen. Split from `performSearchAndWait` so the
+    /// request, its cancellation checks, and the four outcomes stay separately
+    /// readable rather than one long function.
+    private func present(_ outcome: SearchOutcome) async {
+        switch outcome {
         case .unavailable:
             // The query was never sent. Saying "no results" would send the user off
             // rewording a search that never left the device.
@@ -167,11 +196,13 @@ final class SearchSheetViewModel: NSObject, ObservableObject, SearchDelegate {
             // a failure had nowhere to surface and the user landed on home with no
             // explanation. It also left the stacked sheet layer empty across the call.
             guard let resolved = await router.resolveSingleResult(from: response) else {
+                guard !Task.isCancelled else { return }
                 if let error = router.lastError {
                     message = SearchSheetMessage(kind: .error, text: error.localizedDescription)
                 }
                 return
             }
+            guard !Task.isCancelled else { return }
             // Leave search before opening the result, so Close on the detail sheet
             // lands back on home rather than on a stale search screen.
             coordinator.pop()

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -176,6 +176,13 @@ nonisolated extension AppSheetRoute {
 
     /// Height of the home sheet's smallest detent. Shared by `MapPanelRootView`
     /// so the map's bottom safe-area padding matches the collapsed sheet.
+    ///
+    /// Sized to `HomeSheetView`'s search-bar row and nothing else, so the
+    /// collapsed sheet reads as a search field rather than as a list that got
+    /// cut off: a body-metrics capsule (~48pt: one line of text plus its 14pt
+    /// vertical padding, top and bottom) under the row's own 16pt top and 12pt
+    /// bottom padding, less the couple of points the drag indicator already
+    /// occupies above it.
     static let homeCollapsedHeight: CGFloat = 75
 
     var detentConfiguration: SheetDetentConfiguration {

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -176,7 +176,7 @@ nonisolated extension AppSheetRoute {
 
     /// Height of the home sheet's smallest detent. Shared by `MapPanelRootView`
     /// so the map's bottom safe-area padding matches the collapsed sheet.
-    static let homeCollapsedHeight: CGFloat = 80
+    static let homeCollapsedHeight: CGFloat = 75
 
     var detentConfiguration: SheetDetentConfiguration {
         switch self {

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import MapKit
 import OBAKitCore
 
 // MARK: - SheetDetentConfiguration
@@ -83,6 +84,10 @@ nonisolated enum AppSheetRoute: SheetRouteable {
     case routePicker
     case currentTrip(route: Route)
     case transitAlert(alertID: String)
+    case searchResults(SearchResponse)
+    case mapItem(MKMapItem)
+    case routeStops(StopsForRoute)
+    case nearbyStops(coordinate: CLLocationCoordinate2D)
 
     case more
     case settings
@@ -122,6 +127,15 @@ nonisolated extension AppSheetRoute {
             return "\(caseName)-\(route.id)"
         case .transitAlert(let alertID):
             return "\(caseName)-\(alertID)"
+        case .searchResults(let response):
+            return "\(caseName)-\(response.request.searchType.rawValue)-\(response.request.query)"
+        case .mapItem(let item):
+            let coordinate = item.placemark.coordinate
+            return "\(caseName)-\(coordinate.latitude)-\(coordinate.longitude)"
+        case .routeStops(let stopsForRoute):
+            return "\(caseName)-\(stopsForRoute.id)"
+        case .nearbyStops(let coordinate):
+            return "\(caseName)-\(coordinate.latitude)-\(coordinate.longitude)"
         }
     }
 
@@ -140,7 +154,7 @@ nonisolated extension AppSheetRoute {
     /// Detail destinations prefer the stacked layer so the base sheet peeks beneath.
     var prefersStacking: Bool {
         switch self {
-        case .stopDetails, .tripPlanner, .tripDetails, .currentTrip, .transitAlert, .more, .nearbyAll, .recentStopsAll, .bookmarksAll, .settings:
+        case .stopDetails, .tripPlanner, .tripDetails, .currentTrip, .transitAlert, .more, .nearbyAll, .recentStopsAll, .bookmarksAll, .settings, .searchResults, .mapItem, .routeStops, .nearbyStops:
             return true
         case .home, .search, .routePicker:
             return false
@@ -218,6 +232,34 @@ nonisolated extension AppSheetRoute {
         case .tripPlanner, .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:
             return SheetDetentConfiguration(
                 detents: [.medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        case .mapItem:
+            // Medium only: the sheet is a detail card over the map, and the map has
+            // to stay visible behind it. Long content scrolls inside the detent.
+            return SheetDetentConfiguration(
+                detents: [.medium],
+                initialDetent: .medium,
+                isDismissDisabled: false
+            )
+        case .routeStops:
+            // Opens at medium so the route polyline stays on screen; the user can
+            // drag to large for the full stop list.
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .medium,
+                isDismissDisabled: false
+            )
+        case .searchResults:
+            return SheetDetentConfiguration(
+                detents: [.medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        case .nearbyStops:
+            return SheetDetentConfiguration(
+                detents: [.large],
                 initialDetent: .large,
                 isDismissDisabled: false
             )

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -129,7 +129,13 @@ final class AppSheetViewFactory {
     // MARK: - Per-route view builders
 
     func homeView() -> HomeSheetView {
-        HomeSheetView(viewModel: HomeSheetViewModel(application: self.application, stopsObserver: self.stopsObserver))
+        HomeSheetView(
+            application: self.application,
+            viewModel: HomeSheetViewModel(
+                application: self.application,
+                stopsObserver: self.stopsObserver
+            )
+        )
     }
 
     /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -94,11 +94,13 @@ final class AppSheetViewFactory {
         case .search:
             searchView()
 
+        case .nearbyAll, .recentStopsAll, .bookmarksAll:
+            indexPlaceholderView(for: route)
+
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.
-        case .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .tripDetails, .transitAlert, .settings:
+        case .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
 
         case .searchResults(let response):
@@ -199,6 +201,27 @@ final class AppSheetViewFactory {
             ),
             placeholder: SearchPlaceholder.text(for: self.application)
         )
+    }
+
+    /// The home sheet's section headers navigate to these three routes before
+    /// their index screens exist, so they render the "coming soon" placeholder
+    /// in every configuration rather than asserting. `unimplementedView` stays
+    /// armed for routes nobody has wired a push for yet — remove a route from
+    /// here once its real view is registered above.
+    func indexPlaceholderView(for route: AppSheetRoute) -> some View {
+        VStack(spacing: 4) {
+            Text(OBALoc(
+                "app_sheet.unimplemented_route.placeholder",
+                value: "This screen is coming soon.",
+                comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
+            ))
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            Text(route.id)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding()
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -38,18 +38,25 @@ final class AppSheetViewFactory {
     let coordinator: SheetCoordinator<AppSheetRoute>
     let searchDisplayModel: MapSearchDisplayModel
 
-    /// `presentingController` has no default on purpose. Every stop-sheet action
-    /// — schedules, bookmarks, the route filter, report-a-problem, the alarm
-    /// picker — resolves through it, so a call site that omitted it would build
-    /// a factory whose sheet renders correctly and then silently ignores every
-    /// button on it.
+    /// Nothing here is defaulted, on purpose, and for two separate reasons.
+    ///
+    /// `presentingController`: every stop-sheet action — schedules, bookmarks,
+    /// the route filter, report-a-problem, the alarm picker — resolves through
+    /// it, so a call site that omitted it would build a factory whose sheet
+    /// renders correctly and then silently ignores every button on it.
+    ///
+    /// `coordinator` and `searchDisplayModel`: they must be the same instances the
+    /// hosting `MapPanelRootView` observes. A factory built with its own private
+    /// copies would push routes onto a coordinator nobody is watching and draw into
+    /// a display model nobody renders — silently, with the search sheet simply
+    /// appearing to do nothing.
     init(
         application: Application,
         onPresentTrip: @escaping (ArrivalDeparture) -> Void,
-        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in },
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void,
         presentingController: @escaping () -> UIViewController?,
-        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
-        searchDisplayModel: MapSearchDisplayModel = MapSearchDisplayModel()
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
@@ -162,7 +169,7 @@ final class AppSheetViewFactory {
     }
 
     func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
-        MapItemSheetView(application: application, mapItem: mapItem)
+        MapItemSheetView(application: application, mapItem: mapItem, displayModel: searchDisplayModel)
     }
 
     /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.
@@ -186,7 +193,7 @@ final class AppSheetViewFactory {
                 coordinator: self.coordinator,
                 router: self.searchResultRouter
             ),
-            placeholder: HomeSheetViewModel(application: self.application).searchPlaceholder
+            placeholder: SearchPlaceholder.text(for: self.application)
         )
     }
 

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -129,7 +129,7 @@ final class AppSheetViewFactory {
     // MARK: - Per-route view builders
 
     func homeView() -> HomeSheetView {
-        HomeSheetView(viewModel: HomeSheetViewModel(application: self.application))
+        HomeSheetView(viewModel: HomeSheetViewModel(application: self.application, stopsObserver: self.stopsObserver))
     }
 
     /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -88,9 +88,11 @@ final class AppSheetViewFactory {
         // (the home sheet only knows how to push, not pop), otherwise the
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults:
+             .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
+
+        case .searchResults(let response):
+            searchResultsView(response: response)
 
         case .routeStops(let stopsForRoute):
             routeStopsView(stopsForRoute: stopsForRoute)
@@ -172,6 +174,10 @@ final class AppSheetViewFactory {
 
     func routeStopsView(stopsForRoute: StopsForRoute) -> RouteStopsSheetView {
         RouteStopsSheetView(stopsForRoute: stopsForRoute, displayModel: searchDisplayModel)
+    }
+
+    func searchResultsView(response: SearchResponse) -> SearchResultsSheetView {
+        SearchResultsSheetView(application: application, response: response, router: searchResultRouter)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -169,7 +169,7 @@ final class AppSheetViewFactory {
     }
 
     func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
-        MapItemSheetView(application: application, mapItem: mapItem, displayModel: searchDisplayModel)
+        MapItemSheetView(application: application, mapItem: mapItem)
     }
 
     /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -71,6 +71,7 @@ final class AppSheetViewFactory {
     // MARK: - Dispatcher
 
     @ViewBuilder
+    // swiftlint:disable:next cyclomatic_complexity
     func view(for route: AppSheetRoute) -> some View {
         switch route {
         case .home:
@@ -79,15 +80,13 @@ final class AppSheetViewFactory {
         case .more:
             moreView()
 
+        case .search:
+            searchView()
+
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.
-        //
-        // TODO: `.search` is base-layer and has `isDismissDisabled: true`
-        // — its real view needs to wire up an explicit back affordance
-        // (the home sheet only knows how to push, not pop), otherwise the
-        // route is unreachable once entered.
-        case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
+        case .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
 
@@ -117,7 +116,7 @@ final class AppSheetViewFactory {
     // MARK: - Per-route view builders
 
     func homeView() -> HomeSheetView {
-        HomeSheetView(viewModel: HomeSheetViewModel())
+        HomeSheetView(viewModel: HomeSheetViewModel(application: self.application))
     }
 
     /// Bridges `AppSheetRoute.more` to the existing UIKit `MoreViewController`
@@ -178,6 +177,17 @@ final class AppSheetViewFactory {
 
     func searchResultsView(response: SearchResponse) -> SearchResultsSheetView {
         SearchResultsSheetView(application: application, response: response, router: searchResultRouter)
+    }
+
+    func searchView() -> SearchSheetView {
+        SearchSheetView(
+            viewModel: SearchSheetViewModel(
+                application: self.application,
+                coordinator: self.coordinator,
+                router: self.searchResultRouter
+            ),
+            placeholder: HomeSheetViewModel(application: self.application).searchPlaceholder
+        )
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -68,7 +68,8 @@ final class AppSheetViewFactory {
         // (the home sheet only knows how to push, not pop), otherwise the
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .tripDetails, .transitAlert, .settings:
+             .tripPlanner, .tripDetails, .transitAlert, .settings,
+             .searchResults, .mapItem, .routeStops, .nearbyStops:
             unimplementedView(for: route)
 
         case .stopDetails(let stopID):

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -34,6 +34,10 @@ final class AppSheetViewFactory {
     /// `TripPresentationBridge` does.
     let presentingController: () -> UIViewController?
 
+    let onPresentVehicleTrip: (VehicleStatus) -> Void
+    let coordinator: SheetCoordinator<AppSheetRoute>
+    let searchDisplayModel: MapSearchDisplayModel
+
     /// `presentingController` has no default on purpose. Every stop-sheet action
     /// — schedules, bookmarks, the route filter, report-a-problem, the alarm
     /// picker — resolves through it, so a call site that omitted it would build
@@ -42,12 +46,27 @@ final class AppSheetViewFactory {
     init(
         application: Application,
         onPresentTrip: @escaping (ArrivalDeparture) -> Void,
-        presentingController: @escaping () -> UIViewController?
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in },
+        presentingController: @escaping () -> UIViewController?,
+        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
+        searchDisplayModel: MapSearchDisplayModel = MapSearchDisplayModel()
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
+        self.onPresentVehicleTrip = onPresentVehicleTrip
         self.presentingController = presentingController
+        self.coordinator = coordinator
+        self.searchDisplayModel = searchDisplayModel
     }
+
+    /// Built once and shared: the search sheet and the results sheet must route a
+    /// picked result the same way, and both need the same coordinator instance.
+    private(set) lazy var searchResultRouter = SearchResultRouter(
+        application: application,
+        coordinator: coordinator,
+        displayModel: searchDisplayModel,
+        onPresentVehicleTrip: onPresentVehicleTrip
+    )
 
     // MARK: - Dispatcher
 
@@ -70,8 +89,11 @@ final class AppSheetViewFactory {
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults, .routeStops:
+             .searchResults:
             unimplementedView(for: route)
+
+        case .routeStops(let stopsForRoute):
+            routeStopsView(stopsForRoute: stopsForRoute)
 
         case .mapItem(let mapItem):
             mapItemView(mapItem: mapItem)
@@ -146,6 +168,10 @@ final class AppSheetViewFactory {
     /// Swap this branch's return type once a SwiftUI nearby-stops list lands.
     func nearbyStopsView(coordinate: CLLocationCoordinate2D) -> NearbyStopsSheetHost {
         NearbyStopsSheetHost(application: application, coordinate: coordinate)
+    }
+
+    func routeStopsView(stopsForRoute: StopsForRoute) -> RouteStopsSheetView {
+        RouteStopsSheetView(stopsForRoute: stopsForRoute, displayModel: searchDisplayModel)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -37,6 +37,7 @@ final class AppSheetViewFactory {
     let onPresentVehicleTrip: (VehicleStatus) -> Void
     let coordinator: SheetCoordinator<AppSheetRoute>
     let searchDisplayModel: MapSearchDisplayModel
+    let stopsObserver: MapStopsObserver
 
     /// Nothing here is defaulted, on purpose, and for two separate reasons.
     ///
@@ -45,10 +46,11 @@ final class AppSheetViewFactory {
     /// it, so a call site that omitted it would build a factory whose sheet
     /// renders correctly and then silently ignores every button on it.
     ///
-    /// `coordinator` and `searchDisplayModel`: they must be the same instances the
-    /// hosting `MapPanelRootView` observes. A factory built with its own private
-    /// copies would push routes onto a coordinator nobody is watching and draw into
-    /// a display model nobody renders — silently, with the search sheet simply
+    /// `coordinator`, `searchDisplayModel`, and `stopsObserver`: they must be the
+    /// same instances the hosting `MapPanelRootView` observes. A factory built with
+    /// its own private copies would push routes onto a coordinator nobody is
+    /// watching, draw into a display model nobody renders, or observe a different
+    /// stop set than the map is showing — silently, with the search sheet simply
     /// appearing to do nothing.
     init(
         application: Application,
@@ -56,7 +58,8 @@ final class AppSheetViewFactory {
         onPresentVehicleTrip: @escaping (VehicleStatus) -> Void,
         presentingController: @escaping () -> UIViewController?,
         coordinator: SheetCoordinator<AppSheetRoute>,
-        searchDisplayModel: MapSearchDisplayModel
+        searchDisplayModel: MapSearchDisplayModel,
+        stopsObserver: MapStopsObserver
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
@@ -64,6 +67,7 @@ final class AppSheetViewFactory {
         self.presentingController = presentingController
         self.coordinator = coordinator
         self.searchDisplayModel = searchDisplayModel
+        self.stopsObserver = stopsObserver
     }
 
     /// Built once and shared: the search sheet and the results sheet must route a

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -219,7 +219,7 @@ final class AppSheetViewFactory {
             Text(OBALoc(
                 "app_sheet.unimplemented_route.placeholder",
                 value: "This screen is coming soon.",
-                comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
+                comment: "Placeholder shown when a sheet route is pushed but its screen has not been built yet."
             ))
             .font(.headline)
             .foregroundStyle(.secondary)

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import MapKit
 import OBAKitCore
 
 // MARK: - AppSheetViewFactory
@@ -69,8 +70,14 @@ final class AppSheetViewFactory {
         // route is unreachable once entered.
         case .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .tripPlanner, .tripDetails, .transitAlert, .settings,
-             .searchResults, .mapItem, .routeStops, .nearbyStops:
+             .searchResults, .routeStops:
             unimplementedView(for: route)
+
+        case .mapItem(let mapItem):
+            mapItemView(mapItem: mapItem)
+
+        case .nearbyStops(let coordinate):
+            nearbyStopsView(coordinate: coordinate)
 
         case .stopDetails(let stopID):
             stopDetailView(stopID: stopID)
@@ -129,6 +136,16 @@ final class AppSheetViewFactory {
             formatters: self.application.formatters,
             onPresentTrip: onPresentTrip
         )
+    }
+
+    func mapItemView(mapItem: MKMapItem) -> MapItemSheetView {
+        MapItemSheetView(application: application, mapItem: mapItem)
+    }
+
+    /// Bridges `AppSheetRoute.nearbyStops` to the existing `NearbyStopsViewController`.
+    /// Swap this branch's return type once a SwiftUI nearby-stops list lands.
+    func nearbyStopsView(coordinate: CLLocationCoordinate2D) -> NearbyStopsSheetHost {
+        NearbyStopsSheetHost(application: application, coordinate: coordinate)
     }
 
     /// Placeholder until each route gets its own real view. In debug builds we

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -245,22 +245,7 @@ final class AppSheetViewFactory {
 #else
         // swiftlint:disable:next redundant_discardable_let
         let _ = Logger.error("AppSheetRoute.\(route.id) pushed but no view is registered — rendering placeholder.")
-        // Embed `route.id` in the visible copy so an experimental-flag tester
-        // who hits this in the wild has something concrete to report back —
-        // the `Logger.error` line above is invisible to them.
-        VStack(spacing: 4) {
-            Text(OBALoc(
-                "app_sheet.unimplemented_route.placeholder",
-                value: "This screen is coming soon.",
-                comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
-            ))
-            .font(.headline)
-            .foregroundStyle(.secondary)
-            Text(route.id)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-        }
-        .padding()
+        indexPlaceholderView(for: route)
 #endif
     }
 }

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -25,12 +25,22 @@ public final class MapPanelRootController: UIViewController {
 
     public init(application: Application) {
         let bridge = TripPresentationBridge()
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
         let factory = AppSheetViewFactory(
             application: application,
             onPresentTrip: { [weak bridge] arrival in bridge?.present(arrival) },
-            presentingController: { [weak bridge] in bridge?.topmostController() }
+            onPresentVehicleTrip: { [weak bridge] vehicleStatus in bridge?.present(vehicleStatus: vehicleStatus) },
+            presentingController: { [weak bridge] in bridge?.topmostController() },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
         )
-        let rootView = MapPanelRootView(application: application, factory: factory)
+        let rootView = MapPanelRootView(
+            application: application,
+            factory: factory,
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
+        )
         self.host = UIHostingController(rootView: rootView)
         self.bridge = bridge
         super.init(nibName: nil, bundle: nil)
@@ -87,6 +97,33 @@ public final class MapPanelRootController: UIViewController {
                 return
             }
             let trip = TripViewController(application: application, arrivalDeparture: arrival)
+            presentTripController(trip, application: application, presenter: presenter)
+        }
+
+        func present(vehicleStatus: VehicleStatus) {
+            // As above: `topmostController()` is nil exactly when `host` is.
+            guard let host, let application, let presenter = topmostController() else {
+                Logger.error("TripPresentationBridge: dropping vehicle present — host or application is nil")
+                return
+            }
+
+            guard let convertible = TripConvertible(vehicleStatus: vehicleStatus) else {
+                // Same message the UIKit map shows: the vehicle exists but isn't
+                // assigned to a trip, so there's nothing to display.
+                let message = OBALoc(
+                    "map_controller.vehicle_not_on_trip_error",
+                    value: "The vehicle you chose doesn't appear to be on a trip right now, which means we don't know how to show it to you.",
+                    comment: "This message appears when a searched-for vehicle doesn't have an assigned trip."
+                )
+                Task { await AlertPresenter.show(errorMessage: message, presentingController: host) }
+                return
+            }
+
+            let trip = TripViewController(application: application, tripConvertible: convertible)
+            presentTripController(trip, application: application, presenter: presenter)
+        }
+
+        private func presentTripController(_ trip: TripViewController, application: Application, presenter: UIViewController) {
             // Wrap in our own UINavigationController and modally present from
             // the topmost presented controller, not `host` directly:
             //

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -102,7 +102,7 @@ public final class MapPanelRootController: UIViewController {
 
         func present(vehicleStatus: VehicleStatus) {
             // As above: `topmostController()` is nil exactly when `host` is.
-            guard let host, let application, let presenter = topmostController() else {
+            guard let application, let presenter = topmostController() else {
                 Logger.error("TripPresentationBridge: dropping vehicle present — host or application is nil")
                 return
             }
@@ -115,7 +115,13 @@ public final class MapPanelRootController: UIViewController {
                     value: "The vehicle you chose doesn't appear to be on a trip right now, which means we don't know how to show it to you.",
                     comment: "This message appears when a searched-for vehicle doesn't have an assigned trip."
                 )
-                Task { await AlertPresenter.show(errorMessage: message, presentingController: host) }
+                // `presenter`, not `host`, for the reason spelled out in
+                // `presentTripController` below: UIKit ignores `present` on a
+                // controller that already has a `presentedViewController`, and by the
+                // time we get here the base sheet is still up on `host`. Presenting
+                // from `host` silently drops the alert, leaving the rider on home with
+                // no explanation for why their vehicle search went nowhere.
+                Task { await AlertPresenter.show(errorMessage: message, presentingController: presenter) }
                 return
             }
 

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -27,19 +27,26 @@ public final class MapPanelRootController: UIViewController {
         let bridge = TripPresentationBridge()
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         let displayModel = MapSearchDisplayModel()
+        // Built here, not inside `MapPanelRootView`, because the factory is
+        // constructed first and the home sheet's nearby section must observe
+        // the same instance the map renders from. Same reasoning as
+        // `displayModel` above.
+        let stopsObserver = MapStopsObserver(application: application)
         let factory = AppSheetViewFactory(
             application: application,
             onPresentTrip: { [weak bridge] arrival in bridge?.present(arrival) },
             onPresentVehicleTrip: { [weak bridge] vehicleStatus in bridge?.present(vehicleStatus: vehicleStatus) },
             presentingController: { [weak bridge] in bridge?.topmostController() },
             coordinator: coordinator,
-            searchDisplayModel: displayModel
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver
         )
         let rootView = MapPanelRootView(
             application: application,
             factory: factory,
             coordinator: coordinator,
-            searchDisplayModel: displayModel
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver
         )
         self.host = UIHostingController(rootView: rootView)
         self.bridge = bridge

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -83,6 +83,7 @@ struct MapPanelRootView: View {
 
     private let application: Application
     private let factory: AppSheetViewFactory
+    private let viewportRecorder: MapViewportRecorder
 
     init(application: Application, factory: AppSheetViewFactory) {
         _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
@@ -91,6 +92,7 @@ struct MapPanelRootView: View {
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
         self.application = application
         self.factory = factory
+        self.viewportRecorder = MapViewportRecorder(application: application)
 
         // With no location fix, frame the current transit region rather than
         // letting `.automatic` frame the bookmark annotations.
@@ -135,6 +137,7 @@ struct MapPanelRootView: View {
             }
         }
         .onMapCameraChange(frequency: .onEnd) { context in
+            viewportRecorder.record(context.rect)
             visibleRegion = context.region
             visibleMapRectHeight = context.rect.height
             // Keep the "Zoom in for stops" pill in sync with the stop-loading
@@ -431,6 +434,10 @@ extension MapPanelRootView {
             zoomLevel: mapViewModel.zoomLevelForCurrentLocation(),
             mapSize: mapSize
         )
+        // Seed the viewport before the camera animates: `.onMapCameraChange` only
+        // fires on settle, so a search run between launch and the first settle would
+        // otherwise be scoped to a stale rect.
+        viewportRecorder.record(MKMapRect(region))
         withAnimation {
             cameraPosition = .region(region)
         }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -20,6 +20,7 @@ import UIKit
 struct MapPanelRootView: View {
 
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
+    @ObservedObject private var searchDisplay: MapSearchDisplayModel
     @StateObject private var mapViewModel: MapViewModel
     @StateObject private var stopsObserver: MapStopsObserver
 
@@ -85,8 +86,14 @@ struct MapPanelRootView: View {
     private let factory: AppSheetViewFactory
     private let viewportRecorder: MapViewportRecorder
 
-    init(application: Application, factory: AppSheetViewFactory) {
-        _coordinator = StateObject(wrappedValue: SheetCoordinator<AppSheetRoute>(root: .home))
+    init(
+        application: Application,
+        factory: AppSheetViewFactory,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel
+    ) {
+        _coordinator = StateObject(wrappedValue: coordinator)
+        _searchDisplay = ObservedObject(wrappedValue: searchDisplayModel)
         _stopsObserver = StateObject(wrappedValue: MapStopsObserver(application: application))
         let initialMapType = MapBaseType(application.mapRegionManager.userSelectedMapType)
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
@@ -125,7 +132,7 @@ struct MapPanelRootView: View {
             }
             // Regular stops show only zoomed in; `renderStops` already excludes
             // bookmarked stops and precomputes labels.
-            if isZoomedInForStops {
+            if isZoomedInForStops, !searchDisplay.suppressesAmbientStops {
                 ForEach(stopsObserver.renderStops) { renderStop in
                     stopAnnotation(
                         for: renderStop.stop,
@@ -135,6 +142,7 @@ struct MapPanelRootView: View {
                     )
                 }
             }
+            searchResultMapContent(for: searchDisplay.display)
         }
         .onMapCameraChange(frequency: .onEnd) { context in
             viewportRecorder.record(context.rect)
@@ -160,6 +168,7 @@ struct MapPanelRootView: View {
             }
             recomputeStopLabels()
             stopsObserver.updateViewport(context.region)
+            guard !searchDisplay.suppressesAmbientStops else { return }
             application.mapRegionManager.scheduleStopsRequest(in: context.region)
         }
         // The map-type toggle changes the label gate (labels only show on the
@@ -174,6 +183,25 @@ struct MapPanelRootView: View {
             guard let id else { return }
             coordinator.push(.stopDetails(stopID: id))
             selectedStopID = nil
+        }
+        .onChange(of: searchDisplay.cameraTarget) { _, target in
+            guard let target else { return }
+            switch target {
+            case .coordinate(let coordinate, let animated):
+                let region = MKCoordinateRegion(
+                    centeredOn: coordinate,
+                    zoomLevel: 16,
+                    mapSize: mapSize
+                )
+                if animated {
+                    withAnimation { cameraPosition = .region(region) }
+                } else {
+                    cameraPosition = .region(region)
+                }
+            case .rect(let rect):
+                withAnimation { cameraPosition = .rect(rect) }
+            }
+            searchDisplay.consumeCameraTarget()
         }
         .mapStyle(mapViewModel.mapType == .standard ? .standard(emphasis: .muted) : .hybrid)
         .safeAreaPadding(.bottom, 180)

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -190,6 +190,15 @@ struct MapPanelRootView: View {
             coordinator.push(.stopDetails(stopID: id))
             selectedStopID = nil
         }
+        // A searched result stays drawn for exactly as long as the sheet that owns it
+        // is on the stack. Watching the stack — rather than clearing from the owning
+        // sheet's `onDisappear` — keeps the drawing alive across the content
+        // teardowns the sheet system performs without dismissing anything, and still
+        // clears on a real exit, including the drag-down the OS routes through
+        // `truncateStacked`.
+        .onChange(of: coordinator.stackedRoutes) { _, _ in
+            searchDisplay.clearIfOwnerAbsent(from: coordinator.routeStack + coordinator.stackedRoutes)
+        }
         .onChange(of: searchDisplay.cameraTarget) { _, target in
             guard let target else { return }
             switch target {

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -22,7 +22,7 @@ struct MapPanelRootView: View {
     @StateObject private var coordinator: SheetCoordinator<AppSheetRoute>
     @ObservedObject private var searchDisplay: MapSearchDisplayModel
     @StateObject private var mapViewModel: MapViewModel
-    @StateObject private var stopsObserver: MapStopsObserver
+    @ObservedObject private var stopsObserver: MapStopsObserver
 
     /// Presentation state only. The popup reads its data from
     /// `mapViewModel.weatherDisplay` so a refresh that finishes while the card
@@ -90,11 +90,12 @@ struct MapPanelRootView: View {
         application: Application,
         factory: AppSheetViewFactory,
         coordinator: SheetCoordinator<AppSheetRoute>,
-        searchDisplayModel: MapSearchDisplayModel
+        searchDisplayModel: MapSearchDisplayModel,
+        stopsObserver: MapStopsObserver
     ) {
         _coordinator = StateObject(wrappedValue: coordinator)
         _searchDisplay = ObservedObject(wrappedValue: searchDisplayModel)
-        _stopsObserver = StateObject(wrappedValue: MapStopsObserver(application: application))
+        _stopsObserver = ObservedObject(wrappedValue: stopsObserver)
         let initialMapType = MapBaseType(application.mapRegionManager.userSelectedMapType)
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
         self.application = application

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -142,7 +142,13 @@ struct MapPanelRootView: View {
                     )
                 }
             }
-            searchResultMapContent(for: searchDisplay.display)
+            searchResultMapContent(for: searchDisplay.display) { stop in
+                application.stopIconFactory.buildSquircleIcon(
+                    for: stop,
+                    isBookmarked: false,
+                    traits: UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
+                )
+            }
         }
         .onMapCameraChange(frequency: .onEnd) { context in
             viewportRecorder.record(context.rect)

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -100,6 +100,12 @@ final class MapSearchDisplayModel: ObservableObject {
         ))
     }
 
+    /// Moves the camera without changing what's displayed — used when the user picks
+    /// a stop out of a route's list and the polyline should stay on screen.
+    func focus(coordinate: CLLocationCoordinate2D) {
+        cameraTarget = .coordinate(coordinate, animated: true)
+    }
+
     /// Applies-and-forgets the pending camera move. Called by the view once it has
     /// moved the camera.
     func consumeCameraTarget() {

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -62,6 +62,20 @@ final class MapSearchDisplayModel: ObservableObject {
     @Published private(set) var display: Display = .none
     @Published private(set) var cameraTarget: CameraTarget?
 
+    /// The sheet route this display belongs to, and the thing that decides how long
+    /// it stays on the map.
+    ///
+    /// Lifetime is keyed to the route stack rather than to the owning sheet view's
+    /// `onDisappear`, which is what this originally used. `onDisappear` reads like a
+    /// dismissal signal but isn't one: the floating-sheet system rebuilds a sheet's
+    /// content view for reasons that have nothing to do with the user leaving —
+    /// stacked layers being re-presented, the base sheet's content swapping
+    /// underneath — and each rebuild fired a `clear()` that wiped a route off the map
+    /// seconds after it was drawn, while its sheet sat there still visible.
+    ///
+    /// The route stack is the actual record of what's on screen, so ask it.
+    @Published private(set) var owner: AppSheetRoute?
+
     /// While a route is drawn, the ambient stop pins are hidden and stop loading is
     /// skipped so the route's own stops are the only ones on the map — the SwiftUI
     /// counterpart of the UIKit path's `removeAllAnnotations()` plus
@@ -71,17 +85,20 @@ final class MapSearchDisplayModel: ObservableObject {
         return false
     }
 
-    func show(mapItem: MKMapItem, animated: Bool) {
+    func show(mapItem: MKMapItem, animated: Bool, owner: AppSheetRoute) {
+        self.owner = owner
         display = .mapItem(mapItem)
         cameraTarget = .coordinate(mapItem.placemark.coordinate, animated: animated)
     }
 
-    func show(stop: Stop) {
+    func show(stop: Stop, owner: AppSheetRoute) {
+        self.owner = owner
         display = .stop(stop)
         cameraTarget = .coordinate(stop.coordinate, animated: true)
     }
 
-    func show(stopsForRoute: StopsForRoute) {
+    func show(stopsForRoute: StopsForRoute, owner: AppSheetRoute) {
+        self.owner = owner
         let color = stopsForRoute.route.map { Color(uiColor: $0.color ?? ThemeColors.shared.brand) }
             ?? Color(uiColor: ThemeColors.shared.brand)
 
@@ -112,7 +129,22 @@ final class MapSearchDisplayModel: ObservableObject {
         cameraTarget = nil
     }
 
+    /// Drops the display once the route that owns it is no longer anywhere in the
+    /// sheet stack. Called on every change to that stack.
+    ///
+    /// Deriving the decision from the stack, rather than acting on a dismissal event,
+    /// makes this self-correcting: a route that is popped and immediately re-pushed
+    /// (what a search does while it resolves a result) is still present when this
+    /// runs, so nothing is wiped in the gap.
+    ///
+    /// - Parameter routes: Every route currently on screen — both sheet layers.
+    func clearIfOwnerAbsent(from routes: [AppSheetRoute]) {
+        guard let owner, !routes.contains(owner) else { return }
+        clear()
+    }
+
     func clear() {
+        owner = nil
         display = .none
         cameraTarget = nil
     }

--- a/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
+++ b/OBAKit/Sheet/Root/MapSearchDisplayModel.swift
@@ -1,0 +1,113 @@
+//
+//  MapSearchDisplayModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import SwiftUI
+import OBAKitCore
+
+/// What the SwiftUI map should draw for the current search result, and where the
+/// camera should point.
+///
+/// The UIKit equivalent lives inside `MapRegionManager.searchResponse.didSet`, which
+/// mutates an `MKMapView` directly. The SwiftUI panel has no such view to mutate, so
+/// the same decisions are expressed as state here and rendered by `MapPanelRootView`.
+@MainActor
+final class MapSearchDisplayModel: ObservableObject {
+
+    /// Everything the map builder needs for a displayed route, resolved once so it
+    /// isn't re-derived on every body evaluation. `body` re-runs on unrelated state
+    /// changes — including the continuous sheet-height updates while the sheet is
+    /// dragged — so decoding polylines there would be costly.
+    struct RouteDisplay {
+        let polylines: [MKPolyline]
+        let stops: [Stop]
+        let color: Color
+        let mapRect: MKMapRect
+    }
+
+    enum Display {
+        case none
+        case mapItem(MKMapItem)
+        case route(RouteDisplay)
+        case stop(Stop)
+    }
+
+    /// Where the camera should move next. One-shot: the view applies it and calls
+    /// `consumeCameraTarget()`, so a later unrelated body evaluation can't re-move
+    /// the map out from under the user.
+    enum CameraTarget: Equatable {
+        case coordinate(CLLocationCoordinate2D, animated: Bool)
+        case rect(MKMapRect)
+
+        static func == (lhs: CameraTarget, rhs: CameraTarget) -> Bool {
+            switch (lhs, rhs) {
+            case (.coordinate(let l, let la), .coordinate(let r, let ra)):
+                return l.latitude == r.latitude && l.longitude == r.longitude && la == ra
+            case (.rect(let l), .rect(let r)):
+                return l.origin.x == r.origin.x && l.origin.y == r.origin.y
+                    && l.size.width == r.size.width && l.size.height == r.size.height
+            default:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var display: Display = .none
+    @Published private(set) var cameraTarget: CameraTarget?
+
+    /// While a route is drawn, the ambient stop pins are hidden and stop loading is
+    /// skipped so the route's own stops are the only ones on the map — the SwiftUI
+    /// counterpart of the UIKit path's `removeAllAnnotations()` plus
+    /// `searchResponseOverridesStopLoading()`.
+    var suppressesAmbientStops: Bool {
+        if case .route = display { return true }
+        return false
+    }
+
+    func show(mapItem: MKMapItem, animated: Bool) {
+        display = .mapItem(mapItem)
+        cameraTarget = .coordinate(mapItem.placemark.coordinate, animated: animated)
+    }
+
+    func show(stop: Stop) {
+        display = .stop(stop)
+        cameraTarget = .coordinate(stop.coordinate, animated: true)
+    }
+
+    func show(stopsForRoute: StopsForRoute) {
+        let color = stopsForRoute.route.map { Color(uiColor: $0.color ?? ThemeColors.shared.brand) }
+            ?? Color(uiColor: ThemeColors.shared.brand)
+
+        display = .route(RouteDisplay(
+            polylines: stopsForRoute.polylines,
+            stops: stopsForRoute.stops ?? [],
+            color: color,
+            mapRect: stopsForRoute.mapRect
+        ))
+        // Expand the bounding rect so the route isn't flush against the screen
+        // edges, with extra room at the bottom for the sheet — the SwiftUI
+        // equivalent of the UIKit path's `mapRectThatFits(edgePadding:)`.
+        cameraTarget = .rect(stopsForRoute.mapRect.insetBy(
+            dx: -stopsForRoute.mapRect.size.width * 0.15,
+            dy: -stopsForRoute.mapRect.size.height * 0.30
+        ))
+    }
+
+    /// Applies-and-forgets the pending camera move. Called by the view once it has
+    /// moved the camera.
+    func consumeCameraTarget() {
+        cameraTarget = nil
+    }
+
+    func clear() {
+        display = .none
+        cameraTarget = nil
+    }
+}

--- a/OBAKit/Sheet/Root/MapSearchOverlays.swift
+++ b/OBAKit/Sheet/Root/MapSearchOverlays.swift
@@ -1,0 +1,32 @@
+//
+//  MapSearchOverlays.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import OBAKitCore
+
+/// Search-result map content: the route polyline and the searched place marker.
+///
+/// A free function rather than inline map content because `MapPanelRootView.body`
+/// has already exceeded Swift's type-check budget once.
+@MapContentBuilder
+func searchResultMapContent(for display: MapSearchDisplayModel.Display) -> some MapContent {
+    switch display {
+    case .route(let route):
+        ForEach(Array(route.polylines.enumerated()), id: \.offset) { _, polyline in
+            MapPolyline(polyline)
+                .stroke(route.color, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+        }
+    case .mapItem(let item):
+        Marker(item.name ?? "", coordinate: item.placemark.coordinate)
+    case .stop, .none:
+        // Stops are already drawn by the ambient stop layer; nothing extra to add.
+        EmptyMapContent()
+    }
+}

--- a/OBAKit/Sheet/Root/MapSearchOverlays.swift
+++ b/OBAKit/Sheet/Root/MapSearchOverlays.swift
@@ -11,17 +11,36 @@ import SwiftUI
 import MapKit
 import OBAKitCore
 
-/// Search-result map content: the route polyline and the searched place marker.
+/// Search-result map content: the route polyline, the route's own stops, and the
+/// searched place marker.
 ///
 /// A free function rather than inline map content because `MapPanelRootView.body`
 /// has already exceeded Swift's type-check budget once.
+///
+/// - Parameter stopIcon: Builds the pin image for a stop. Passed in rather than
+///   resolved here because the icon depends on `Application.stopIconFactory` and the
+///   current interface style, both of which live on the view.
 @MapContentBuilder
-func searchResultMapContent(for display: MapSearchDisplayModel.Display) -> some MapContent {
+func searchResultMapContent(
+    for display: MapSearchDisplayModel.Display,
+    stopIcon: @escaping (Stop) -> UIImage
+) -> some MapContent {
     switch display {
     case .route(let route):
         ForEach(Array(route.polylines.enumerated()), id: \.offset) { _, polyline in
             MapPolyline(polyline)
                 .stroke(route.color, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+        }
+        // A drawn route suppresses the ambient stop layer, so these are the only
+        // stops on the map — matching the UIKit route search, which replaces the
+        // visible annotations with the route's own. Tagged like ambient stops so
+        // tapping one opens its details.
+        ForEach(route.stops) { stop in
+            Annotation("", coordinate: stop.coordinate) {
+                Image(uiImage: stopIcon(stop))
+                    .accessibilityLabel(Formatters.formattedAccessibilityLabel(stop: stop))
+            }
+            .tag(stop.id)
         }
     case .mapItem(let item):
         Marker(item.name ?? "", coordinate: item.placemark.coordinate)

--- a/OBAKit/Sheet/Root/MapStopsObserver.swift
+++ b/OBAKit/Sheet/Root/MapStopsObserver.swift
@@ -117,10 +117,18 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
 
     /// Records the settled viewport and prunes against it. Pruning here (not
     /// only in `stopsUpdated`) bounds the set even on settles that load no
-    /// stops. Loop-safe: a re-fired same-region settle changes nothing.
+    /// stops. Loop-safe: a re-fired same-region settle changes nothing — neither
+    /// `stops` nor `viewportCenter` is republished, so observers aren't invalidated.
     func updateViewport(_ region: MKCoordinateRegion) {
         viewport = region
-        viewportCenter = region.center
+        // `CLLocationCoordinate2D` isn't `Equatable`, so `@Published` can't drop a
+        // same-value write for us. Comparing by hand is what keeps a re-fired
+        // settle from firing `objectWillChange` — and with it a `MapPanelRootView`
+        // body eval and a full re-sort of the nearby section — for no change.
+        if viewportCenter?.latitude != region.center.latitude
+            || viewportCenter?.longitude != region.center.longitude {
+            viewportCenter = region.center
+        }
         if pruneAccumulated() {
             publish()
         }

--- a/OBAKit/Sheet/Root/MapStopsObserver.swift
+++ b/OBAKit/Sheet/Root/MapStopsObserver.swift
@@ -65,6 +65,11 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     /// Last settled viewport, the prune reference. Nil = no prune (set grows).
     private var viewport: MKCoordinateRegion?
 
+    /// Center of the last settled viewport, published so the home sheet's
+    /// nearby section can order stops by it. Nil until the first settle, and
+    /// cleared on `reset()` so a stale center never outlives its render set.
+    @Published private(set) var viewportCenter: CLLocationCoordinate2D?
+
     private let application: Application
 
     init(application: Application, pruneSpanFactor: Double = 4.0, renderCap: Int = 400) {
@@ -105,6 +110,7 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     func reset() {
         accumulated.removeAll()
         viewport = nil
+        viewportCenter = nil
         guard !stops.isEmpty else { return }
         stops = []
     }
@@ -114,6 +120,7 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     /// stops. Loop-safe: a re-fired same-region settle changes nothing.
     func updateViewport(_ region: MKCoordinateRegion) {
         viewport = region
+        viewportCenter = region.center
         if pruneAccumulated() {
             publish()
         }

--- a/OBAKit/Sheet/Root/MapStopsObserver.swift
+++ b/OBAKit/Sheet/Root/MapStopsObserver.swift
@@ -70,6 +70,18 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     /// cleared on `reset()` so a stale center never outlives its render set.
     @Published private(set) var viewportCenter: CLLocationCoordinate2D?
 
+    /// True once the map has reported a settled camera, through *either* branch
+    /// of `MapPanelRootView.onMapCameraChange` — a zoomed-in settle or a
+    /// zoomed-out `reset()`. Latched, so it survives the reset that a zoom-out
+    /// performs.
+    ///
+    /// The home sheet reads it to hold its empty state back until "there's
+    /// nothing nearby" is a fact rather than the pre-first-settle default. Both
+    /// branches count: a map parked at region-level zoom never settles into
+    /// `updateViewport(_:)`, and that's exactly a case where the empty state is
+    /// the correct thing to show.
+    @Published private(set) var hasSettledOnce = false
+
     private let application: Application
 
     init(application: Application, pruneSpanFactor: Double = 4.0, renderCap: Int = 400) {
@@ -110,7 +122,18 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     func reset() {
         accumulated.removeAll()
         viewport = nil
-        viewportCenter = nil
+        if !hasSettledOnce {
+            hasSettledOnce = true
+        }
+        // Guarded for the same reason `updateViewport(_:)` hand-rolls its
+        // comparison: `CLLocationCoordinate2D` isn't `Equatable`, so `@Published`
+        // won't drop a nil-over-nil write. `MapPanelRootView` calls `reset()` on
+        // *every* settle while zoomed out, not just on the zoom-out transition,
+        // so an unguarded clear would fire `objectWillChange` on each pan and
+        // cascade into the nearby section and the whole home sheet.
+        if viewportCenter != nil {
+            viewportCenter = nil
+        }
         guard !stops.isEmpty else { return }
         stops = []
     }
@@ -121,6 +144,9 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
     /// `stops` nor `viewportCenter` is republished, so observers aren't invalidated.
     func updateViewport(_ region: MKCoordinateRegion) {
         viewport = region
+        if !hasSettledOnce {
+            hasSettledOnce = true
+        }
         // `CLLocationCoordinate2D` isn't `Equatable`, so `@Published` can't drop a
         // same-value write for us. Comparing by hand is what keeps a re-fired
         // settle from firing `objectWillChange` — and with it a `MapPanelRootView`

--- a/OBAKit/Sheet/Root/MapStopsObserver.swift
+++ b/OBAKit/Sheet/Root/MapStopsObserver.swift
@@ -200,24 +200,11 @@ final class MapStopsObserver: NSObject, ObservableObject, MapRegionDelegate, Reg
 
         // Count cap: keep the `renderCap` nearest to center, evict the rest.
         if accumulated.count > renderCap {
-            let nearest = accumulated.values
-                .sorted { squaredDistance($0, to: center) < squaredDistance($1, to: center) }
-                .prefix(renderCap)
+            let nearest = Stop.nearest(Array(accumulated.values), to: center, limit: renderCap)
             accumulated = Dictionary(nearest.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         }
 
         return true
-    }
-
-    /// Squared distance with longitude scaled by `cos(latitude)` so lat/lon
-    /// degrees compare on a common metric scale. Ordering only — no sqrt.
-    ///
-    /// Internal rather than private so the cap-eviction tests can assert against
-    /// this exact ordering instead of maintaining a second copy of the formula.
-    func squaredDistance(_ stop: Stop, to center: CLLocationCoordinate2D) -> Double {
-        let dLat = stop.coordinate.latitude - center.latitude
-        let dLon = (stop.coordinate.longitude - center.longitude) * cos(center.latitude * .pi / 180)
-        return dLat * dLat + dLon * dLon
     }
 
     private func orderedStops() -> [Stop] {

--- a/OBAKit/Sheet/Root/MapViewportRecorder.swift
+++ b/OBAKit/Sheet/Root/MapViewportRecorder.swift
@@ -1,0 +1,40 @@
+//
+//  MapViewportRecorder.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import OBAKitCore
+
+/// Records the SwiftUI map panel's settled viewport into
+/// `MapRegionManager.lastVisibleMapRect`.
+///
+/// The UIKit map writes that value from `mapView(_:regionDidChangeAnimated:)`, but
+/// the manager's own `MKMapView` is never installed in the SwiftUI panel, so nothing
+/// here keeps it current. Address and route searches use it *as the region they
+/// query* (`SearchManager.fetchAddress` / `fetchRoute`), and its getter falls back to
+/// the current region's whole service rect rather than `nil` — so a missing write
+/// doesn't fail loudly, it just scopes searches to the wrong area.
+///
+/// A dedicated type rather than a method on `MapViewModel`: that view model
+/// documents itself as containing no MapKit imports so it stays usable from both the
+/// UIKit and SwiftUI hosts.
+@MainActor
+final class MapViewportRecorder {
+
+    private let application: Application
+
+    init(application: Application) {
+        self.application = application
+    }
+
+    /// Persists `rect` as the panel's last visible viewport.
+    func record(_ rect: MKMapRect) {
+        application.mapRegionManager.lastVisibleMapRect = rect
+    }
+}

--- a/OBAKit/Strings/Strings+Sheet.swift
+++ b/OBAKit/Strings/Strings+Sheet.swift
@@ -11,7 +11,7 @@ import Foundation
 import OBAKitCore
 
 /// Localized strings consumed by the SwiftUI sheet surfaces
-/// (`MapPanelRootView` and its views).
+/// (`MapPanelRootView` and its views) and related UIKit components.
 public extension Strings {
 
     // MARK: - Route Picker
@@ -88,5 +88,19 @@ public extension Strings {
         "current_trip_controller.distance_fmt",
         value: "%@ away",
         comment: "Distance from user to vehicle. e.g. '0.2 mi away'"
+    )
+
+    // MARK: - Shared Section Titles
+
+    nonisolated static let nearbyStops = OBALoc(
+        "nearby_stops_controller.title",
+        value: "Nearby Stops",
+        comment: "The title of the Nearby Stops controller."
+    )
+
+    nonisolated static let bookmarks = OBALoc(
+        "search_controller.bookmarks.header",
+        value: "Bookmarks",
+        comment: "Title of the Bookmarks search header"
     )
 }

--- a/OBAKit/Strings/Strings+Sheet.swift
+++ b/OBAKit/Strings/Strings+Sheet.swift
@@ -92,6 +92,9 @@ public extension Strings {
 
     // MARK: - Shared Section Titles
 
+    // nonisolated: OBAKit defaults to @MainActor isolation. These constants are accessed from nonisolated
+    // contexts (e.g., `NearbyStopsListViewController.Section`, which is `nonisolated`), so they must be
+    // explicitly marked to remain reachable.
     nonisolated static let nearbyStops = OBALoc(
         "nearby_stops_controller.title",
         value: "Nearby Stops",

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "التتبّع على شاشة القفل";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "ستتوفر هذه الشاشة قريبًا.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "المجدولة فقط";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "تثبيت";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "تتبّع";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "إلغاء التثبيت";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "حذف الإشارة المرجعية";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "لا توجد رحلات مغادرة قادمة";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "مثبت";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "ترتيب حسب المسافة";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "مصغّرة";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "ستظهر هنا المواقف القريبة والمواقف التي شاهدتها والإشارات المرجعية الخاصة بك.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "لا يوجد شيء هنا بعد";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "يعرض جميع العناصر في هذا القسم.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "يُرجى التحقق من إعدادات «الأنشطة المباشرة» في تطبيق «الإعدادات».";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "اختر خطك";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "لا توجد محطات";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "التاريخ";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d نتيجة";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "تعذر فتح نتيجة البحث هذه.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "مسح";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "مصغّرة";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "البحث قريبًا";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "يُرجى التحقق من إعدادات «الأنشطة المباشرة» في تطبيق «الإعدادات».";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "مصغّرة";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "يُرجى التحقق من إعدادات «الأنشطة المباشرة» في تطبيق «الإعدادات».";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "نتائج البحث";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "لا توجد نتائج";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d نتيجة";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "مسح";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "الهيئات المتأثرة";

--- a/OBAKit/Strings/ar.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ar.lproj/Localizable.stringsdict
@@ -50,6 +50,30 @@
 			<string>%d حالة ناجحة</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>لا توجد نتائج</string>
+			<key>one</key>
+			<string>نتيجة واحدة</string>
+			<key>two</key>
+			<string>نتيجتان</string>
+			<key>few</key>
+			<string>%d نتائج</string>
+			<key>many</key>
+			<string>%d نتيجة</string>
+			<key>other</key>
+			<string>%d نتيجة</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Track on Lock Screen";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "This screen is coming soon.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Scheduled Only";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Pin";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Track";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Unpin";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Delete Bookmark";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "No upcoming departures";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Pinned";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Sort by Distance";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimized";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Nearby stops, stops you've viewed, and your bookmarks will show up here.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Nothing Here Yet";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Shows all items in this section.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Please check your Live Activities settings in Settings.";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -942,6 +942,15 @@
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Search Results";
 
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "No results";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d results";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Clear";
+
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Affected Agencies";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -316,9 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimized";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Search coming soon";
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Please check your Live Activities settings in Settings.";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Select Your Route";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "No stops";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Date";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d results";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "This search result could not be opened.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Clear";

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d successful</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 result</string>
+			<key>other</key>
+			<string>%d results</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Revise los ajustes de Actividades en Vivo en Configuración.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Resultados de Busqueda";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Sin resultados";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Borrar";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agencias Afectadas";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Búsqueda próximamente";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Revise los ajustes de Actividades en Vivo en Configuración.";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Seguir en la pantalla bloqueada";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Esta pantalla estará disponible pronto.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Solo Programadas";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Fijar";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Seguir";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Dejar de fijar";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Borrar Marcador";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "No hay próximas salidas";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Fijado";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Ordenar por Distancia";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Las paradas cercanas, las paradas que has visto y tus marcadores aparecerán aquí.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Aún no hay nada aquí";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Muestra todos los elementos de esta sección.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Revise los ajustes de Actividades en Vivo en Configuración.";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Seleccione su Ruta";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Sin paradas";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Fecha";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "No se pudo abrir este resultado de búsqueda.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Borrar";

--- a/OBAKit/Strings/es.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/es.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d exitosos</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 resultado</string>
+			<key>other</key>
+			<string>%d resultados</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Naka-minimize";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Pakisuri ang iyong mga setting ng Live Activities sa Mga Setting.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Mga Resulta ng Paghahanap";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Walang resulta";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d na resulta";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "I-clear";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Mga Apektadong Ahensya";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "I-track sa Lock Screen";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Paparating na ang screen na ito.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Nakaiskedyul Lang";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "I-pin";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "I-track";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "I-unpin";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "I-delete ang Bookmark";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Walang paparating na byahe";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Naka-pin";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "I-sort ayon sa Distansya";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Naka-minimize";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Lilitaw dito ang mga kalapit na hintuan, mga hintuang tiningnan mo, at ang iyong mga bookmark.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Wala Pa Rito";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Ipinapakita ang lahat ng item sa seksyong ito.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Pakisuri ang iyong mga setting ng Live Activities sa Mga Setting.";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Piliin ang Iyong Ruta";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Walang mga hintuan";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Petsa";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d na resulta";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Hindi mabuksan ang resultang ito ng paghahanap.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "I-clear";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Naka-minimize";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Paparating na ang paghahanap";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Pakisuri ang iyong mga setting ng Live Activities sa Mga Setting.";

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d na matagumpay</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d resulta</string>
+			<key>other</key>
+			<string>%d na resulta</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Réduit";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Recherche bientôt disponible";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vérifiez vos réglages des activités en direct dans les Réglages.";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Réduit";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vérifiez vos réglages des activités en direct dans les Réglages.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Résultats de recherche";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Aucun résultat";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d résultats";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Effacer";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agences concernées";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Sélectionnez votre ligne";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Aucun arrêt";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Date";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d résultats";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Impossible d'ouvrir ce résultat de recherche.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Effacer";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Suivre sur l'écran verrouillé";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Cet écran arrive bientôt.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Horaires théoriques uniquement";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Épingler";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Suivre";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Détacher";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Supprimer le favori";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Aucun départ à venir";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Épinglé";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Trier par distance";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Réduit";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Les arrêts à proximité, les arrêts consultés et vos favoris apparaîtront ici.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Rien pour l'instant";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Affiche tous les éléments de cette section.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vérifiez vos réglages des activités en direct dans les Réglages.";

--- a/OBAKit/Strings/fr.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fr.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d réussites</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d résultat</string>
+			<key>other</key>
+			<string>%d résultats</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Traccia sulla schermata di blocco";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Questa schermata sarà presto disponibile.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Solo orario previsto";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Fissa";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Traccia";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Rimuovi";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Elimina promemoria";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Nessuna partenza in arrivo";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Fissato";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Ordina per distanza";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizzata";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Le fermate vicine, le fermate che hai visualizzato e i tuoi segnalibri appariranno qui.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Ancora niente qui";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Mostra tutti gli elementi di questa sezione.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Controlla le impostazioni delle Attività in tempo reale in Impostazioni.";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizzata";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Controlla le impostazioni delle Attività in tempo reale in Impostazioni.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Risultati della ricerca";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Nessun risultato";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d risultati";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Cancella";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Enti interessati";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizzata";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Ricerca presto disponibile";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Controlla le impostazioni delle Attività in tempo reale in Impostazioni.";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Seleziona la tua linea";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Nessuna fermata";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d risultati";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Impossibile aprire questo risultato di ricerca.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Cancella";

--- a/OBAKit/Strings/it.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/it.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d riusciti</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 risultato</string>
+			<key>other</key>
+			<string>%d risultati</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "최소화됨";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "설정에서 실시간 액티비티 설정을 확인해 주세요.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "검색 결과";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "결과 없음";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "결과 %d개";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "지우기";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "영향을 받는 운영 기관";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "노선 선택";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "정류장 없음";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "날짜";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "결과 %d개";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "이 검색 결과를 열 수 없습니다.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "지우기";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "최소화됨";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "검색 기능 준비 중";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "설정에서 실시간 액티비티 설정을 확인해 주세요.";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "잠금 화면에서 추적";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "이 화면은 곧 제공될 예정입니다.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "시간표 기준만";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "고정";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "추적";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "고정 해제";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "즐겨찾기 삭제";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "예정된 출발 없음";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "고정됨";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "거리순 정렬";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "최소화됨";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "주변 정류장, 최근에 본 정류장, 즐겨찾기가 여기에 표시됩니다.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "아직 아무것도 없습니다";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "이 섹션의 모든 항목을 표시합니다.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "설정에서 실시간 액티비티 설정을 확인해 주세요.";

--- a/OBAKit/Strings/ko.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ko.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>성공 %d건</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>결과 %d개</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Śledź na ekranie blokady";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Ten ekran będzie dostępny wkrótce.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Tylko rozkładowe";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Przypnij";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Śledź";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Odepnij";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Usuń zakładkę";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Brak nadchodzących odjazdów";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Przypięto";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Sortuj po odległości";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Zminimalizowany";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Pojawią się tutaj przystanki w pobliżu, oglądane przystanki i Twoje zakładki.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Jeszcze nic tu nie ma";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Pokazuje wszystkie elementy w tej sekcji.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Sprawdź ustawienia Aktywności na żywo w aplikacji Ustawienia.";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Zminimalizowany";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Wyszukiwanie już wkrótce";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Sprawdź ustawienia Aktywności na żywo w aplikacji Ustawienia.";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Zminimalizowany";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Sprawdź ustawienia Aktywności na żywo w aplikacji Ustawienia.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Wyniki wyszukiwania";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Brak wyników";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d wyników";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Wyczyść";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Dotyczy tych przewoźników";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Wybierz swoją linię";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Brak przystanków";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d wyników";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Nie można otworzyć tego wyniku wyszukiwania.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Wyczyść";

--- a/OBAKit/Strings/pl.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pl.lproj/Localizable.stringsdict
@@ -42,6 +42,26 @@
 			<string>%d udanego zadania</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 wynik</string>
+			<key>few</key>
+			<string>%d wyniki</string>
+			<key>many</key>
+			<string>%d wyników</string>
+			<key>other</key>
+			<string>%d wyniku</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Selecione Sua Linha";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Nenhuma parada";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Data";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Não foi possível abrir este resultado de busca.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Limpar";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Verifique os ajustes de Atividades ao Vivo nos Ajustes do sistema.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Resultados da Busca";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Nenhum resultado";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d resultados";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Limpar";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Agências Afetadas";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Busca em breve";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Verifique os ajustes de Atividades ao Vivo nos Ajustes do sistema.";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Acompanhar na Tela Bloqueada";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Esta tela estará disponível em breve.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Apenas Programadas";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Fixar";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Acompanhar";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Desafixar";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Apagar Favorito";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Nenhuma partida futura";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Fixado";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Ordenar por Distância";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimizado";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Paradas próximas, paradas que você visualizou e seus favoritos aparecerão aqui.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Ainda não há nada aqui";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Mostra todos os itens desta seção.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Verifique os ajustes de Atividades ao Vivo nos Ajustes do sistema.";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d bem-sucedidas</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 resultado</string>
+			<key>other</key>
+			<string>%d resultados</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Свёрнуто";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Поиск скоро появится";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Проверьте настройки Live-активностей в приложении «Настройки».";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Отслеживать на экране блокировки";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Этот экран скоро появится.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Только по расписанию";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Закрепить";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Отслеживать";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Открепить";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Удалить закладку";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Нет ближайших рейсов";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Закреплено";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Сортировать по расстоянию";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Свёрнуто";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Здесь появятся остановки рядом, просмотренные остановки и ваши закладки.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Здесь пока ничего нет";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Показывает все элементы этого раздела.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Проверьте настройки Live-активностей в приложении «Настройки».";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Свёрнуто";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Проверьте настройки Live-активностей в приложении «Настройки».";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Результаты поиска";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Нет результатов";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d результатов";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Очистить";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Затронутые агентства";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Выберите маршрут";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Нет остановок";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Дата";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d результатов";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Не удалось открыть этот результат поиска.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Очистить";

--- a/OBAKit/Strings/ru.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ru.lproj/Localizable.stringsdict
@@ -42,6 +42,26 @@
 			<string>%d успешного переноса</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d результат</string>
+			<key>few</key>
+			<string>%d результата</string>
+			<key>many</key>
+			<string>%d результатов</string>
+			<key>other</key>
+			<string>%d результата</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "Theo dõi trên Màn hình khóa";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "Màn hình này sắp ra mắt.";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "Chỉ theo lịch trình";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "Ghim";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "Theo dõi";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "Bỏ ghim";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "Xóa dấu trang";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "Không có chuyến sắp tới";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "Đã ghim";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "Sắp xếp theo khoảng cách";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Thu nhỏ";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "Các điểm dừng lân cận, điểm dừng bạn đã xem và dấu trang của bạn sẽ hiển thị ở đây.";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "Chưa có gì ở đây";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "Hiển thị tất cả mục trong phần này.";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vui lòng kiểm tra cài đặt Hoạt động Trực tiếp trong Cài đặt.";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Thu nhỏ";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "Tìm kiếm sắp ra mắt";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vui lòng kiểm tra cài đặt Hoạt động Trực tiếp trong Cài đặt.";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Thu nhỏ";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "Vui lòng kiểm tra cài đặt Hoạt động Trực tiếp trong Cài đặt.";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "Kết quả tìm kiếm";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "Không có kết quả";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d kết quả";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "Xóa";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "Đơn vị vận tải bị ảnh hưởng";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "Chọn tuyến của bạn";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "Không có điểm dừng";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "Ngày";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d kết quả";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "Không thể mở kết quả tìm kiếm này.";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "Xóa";

--- a/OBAKit/Strings/vi.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/vi.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d thành công</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d kết quả</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "在锁定屏幕上追踪";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "此页面即将推出。";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "仅时刻表";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "置顶";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "追踪";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "取消置顶";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "删除书签";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "暂无即将发车的班次";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "已置顶";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "按距离排序";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "已最小化";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "附近的车站、您查看过的车站以及您的书签将显示在这里。";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "这里还没有内容";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "显示此部分的所有项目。";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "请在“设置”中检查“实时活动”的相关设置。";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "已最小化";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "搜索功能即将推出";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "请在“设置”中检查“实时活动”的相关设置。";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "已最小化";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "请在“设置”中检查“实时活动”的相关设置。";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "搜索结果";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "无结果";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d 个结果";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "清除";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "受此影响的公交公司";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "选择您的线路";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "无站点";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "日期";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d 个结果";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "无法打开此搜索结果。";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "清除";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d项成功</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个结果</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -316,7 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "最小化";
 
-
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "請檢查「設定」中的「即時動態」設定。";
 
@@ -942,6 +941,15 @@
 
 /* The title of the Search Results controller. */
 "search_results_controller.title" = "搜尋結果";
+
+/* Title shown when a disambiguation sheet has no results to show. */
+"search_results_sheet.empty.title" = "無結果";
+
+/* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"search_results_sheet.result_count_fmt" = "%d 個結果";
+
+/* Accessibility label for the button that clears the search query. */
+"search_sheet.clear_query" = "清除";
 
 /* The transit agencies affected by this service alert. */
 "service_alert_controller.affected_agencies" = "受影響的營運機構";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Toggle label that starts a Live Activity widget on the Lock Screen when an alarm is set. */
 "alarm_time_picker.track_on_lock_screen" = "在鎖定畫面上追蹤";
 
-/* Placeholder shown in release builds when a sheet route is pushed but has no view registered. */
+/* Placeholder shown when a sheet route is pushed but its screen has not been built yet. */
 "app_sheet.unimplemented_route.placeholder" = "此畫面即將推出。";
 
 /* Filter option to show all departures regardless of real-time data availability */
@@ -58,8 +58,14 @@
 /* Filter option to show only departures with scheduled data and no real-time information */
 "arrival_departure_filter.scheduled_only" = "僅時刻表";
 
+/* Context menu action that pins a bookmark to the top of the home sheet's bookmarks section. */
+"bookmarks_controller.context_menu.pin" = "置頂";
+
 /* Action to start a Live Activity for a specific bookmark */
 "bookmarks_controller.context_menu.track_live_activity" = "追蹤";
+
+/* Context menu action that removes a bookmark's pin, returning it to the normal ordering. */
+"bookmarks_controller.context_menu.unpin" = "取消置頂";
 
 /* The title to display to confirm the user's action to delete a bookmark. */
 "bookmarks_controller.delete_bookmark.actionsheet.title" = "刪除書籤";
@@ -69,6 +75,9 @@
 
 /* Shown on a bookmark card when arrival data has loaded but there are no departures in the near future */
 "bookmarks_controller.no_upcoming_departures" = "暫無即將發車的班次";
+
+/* VoiceOver suffix announcing that a bookmark row is pinned. */
+"bookmarks_controller.pinned.a11y_label" = "已置頂";
 
 /* A menu item that allows the user to sort their bookmarks by distance from the user. */
 "bookmarks_controller.sort_menu.sort_by_distance" = "依距離排序";
@@ -315,6 +324,15 @@
 
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "最小化";
+
+/* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.body" = "附近站牌、您檢視過的站牌以及您的書籤將顯示在這裡。";
+
+/* Title for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
+"home_sheet.empty_set.title" = "這裡還沒有內容";
+
+/* VoiceOver hint for a home sheet section header, which opens that section's full list. */
+"home_sheet.section_header.a11y_hint" = "顯示此區段的所有項目。";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "請檢查「設定」中的「即時動態」設定。";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -316,8 +316,6 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "最小化";
 
-/* Placeholder text inside the disabled search bar on the home sheet, shown while search is unimplemented. */
-"home_sheet.search_bar.coming_soon" = "搜尋功能即將推出";
 
 /* Alert message for Live Activity error. \"Settings\" is the iOS Settings app. */
 "live_activity.error.message" = "請檢查「設定」中的「即時動態」設定。";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -858,6 +858,9 @@
 /* Title for the route picker screen where the user selects their transit route. */
 "route_picker.title" = "選擇您的路線";
 
+/* Title shown when a route's stop list could not be loaded or is empty. */
+"route_stops_sheet.empty.title" = "無站點";
+
 /* Label for date picker in schedule view */
 "schedule_view.date" = "日期";
 
@@ -947,6 +950,9 @@
 
 /* Header showing how many results a search matched, e.g. '12 results'. %d is the number of results. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "search_results_sheet.result_count_fmt" = "%d 個結果";
+
+/* Error shown when a tapped search result cannot be turned into something to display. */
+"search_results_sheet.unresolvable_result" = "無法開啟此搜尋結果。";
 
 /* Accessibility label for the button that clears the search query. */
 "search_sheet.clear_query" = "清除";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
@@ -30,6 +30,20 @@
 			<string>%d 個成功</string>
 		</dict>
 	</dict>
+	<key>search_results_sheet.result_count_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個結果</string>
+		</dict>
+	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -8,7 +8,6 @@
 //
 
 import ActivityKit
-import CoreLocation
 import Combine
 import CoreLocation
 import SwiftUI

--- a/OBAKit/TripPlanning/MapItemView.swift
+++ b/OBAKit/TripPlanning/MapItemView.swift
@@ -41,63 +41,63 @@ public struct MapItemView: View {
 
     public var body: some View {
         VStack(spacing: 0) {
-                headerView
-                    .padding(.top, 20)
-                    .padding(.horizontal)
+            headerView
+                .padding(.top, 20)
+                .padding(.horizontal)
 
-                ScrollView {
-                     VStack(spacing: 20) {
-                        // Action Buttons and Nearby Stops
-                        VStack(spacing: 12) {
-                            actionButtonsRow
-                                .padding(.horizontal)
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Action Buttons and Nearby Stops
+                    VStack(spacing: 12) {
+                        actionButtonsRow
+                            .padding(.horizontal)
 
-                            // Nearby Stops Button - show as full-width only when call/website buttons exist
-                            if viewModel.phoneNumber != nil || viewModel.url != nil {
-                                Button(
-                                    action: {
-                                        viewModel.showNearbyStops()
-                                    },
-                                    label: {
-                                        HStack {
-                                            Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button to view nearby stops"))
-                                                .bold()
-                                            Spacer()
-                                            Image(systemName: "chevron.right")
-                                                .font(.caption)
-                                                .bold()
-                                        }
-                                        .padding()
-                                        .background(Color(uiColor: .secondarySystemBackground))
-                                        .clipShape(.rect(cornerRadius: 12))
+                        // Nearby Stops Button - show as full-width only when call/website buttons exist
+                        if viewModel.phoneNumber != nil || viewModel.url != nil {
+                            Button(
+                                action: {
+                                    viewModel.showNearbyStops()
+                                },
+                                label: {
+                                    HStack {
+                                        Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button to view nearby stops"))
+                                            .bold()
+                                        Spacer()
+                                        Image(systemName: "chevron.right")
+                                            .font(.caption)
+                                            .bold()
                                     }
-                                )
-                                .padding(.horizontal)
-                                .foregroundStyle(.primary)
-                                .accessibilityLabel(OBALoc("map_item_controller.nearby_stops_accessibility", value: "View nearby transit stops", comment: "Accessibility label for nearby stops button"))
-                            }
+                                    .padding()
+                                    .background(Color(uiColor: .secondarySystemBackground))
+                                    .clipShape(.rect(cornerRadius: 12))
+                                }
+                            )
+                            .padding(.horizontal)
+                            .foregroundStyle(.primary)
+                            .accessibilityLabel(OBALoc("map_item_controller.nearby_stops_accessibility", value: "View nearby transit stops", comment: "Accessibility label for nearby stops button"))
                         }
-
-                        if let scene = viewModel.lookAroundScene {
-                            lookAroundSection(scene: scene)
-                        }
-
-                        if viewModel.hasAboutContent {
-                            aboutSection
-                                .padding(.horizontal)
-                        }
-
-                        // Remove Pin button for user-dropped pins
-                        if viewModel.canRemovePin {
-                            removePinSection
-                                .padding(.horizontal)
-                        }
-
-                        Spacer(minLength: 40)
                     }
-                    .padding(.top)
+
+                    if let scene = viewModel.lookAroundScene {
+                        lookAroundSection(scene: scene)
+                    }
+
+                    if viewModel.hasAboutContent {
+                        aboutSection
+                            .padding(.horizontal)
+                    }
+
+                    // Remove Pin button for user-dropped pins
+                    if viewModel.canRemovePin {
+                        removePinSection
+                            .padding(.horizontal)
+                    }
+
+                    Spacer(minLength: 40)
                 }
+                .padding(.top)
             }
+        }
         .lookAroundViewer(
             isPresented: $showLookAroundViewer,
             initialScene: viewModel.lookAroundScene

--- a/OBAKit/TripPlanning/MapItemView.swift
+++ b/OBAKit/TripPlanning/MapItemView.swift
@@ -24,23 +24,23 @@ public struct MapItemView: View {
     /// The view model that manages the data and business logic
     private var viewModel: MapItemViewModel
 
+    /// Whether to show the Share button; the UIKit host shows it, the sheet uses a native ShareLink
+    private let showsShareButton: Bool
+
     /// State for controlling the Look Around viewer presentation
     @State private var showLookAroundViewer = false
 
     /// Initializes a new map item view.
     ///
     /// - Parameter viewModel: The view model containing the map item data and handling user actions
-    public init(viewModel: MapItemViewModel) {
+    /// - Parameter showsShareButton: Whether to show the Share button (default: true for UIKit host)
+    public init(viewModel: MapItemViewModel, showsShareButton: Bool = true) {
         self.viewModel = viewModel
+        self.showsShareButton = showsShareButton
     }
 
     public var body: some View {
-        ZStack {
-            Color.clear
-                .background(.ultraThinMaterial)
-                .ignoresSafeArea(.all)
-
-            VStack(spacing: 0) {
+        VStack(spacing: 0) {
                 headerView
                     .padding(.top, 20)
                     .padding(.horizontal)
@@ -98,7 +98,6 @@ public struct MapItemView: View {
                     .padding(.top)
                 }
             }
-        }
         .lookAroundViewer(
             isPresented: $showLookAroundViewer,
             initialScene: viewModel.lookAroundScene
@@ -130,17 +129,19 @@ public struct MapItemView: View {
 
             HStack(alignment: .top) {
                 // Share Button
-                Button("Share", systemImage: "square.and.arrow.up") {
-                    viewModel.shareLocation()
+                if showsShareButton {
+                    Button("Share", systemImage: "square.and.arrow.up") {
+                        viewModel.shareLocation()
+                    }
+                    .labelStyle(.iconOnly)
+                    .font(.title3)
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(.circle)
+                    .background(.regularMaterial)
+                    .clipShape(.circle)
+                    .accessibilityLabel(OBALoc("map_item_controller.share_button", value: "Share Location", comment: "Accessibility label for share button"))
                 }
-                .labelStyle(.iconOnly)
-                .font(.title3)
-                .foregroundStyle(.primary)
-                .frame(width: 44, height: 44)
-                .contentShape(.circle)
-                .background(.regularMaterial)
-                .clipShape(.circle)
-                .accessibilityLabel(OBALoc("map_item_controller.share_button", value: "Share Location", comment: "Accessibility label for share button"))
 
                 Spacer()
 

--- a/OBAKit/TripPlanning/MapItemViewController.swift
+++ b/OBAKit/TripPlanning/MapItemViewController.swift
@@ -19,19 +19,33 @@ import OBAKitCore
 /// and provides a link to view nearby transit stops.
 ///
 class MapItemViewController: UIViewController, AppContext {
-    private let makeViewModel: (MapItemViewController) -> MapItemViewModel
-    private var viewModel: MapItemViewModel!
+    let application: Application
 
-    var application: Application { viewModel.application }
+    private let mapItem: MKMapItem
+    private weak var modalDelegate: ModalDelegate?
+    private let removePinHandler: (() -> Void)?
+    private let planTripHandler: () -> Void
 
     /// The hosting controller that embeds the SwiftUI view
     private var hostingController: UIHostingController<AnyView>?
 
-    /// The view model needs `MapItemActions` bound to *this* controller as their
-    /// presenter, which doesn't exist until after `super.init`. The caller supplies
-    /// a builder instead of a finished view model, and it runs in `viewDidLoad`.
-    init(makeViewModel: @escaping (MapItemViewController) -> MapItemViewModel) {
-        self.makeViewModel = makeViewModel
+    /// The view model, built in `viewDidLoad` because `MapItemActions.uiKit` needs
+    /// this controller as its presenter — which isn't available until after
+    /// `super.init`.
+    private var viewModel: MapItemViewModel?
+
+    init(
+        application: Application,
+        mapItem: MKMapItem,
+        delegate: ModalDelegate?,
+        removePinHandler: (() -> Void)? = nil,
+        planTripHandler: @escaping () -> Void
+    ) {
+        self.application = application
+        self.mapItem = mapItem
+        self.modalDelegate = delegate
+        self.removePinHandler = removePinHandler
+        self.planTripHandler = planTripHandler
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -40,7 +54,14 @@ class MapItemViewController: UIViewController, AppContext {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        viewModel = makeViewModel(self)
+        let viewModel = MapItemViewModel(
+            mapItem: mapItem,
+            application: application,
+            actions: .uiKit(presenter: self, delegate: modalDelegate, application: application),
+            removePinHandler: removePinHandler,
+            planTripHandler: planTripHandler
+        )
+        self.viewModel = viewModel
 
         view.backgroundColor = .clear
 
@@ -52,7 +73,7 @@ class MapItemViewController: UIViewController, AppContext {
         background.pinToSuperview(.edges)
 
         let mapItemView = MapItemView(viewModel: viewModel, showsShareButton: true)
-            .environment(\.coreApplication, viewModel.application)
+            .environment(\.coreApplication, application)
 
         let hostingController = UIHostingController(rootView: AnyView(mapItemView))
         hostingController.view.backgroundColor = .clear

--- a/OBAKit/TripPlanning/MapItemViewController.swift
+++ b/OBAKit/TripPlanning/MapItemViewController.swift
@@ -19,18 +19,19 @@ import OBAKitCore
 /// and provides a link to view nearby transit stops.
 ///
 class MapItemViewController: UIViewController, AppContext {
-    var application: Application {
-        viewModel.application
-    }
+    private let makeViewModel: (MapItemViewController) -> MapItemViewModel
+    private var viewModel: MapItemViewModel!
+
+    var application: Application { viewModel.application }
 
     /// The hosting controller that embeds the SwiftUI view
     private var hostingController: UIHostingController<AnyView>?
 
-    /// The view model that manages the business logic
-    private let viewModel: MapItemViewModel
-
-    init(_ viewModel: MapItemViewModel) {
-        self.viewModel = viewModel
+    /// The view model needs `MapItemActions` bound to *this* controller as their
+    /// presenter, which doesn't exist until after `super.init`. The caller supplies
+    /// a builder instead of a finished view model, and it runs in `viewDidLoad`.
+    init(makeViewModel: @escaping (MapItemViewController) -> MapItemViewModel) {
+        self.makeViewModel = makeViewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -39,11 +40,18 @@ class MapItemViewController: UIViewController, AppContext {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        viewModel = makeViewModel(self)
+
         view.backgroundColor = .clear
 
-        viewModel.setPresentingViewController(self)
+        // The blurred surface used to live inside `MapItemView`. It's panel chrome,
+        // not content — and inside a SwiftUI sheet it fights the sheet's own
+        // material — so the UIKit host owns it now.
+        let background = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+        view.addSubview(background)
+        background.pinToSuperview(.edges)
 
-        let mapItemView = MapItemView(viewModel: viewModel)
+        let mapItemView = MapItemView(viewModel: viewModel, showsShareButton: true)
             .environment(\.coreApplication, viewModel.application)
 
         let hostingController = UIHostingController(rootView: AnyView(mapItemView))

--- a/OBAKit/TripPlanning/MapItemViewModel.swift
+++ b/OBAKit/TripPlanning/MapItemViewModel.swift
@@ -13,6 +13,69 @@ import Contacts
 import SafariServices
 import OBAKitCore
 
+/// The presentation-dependent half of the map-item screen, injected so the same
+/// view model drives both the UIKit floating panel and the SwiftUI sheet.
+///
+/// Everything else the screen does — opening Maps, dialing a phone number — is
+/// app-level and needs no presenter.
+@MainActor
+public struct MapItemActions {
+    public var openWebsite: (URL) -> Void
+    public var showNearbyStops: (CLLocationCoordinate2D) -> Void
+    public var dismiss: () -> Void
+    /// Only the UIKit host uses this — the sheet renders a native `ShareLink` from
+    /// `MapItemViewModel.shareURL` instead and passes a no-op here.
+    public var share: (URL) -> Void
+
+    public init(
+        openWebsite: @escaping (URL) -> Void,
+        showNearbyStops: @escaping (CLLocationCoordinate2D) -> Void,
+        dismiss: @escaping () -> Void,
+        share: @escaping (URL) -> Void = { _ in }
+    ) {
+        self.openWebsite = openWebsite
+        self.showNearbyStops = showNearbyStops
+        self.dismiss = dismiss
+        self.share = share
+    }
+
+    /// Reproduces the pre-sheet behavior: an in-app Safari controller and a pushed
+    /// `NearbyStopsViewController`, both presented from `presenter`, dismissal via
+    /// the modal delegate.
+    public static func uiKit(
+        presenter: UIViewController,
+        delegate: ModalDelegate?,
+        application: Application
+    ) -> MapItemActions {
+        MapItemActions(
+            openWebsite: { [weak presenter] url in
+                guard let presenter else { return }
+                application.viewRouter.present(SFSafariViewController(url: url), from: presenter)
+            },
+            showNearbyStops: { [weak presenter] coordinate in
+                guard let presenter else { return }
+                let nearbyStops = NearbyStopsViewController(coordinate: coordinate, application: application)
+                application.viewRouter.navigate(to: nearbyStops, from: presenter)
+            },
+            dismiss: { [weak presenter, weak delegate] in
+                guard let presenter else { return }
+                delegate?.dismissModalController(presenter)
+            },
+            share: { [weak presenter] url in
+                guard let presenter else { return }
+                let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                // iPad support, unchanged from the previous `shareLocation()` body.
+                if let popover = activityController.popoverPresentationController {
+                    popover.sourceView = presenter.view
+                    popover.sourceRect = CGRect(x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0)
+                    popover.permittedArrowDirections = []
+                }
+                presenter.present(activityController, animated: true)
+            }
+        )
+    }
+}
+
 /// A view model that manages the data and business logic for displaying map item information.
 ///
 /// This view model extracts and formats data from an `MKMapItem` and handles user interactions
@@ -34,11 +97,8 @@ public class MapItemViewModel {
     /// Optional handler for removing a user-dropped pin
     let removePinHandler: (() -> Void)?
 
-    /// Delegate for handling modal dismissal
-    weak var delegate: ModalDelegate?
-
-    /// The presenting view controller for navigation actions
-    private weak var presentingViewController: UIViewController?
+    /// Presentation-dependent actions injected at init time
+    private let actions: MapItemActions
 
     /// The name/title of the location
     var title: String
@@ -79,13 +139,13 @@ public class MapItemViewModel {
     /// - Parameters:
     ///   - mapItem: The map item containing location information
     ///   - application: The OBA application instance
-    ///   - delegate: Optional delegate for handling modal dismissal
+    ///   - actions: Injected actions for presentation-dependent operations
     ///   - removePinHandler: Optional handler called when user wants to remove a dropped pin
     ///   - planTripHandler: Handler called when user wants to plan a trip
-    public init(mapItem: MKMapItem, application: Application, delegate: ModalDelegate?, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
+    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
         self.mapItem = mapItem
         self.application = application
-        self.delegate = delegate
+        self.actions = actions
         self.removePinHandler = removePinHandler
         self.planTripHandler = planTripHandler
 
@@ -146,15 +206,6 @@ public class MapItemViewModel {
         }
     }
 
-    /// Sets the presenting view controller for navigation actions.
-    ///
-    /// This must be called before any navigation actions (like showing nearby stops or opening URLs)
-    /// to ensure proper view controller presentation.
-    ///
-    /// - Parameter viewController: The view controller that will present navigation actions
-    func setPresentingViewController(_ viewController: UIViewController) {
-        self.presentingViewController = viewController
-    }
 
     /// Opens the location in the Maps app.
     ///
@@ -172,28 +223,15 @@ public class MapItemViewModel {
         application.open(url, options: [:], completionHandler: nil)
     }
 
-    /// Opens the location's website in a Safari view controller.
-    ///
-    /// This presents an in-app Safari browser with the location's website.
-    /// Does nothing if no URL is available or if the presenting view controller hasn't been set.
+    /// Opens the location's website through the injected action.
     func openURL() {
-        guard let url = url else { return }
-        guard let presenter = presentingViewController else { return }
-        let safari = SFSafariViewController(url: url)
-        application.viewRouter.present(safari, from: presenter)
+        guard let url else { return }
+        actions.openWebsite(url)
     }
 
-    /// Navigates to the nearby stops view controller.
-    ///
-    /// This pushes a new view controller showing transit stops near the location.
-    /// Does nothing if the presenting view controller hasn't been set.
+    /// Shows nearby stops through the injected action.
     func showNearbyStops() {
-        guard let presenter = presentingViewController else { return }
-        let nearbyStops = NearbyStopsViewController(
-            coordinate: mapItem.placemark.coordinate,
-            application: application
-        )
-        application.viewRouter.navigate(to: nearbyStops, from: presenter)
+        actions.showNearbyStops(mapItem.placemark.coordinate)
     }
 
     /// Plans a trip from/to this location.
@@ -209,31 +247,21 @@ public class MapItemViewModel {
         removePinHandler?()
     }
 
-    /// Dismisses the view by calling the delegate's dismissModalController method.
-    ///
-    /// This properly dismisses the FloatingPanel that contains the MapItemViewController.
+    /// Dismisses the view through the injected action.
     func dismissView() {
-        guard let presenter = presentingViewController else { return }
-        delegate?.dismissModalController(presenter)
+        actions.dismiss()
     }
 
-    /// Uses the MapKit Place ID when available to generate a stable "Place Link" URL,
-    /// falling back to query + coordinates when the place identity is not available.
+    /// The Apple Maps link for this place. Exposed so the SwiftUI sheet can use a
+    /// native `ShareLink`; the UIKit path still routes through `shareLocation()`.
+    var shareURL: URL? {
+        appleMapsShareURL(for: mapItem)
+    }
+
+    /// Shares the location through the injected action.
     func shareLocation() {
-        guard let presenter = presentingViewController else { return }
-        guard let url = appleMapsShareURL(for: mapItem) else { return }
-
-        let activityItems: [Any] = [url]
-        let activityController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-
-        // iPad support
-        if let popover = activityController.popoverPresentationController {
-            popover.sourceView = presenter.view
-            popover.sourceRect = CGRect(x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-
-        presenter.present(activityController, animated: true)
+        guard let shareURL else { return }
+        actions.share(shareURL)
     }
 
     /// Generates an Apple Maps share URL using the Place ID when available,

--- a/OBAKit/TripPlanning/MapItemViewModel.swift
+++ b/OBAKit/TripPlanning/MapItemViewModel.swift
@@ -92,7 +92,10 @@ public class MapItemViewModel {
     /// The OBA application instance for accessing services and navigation
     let application: Application
 
-    let planTripHandler: () -> Void
+    /// `nil` on surfaces that have no trip-planner destination to hand off to.
+    /// Gates `showPlanTripButton`, so those surfaces don't render a button that
+    /// does nothing when tapped.
+    let planTripHandler: (() -> Void)?
 
     /// Optional handler for removing a user-dropped pin
     let removePinHandler: (() -> Void)?
@@ -141,8 +144,9 @@ public class MapItemViewModel {
     ///   - application: The OBA application instance
     ///   - actions: Injected actions for presentation-dependent operations
     ///   - removePinHandler: Optional handler called when user wants to remove a dropped pin
-    ///   - planTripHandler: Handler called when user wants to plan a trip
-    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: @escaping () -> Void) {
+    ///   - planTripHandler: Handler called when user wants to plan a trip, or `nil`
+    ///     to hide the Plan Trip button entirely
+    public init(mapItem: MKMapItem, application: Application, actions: MapItemActions, removePinHandler: (() -> Void)? = nil, planTripHandler: (() -> Void)?) {
         self.mapItem = mapItem
         self.application = application
         self.actions = actions
@@ -155,7 +159,7 @@ public class MapItemViewModel {
             self.formattedAddress = CNPostalAddressFormatter.string(from: address, style: .mailingAddress)
         }
 
-        self.showPlanTripButton = application.features.tripPlanning == .running
+        self.showPlanTripButton = application.features.tripPlanning == .running && planTripHandler != nil
         self.phoneNumber = mapItem.phoneNumber
         self.url = mapItem.url
 
@@ -206,7 +210,6 @@ public class MapItemViewModel {
         }
     }
 
-
     /// Opens the location in the Maps app.
     ///
     /// This launches the system Maps application and displays the location.
@@ -237,7 +240,7 @@ public class MapItemViewModel {
     /// Plans a trip from/to this location.
     ///
     func planTrip() {
-        planTripHandler()
+        planTripHandler?()
     }
 
     /// Removes the user-dropped pin and dismisses the view.

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -68,7 +68,7 @@ public class BookmarkDataLoader: NSObject {
     /// bookmark in the current region. Lets a caller that only displays a few
     /// bookmarks — the home sheet's preview section — reuse this loader without
     /// paying for the whole set.
-    private let bookmarkProvider: (@MainActor () -> [Bookmark])?
+    private let bookmarkProvider: (() -> [Bookmark])?
 
     /// When `false`, `startRefreshTimer()` is a no-op, so the loader fetches
     /// only when explicitly asked. Callers that display a handful of bookmarks
@@ -78,7 +78,7 @@ public class BookmarkDataLoader: NSObject {
     public init(
         application: CoreApplication,
         delegate: BookmarkDataDelegate,
-        bookmarkProvider: (@MainActor () -> [Bookmark])? = nil,
+        bookmarkProvider: (() -> [Bookmark])? = nil,
         autoRefreshes: Bool = true
     ) {
         self.application = application
@@ -100,9 +100,13 @@ public class BookmarkDataLoader: NSObject {
         }
     }
 
-    /// Whether a repeating refresh is currently armed. Exposed so callers that
-    /// opted out of auto-refresh can assert they really did.
-    @MainActor public var hasScheduledRefresh: Bool {
+    /// Whether a repeating refresh is currently armed.
+    ///
+    /// Deliberately `internal`, not `public`: nothing in the app reads it, and
+    /// it exists so `BookmarkDataLoaderTests` can assert that a loader built with
+    /// `autoRefreshes: false` really installs no timer. `@testable import` reaches
+    /// it; the framework's public surface doesn't grow for a test.
+    var hasScheduledRefresh: Bool {
         timer?.isValid ?? false
     }
 

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -64,17 +64,46 @@ public class BookmarkDataLoader: NSObject {
         fetchedStopIDs.contains(stopID)
     }
 
-    public init(application: CoreApplication, delegate: BookmarkDataDelegate) {
+    /// When set, supplies the bookmarks a batch should fetch instead of every
+    /// bookmark in the current region. Lets a caller that only displays a few
+    /// bookmarks — the home sheet's preview section — reuse this loader without
+    /// paying for the whole set.
+    private let bookmarkProvider: (@MainActor () -> [Bookmark])?
+
+    /// When `false`, `startRefreshTimer()` is a no-op, so the loader fetches
+    /// only when explicitly asked. Callers that display a handful of bookmarks
+    /// outside a dedicated screen don't want a background 30-second cycle.
+    private let autoRefreshes: Bool
+
+    public init(
+        application: CoreApplication,
+        delegate: BookmarkDataDelegate,
+        bookmarkProvider: (@MainActor () -> [Bookmark])? = nil,
+        autoRefreshes: Bool = true
+    ) {
         self.application = application
         self.delegate = delegate
+        self.bookmarkProvider = bookmarkProvider
+        self.autoRefreshes = autoRefreshes
     }
 
     public func startRefreshTimer() {
         timer?.invalidate()
 
+        guard autoRefreshes else {
+            timer = nil
+            return
+        }
+
         timer = Timer.scheduledMainActorTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] in
             self?.loadData()
         }
+    }
+
+    /// Whether a repeating refresh is currently armed. Exposed so callers that
+    /// opted out of auto-refresh can assert they really did.
+    @MainActor public var hasScheduledRefresh: Bool {
+        timer?.isValid ?? false
     }
 
     public func cancelUpdates() {
@@ -125,7 +154,10 @@ public class BookmarkDataLoader: NSObject {
     }
 
     private func eligibleBookmarks() -> [Bookmark] {
-        application.userDataStore.bookmarks.filter {
+        if let bookmarkProvider {
+            return bookmarkProvider()
+        }
+        return application.userDataStore.bookmarks.filter {
             $0.regionIdentifier == application.regionsService.currentRegion?.id
         }
     }

--- a/OBAKitCore/Models/REST/References/Stop+Distance.swift
+++ b/OBAKitCore/Models/REST/References/Stop+Distance.swift
@@ -1,0 +1,36 @@
+//
+//  Stop+Distance.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+
+public extension Stop {
+
+    /// Squared distance with longitude scaled by `cos(latitude)` so lat/lon
+    /// degrees compare on a common metric scale. Ordering only — no sqrt, and
+    /// the result is not meaningful as a real-world distance.
+    nonisolated static func squaredDistance(_ stop: Stop, to center: CLLocationCoordinate2D) -> Double {
+        let coordinate = stop.location.coordinate
+        let dLat = coordinate.latitude - center.latitude
+        let dLon = (coordinate.longitude - center.longitude) * cos(center.latitude * .pi / 180)
+        return dLat * dLat + dLon * dLon
+    }
+
+    /// The `limit` stops closest to `center`, nearest first.
+    ///
+    /// Shared by `MapStopsObserver`'s cap eviction and the home sheet's nearby
+    /// section so both order stops by exactly the same metric.
+    nonisolated static func nearest(_ stops: [Stop], to center: CLLocationCoordinate2D, limit: Int) -> [Stop] {
+        guard limit > 0 else { return [] }
+        return stops
+            .sorted { squaredDistance($0, to: center) < squaredDistance($1, to: center) }
+            .prefix(limit)
+            .map { $0 }
+    }
+}

--- a/OBAKitCore/Models/UserData/Bookmarks/Bookmark.swift
+++ b/OBAKitCore/Models/UserData/Bookmarks/Bookmark.swift
@@ -36,10 +36,36 @@ import Foundation
     public let stopID: StopID
 
     /// Whether or not this `Bookmark` should be displayed in the Today widget, for example. `false` by default.
+    ///
+    /// - Note: Despite the name, this is the "Show in Today View" toggle, not a
+    ///   general-purpose favourite. See `isPinned` for the home sheet's pinning.
     public var isFavorite: Bool
 
+    /// Whether the user has pinned this `Bookmark` to the top of the home sheet's
+    /// bookmarks section. `false` by default.
+    ///
+    /// Distinct from `isFavorite`, which drives widget visibility — pinning is
+    /// purely about placement on the home sheet, and conflating the two would
+    /// change what appears in the user's widget.
+    public var isPinned: Bool
+
     /// The order in which this `Bookmark` is sorted in. By default, this value is set to be `Int.max`
+    ///
+    /// - Note: This is a *per-group* index — `UserDataStore.bookmarksInGroup(_:)`
+    ///   renumbers each group from zero — so it is not comparable across groups.
     public var sortOrder: Int
+
+    /// When this `Bookmark` was created.
+    ///
+    /// Recorded because `sortOrder` can't answer "which of these is newest":
+    /// a new bookmark is appended to the end of its group, and the user can
+    /// reorder the list afterwards. Surfaces that need most-recent-first — the
+    /// home sheet's bookmarks preview, which shows only a handful — order by this.
+    ///
+    /// `Bookmark`s persisted before this property existed decode as
+    /// `.distantPast`, so they sort after anything created since and keep their
+    /// own relative order.
+    public let dateCreated: Date
 
     /// This object stores a complete copy of its underlying `Stop` in order to be able to show additional information
     /// to the user.
@@ -62,15 +88,29 @@ import Foundation
 
     // MARK: - Init
 
-    public convenience init(name: String, regionIdentifier: Int, arrivalDeparture: ArrivalDeparture) {
-        self.init(name: name, regionIdentifier: regionIdentifier, arrivalDeparture: arrivalDeparture, stop: arrivalDeparture.stop)
+    public convenience init(name: String, regionIdentifier: Int, arrivalDeparture: ArrivalDeparture, dateCreated: Date = Date()) {
+        self.init(
+            name: name,
+            regionIdentifier: regionIdentifier,
+            arrivalDeparture: arrivalDeparture,
+            stop: arrivalDeparture.stop,
+            dateCreated: dateCreated
+        )
     }
 
-    public convenience init(name: String, regionIdentifier: Int, stop: Stop) {
-        self.init(name: name, regionIdentifier: regionIdentifier, arrivalDeparture: nil, stop: stop)
+    public convenience init(name: String, regionIdentifier: Int, stop: Stop, dateCreated: Date = Date()) {
+        self.init(
+            name: name,
+            regionIdentifier: regionIdentifier,
+            arrivalDeparture: nil,
+            stop: stop,
+            dateCreated: dateCreated
+        )
     }
 
-    public init(name: String, regionIdentifier: Int, arrivalDeparture: ArrivalDeparture?, stop: Stop) {
+    /// `dateCreated` is injectable so tests can pin an ordering instead of
+    /// racing the clock; production callers take the default.
+    public init(name: String, regionIdentifier: Int, arrivalDeparture: ArrivalDeparture?, stop: Stop, dateCreated: Date = Date()) {
         if let arrivalDeparture = arrivalDeparture {
             self.routeShortName = arrivalDeparture.routeShortName
             self.routeID = arrivalDeparture.routeID
@@ -85,14 +125,16 @@ import Foundation
         self.stop = stop
         self.stopID = stop.id
         self.isFavorite = false
+        self.isPinned = false
         self.name = name
         self.regionIdentifier = regionIdentifier
         self.id = UUID()
         self.sortOrder = .max
+        self.dateCreated = dateCreated
     }
 
     private enum CodingKeys: String, CodingKey {
-        case groupID, isFavorite, name, regionIdentifier, stop, stopID, id, sortOrder
+        case groupID, isFavorite, isPinned, name, regionIdentifier, stop, stopID, id, sortOrder, dateCreated
 
         // Trip bookmark keys
         case routeShortName, tripHeadsign, routeID
@@ -103,12 +145,20 @@ import Foundation
 
         groupID = try? container.decodeIfPresent(UUID.self, forKey: .groupID)
         isFavorite = try container.decode(Bool.self, forKey: .isFavorite)
+        // Absent from bookmarks written before pinning existed; nothing was
+        // pinned then, so `false` is the truthful default.
+        isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         name = try container.decode(String.self, forKey: .name)
         regionIdentifier = try container.decode(Int.self, forKey: .regionIdentifier)
         sortOrder = try container.decode(Int.self, forKey: .sortOrder)
         stop = try container.decode(Stop.self, forKey: .stop)
         stopID = try container.decode(StopID.self, forKey: .stopID)
         id = try container.decode(UUID.self, forKey: .id)
+        // Absent from bookmarks written before this property existed. Falling back
+        // to `.distantPast` — rather than "now" — keeps a decode from making every
+        // stored bookmark look freshly created, which would scramble
+        // most-recent-first ordering on the first launch after upgrading.
+        dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? .distantPast
 
         routeShortName = try container.decodeIfPresent(String.self, forKey: .routeShortName)
         tripHeadsign = try container.decodeIfPresent(String.self, forKey: .tripHeadsign)
@@ -129,6 +179,11 @@ import Foundation
             routeID == bookmark.routeID
     }
 
+    /// - Note: `dateCreated` is deliberately excluded here and from `hash`. It's
+    ///   provenance, not content — two bookmarks that differ only in when they
+    ///   were made are the same bookmark to a user — and `Date` loses sub-second
+    ///   precision through the store's encoder, so including it would make a
+    ///   round-tripped bookmark unequal to the one that was written.
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Bookmark else { return false }
 
@@ -141,6 +196,7 @@ import Foundation
             stopID == rhs.stopID &&
             stop == rhs.stop &&
             isFavorite == rhs.isFavorite &&
+            isPinned == rhs.isPinned &&
             routeShortName == rhs.routeShortName &&
             routeID == rhs.routeID &&
             tripHeadsign == rhs.tripHeadsign
@@ -155,6 +211,7 @@ import Foundation
         hasher.combine(stopID)
         hasher.combine(stop)
         hasher.combine(isFavorite)
+        hasher.combine(isPinned)
         hasher.combine(routeShortName)
         hasher.combine(routeID)
         hasher.combine(sortOrder)
@@ -171,9 +228,11 @@ import Foundation
         descriptionBuilder.add(key: "stopID", value: stopID)
 
         descriptionBuilder.add(key: "isFavorite", value: isFavorite)
+        descriptionBuilder.add(key: "isPinned", value: isPinned)
         descriptionBuilder.add(key: "routeShortName", value: routeShortName)
         descriptionBuilder.add(key: "routeID", value: routeID)
         descriptionBuilder.add(key: "sortOrder", value: sortOrder)
+        descriptionBuilder.add(key: "dateCreated", value: dateCreated)
         descriptionBuilder.add(key: "tripHeadsign", value: tripHeadsign)
         return descriptionBuilder.description
     }

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -671,8 +671,6 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     public func addRecentStop(_ stop: Stop, region: Region) {
         var recentStops = self.recentStops
 
-        stop.regionIdentifier = region.regionIdentifier
-
         updateBookmarksWithStop(stop, region: region)
 
         if let idx = recentStops.firstIndex(of: stop) {

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -129,6 +129,10 @@ public protocol UserDataStore: NSObjectProtocol {
     /// A list of recently-viewed stops
     var recentStops: [Stop] { get }
 
+    /// Recent stops belonging to `region`, most-recently-used first.
+    /// Returns `[]` when `region` is nil.
+    func recentStops(in region: Region?) -> [Stop]
+
     /// Add a `Stop` to the list of recently-viewed `Stop`s
     ///
     /// - Parameter stop: The stop to add to the list
@@ -667,6 +671,8 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     public func addRecentStop(_ stop: Stop, region: Region) {
         var recentStops = self.recentStops
 
+        stop.regionIdentifier = region.regionIdentifier
+
         updateBookmarksWithStop(stop, region: region)
 
         if let idx = recentStops.firstIndex(of: stop) {
@@ -699,6 +705,11 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     public func findRecentStops(matching searchText: String) -> [Stop] {
         let cleanedText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         return recentStops.filter { $0.matchesQuery(cleanedText) }
+    }
+
+    public func recentStops(in region: Region?) -> [Stop] {
+        guard let region = region else { return [] }
+        return recentStops.filter { $0.regionIdentifier == region.regionIdentifier }
     }
 
     // MARK: - Recent Map Items

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -95,6 +95,22 @@ public protocol UserDataStore: NSObjectProtocol {
     ///   - index: The sort order or index of the bookmark in its group. Pass in `Int.max` to append to the end.
     func add(_ bookmark: Bookmark, to group: BookmarkGroup?, index: Int)
 
+    /// Sets whether `bookmark` is pinned to the top of the home sheet's bookmarks
+    /// section, and persists the change.
+    ///
+    /// Separate from `add(_:to:)` on purpose. `bookmarks` is computed over
+    /// `UserDefaults` — its getter decodes fresh instances — so mutating a
+    /// `Bookmark` in memory doesn't persist, and routing the write through
+    /// `add(_:to:)` would re-append the bookmark and renumber `sortOrder` within
+    /// its group, quietly moving it to the bottom of the Bookmarks tab. This
+    /// updates in place and leaves group membership and `sortOrder` alone.
+    ///
+    /// Posts `.bookmarksDidChange`. No-op if `bookmark` isn't in the store.
+    /// - Parameters:
+    ///   - isPinned: The new pinned state.
+    ///   - bookmark: The `Bookmark` to update.
+    func setPinned(_ isPinned: Bool, for bookmark: Bookmark)
+
     /// Deletes the specified `Bookmark` from the `UserDataStore`.
     /// - Parameter bookmark: The `Bookmark` to delete.
     func delete(bookmark: Bookmark)
@@ -602,6 +618,22 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
 
         bookmarks = all
+        NotificationCenter.default.post(name: .bookmarksDidChange, object: self)
+    }
+
+    public func setPinned(_ isPinned: Bool, for bookmark: Bookmark) {
+        var allBookmarks = bookmarks
+        guard let index = allBookmarks.firstIndex(where: { $0.id == bookmark.id }) else { return }
+        guard allBookmarks[index].isPinned != isPinned else { return }
+
+        allBookmarks[index].isPinned = isPinned
+        // Keep the caller's instance in step. `bookmarks`' getter decodes fresh
+        // objects, so the one the caller is holding is a different instance than
+        // the one just written — without this its `isPinned` would still read
+        // stale to whoever kept a reference.
+        bookmark.isPinned = isPinned
+        bookmarks = allBookmarks
+
         NotificationCenter.default.post(name: .bookmarksDidChange, object: self)
     }
 

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -70,6 +70,10 @@ public class Strings: NSObject {
 
     public static let recentStops = OBALoc("common.recent_stops", value: "Recent Stops", comment: "i.e. recently viewed or visited stops for transit vehicles, like a bus stop, ferry terminal, or train station.")
 
+    public static let nearbyStops = OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller.")
+
+    public static let bookmarks = OBALoc("search_controller.bookmarks.header", value: "Bookmarks", comment: "Title of the Bookmarks search header")
+
     public static let recentSearches = OBALoc("common.recent_searches", value: "Recent Searches", comment: "i.e. recently selected search results for map locations from the trip planner.")
 
     public static let clearRecentSearches = OBALoc("common.clear_recent_searches", value: "Clear Recent Searches", comment: "Button to clear recent search results")

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -70,10 +70,6 @@ public class Strings: NSObject {
 
     public static let recentStops = OBALoc("common.recent_stops", value: "Recent Stops", comment: "i.e. recently viewed or visited stops for transit vehicles, like a bus stop, ferry terminal, or train station.")
 
-    public static let nearbyStops = OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller.")
-
-    public static let bookmarks = OBALoc("search_controller.bookmarks.header", value: "Bookmarks", comment: "Title of the Bookmarks search header")
-
     public static let recentSearches = OBALoc("common.recent_searches", value: "Recent Searches", comment: "i.e. recently selected search results for map locations from the trip planner.")
 
     public static let clearRecentSearches = OBALoc("common.clear_recent_searches", value: "Clear Recent Searches", comment: "Button to clear recent search results")

--- a/OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift
@@ -1,0 +1,155 @@
+//
+//  BookmarkDataLoaderTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class BookmarkDataLoaderTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    /// Thread-safe counter for tracking request counts.
+    private final class RequestCounter {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var count: Int = 0
+
+        nonisolated func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+        }
+    }
+
+    /// Counts arrivals requests so the scoped-provider test can assert the
+    /// loader fetched only the bookmarks it was handed.
+    @MainActor
+    private final class RecordingDelegate: NSObject, BookmarkDataDelegate {
+        var updateCount = 0
+        func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) { updateCount += 1 }
+    }
+
+    /// Builds real *trip* bookmarks — `isTripBookmark` requires a route short
+    /// name, route id, and trip headsign, which only a decoded `ArrivalDeparture`
+    /// supplies. A bookmark that isn't a trip bookmark is skipped by the loader
+    /// without a request, which would silently zero out the counts below.
+    @MainActor
+    private func makeTripBookmarks(count: Int, application: Application) throws -> [Bookmark] {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
+
+        return (0..<count).map { index in
+            let bookmark = Bookmark(
+                name: "Bookmark \(index)",
+                regionIdentifier: pugetSoundRegionIdentifier,
+                arrivalDeparture: arrivalDeparture
+            )
+            bookmark.sortOrder = index
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+    }
+
+    /// The provider — not the whole store — decides what gets fetched.
+    @Test @MainActor
+    func `Bookmark provider scopes fetches to the supplied bookmarks`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let requestCounter = RequestCounter()
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            let matches = request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            if matches { requestCounter.increment() }
+            return matches
+        }
+
+        let all = try makeTripBookmarks(count: 6, application: application)
+        let scoped = Array(all.prefix(2))
+
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(
+            application: application,
+            delegate: delegate,
+            bookmarkProvider: { scoped },
+            autoRefreshes: false
+        )
+
+        await loader.loadDataAndWait()
+
+        // Six bookmarks exist; only the two handed to the provider are fetched.
+        #expect(requestCounter.count == 2)
+    }
+
+    /// With auto-refresh off, the loader installs no repeating timer.
+    @Test @MainActor
+    func `Auto refresh disabled installs no timer`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let bookmarks = try makeTripBookmarks(count: 1, application: application)
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(
+            application: application,
+            delegate: delegate,
+            bookmarkProvider: { bookmarks },
+            autoRefreshes: false
+        )
+
+        await loader.loadDataAndWait()
+
+        #expect(loader.hasScheduledRefresh == false)
+    }
+
+    /// The Bookmarks tab's construction is untouched: every region bookmark is
+    /// fetched and the repeating timer is installed.
+    @Test @MainActor
+    func `Default initializer fetches all region bookmarks and schedules refresh`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let requestCounter = RequestCounter()
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            let matches = request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            if matches { requestCounter.increment() }
+            return matches
+        }
+
+        _ = try makeTripBookmarks(count: 3, application: application)
+
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(application: application, delegate: delegate)
+
+        await loader.loadDataAndWait()
+
+        #expect(requestCounter.count == 3)
+        #expect(loader.hasScheduledRefresh)
+
+        loader.cancelUpdates()
+    }
+}

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -159,7 +159,16 @@ class Fixtures {
             "agencyId": "test_agency",
             "id": id,
             "shortName": "1",
-            "type": 3
+            "type": 3,
+            "agency": [
+                "id": "test_agency",
+                "name": "Test Agency",
+                "lang": "en",
+                "phone": "555-0000",
+                "privateService": false,
+                "timezone": "America/Los_Angeles",
+                "url": "https://example.com"
+            ]
         ]
         return try dictionaryToModel(type: Route.self, dictionary: dictionary)
     }

--- a/OBAKitTests/Helpers/Mocks/GatedDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/GatedDataLoader.swift
@@ -1,0 +1,87 @@
+//
+//  GatedDataLoader.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Wraps a `MockDataLoader` and holds a request open until the test lets it go, so
+/// state that exists only *while* a request is in flight — a row's loading id, an
+/// in-progress flag — can be observed rather than inferred from what's left behind
+/// afterwards.
+///
+/// `CountingDataLoader` yields once so concurrent tasks interleave; this one blocks
+/// until told otherwise, which is what an assertion made mid-request needs to be
+/// deterministic rather than a race against a mock that answers instantly.
+// @unchecked Sendable: all mutable state is guarded by `lock`.
+// `nonisolated` for the same reason `MockDataLoader` is: `data(for:)` runs on
+// whatever task issued the request, not on the test target's default main actor.
+nonisolated final class GatedDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
+
+    private let inner: MockDataLoader
+    private let lock = NSLock()
+
+    private var hasArrived = false
+    private var arrivalContinuation: CheckedContinuation<Void, Never>?
+
+    private var isReleased = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(_ inner: MockDataLoader) {
+        self.inner = inner
+    }
+
+    /// Suspends until a request reaches the loader — i.e. until the code under test
+    /// has run everything it does before awaiting the network.
+    func waitForRequest() async {
+        await withCheckedContinuation { continuation in
+            let alreadyArrived = lock.withLock { () -> Bool in
+                if hasArrived { return true }
+                arrivalContinuation = continuation
+                return false
+            }
+            // Resumed outside the lock: `resume()` can run the waiter inline, and a
+            // waiter that comes straight back here would deadlock on a held lock.
+            if alreadyArrived { continuation.resume() }
+        }
+    }
+
+    /// Lets the held request run to completion.
+    func releaseRequest() {
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            isReleased = true
+            defer { releaseContinuation = nil }
+            return releaseContinuation
+        }
+        continuation?.resume()
+    }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        inner.dataTask(with: request, completionHandler: completionHandler)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let arrival = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            hasArrived = true
+            defer { arrivalContinuation = nil }
+            return arrivalContinuation
+        }
+        arrival?.resume()
+
+        await withCheckedContinuation { continuation in
+            let alreadyReleased = lock.withLock { () -> Bool in
+                if isReleased { return true }
+                releaseContinuation = continuation
+                return false
+            }
+            if alreadyReleased { continuation.resume() }
+        }
+
+        return try await inner.data(for: request)
+    }
+}

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -70,13 +70,22 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     /// `recordedRequestURLsLock` because real callers fan out across multiple
     /// concurrent tasks (e.g. `AgencyAlertsStore.update()`'s alerts task group).
     private var _recordedRequestURLs = [URL]()
+    private var _recordedRequests = [URLRequest]()
     private let recordedRequestURLsLock = NSLock()
     var recordedRequestURLs: [URL] {
         recordedRequestURLsLock.withLock { _recordedRequestURLs }
     }
-    private func recordRequest(_ url: URL?) {
+    var requests: [URLRequest] {
+        recordedRequestURLsLock.withLock { _recordedRequests }
+    }
+    private func recordRequest(_ url: URL?, request: URLRequest? = nil) {
         guard let url else { return }
-        recordedRequestURLsLock.withLock { _recordedRequestURLs.append(url) }
+        recordedRequestURLsLock.withLock {
+            _recordedRequestURLs.append(url)
+            if let request {
+                _recordedRequests.append(request)
+            }
+        }
     }
 
     /// Clears recorded request URLs. Useful in tests that need to ignore the
@@ -93,7 +102,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        recordRequest(request.url)
+        recordRequest(request.url, request: request)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }
@@ -121,7 +130,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
             throw URLError(.cancelled)
         }
 
-        recordRequest(request.url)
+        recordRequest(request.url, request: request)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }

--- a/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
+++ b/OBAKitTests/Helpers/Mocks/MockDataLoader.swift
@@ -70,22 +70,13 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     /// `recordedRequestURLsLock` because real callers fan out across multiple
     /// concurrent tasks (e.g. `AgencyAlertsStore.update()`'s alerts task group).
     private var _recordedRequestURLs = [URL]()
-    private var _recordedRequests = [URLRequest]()
     private let recordedRequestURLsLock = NSLock()
     var recordedRequestURLs: [URL] {
         recordedRequestURLsLock.withLock { _recordedRequestURLs }
     }
-    var requests: [URLRequest] {
-        recordedRequestURLsLock.withLock { _recordedRequests }
-    }
-    private func recordRequest(_ url: URL?, request: URLRequest? = nil) {
+    private func recordRequest(_ url: URL?) {
         guard let url else { return }
-        recordedRequestURLsLock.withLock {
-            _recordedRequestURLs.append(url)
-            if let request {
-                _recordedRequests.append(request)
-            }
-        }
+        recordedRequestURLsLock.withLock { _recordedRequestURLs.append(url) }
     }
 
     /// Clears recorded request URLs. Useful in tests that need to ignore the
@@ -102,7 +93,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        recordRequest(request.url, request: request)
+        recordRequest(request.url)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }
@@ -130,7 +121,7 @@ nonisolated class MockDataLoader: NSObject, URLDataLoader, @unchecked Sendable {
             throw URLError(.cancelled)
         }
 
-        recordRequest(request.url, request: request)
+        recordRequest(request.url)
         guard let response = matchResponse(to: request) else {
             fatalError("\(testName): Missing response to URL: \(request.url!)")
         }

--- a/OBAKitTests/Modeling/StopDistanceTests.swift
+++ b/OBAKitTests/Modeling/StopDistanceTests.swift
@@ -1,0 +1,70 @@
+//
+//  StopDistanceTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+import Testing
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class StopDistanceTests: OBATestCase {
+
+    /// Stops are returned nearest-first, and the list is truncated to `limit`.
+    @Test func `Nearest returns the closest stops in order`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        let nearest = Stop.nearest(stops, to: anchor, limit: 3)
+
+        #expect(nearest.count == 3)
+        // The anchor stop is zero distance from itself, so it must come first.
+        #expect(nearest.first?.id == stops.first?.id)
+
+        let distances = nearest.map { Stop.squaredDistance($0, to: anchor) }
+        #expect(distances == distances.sorted())
+    }
+
+    /// A limit larger than the input returns everything, still ordered.
+    @Test func `Nearest returns everything when the limit exceeds the input`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        let nearest = Stop.nearest(stops, to: anchor, limit: stops.count + 10)
+
+        #expect(nearest.count == stops.count)
+    }
+
+    /// Degenerate inputs return empty rather than trapping.
+    @Test func `Nearest returns empty for empty input or a non positive limit`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        #expect(Stop.nearest([], to: anchor, limit: 4).isEmpty)
+        #expect(Stop.nearest(stops, to: anchor, limit: 0).isEmpty)
+        #expect(Stop.nearest(stops, to: anchor, limit: -1).isEmpty)
+    }
+
+    /// Longitude is scaled by cos(latitude), so a degree of longitude counts
+    /// for less than a degree of latitude away from the equator. Without the
+    /// scaling these two would compare equal.
+    @Test func `Squared distance scales longitude by latitude`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let reference = try #require(stops.first)
+        let anchor = reference.location.coordinate
+
+        let latOffset = CLLocationCoordinate2D(latitude: anchor.latitude + 1, longitude: anchor.longitude)
+        let lonOffset = CLLocationCoordinate2D(latitude: anchor.latitude, longitude: anchor.longitude + 1)
+
+        let latDistance = Stop.squaredDistance(reference, to: latOffset)
+        let lonDistance = Stop.squaredDistance(reference, to: lonOffset)
+
+        // Seattle is well north of the equator, so cos(lat) < 1.
+        #expect(lonDistance < latDistance)
+    }
+}

--- a/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/BookmarkTests.swift
@@ -46,6 +46,75 @@ final class BookmarkTests: OBATestCase {
         #expect(roundtripped.stop == stop)
     }
 
+    /// `dateCreated` survives the store's encoder, since the home sheet's
+    /// most-recent-first ordering reads it back off persisted bookmarks.
+    @Test func `Codable roundtripping preserves dateCreated`() {
+        let created = Date(timeIntervalSince1970: 1_700_000_000)
+        let bookmark = Bookmark(
+            name: "BM 1",
+            regionIdentifier: region.regionIdentifier,
+            stop: stops[0],
+            dateCreated: created
+        )
+
+        let roundtripped = try! Fixtures.roundtripCodable(type: Bookmark.self, model: bookmark)
+
+        #expect(roundtripped.dateCreated.timeIntervalSince1970 == created.timeIntervalSince1970)
+    }
+
+    /// Bookmarks written before `dateCreated` existed have no such key. They must
+    /// decode as `.distantPast` rather than throwing or defaulting to "now" —
+    /// "now" would make every stored bookmark look freshly created on the first
+    /// launch after upgrading and scramble most-recent-first ordering.
+    @Test func `Decoding a bookmark saved without dateCreated yields distantPast`() throws {
+        let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
+
+        // Encode, then strip the key to reproduce a pre-upgrade payload.
+        let encoded = try PropertyListEncoder().encode(bookmark)
+        var plist = try #require(
+            try PropertyListSerialization.propertyList(from: encoded, format: nil) as? [String: Any]
+        )
+        try #require(plist.removeValue(forKey: "dateCreated") != nil, "Expected dateCreated in the encoded form")
+
+        let legacy = try PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
+        let decoded = try PropertyListDecoder().decode(Bookmark.self, from: legacy)
+
+        #expect(decoded.dateCreated == .distantPast)
+        #expect(decoded.id == bookmark.id)
+        #expect(decoded.name == "BM 1")
+    }
+
+    /// Pinning is persisted state, so it has to survive the store's encoder.
+    @Test func `Codable roundtripping preserves isPinned`() {
+        let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
+        #expect(bookmark.isPinned == false, "New bookmarks start unpinned")
+
+        bookmark.isPinned = true
+        let roundtripped = try! Fixtures.roundtripCodable(type: Bookmark.self, model: bookmark)
+
+        #expect(roundtripped.isPinned)
+    }
+
+    /// Bookmarks written before pinning existed have no `isPinned` key. Nothing
+    /// was pinned then, so `false` is the truthful default — and decoding must
+    /// not throw.
+    @Test func `Decoding a bookmark saved without isPinned yields false`() throws {
+        let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
+        bookmark.isPinned = true
+
+        let encoded = try PropertyListEncoder().encode(bookmark)
+        var plist = try #require(
+            try PropertyListSerialization.propertyList(from: encoded, format: nil) as? [String: Any]
+        )
+        try #require(plist.removeValue(forKey: "isPinned") != nil, "Expected isPinned in the encoded form")
+
+        let legacy = try PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
+        let decoded = try PropertyListDecoder().decode(Bookmark.self, from: legacy)
+
+        #expect(decoded.isPinned == false)
+        #expect(decoded.id == bookmark.id)
+    }
+
     @Test func `Updating stop property with right stop`() {
         let bookmark = Bookmark(name: "BM 1", regionIdentifier: region.regionIdentifier, stop: stops[0])
         #expect(bookmark.stop.routes.count > 1)

--- a/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
@@ -145,6 +145,103 @@ final class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.bookmarks == [bookmark])
     }
 
+    // MARK: - Pinning
+
+    /// `bookmarks` is computed over `UserDefaults` — its getter decodes fresh
+    /// instances — so a pin only sticks if the store writes the array back.
+    @Test func `Set pinned persists through the store`() {
+        let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[0])
+        userDefaultsStore.add(bookmark)
+        #expect(self.userDefaultsStore.bookmarks.first?.isPinned == false)
+
+        userDefaultsStore.setPinned(true, for: bookmark)
+        #expect(self.userDefaultsStore.bookmarks.first?.isPinned == true)
+        // The caller's own instance is updated too, so a held reference doesn't
+        // read stale.
+        #expect(bookmark.isPinned)
+
+        userDefaultsStore.setPinned(false, for: bookmark)
+        #expect(self.userDefaultsStore.bookmarks.first?.isPinned == false)
+        #expect(bookmark.isPinned == false)
+    }
+
+    /// Pinning must not disturb the user's manual ordering. Routing the write
+    /// through `add(_:to:)` would have re-appended the bookmark and renumbered
+    /// `sortOrder`, silently moving it to the bottom of its group.
+    @Test func `Set pinned leaves sort order and group membership alone`() {
+        let group = BookmarkGroup(name: "Commute", sortOrder: 0)
+        let first = Bookmark(name: "First", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[0])
+        let second = Bookmark(name: "Second", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[1])
+        userDefaultsStore.add(first, to: group)
+        userDefaultsStore.add(second, to: group)
+
+        let orderBefore = userDefaultsStore.bookmarksInGroup(group).map { ($0.id, $0.sortOrder) }
+
+        userDefaultsStore.setPinned(true, for: first)
+
+        let orderAfter = userDefaultsStore.bookmarksInGroup(group).map { ($0.id, $0.sortOrder) }
+        #expect(orderBefore.map(\.0) == orderAfter.map(\.0))
+        #expect(orderBefore.map(\.1) == orderAfter.map(\.1))
+        #expect(self.userDefaultsStore.findBookmark(id: first.id)?.groupID == group.id)
+    }
+
+    /// Consumers refresh off `.bookmarksDidChange`, so the toggle has to post it.
+    @Test func `Set pinned posts bookmarksDidChange`() async {
+        let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[0])
+        userDefaultsStore.add(bookmark)
+
+        await confirmation("bookmarksDidChange posted") { posted in
+            let token = NotificationCenter.default.addObserver(
+                forName: .bookmarksDidChange,
+                object: userDefaultsStore,
+                queue: nil
+            ) { _ in posted() }
+            defer { NotificationCenter.default.removeObserver(token) }
+
+            userDefaultsStore.setPinned(true, for: bookmark)
+        }
+    }
+
+    /// Thread-safe flag — notification delivery isn't actor-isolated.
+    private final class NotifiedFlag {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var value = false
+
+        nonisolated func set() {
+            lock.lock()
+            defer { lock.unlock() }
+            value = true
+        }
+    }
+
+    /// A no-op toggle shouldn't churn storage or wake every listener.
+    @Test func `Set pinned to the current value does nothing`() {
+        let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[0])
+        userDefaultsStore.add(bookmark)
+
+        let notified = NotifiedFlag()
+        let token = NotificationCenter.default.addObserver(
+            forName: .bookmarksDidChange,
+            object: userDefaultsStore,
+            queue: nil
+        ) { _ in notified.set() }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        userDefaultsStore.setPinned(false, for: bookmark)
+
+        #expect(notified.value == false)
+    }
+
+    /// A bookmark that was never added has nothing to update.
+    @Test func `Set pinned on an unknown bookmark is a no-op`() {
+        let stranger = Bookmark(name: "Not Stored", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stops[0])
+
+        userDefaultsStore.setPinned(true, for: stranger)
+
+        #expect(self.userDefaultsStore.bookmarks.isEmpty)
+        #expect(stranger.isPinned == false)
+    }
+
     @Test func `Bookmark find by ID`() {
         let stop = stops[0]
         let bookmark = Bookmark(name: "My Bookmark", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)

--- a/OBAKitTests/Modeling/UserData/RecentStopsTests.swift
+++ b/OBAKitTests/Modeling/UserData/RecentStopsTests.swift
@@ -21,6 +21,11 @@ final class RecentStopsTests: OBATestCase {
         let first = try #require(stops.first)
         let second = try #require(stops.dropFirst().first)
 
+        // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+        // fixture stops bypass that path, so we assign it here to match production state.
+        first.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        second.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+
         let store = UserDefaultsStore(userDefaults: userDefaults)
         store.addRecentStop(first, region: Fixtures.pugetSoundRegion)
         store.addRecentStop(second, region: Fixtures.pugetSoundRegion)
@@ -35,6 +40,10 @@ final class RecentStopsTests: OBATestCase {
     @Test func `Recent stops in region returns empty for a nil region`() throws {
         let stops = try Fixtures.loadSomeStops()
         let first = try #require(stops.first)
+
+        // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+        // fixture stops bypass that path, so we assign it here to match production state.
+        first.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
 
         let store = UserDefaultsStore(userDefaults: userDefaults)
         store.addRecentStop(first, region: Fixtures.pugetSoundRegion)

--- a/OBAKitTests/Modeling/UserData/RecentStopsTests.swift
+++ b/OBAKitTests/Modeling/UserData/RecentStopsTests.swift
@@ -1,0 +1,44 @@
+//
+//  RecentStopsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class RecentStopsTests: OBATestCase {
+
+    /// Only stops belonging to the supplied region come back, and the store's
+    /// most-recently-used ordering is preserved.
+    @Test func `Recent stops in region filters by region identifier`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let first = try #require(stops.first)
+        let second = try #require(stops.dropFirst().first)
+
+        let store = UserDefaultsStore(userDefaults: userDefaults)
+        store.addRecentStop(first, region: Fixtures.pugetSoundRegion)
+        store.addRecentStop(second, region: Fixtures.pugetSoundRegion)
+
+        let recents = store.recentStops(in: Fixtures.pugetSoundRegion)
+
+        // addRecentStop inserts at index 0, so the newest is first.
+        #expect(recents.map(\.id) == [second.id, first.id])
+    }
+
+    /// A nil region yields an empty list rather than every stored stop.
+    @Test func `Recent stops in region returns empty for a nil region`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let first = try #require(stops.first)
+
+        let store = UserDefaultsStore(userDefaults: userDefaults)
+        store.addRecentStop(first, region: Fixtures.pugetSoundRegion)
+
+        #expect(store.recentStops(in: nil).isEmpty)
+    }
+}

--- a/OBAKitTests/Search/SearchInteractorTests.swift
+++ b/OBAKitTests/Search/SearchInteractorTests.swift
@@ -1,0 +1,126 @@
+//
+//  SearchInteractorTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// What the search list offers for a given query.
+@Suite(.serialized)
+final class SearchInteractorTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    /// `SearchInteractor` holds its delegate weakly, so the suite keeps it alive.
+    private var delegate: StubDelegate!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private final class StubDelegate: NSObject, SearchDelegate {
+        func performSearch(request: SearchRequest) { }
+        func showMapItem(_ mapItem: MKMapItem) { }
+        func searchInteractor(_ searchInteractor: SearchInteractor, showStop stop: Stop) { }
+        func searchInteractorClearRecentSearches(_ searchInteractor: SearchInteractor) { }
+        var isVehicleSearchAvailable: Bool { false }
+    }
+
+    @MainActor
+    private func makeInteractor() -> (SearchInteractor, Application) {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stub = StubDelegate()
+        delegate = stub
+        return (SearchInteractor(application: application, delegate: stub), application)
+    }
+
+    // MARK: - Empty query
+
+    /// The empty query offers recent *searches* and nothing else — matching the UIKit
+    /// panel, which has never surfaced recent stops here.
+    @Test @MainActor
+    func `An empty query shows recent searches only`() throws {
+        let (interactor, application) = makeInteractor()
+
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+        application.userDataStore.addRecentMapItem(item)
+
+        // Present, and deliberately not offered on an empty query.
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: "")
+
+        #expect(interactor.sections.map(\.id) == [.recentMapItems])
+    }
+
+    /// No recent searches means no sections at all, so the view falls through to its
+    /// empty state. Recent stops are *not* used as a stand-in.
+    @Test @MainActor
+    func `An empty query with no recent searches shows nothing`() throws {
+        let (interactor, application) = makeInteractor()
+        application.userDataStore.deleteAllRecentMapItems()
+
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: "")
+
+        #expect(interactor.sections.isEmpty)
+    }
+
+    // MARK: - Recent stops
+
+    /// Recent stops are matched against a typed query, which is the only place they
+    /// appear.
+    @Test @MainActor
+    func `A query matches recent stops by name`() throws {
+        let (interactor, application) = makeInteractor()
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        interactor.searchModeObjects(text: stop.name)
+
+        let section = try #require(interactor.sections.first { $0.id == .recentStops })
+        #expect(section.content.map(\.title) == [stop.name])
+    }
+
+    /// Recent-stop rows render in a `ForEach`, and stop names repeat across the two
+    /// directions of a corner — the row id has to come from the stop, not the title,
+    /// or a query matching both drops one of them.
+    @Test @MainActor
+    func `Recent stops sharing a name get distinct row ids`() throws {
+        let (interactor, application) = makeInteractor()
+
+        let stops = try Fixtures.loadSomeStops()
+        let sharedName = try #require(
+            Dictionary(grouping: stops, by: \.name).first { $0.value.count > 1 }?.value,
+            "Fixture no longer contains two stops sharing a name; pick another fixture."
+        )
+        for stop in sharedName {
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        interactor.searchModeObjects(text: try #require(sharedName.first).name)
+
+        let section = try #require(interactor.sections.first { $0.id == .recentStops })
+        #expect(section.content.count == sharedName.count)
+        #expect(Set(section.content.map(\.id)).count == section.content.count)
+    }
+}

--- a/OBAKitTests/Search/SearchManagerTests.swift
+++ b/OBAKitTests/Search/SearchManagerTests.swift
@@ -1,0 +1,140 @@
+//
+//  SearchManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// `fetchResults` is the returning entry point the SwiftUI panel consumes. These
+/// tests pin its output per search type; `search(request:)`'s publishing behavior for
+/// the UIKit path is covered separately at the end.
+@Suite(.serialized)
+final class SearchManagerTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Stubs
+
+    private func stubStopsForLocation(dataLoader: MockDataLoader) {
+        let data = Fixtures.loadData(file: "stops_for_location_seattle.json")
+        dataLoader.mock(data: data) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+    }
+
+    private func stubRoutesForLocation(dataLoader: MockDataLoader) {
+        let data = Fixtures.loadData(file: "routes_for_location_query.json")
+        dataLoader.mock(data: data) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+    }
+
+    // MARK: - Stop number
+
+    @Test @MainActor
+    func `Fetch results for a stop number returns the matching stops`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubStopsForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        let request = SearchRequest(query: "1_75403", type: .stopNumber)
+        let response = try #require(await manager.fetchResults(for: request))
+
+        #expect(response.request === request)
+        #expect(response.results.isEmpty == false)
+        #expect(response.results.allSatisfy { $0 is Stop })
+    }
+
+    // MARK: - Route
+
+    @Test @MainActor
+    func `Fetch results for a route returns the matching routes`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRoutesForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        let request = SearchRequest(query: "44", type: .route)
+        let response = try #require(await manager.fetchResults(for: request))
+
+        #expect(response.results.allSatisfy { $0 is Route })
+    }
+
+    // MARK: - Errors are thrown, not swallowed
+
+    @Test @MainActor
+    func `Fetch results throws when the route request fails`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
+        }
+    }
+
+    // MARK: - The search region comes from lastVisibleMapRect
+
+    @Test @MainActor
+    func `Route search queries the recorded viewport`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRoutesForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        // A small rect near Seattle; the request's lat/lon must land inside it.
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            latitudinalMeters: 2_000,
+            longitudinalMeters: 2_000
+        )
+        application.mapRegionManager.lastVisibleMapRect = MKMapRect(region)
+
+        let manager = SearchManager(application: application)
+        _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
+
+        let sent = try #require(dataLoader.requests.first { $0.url?.path.contains("routes-for-location") ?? false })
+        let url = try #require(sent.url)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let lat = try #require(components.queryItems?.first { $0.name == "lat" }?.value.flatMap(Double.init))
+        let lon = try #require(components.queryItems?.first { $0.name == "lon" }?.value.flatMap(Double.init))
+
+        #expect(abs(lat - 47.6) < 0.05)
+        #expect(abs(lon - (-122.3)) < 0.05)
+    }
+
+    // MARK: - The UIKit path still publishes
+
+    @Test @MainActor
+    func `Search publishes the response to the region manager`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubStopsForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let manager = SearchManager(application: application)
+
+        await manager.search(request: SearchRequest(query: "1_75403", type: .stopNumber))
+
+        #expect(application.mapRegionManager.searchResponse != nil)
+    }
+}

--- a/OBAKitTests/Search/SearchManagerTests.swift
+++ b/OBAKitTests/Search/SearchManagerTests.swift
@@ -100,7 +100,17 @@ final class SearchManagerTests: OBATestCase {
     @Test @MainActor
     func `Route search queries the recorded viewport`() async throws {
         let dataLoader = MockDataLoader(testName: name)
-        stubRoutesForLocation(dataLoader: dataLoader)
+        let capturedRequest = SendableBox<URLRequest?>(nil)
+
+        let data = Fixtures.loadData(file: "routes_for_location_query.json")
+        dataLoader.mock(data: data) { request in
+            if request.url?.path.contains("/api/where/routes-for-location.json") ?? false {
+                capturedRequest.value = request
+                return true
+            }
+            return false
+        }
+
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
         // A small rect near Seattle; the request's lat/lon must land inside it.
@@ -114,7 +124,7 @@ final class SearchManagerTests: OBATestCase {
         let manager = SearchManager(application: application)
         _ = try await manager.fetchResults(for: SearchRequest(query: "44", type: .route))
 
-        let sent = try #require(dataLoader.requests.first { $0.url?.path.contains("routes-for-location") ?? false })
+        let sent = try #require(capturedRequest.value)
         let url = try #require(sent.url)
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let lat = try #require(components.queryItems?.first { $0.name == "lat" }?.value.flatMap(Double.init))

--- a/OBAKitTests/Search/SearchResultRouterTests.swift
+++ b/OBAKitTests/Search/SearchResultRouterTests.swift
@@ -1,0 +1,124 @@
+//
+//  SearchResultRouterTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Turning one search result into a map display plus a sheet route.
+@Suite(.serialized)
+final class SearchResultRouterTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeRouter(
+        dataLoader: MockDataLoader,
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void = { _ in }
+    ) -> (SearchResultRouter, SheetCoordinator<AppSheetRoute>, MapSearchDisplayModel) {
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: onPresentVehicleTrip
+        )
+        return (router, coordinator, displayModel)
+    }
+
+    @Test @MainActor
+    func `A stop result pushes stop details and centers the map`() async throws {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        await router.present(result: stop)
+
+        #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
+        if case .stop = displayModel.display {} else {
+            Issue.record("Expected the stop to be displayed on the map")
+        }
+    }
+
+    @Test @MainActor
+    func `A map item result pushes the map item sheet and centers the map`() async {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        await router.present(result: item)
+
+        #expect(coordinator.stackedRoutes.contains(.mapItem(item)))
+        if case .mapItem = displayModel.display {} else {
+            Issue.record("Expected the map item to be displayed on the map")
+        }
+    }
+
+    /// A `Route` isn't renderable on its own — it has to be resolved into
+    /// `StopsForRoute` first, which is where the polyline and stop list come from.
+    @Test @MainActor
+    func `A route result resolves stops for route then pushes the route stops sheet`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+        #expect(displayModel.suppressesAmbientStops == true)
+        #expect(router.lastError == nil)
+    }
+
+    @Test @MainActor
+    func `A failed route resolution records the error and pushes nothing`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, _) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(coordinator.stackedRoutes.isEmpty)
+        #expect(router.lastError != nil)
+    }
+
+    @Test @MainActor
+    func `Presenting a single result returns false when the response holds several`() async throws {
+        let (router, coordinator, _) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let stops = try Fixtures.loadSomeStops()
+        let response = SearchResponse(
+            request: SearchRequest(query: "1", type: .stopNumber),
+            results: Array(stops.prefix(3)),
+            boundingRegion: nil,
+            error: nil
+        )
+
+        let handled = await router.presentSingleResult(from: response)
+
+        #expect(handled == false)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+}

--- a/OBAKitTests/Search/SearchResultRouterTests.swift
+++ b/OBAKitTests/Search/SearchResultRouterTests.swift
@@ -90,6 +90,37 @@ final class SearchResultRouterTests: OBATestCase {
         #expect(router.lastError == nil)
     }
 
+    /// The map display is cleared when its owning route leaves the sheet stack, so
+    /// the route recorded as the owner has to be the very one that got pushed. If
+    /// the two drift, the display is either wiped while its sheet is still up or
+    /// stranded on the map after it goes away.
+    @Test @MainActor
+    func `The recorded display owner is the route that was pushed`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        await router.present(result: route)
+
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
+    /// Stops and map items own their displays too — the map-item sheet no longer
+    /// clears the marker from its own `onDisappear`.
+    @Test @MainActor
+    func `A map item result owns its display`() async {
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        await router.present(result: item)
+
+        #expect(displayModel.owner == .mapItem(item))
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
     @Test @MainActor
     func `A failed route resolution records the error and pushes nothing`() async throws {
         let dataLoader = MockDataLoader(testName: name)
@@ -105,8 +136,66 @@ final class SearchResultRouterTests: OBATestCase {
         #expect(router.lastError != nil)
     }
 
+    // MARK: - Resolve / present split
+
+    /// Resolving performs the network work but touches nothing on screen, so callers
+    /// can keep their own UI up (and report a failure there) before committing to the
+    /// navigation.
     @Test @MainActor
-    func `Presenting a single result returns false when the response holds several`() async throws {
+    func `Resolving leaves the sheet stack and the map untouched`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let resolved = await router.resolve(result: route)
+
+        #expect(resolved != nil)
+        #expect(coordinator.stackedRoutes.isEmpty)
+        #expect(displayModel.owner == nil)
+        if case .none = displayModel.display {} else {
+            Issue.record("Resolving must not draw anything, got \(displayModel.display)")
+        }
+    }
+
+    /// Drawing and pushing happen in one synchronous step, so the stacked layer never
+    /// sits empty between them.
+    @Test @MainActor
+    func `Presenting a resolution draws it and pushes its sheet together`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_route_1_44.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, displayModel) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+        let resolved = try #require(await router.resolve(result: route))
+
+        router.present(resolved)
+
+        #expect(displayModel.suppressesAmbientStops == true)
+        #expect(displayModel.owner == coordinator.stackedRoutes.last)
+    }
+
+    @Test @MainActor
+    func `A failed resolution yields nothing and records the error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (router, coordinator, _) = makeRouter(dataLoader: dataLoader)
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let resolved = await router.resolve(result: route)
+
+        #expect(resolved == nil)
+        #expect(router.lastError != nil)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    @Test @MainActor
+    func `Resolving a single result returns nil when the response holds several`() async throws {
         let (router, coordinator, _) = makeRouter(dataLoader: MockDataLoader(testName: name))
         let stops = try Fixtures.loadSomeStops()
         let response = SearchResponse(
@@ -116,9 +205,9 @@ final class SearchResultRouterTests: OBATestCase {
             error: nil
         )
 
-        let handled = await router.presentSingleResult(from: response)
+        let resolved = await router.resolveSingleResult(from: response)
 
-        #expect(handled == false)
+        #expect(resolved == nil)
         #expect(coordinator.stackedRoutes.isEmpty)
     }
 }

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -82,4 +82,44 @@ final class SearchResultRowTests: OBATestCase {
 
         #expect(selected == true)
     }
+
+    // MARK: - Row identity
+
+    /// The disambiguation list renders through `ForEach`, so ids have to be unique.
+    /// Stop names are not: the two directions of a corner share one, and the Seattle
+    /// fixture has six such pairs among 26 stops. Deriving ids from titles collided
+    /// in exactly the case this list exists to handle.
+    @Test @MainActor
+    func `Stops sharing a name still get distinct row ids`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stops = try Fixtures.loadSomeStops()
+
+        let duplicatedName = try #require(
+            Dictionary(grouping: stops, by: \.name).first { $0.value.count > 1 }?.value,
+            "Fixture no longer contains two stops sharing a name; pick another fixture."
+        )
+
+        let rows = duplicatedName.compactMap {
+            SearchResultRow.row(for: $0, application: application, onSelect: { })
+        }
+
+        #expect(rows.count == duplicatedName.count)
+        #expect(Set(rows.map(\.id)).count == rows.count)
+    }
+
+    @Test @MainActor
+    func `Routes sharing a short name still get distinct row ids`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        // Two agencies can both run a route called "1".
+        let first = try Fixtures.createRoute(id: "1_44")
+        let second = try Fixtures.createRoute(id: "2_44")
+
+        let rows = [first, second].compactMap {
+            SearchResultRow.row(for: $0, application: application, onSelect: { })
+        }
+
+        #expect(rows.count == 2)
+        #expect(rows[0].title == rows[1].title)
+        #expect(rows[0].id != rows[1].id)
+    }
 }

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -122,4 +122,42 @@ final class SearchResultRowTests: OBATestCase {
         #expect(rows[0].title == rows[1].title)
         #expect(rows[0].id != rows[1].id)
     }
+
+    /// The shared factory reproduces what the inline `Stop` branch produced,
+    /// for whichever kind the caller asks for.
+    @Test @MainActor
+    func `Stop factory builds a row with the requested kind`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let row = SearchListRow.stop(
+            stop,
+            application: application,
+            kind: .nearbyStop(id: stop.id),
+            onSelect: {}
+        )
+
+        #expect(row.title == stop.name)
+        #expect(row.accessory == .disclosureIndicator)
+        if case .nearbyStop(let id) = row.kind {
+            #expect(id == stop.id)
+        } else {
+            Issue.record("Expected a .nearbyStop kind, got \(row.kind)")
+        }
+    }
+
+    /// A stop shown in both the nearby and recent sections must not produce two
+    /// rows with the same `id`, or `ForEach` collapses them.
+    @Test @MainActor
+    func `Nearby and recent kinds yield distinct identifiers for one stop`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let nearby = SearchListRow.stop(stop, application: application, kind: .nearbyStop(id: stop.id), onSelect: {})
+        let recent = SearchListRow.stop(stop, application: application, kind: .recentStop(id: stop.id), onSelect: {})
+
+        #expect(nearby.id != recent.id)
+    }
 }

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -1,0 +1,85 @@
+//
+//  SearchResultRowTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Row mapping for the disambiguation sheet: one row per result type, reusing the
+/// same row model as the search list so the two screens look alike.
+@Suite(.serialized)
+final class SearchResultRowTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @Test @MainActor
+    func `A stop result becomes a titled row`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let row = try #require(SearchResultRow.row(for: stop, application: application, onSelect: { }))
+
+        #expect(row.title == stop.name)
+        #expect(row.accessory == .disclosureIndicator)
+    }
+
+    @Test @MainActor
+    func `A route result shows its short name and agency`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let route = try Fixtures.createRoute(id: "1_44")
+
+        let row = try #require(SearchResultRow.row(for: route, application: application, onSelect: { }))
+
+        #expect(row.title == route.shortName)
+        #expect(row.subtitle?.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func `A map item result shows the place name`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
+        let item = MKMapItem(placemark: placemark)
+        item.name = "Pike Place Market"
+
+        let row = try #require(SearchResultRow.row(for: item, application: application, onSelect: { }))
+
+        #expect(row.title == "Pike Place Market")
+    }
+
+    @Test @MainActor
+    func `An unknown result type produces no row`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+
+        #expect(SearchResultRow.row(for: "just a string", application: application, onSelect: { }) == nil)
+    }
+
+    @Test @MainActor
+    func `Selecting a row invokes its handler`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var selected = false
+
+        let row = try #require(SearchResultRow.row(for: stop, application: application, onSelect: { selected = true }))
+        row.action?()
+
+        #expect(selected == true)
+    }
+}

--- a/OBAKitTests/Search/SearchResultRowTests.swift
+++ b/OBAKitTests/Search/SearchResultRowTests.swift
@@ -134,30 +134,16 @@ final class SearchResultRowTests: OBATestCase {
         let row = SearchListRow.stop(
             stop,
             application: application,
-            kind: .nearbyStop(id: stop.id),
+            kind: .recentStop(id: stop.id),
             onSelect: {}
         )
 
         #expect(row.title == stop.name)
         #expect(row.accessory == .disclosureIndicator)
-        if case .nearbyStop(let id) = row.kind {
+        if case .recentStop(let id) = row.kind {
             #expect(id == stop.id)
         } else {
-            Issue.record("Expected a .nearbyStop kind, got \(row.kind)")
+            Issue.record("Expected a .recentStop kind, got \(row.kind)")
         }
-    }
-
-    /// A stop shown in both the nearby and recent sections must not produce two
-    /// rows with the same `id`, or `ForEach` collapses them.
-    @Test @MainActor
-    func `Nearby and recent kinds yield distinct identifiers for one stop`() throws {
-        let dataLoader = MockDataLoader(testName: name)
-        let application = buildApplication(queue: queue, dataLoader: dataLoader)
-        let stop = try #require(try Fixtures.loadSomeStops().first)
-
-        let nearby = SearchListRow.stop(stop, application: application, kind: .nearbyStop(id: stop.id), onSelect: {})
-        let recent = SearchListRow.stop(stop, application: application, kind: .recentStop(id: stop.id), onSelect: {})
-
-        #expect(nearby.id != recent.id)
     }
 }

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -1,0 +1,116 @@
+//
+//  SearchSheetViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The search session: what `MapFloatingPanelController` does for the UIKit panel.
+@Suite(.serialized)
+final class SearchSheetViewModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(dataLoader: MockDataLoader) -> (SearchSheetViewModel, Application, SheetCoordinator<AppSheetRoute>) {
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: { _ in }
+        )
+        let viewModel = SearchSheetViewModel(application: application, coordinator: coordinator, router: router)
+        return (viewModel, application, coordinator)
+    }
+
+    @Test @MainActor
+    func `Typing rebuilds the interactor sections`() {
+        let (viewModel, _, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+
+        viewModel.updateQuery("cap hill")
+
+        #expect(viewModel.searchInteractor.sections.isEmpty == false)
+    }
+
+    /// Quick-search rows are only offered for vehicles when Obaco is running, which
+    /// is what `isVehicleSearchAvailable` gates.
+    @Test @MainActor
+    func `Vehicle search availability mirrors the obaco feature`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+
+        #expect(viewModel.isVehicleSearchAvailable == (application.features.obaco == .running))
+    }
+
+    @Test @MainActor
+    func `Showing a stop pops search and pushes stop details`() async throws {
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        viewModel.searchInteractor(viewModel.searchInteractor, showStop: stop)
+        // `SearchDelegate` is synchronous, so presentation runs in a detached task.
+        await viewModel.pendingPresentation?.value
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
+    }
+
+    @Test @MainActor
+    func `Showing a map item records it as a recent search`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+
+        viewModel.showMapItem(item)
+
+        #expect(application.userDataStore.recentMapItems.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func `Clearing recent searches empties the store and rebuilds sections`() {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        item.name = "Pike Place Market"
+        application.userDataStore.addRecentMapItem(item)
+
+        viewModel.confirmClearRecentSearches()
+
+        #expect(application.userDataStore.recentMapItems.isEmpty)
+    }
+
+    /// A search that matches nothing reports inline rather than popping an alert.
+    @Test @MainActor
+    func `A search with no results sets the no results message`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
+
+        #expect(viewModel.showsNoResults == true)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+}

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -77,12 +77,16 @@ final class SearchSheetViewModelTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Showing a map item records it as a recent search`() {
+    func `Showing a map item records it as a recent search`() async {
         let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
         item.name = "Pike Place Market"
 
         viewModel.showMapItem(item)
+        // The detached presentation task pops search and pushes the map item. The
+        // suite is `.serialized`, so leaving it in flight lets it land during the
+        // next test.
+        await viewModel.pendingPresentation?.value
 
         #expect(application.userDataStore.recentMapItems.isEmpty == false)
     }
@@ -199,6 +203,74 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.message?.kind == .error)
         #expect(coordinator.currentRoute == .search, "Search must stay up to show the failure")
         #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Vehicle search
+
+    /// The vehicle exists; its *details* request is what failed. `fetchVehicleID` used
+    /// to swallow that and hand back an empty response, which classifies as
+    /// `.noResults` — telling the user their query matched nothing and sending them
+    /// off rewording a search that was fine. It has to read as the failure it is.
+    @Test @MainActor
+    func `A failed vehicle details fetch reports an error rather than no results`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let vehicles = #"[{"id": "1", "name": "Metro Transit", "vehicle_id": "1_4351"}]"#
+        dataLoader.mock(data: Data(vehicles.utf8)) { request in
+            request.url?.path.contains("/api/v1/regions/") ?? false
+        }
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/vehicle/") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "4351", type: .vehicleID))
+
+        #expect(viewModel.message?.kind == .error)
+        #expect(viewModel.message?.text != SearchSheetViewModel.noResultsText)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Superseded searches
+
+    /// Cancelling `searchTask` doesn't stop the request already in flight, so a
+    /// superseded search runs to completion. It must not report, navigate, or clear
+    /// `isSearching` — that flag belongs to the search that replaced it, and clearing
+    /// it dismisses the progress HUD while the newer search is still running.
+    @Test @MainActor
+    func `A cancelled search neither reports nor navigates`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        let search = Task { await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route)) }
+        search.cancel()
+        await search.value
+
+        #expect(viewModel.message == nil, "A search the user abandoned must not raise an alert")
+        #expect(viewModel.isSearching, "Clearing this would dismiss the HUD out from under the newer search")
+        #expect(coordinator.currentRoute == .search)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    // MARK: - Analytics
+
+    /// The sheet system tears a sheet's content view down and rebuilds it without the
+    /// user going anywhere, so `onAppear` can fire more than once per entry into
+    /// search. The event is documented as once per entry.
+    @Test @MainActor
+    func `Reporting search opened more than once counts once`() throws {
+        let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        let analytics = try #require(application.analytics as? AnalyticsMock)
+
+        viewModel.reportSearchOpened()
+        viewModel.reportSearchOpened()
+        viewModel.reportSearchOpened()
+
+        let opens = analytics.reportedEvents.filter { $0.label == AnalyticsLabels.searchSelected }
+        #expect(opens.count == 1)
     }
 
     // MARK: - Outcome classification

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -154,6 +154,53 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.message == nil)
     }
 
+    // MARK: - Single-result sequencing
+
+    /// A single result is resolved *before* search is left, so the sheet stack never
+    /// sits empty across the network call and the user isn't dropped on home while a
+    /// request is still in flight.
+    @Test @MainActor
+    func `A single result leaves search only once it resolves`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes-for-location-10.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        dataLoader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "10", type: .route))
+
+        #expect(viewModel.message == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+    }
+
+    /// The regression: search used to be popped *before* the route was resolved, so a
+    /// failure set `message` on a view model whose view — and whose alert — had
+    /// already been torn down. The user landed on home with no explanation. Search has
+    /// to stay up so it can report the failure.
+    @Test @MainActor
+    func `A single result that fails to resolve keeps search up and reports the error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes-for-location-10.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: dataLoader)
+        coordinator.push(.search)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "10", type: .route))
+
+        #expect(viewModel.message?.kind == .error)
+        #expect(coordinator.currentRoute == .search, "Search must stay up to show the failure")
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
     // MARK: - Outcome classification
 
     /// A `nil` response means the search never ran (no API service, no Obaco service,

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -76,6 +76,22 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(coordinator.stackedRoutes.contains(.stopDetails(stopID: stop.id)))
     }
 
+    /// Closing search has to take a resolving presentation with it. Otherwise it
+    /// lands afterwards and hands the rider a detail sheet they already backed out of.
+    @Test @MainActor
+    func `Closing search cancels an in-flight presentation`() async throws {
+        let (viewModel, _, coordinator) = makeViewModel(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        viewModel.searchInteractor(viewModel.searchInteractor, showStop: stop)
+        viewModel.close()
+        await viewModel.pendingPresentation?.value
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
     @Test @MainActor
     func `Showing a map item records it as a recent search`() async {
         let (viewModel, application, _) = makeViewModel(dataLoader: MockDataLoader(testName: name))

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -113,4 +113,43 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(viewModel.showsNoResults == true)
         #expect(coordinator.stackedRoutes.isEmpty)
     }
+
+    // MARK: - Outcome classification
+
+    /// A `nil` response means the search never ran (no API service, no Obaco service,
+    /// no map rect) — a different thing from a query that ran and matched nothing.
+    /// Reporting the first as "no results" would send the user off rewording a query
+    /// that never left the device.
+    ///
+    /// Asserted against the pure classifier because the `nil` case can't be produced
+    /// through the test `Application`, which always has a region, an API service, and
+    /// an Obaco service.
+    @Test @MainActor
+    func `A nil response is unavailable rather than no results`() {
+        #expect(SearchSheetViewModel.SearchOutcome(response: nil) == .unavailable)
+    }
+
+    @Test @MainActor
+    func `An empty response is no results`() {
+        let response = SearchResponse(
+            request: SearchRequest(query: "zzzz", type: .route),
+            results: [],
+            boundingRegion: nil,
+            error: nil
+        )
+
+        #expect(SearchSheetViewModel.SearchOutcome(response: response) == .noResults)
+    }
+
+    @Test @MainActor
+    func `One result routes straight through and several disambiguate`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let request = SearchRequest(query: "1", type: .stopNumber)
+
+        let one = SearchResponse(request: request, results: Array(stops.prefix(1)), boundingRegion: nil, error: nil)
+        let many = SearchResponse(request: request, results: Array(stops.prefix(3)), boundingRegion: nil, error: nil)
+
+        #expect(SearchSheetViewModel.SearchOutcome(response: one) == .single(one))
+        #expect(SearchSheetViewModel.SearchOutcome(response: many) == .disambiguate(many))
+    }
 }

--- a/OBAKitTests/Search/SearchSheetViewModelTests.swift
+++ b/OBAKitTests/Search/SearchSheetViewModelTests.swift
@@ -99,9 +99,10 @@ final class SearchSheetViewModelTests: OBATestCase {
         #expect(application.userDataStore.recentMapItems.isEmpty)
     }
 
-    /// A search that matches nothing reports inline rather than popping an alert.
+    /// A search that matches nothing raises a message, which the view turns into the
+    /// same alert the UIKit path shows.
     @Test @MainActor
-    func `A search with no results sets the no results message`() async throws {
+    func `A search with no results raises a no results message`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
             request.url?.path.contains("/api/where/routes-for-location.json") ?? false
@@ -110,8 +111,47 @@ final class SearchSheetViewModelTests: OBATestCase {
 
         await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
 
-        #expect(viewModel.showsNoResults == true)
+        #expect(viewModel.message?.kind == .noResults)
         #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    /// The message carries a fresh identity per occurrence, so repeating a search
+    /// that fails the same way twice raises two distinct values — otherwise, once
+    /// the alert had been dismissed, the second failure would look like no change
+    /// and never present.
+    @Test @MainActor
+    func `Repeating a failed search raises a distinct message each time`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, _) = makeViewModel(dataLoader: dataLoader)
+        let request = SearchRequest(query: "zzzz", type: .route)
+
+        await viewModel.performSearchAndWait(request: request)
+        let first = try #require(viewModel.message)
+
+        await viewModel.performSearchAndWait(request: request)
+        let second = try #require(viewModel.message)
+
+        #expect(first.text == second.text)
+        #expect(first != second)
+    }
+
+    @Test @MainActor
+    func `Typing clears a pending message`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: Fixtures.loadData(file: "routes_for_location_outofrange.json")) { request in
+            request.url?.path.contains("/api/where/routes-for-location.json") ?? false
+        }
+        let (viewModel, _, _) = makeViewModel(dataLoader: dataLoader)
+
+        await viewModel.performSearchAndWait(request: SearchRequest(query: "zzzz", type: .route))
+        #expect(viewModel.message != nil)
+
+        viewModel.updateQuery("cap hill")
+
+        #expect(viewModel.message == nil)
     }
 
     // MARK: - Outcome classification

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -322,4 +322,96 @@ final class SearchViewModelTests: OBATestCase {
         #expect(vm.loadingVehicleID == nil)
         #expect(vm.vehicleError != nil)
     }
+
+    /// `loadingVehicleID` is the only thing driving the in-row progress indicator, so
+    /// asserting it's nil afterwards isn't enough — a version that never set it at all
+    /// would pass that. Observed while the request is held open.
+    @Test @MainActor
+    func `Loading vehicle id names the vehicle being fetched while the request is in flight`() async {
+        let loader = GatedDataLoader(makeSuccessLoader())
+        let config = APIServiceConfiguration(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, regionIdentifier: pugetSoundRegionIdentifier, surveyBaseURL: surveyBaseURL)
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: RESTAPIService(config, dataLoader: loader)
+        )
+
+        let lookup = Task { await vm.selectVehicle(vehicleID: vehicleID) }
+        await loader.waitForRequest()
+
+        #expect(vm.loadingVehicleID == vehicleID)
+
+        loader.releaseRequest()
+        await lookup.value
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
+
+    // MARK: - Vehicle retry affordance
+
+    @Test @MainActor
+    func `Failed vehicle id is nil before any request`() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        #expect(vm.failedVehicleID == nil)
+    }
+
+    /// `failedVehicleID` is the user's only escape from a failed lookup: it's what
+    /// lets the inline error row offer a retry rather than dead-ending them.
+    @Test @MainActor
+    func `Failed vehicle id names the vehicle whose lookup failed`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+        #expect(vm.vehicleError != nil)
+    }
+
+    @Test @MainActor
+    func `Failed vehicle id is set when the vehicle is not on any trip`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeKeyNotFoundLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+        #expect((vm.vehicleError as? SearchError) == .noTripsAvailable)
+    }
+
+    /// The misconfiguration path bails before `loadingVehicleID` is ever set, so it
+    /// has to name the vehicle on its own or the error row loses its retry.
+    @Test @MainActor
+    func `Failed vehicle id is set when there is no api service`() async {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == vehicleID)
+    }
+
+    /// A retry that succeeds has to clear it, or the error row outlives the error.
+    @Test @MainActor
+    func `Failed vehicle id is cleared by a successful retry`() async {
+        let loader = makeNetworkErrorLoader()
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: loader)
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+        #expect(vm.failedVehicleID == vehicleID)
+
+        loader.removeMappedResponses()
+        loader.mock(URLString: vehicleURLString, with: Fixtures.loadData(file: "api_where_vehicle_1_4351.json"))
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.failedVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
 }

--- a/OBAKitTests/Search/SearchViewModelTests.swift
+++ b/OBAKitTests/Search/SearchViewModelTests.swift
@@ -286,4 +286,40 @@ final class SearchViewModelTests: OBATestCase {
         #expect(vm.vehicleError == nil)
         #expect(vm.vehicleSearchResponse != nil)
     }
+
+    // MARK: - Row-level loading state
+
+    @Test @MainActor
+    func `Loading vehicle id is nil before any request`() {
+        let vm = SearchViewModel(searchResponse: makeSearchResponse(searchType: .vehicleID), apiService: nil)
+        #expect(vm.loadingVehicleID == nil)
+    }
+
+    /// The results sheet shows progress on the tapped row, so the id has to be
+    /// observable while the request is in flight and cleared afterwards.
+    @Test @MainActor
+    func `Loading vehicle id is cleared once the request finishes`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeSuccessLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleSearchResponse != nil)
+    }
+
+    @Test @MainActor
+    func `Loading vehicle id is cleared after a failure`() async {
+        let vm = SearchViewModel(
+            searchResponse: makeSearchResponse(searchType: .vehicleID, query: vehicleID),
+            apiService: buildRESTService(dataLoader: makeNetworkErrorLoader())
+        )
+
+        await vm.selectVehicle(vehicleID: vehicleID)
+
+        #expect(vm.loadingVehicleID == nil)
+        #expect(vm.vehicleError != nil)
+    }
 }

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -72,8 +72,8 @@ final class AppSheetRouteTests {
 
     @Test func `Home detent starts at small and offers all three`() {
         let config = AppSheetRoute.home.detentConfiguration
-        #expect(config.detents == [.height(80), .medium, AppSheetRoute.largeDetent])
-        #expect(config.initialDetent == .height(80))
+        #expect(config.detents == [.height(AppSheetRoute.homeCollapsedHeight), .medium, AppSheetRoute.largeDetent])
+        #expect(config.initialDetent == .height(AppSheetRoute.homeCollapsedHeight))
         #expect(config.showDragIndicator == true)
         #expect(config.isDismissDisabled == true)
     }
@@ -160,7 +160,7 @@ final class AppSheetRouteTests {
     @Test func `Home collapsed height matches map bottom inset`() {
         // Shared with `MapPanelRootView` so the map's bottom safe-area padding
         // matches the collapsed sheet — keep the constant pinned.
-        #expect(AppSheetRoute.homeCollapsedHeight == 80)
+        #expect(AppSheetRoute.homeCollapsedHeight == 75)
     }
 
     // MARK: - SheetDetentConfiguration defaults

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Testing
+import MapKit
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -223,6 +224,70 @@ final class AppSheetRouteTests {
         #expect(sheetRoute1.hashValue == sheetRoute2.hashValue)
     }
 
+    // MARK: - Search result routes
+
+    @Test func `Id embeds map item coordinates`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        #expect(AppSheetRoute.mapItem(item).id == "mapItem-47.6--122.3")
+    }
+
+    @Test func `Id embeds the route id for route stops`() throws {
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        #expect(AppSheetRoute.routeStops(stopsForRoute).id == "routeStops-\(stopsForRoute.id)")
+    }
+
+    @Test func `Id embeds the query and type for search results`() {
+        let request = SearchRequest(query: "44", type: .route)
+        let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+        #expect(AppSheetRoute.searchResults(response).id == "searchResults-\(SearchType.route.rawValue)-44")
+    }
+
+    @Test func `Id embeds nearby stops coordinates`() {
+        let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+        #expect(AppSheetRoute.nearbyStops(coordinate: coordinate).id == "nearbyStops-47.6--122.3")
+    }
+
+    @Test func `Search result routes prefer stacking`() throws {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let response = SearchResponse(request: SearchRequest(query: "q", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        #expect(AppSheetRoute.mapItem(item).prefersStacking == true)
+        #expect(AppSheetRoute.routeStops(stopsForRoute).prefersStacking == true)
+        #expect(AppSheetRoute.searchResults(response).prefersStacking == true)
+        #expect(AppSheetRoute.nearbyStops(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)).prefersStacking == true)
+    }
+
+    @Test func `Map item route offers only the medium detent`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let config = AppSheetRoute.mapItem(item).detentConfiguration
+
+        #expect(config.detents == [.medium])
+        #expect(config.initialDetent == .medium)
+    }
+
+    @Test func `Route stops route opens at medium so the polyline stays visible`() throws {
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let config = AppSheetRoute.routeStops(stopsForRoute).detentConfiguration
+
+        #expect(config.detents == [.medium, .large])
+        #expect(config.initialDetent == .medium)
+    }
+
+    /// `SheetCoordinator.push` preconditions on this for every stacked route: the OS
+    /// owns drag-down on that layer, and locking dismissal would leave
+    /// `stackedEntries` pointing at a sheet that is no longer on screen.
+    @Test func `Stacked search routes allow interactive dismissal`() throws {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)))
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let response = SearchResponse(request: SearchRequest(query: "q", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        #expect(AppSheetRoute.mapItem(item).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.routeStops(stopsForRoute).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.searchResults(response).detentConfiguration.isDismissDisabled == false)
+        #expect(AppSheetRoute.nearbyStops(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2)).detentConfiguration.isDismissDisabled == false)
+    }
+
     // MARK: - Exhaustiveness guard
 
     /// Adding a new `AppSheetRoute` case must fail to compile here, forcing
@@ -231,7 +296,8 @@ final class AppSheetRouteTests {
         switch route {
         case .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
              .stopDetails, .tripPlanner, .tripDetails, .routePicker,
-             .currentTrip, .transitAlert, .more, .settings:
+             .currentTrip, .transitAlert, .more, .settings,
+             .searchResults, .mapItem, .routeStops, .nearbyStops:
             break
         }
     }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -33,13 +33,30 @@ final class AppSheetViewFactoryTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
+    /// The coordinator and display model are required dependencies, so every test
+    /// builds the factory the same way the app does.
+    @MainActor
+    private func makeFactory(
+        application: Application,
+        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
+        displayModel: MapSearchDisplayModel = MapSearchDisplayModel()
+    ) -> AppSheetViewFactory {
+        AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in },
+            onPresentVehicleTrip: { _ in },
+            presentingController: { nil },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel
+        )
+    }
+
     @Test @MainActor
     func `More view returns more sheet host forwarding application`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let host = factory.moreView()
+        let host = makeFactory(application: application).moreView()
 
         // Reference identity: the factory must forward its own `Application`
         // into the host, not construct a new one or drop it. `MoreSheetHost`'s
@@ -54,8 +71,7 @@ final class AppSheetViewFactoryTests: OBATestCase {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let view = factory.stopDetailView(stopID: "1_10914")
+        let view = makeFactory(application: application).stopDetailView(stopID: "1_10914")
 
         #expect(view.stopID == "1_10914")
     }
@@ -71,8 +87,7 @@ final class AppSheetViewFactoryTests: OBATestCase {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
-        let view = factory.stopDetailView(stopID: "1_10914")
+        let view = makeFactory(application: application).stopDetailView(stopID: "1_10914")
 
         #expect(view.makePresenter().application === application)
         #expect(view.makeViewModel().stopID == "1_10914")
@@ -83,40 +98,55 @@ final class AppSheetViewFactoryTests: OBATestCase {
     }
 
     @Test @MainActor
-    func `Route stops view returns route stops sheet view forwarding the stops for route`() {
+    func `Route stops view returns route stops sheet view forwarding the stops for route`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
-        let stopsForRoute = try! Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
-        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+        let view = makeFactory(application: application).routeStopsView(stopsForRoute: stopsForRoute)
 
         #expect(view.stopsForRoute.route.id == stopsForRoute.route.id)
     }
 
+    /// The route-stops sheet clears the map on dismissal, so it has to be handed the
+    /// same display model the map renders — not a private one.
     @Test @MainActor
-    func `Search results view returns search results sheet view forwarding the response`() {
+    func `Route stops view forwards the shared display model`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let displayModel = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        let factory = makeFactory(application: application, displayModel: displayModel)
+        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+
+        #expect(view.displayModel === displayModel)
+    }
+
+    /// Both search surfaces have to route a picked result through the *same* router,
+    /// or the two screens can drift on what "opening a result" means.
+    @Test @MainActor
+    func `Search results view is handed the factory's shared router`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
         let request = SearchRequest(query: "test", type: .stopNumber)
         let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = makeFactory(application: application)
         let view = factory.searchResultsView(response: response)
 
-        #expect(view.response.request.query == response.request.query)
+        #expect(view.router === factory.searchResultRouter)
+        #expect(view.application === application)
     }
 
     @Test @MainActor
-    func `Search view returns search sheet view forwarding the application`() {
+    func `Search view returns search sheet view forwarding the placeholder`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
 
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
-        let view = factory.searchView()
+        let view = makeFactory(application: application).searchView()
 
-        // SearchSheetView's viewModel is internal state via @StateObject, so we verify
-        // indirectly by checking that the view rendered successfully with the placeholder
+        #expect(view.placeholder == SearchPlaceholder.text(for: application))
         #expect(!view.placeholder.isEmpty)
     }
 }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -153,20 +153,24 @@ final class AppSheetViewFactoryTests: OBATestCase {
     }
 
     /// The three index routes are wired for navigation before their screens
-    /// exist, so they must render a placeholder instead of tripping the
-    /// debug assertion that guards genuinely unwired routes.
+    /// exist, so the dispatcher must send them to the placeholder instead of to
+    /// `unimplementedView`, whose DEBUG `assertionFailure` guards genuinely
+    /// unwired routes.
+    ///
+    /// Goes through `view(for:)` rather than calling `indexPlaceholderView`
+    /// directly: the dispatch is the thing under test. `view(for:)` is
+    /// `@ViewBuilder`, so its switch — and any `assertionFailure` on the branch
+    /// it picks — runs at call time. Completing this loop without trapping is
+    /// the assertion; calling the placeholder builder directly would pass even
+    /// if the routes were dropped from the dispatcher.
     @Test @MainActor
-    func `Index routes render a placeholder without asserting`() {
+    func `Index routes dispatch to a placeholder without asserting`() {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
         let factory = makeFactory(application: application)
 
-        // Reaching `unimplementedView` would call assertionFailure and trap the
-        // test run, so simply building each view is the assertion.
         for route in [AppSheetRoute.nearbyAll, .recentStopsAll, .bookmarksAll] {
-            _ = factory.indexPlaceholderView(for: route)
+            _ = factory.view(for: route)
         }
-
-        #expect(Bool(true))
     }
 }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -81,4 +81,42 @@ final class AppSheetViewFactoryTests: OBATestCase {
         #expect(view.formatters === application.formatters)
         #expect(view.userDefaults === application.userDefaults)
     }
+
+    @Test @MainActor
+    func `Route stops view returns route stops sheet view forwarding the stops for route`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stopsForRoute = try! Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.routeStopsView(stopsForRoute: stopsForRoute)
+
+        #expect(view.stopsForRoute.route.id == stopsForRoute.route.id)
+    }
+
+    @Test @MainActor
+    func `Search results view returns search results sheet view forwarding the response`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let request = SearchRequest(query: "test", type: .stopNumber)
+        let response = SearchResponse(request: request, results: [], boundingRegion: nil, error: nil)
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.searchResultsView(response: response)
+
+        #expect(view.response.request.query == response.request.query)
+    }
+
+    @Test @MainActor
+    func `Search view returns search sheet view forwarding the application`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let view = factory.searchView()
+
+        // SearchSheetView's viewModel is internal state via @StateObject, so we verify
+        // indirectly by checking that the view rendered successfully with the placeholder
+        #expect(!view.placeholder.isEmpty)
+    }
 }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -33,13 +33,14 @@ final class AppSheetViewFactoryTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
-    /// The coordinator and display model are required dependencies, so every test
+    /// The coordinator, display model, and stops observer are required dependencies, so every test
     /// builds the factory the same way the app does.
     @MainActor
     private func makeFactory(
         application: Application,
         coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
-        displayModel: MapSearchDisplayModel = MapSearchDisplayModel()
+        displayModel: MapSearchDisplayModel = MapSearchDisplayModel(),
+        stopsObserver: MapStopsObserver? = nil
     ) -> AppSheetViewFactory {
         AppSheetViewFactory(
             application: application,
@@ -47,7 +48,8 @@ final class AppSheetViewFactoryTests: OBATestCase {
             onPresentVehicleTrip: { _ in },
             presentingController: { nil },
             coordinator: coordinator,
-            searchDisplayModel: displayModel
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver ?? MapStopsObserver(application: application)
         )
     }
 

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -151,4 +151,22 @@ final class AppSheetViewFactoryTests: OBATestCase {
         #expect(view.placeholder == SearchPlaceholder.text(for: application))
         #expect(!view.placeholder.isEmpty)
     }
+
+    /// The three index routes are wired for navigation before their screens
+    /// exist, so they must render a placeholder instead of tripping the
+    /// debug assertion that guards genuinely unwired routes.
+    @Test @MainActor
+    func `Index routes render a placeholder without asserting`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let factory = makeFactory(application: application)
+
+        // Reaching `unimplementedView` would call assertionFailure and trap the
+        // test run, so simply building each view is the assertion.
+        for route in [AppSheetRoute.nearbyAll, .recentStopsAll, .bookmarksAll] {
+            _ = factory.indexPlaceholderView(for: route)
+        }
+
+        #expect(Bool(true))
+    }
 }

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -194,4 +194,105 @@ final class HomeSectionModelTests: OBATestCase {
 
         #expect(model.stops.map(\.id) == [stop.id])
     }
+
+    // MARK: - Bookmarks
+
+    @MainActor
+    private func seedBookmarks(count: Int, application: Application) throws -> [Bookmark] {
+        let stops = try Fixtures.loadSomeStops()
+        // sortOrder is assigned in reverse so the test proves the model sorts
+        // rather than accidentally matching insertion order.
+        return (0..<count).map { index in
+            let bookmark = Bookmark(
+                name: "Bookmark \(index)",
+                regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+                stop: stops[index % stops.count]
+            )
+            bookmark.sortOrder = count - index
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+    }
+
+    /// The four shown are chosen by `sortOrder`, not by insertion order —
+    /// `findBookmarks(in:)` returns raw persisted order, so the model must sort.
+    @Test @MainActor
+    func `Bookmarks section selects by sort order up to the limit`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 6, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        #expect(model.rows.count == 4)
+        let sortOrders = model.rows.map(\.bookmark.sortOrder)
+        #expect(sortOrders == sortOrders.sorted())
+    }
+
+    /// Whole-stop bookmarks have no trip to fetch, so they never report as
+    /// having loaded arrival data and never carry departures.
+    @Test @MainActor
+    func `Bookmarks section leaves stop bookmarks without arrival data`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        for row in model.rows {
+            #expect(row.isTripBookmark == false)
+            #expect(row.arrivalDepartures.isEmpty)
+            #expect(row.hasLoadedArrivalData == false)
+        }
+    }
+
+    /// A second activation inside the staleness window does not re-fetch.
+    @Test @MainActor
+    func `Bookmarks section skips a repeat load inside the staleness window`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(5), staleAfter: 30) == false)
+    }
+
+    /// Once the window lapses, the next activation re-fetches.
+    @Test @MainActor
+    func `Bookmarks section reloads after the staleness window lapses`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(31), staleAfter: 30))
+    }
+
+    /// A changed selection re-fetches even inside the staleness window —
+    /// otherwise a newly added bookmark would show blank until the window lapsed.
+    @Test @MainActor
+    func `Bookmarks section reloads when the selection changes`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+
+        _ = try seedBookmarks(count: 1, application: application)
+
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30))
+    }
 }

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -1,0 +1,114 @@
+//
+//  HomeSectionModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class HomeSectionModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Nearby
+
+    /// The section caps at its limit and orders by the observer's viewport center.
+    @Test @MainActor
+    func `Nearby section publishes the nearest stops up to the limit`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+
+        #expect(model.stops.count == 4)
+        let expected = Stop.nearest(observer.stops, to: region.center, limit: 4).map(\.id)
+        #expect(model.stops.map(\.id) == expected)
+    }
+
+    /// Zooming out resets the observer, and the section empties with it.
+    @Test @MainActor
+    func `Nearby section empties when the observer resets`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+        #expect(!model.stops.isEmpty)
+
+        observer.reset()
+
+        #expect(model.stops.isEmpty)
+    }
+
+    /// Before the first settle there is no center to sort by, so the section
+    /// shows the observer's own ordering rather than nothing at all.
+    @Test @MainActor
+    func `Nearby section falls back to observer order before the first settle`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        // Deliberately no updateViewport — viewportCenter stays nil.
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+
+        #expect(model.stops.map(\.id) == observer.stops.prefix(4).map(\.id))
+    }
+}

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -197,37 +197,201 @@ final class HomeSectionModelTests: OBATestCase {
 
     // MARK: - Bookmarks
 
+    /// A fixed clock for creation dates. Bookmarks seeded later get later dates,
+    /// so "newest" is a property of the test rather than of how fast it runs —
+    /// `Date()` inside a loop can land several bookmarks on the same instant.
+    private static let seedEpoch = Date(timeIntervalSince1970: 1_700_000_000)
+
     @MainActor
-    private func seedBookmarks(count: Int, application: Application) throws -> [Bookmark] {
+    private func seedBookmarks(count: Int, application: Application, startingAt offset: Int = 0) throws -> [Bookmark] {
         let stops = try Fixtures.loadSomeStops()
-        // sortOrder is assigned in reverse so the test proves the model sorts
-        // rather than accidentally matching insertion order.
         return (0..<count).map { index in
             let bookmark = Bookmark(
-                name: "Bookmark \(index)",
+                name: "Bookmark \(offset + index)",
                 regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
-                stop: stops[index % stops.count]
+                stop: stops[(offset + index) % stops.count],
+                // One minute apart, ascending: the last one seeded is the newest.
+                dateCreated: Self.seedEpoch.addingTimeInterval(Double(offset + index) * 60)
             )
+            // Deliberately the inverse of creation order, so a test that passes
+            // can't be passing because the two happen to agree.
             bookmark.sortOrder = count - index
             application.userDataStore.add(bookmark, to: nil)
             return bookmark
         }
     }
 
-    /// The four shown are chosen by `sortOrder`, not by insertion order —
-    /// `findBookmarks(in:)` returns raw persisted order, so the model must sort.
+    /// Thread-safe counter — `MockDataLoader` matches requests off the main actor.
+    private final class RequestCounter {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var count: Int = 0
+
+        nonisolated func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+        }
+    }
+
+    /// Real *trip* bookmarks. `BookmarkDataLoader` skips anything that isn't one
+    /// without issuing a request, so the stop bookmarks `seedBookmarks` builds
+    /// would silently zero out any request-count assertion.
+    @MainActor
+    private func makeTripBookmarks(count: Int, application: Application, startingAt offset: Int = 0) throws -> [Bookmark] {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
+
+        return (0..<count).map { index in
+            let bookmark = Bookmark(
+                name: "Trip Bookmark \(offset + index)",
+                regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+                arrivalDeparture: arrivalDeparture,
+                dateCreated: Self.seedEpoch.addingTimeInterval(Double(offset + index) * 60)
+            )
+            bookmark.sortOrder = offset + index
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+    }
+
+    /// The preview shows the `limit` most recently created bookmarks, newest
+    /// first — not the first `limit` of the user's manual order.
+    ///
+    /// `seedBookmarks` assigns `sortOrder` as the inverse of creation order, so
+    /// this can't pass by the two agreeing.
     @Test @MainActor
-    func `Bookmarks section selects by sort order up to the limit`() throws {
+    func `Bookmarks section shows the most recently created first`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
-        _ = try seedBookmarks(count: 6, application: application)
+        let seeded = try seedBookmarks(count: 6, application: application)
 
         try #require(application.currentRegion != nil)
         let model = HomeBookmarksSectionModel(application: application, limit: 4)
 
         #expect(model.rows.count == 4)
+        // Bookmarks 5, 4, 3, 2 — the four newest, newest first.
+        let expected = seeded.suffix(4).reversed().map(\.id)
+        #expect(model.rows.map(\.bookmark.id) == Array(expected))
+    }
+
+    /// The whole point of the change: a bookmark created *after* the preview is
+    /// already full still shows up, because it's newest — under the old
+    /// `sortOrder` ascending rule it was appended last and fell past the cut.
+    @Test @MainActor
+    func `A newly created bookmark enters an already full preview`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 4, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        try #require(model.rows.count == 4)
+
+        let newest = try #require(try seedBookmarks(count: 1, application: application, startingAt: 9).first)
+        model.refreshSelection()
+
+        #expect(model.rows.first?.bookmark.id == newest.id)
+        #expect(model.rows.count == 4)
+    }
+
+    /// Pinned bookmarks lead, then the newest unpinned fill up to the limit.
+    @Test @MainActor
+    func `Pinned bookmarks come first and unpinned fill the rest`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        let seeded = try seedBookmarks(count: 6, application: application)
+
+        // Pin the two *oldest*, which newest-first would otherwise never show.
+        let pinned = Array(seeded.prefix(2))
+        for bookmark in pinned {
+            application.userDataStore.setPinned(true, for: bookmark)
+        }
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        #expect(model.rows.count == 4)
+        // Pins first, newest pin first among them.
+        #expect(model.rows.prefix(2).map(\.bookmark.id) == pinned.reversed().map(\.id))
+        #expect(model.rows.prefix(2).map(\.isPinned) == [true, true])
+        // Then the two newest unpinned.
+        #expect(model.rows.dropFirst(2).map(\.bookmark.id) == seeded.suffix(2).reversed().map(\.id))
+    }
+
+    /// `limit` is a floor, not a cap: pin more than it and every pin still shows.
+    @Test @MainActor
+    func `More pinned than the limit shows all of them`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        let seeded = try seedBookmarks(count: 8, application: application)
+
+        let pinned = Array(seeded.prefix(6))
+        for bookmark in pinned {
+            application.userDataStore.setPinned(true, for: bookmark)
+        }
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        // All six pins, and no unpinned — the limit is already exceeded.
+        #expect(model.rows.count == 6)
+        #expect(model.rows.map(\.isPinned) == Array(repeating: true, count: 6))
+        #expect(Set(model.rows.map(\.bookmark.id)) == Set(pinned.map(\.id)))
+    }
+
+    /// Pinning from the row reorders the section without anyone calling reload —
+    /// the store posts `.bookmarksDidChange` and the model is already listening.
+    @Test @MainActor
+    func `Toggling a pin reorders the section through the notification`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        let seeded = try seedBookmarks(count: 6, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        // The oldest starts out below the cut.
+        let oldest = try #require(seeded.first)
+        try #require(!model.rows.contains { $0.bookmark.id == oldest.id })
+
+        model.togglePin(oldest)
+
+        await poll(
+            until: { model.rows.first?.bookmark.id == oldest.id },
+            "Pinning did not move the bookmark to the top of the section"
+        )
+        #expect(model.rows.first?.isPinned == true)
+    }
+
+    /// Bookmarks stored before `dateCreated` existed all decode as `.distantPast`.
+    /// Among those the user's manual order is the only signal left, so the tie
+    /// break is `sortOrder` ascending — not reversed along with the dates.
+    @Test @MainActor
+    func `Legacy bookmarks without a creation date keep their manual order`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // `.distantPast` for every one, as a pre-`dateCreated` decode produces.
+        let legacy = (0..<3).map { index -> Bookmark in
+            let bookmark = Bookmark(
+                name: "Legacy \(index)",
+                regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+                stop: stops[index % stops.count],
+                dateCreated: .distantPast
+            )
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
         let sortOrders = model.rows.map(\.bookmark.sortOrder)
-        #expect(sortOrders == sortOrders.sorted())
+        #expect(sortOrders == sortOrders.sorted(), "Same-date bookmarks must stay in manual order")
+        #expect(model.rows.map(\.bookmark.id) == legacy.map(\.id))
     }
 
     /// Whole-stop bookmarks have no trip to fetch, so they never report as
@@ -296,9 +460,15 @@ final class HomeSectionModelTests: OBATestCase {
         #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30))
     }
 
-    /// Posting `.bookmarksDidChange` causes the section to pick up a newly
-    /// added bookmark. The notification is delivered asynchronously via a
-    /// main-actor hop, so we poll until the rows are updated.
+    /// A newly added bookmark reaches the section without anyone re-activating
+    /// the sheet.
+    ///
+    /// `UserDefaultsStore.add(_:to:)` posts `.bookmarksDidChange` itself, so
+    /// seeding is the trigger — the test doesn't synthesize the notification.
+    /// That matters now that the model observes `object: application.userDataStore`
+    /// rather than `object: nil`: a hand-rolled global post wouldn't reach it, and
+    /// wouldn't be exercising the real path either. Delivery hops to the main
+    /// actor, so poll rather than assert immediately.
     @Test @MainActor
     func `Bookmarks section updates when bookmarks did change notification is posted`() async throws {
         let dataLoader = MockDataLoader(testName: name)
@@ -310,15 +480,80 @@ final class HomeSectionModelTests: OBATestCase {
         let initialRowCount = model.rows.count
         #expect(initialRowCount == 2)
 
-        // Add a new bookmark, then post the notification
-        _ = try seedBookmarks(count: 1, application: application)
-        NotificationCenter.default.post(name: .bookmarksDidChange, object: nil)
+        _ = try seedBookmarks(count: 1, application: application, startingAt: 2)
 
-        // Poll until the rows are updated with the new bookmark
         await poll(until: {
             model.rows.count == initialRowCount + 1
         }, "Bookmarks section did not pick up the newly added bookmark after notification")
 
         #expect(model.rows.count == 3)
+    }
+
+    /// Bookmarking a stop while the home sheet is open has to *fetch arrivals*
+    /// for the new bookmark, not just add a blank row.
+    ///
+    /// Regression test. `bookmarksDidChange()` used to call `refreshSelection()`
+    /// before `loadIfNeeded()`, which advanced `selection` ahead of the snapshot
+    /// `loadIfNeeded()` compares against — so `selectionChanged` was always false
+    /// on this path and a bookmark added inside the 30-second staleness window
+    /// never got a fetch. Counting requests is what pins it: the row count test
+    /// above passes either way, because `refreshSelection()` rebuilds rows on its
+    /// own.
+    @Test @MainActor
+    func `Bookmarks section fetches arrivals for a bookmark added while active`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+
+        let requestCounter = RequestCounter()
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            let matches = request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            if matches { requestCounter.increment() }
+            return matches
+        }
+
+        _ = try makeTripBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        #expect(model.loadIfNeeded())
+        await poll(until: { requestCounter.count == 2 }, "Initial activation did not fetch both bookmarks")
+
+        // A third bookmark arrives while the sheet is up and well inside the
+        // staleness window. `add(_:to:)` posts `.bookmarksDidChange`.
+        _ = try makeTripBookmarks(count: 1, application: application, startingAt: 2)
+
+        await poll(
+            until: { requestCounter.count > 2 },
+            "Adding a bookmark did not fetch arrivals — the notification path lost the selection change"
+        )
+    }
+
+    /// A region switch re-fetches even inside the staleness window.
+    ///
+    /// Seeded with no bookmarks on purpose: with bookmarks present, moving region
+    /// also empties the selection, so `selectionChanged` would carry the test and
+    /// the region branch would never be the thing under test.
+    @Test @MainActor
+    func `Bookmarks section reloads when the region changes`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        // Selecting a region re-resolves agencies against the new server, and an
+        // unstubbed request is a fatal error in `MockDataLoader`.
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.tampaRegion.OBABaseURL)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+        #expect(model.selection.isEmpty)
+        // Nothing changed, still fresh.
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30) == false)
+
+        application.regionsService.currentRegion = Fixtures.tampaRegion
+
+        // Selection is still empty, so only the region branch can carry this.
+        #expect(model.selection.isEmpty)
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(2), staleAfter: 30))
     }
 }

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -29,6 +29,37 @@ final class HomeSectionModelTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
+    // MARK: - Helpers
+
+    private func buildApplicationWithRegion(queue: OperationQueue, dataLoader: MockDataLoader) -> Application {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return Application(config: config)
+    }
+
     // MARK: - Nearby
 
     /// The section caps at its limit and orders by the observer's viewport center.
@@ -118,7 +149,7 @@ final class HomeSectionModelTests: OBATestCase {
     @Test @MainActor
     func `Recent section caps at the limit in most recently used order`() throws {
         let dataLoader = MockDataLoader(testName: name)
-        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
         let stops = try Fixtures.loadSomeStops()
 
         // Added oldest-first; the store inserts each at index 0, so the last
@@ -127,6 +158,8 @@ final class HomeSectionModelTests: OBATestCase {
             application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
         }
 
+        try #require(application.currentRegion != nil)
+        try #require(Fixtures.pugetSoundRegion.regionIdentifier == application.currentRegion!.regionIdentifier, "Region mismatch: fixture ID \(Fixtures.pugetSoundRegion.regionIdentifier) != app current ID \(application.currentRegion!.regionIdentifier)")
         let model = HomeRecentStopsSectionModel(application: application, limit: 4)
 
         #expect(model.stops.count == 4)
@@ -141,9 +174,10 @@ final class HomeSectionModelTests: OBATestCase {
     @Test @MainActor
     func `Recent section reload picks up newly added stops`() throws {
         let dataLoader = MockDataLoader(testName: name)
-        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
         let stops = try Fixtures.loadSomeStops()
 
+        try #require(application.currentRegion != nil)
         let model = HomeRecentStopsSectionModel(application: application, limit: 4)
         #expect(model.stops.isEmpty)
 

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import Combine
 import Foundation
 import MapKit
 import Testing
@@ -440,6 +441,134 @@ final class HomeSectionModelTests: OBATestCase {
 
         #expect(model.loadIfNeeded(now: start, staleAfter: 30))
         #expect(model.loadIfNeeded(now: start.addingTimeInterval(31), staleAfter: 30))
+    }
+
+    /// A failed batch reopens the staleness gate, so the next activation retries.
+    ///
+    /// `loadIfNeeded()` has to stamp `lastFetchDate` before the batch resolves —
+    /// otherwise two activations in the same run loop would both fetch. That
+    /// stamp is only meaningful if the batch succeeded: without the failure
+    /// path, a failed fetch left the rows stuck in "Loading…" for the rest of
+    /// the 30-second window, and this section has neither the polling timer nor
+    /// the pull-to-refresh that rescue the Bookmarks tab.
+    @Test @MainActor
+    func `Bookmarks section retries inside the staleness window after a failed batch`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try makeTripBookmarks(count: 1, application: application)
+
+        dataLoader.mock(data: Data(), statusCode: 500) { request in
+            request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+        try #require(model.loadIfNeeded(now: start, staleAfter: 30))
+
+        // Drive a batch to completion so the loader reports its outcome.
+        await model.loader.loadDataAndWait()
+        try #require(model.loader.lastBatchHadError, "Precondition: the batch must have failed")
+
+        #expect(
+            model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30),
+            "A failed batch must not gate out the next activation"
+        )
+    }
+
+    /// The control for the test above: a *successful* batch leaves the gate shut,
+    /// so the failure path can't be passing because the gate stopped working.
+    @Test @MainActor
+    func `Bookmarks section keeps the staleness gate shut after a successful batch`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try makeTripBookmarks(count: 1, application: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+        try #require(model.loadIfNeeded(now: start, staleAfter: 30))
+
+        await model.loader.loadDataAndWait()
+        try #require(model.loader.lastBatchHadError == false, "Precondition: the batch must have succeeded")
+
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30) == false)
+    }
+
+    /// A repeat reload with an unchanged store publishes nothing.
+    ///
+    /// `activate()` runs on every sheet re-appearance, and the view model
+    /// forwards each section's `objectWillChange` as its own — so an
+    /// unconditional assignment here would cost a full home-sheet body
+    /// evaluation every time the user returned from a stacked sheet.
+    @Test @MainActor
+    func `Recent section does not republish when the store is unchanged`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+        let stop = try #require(stops.first)
+        stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        let model = HomeRecentStopsSectionModel(application: application)
+        try #require(model.stops.isEmpty == false)
+
+        let counter = ChangeCounter()
+        let cancellable = model.objectWillChange.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        model.reload()
+        model.reload()
+        #expect(counter.count == 0, "An unchanged reload must not invalidate observers")
+
+        // A real change still publishes.
+        let second = try #require(stops.dropFirst().first)
+        second.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(second, region: Fixtures.pugetSoundRegion)
+        model.reload()
+        #expect(counter.count == 1, "A changed store must still publish")
+    }
+
+    /// The bookmarks counterpart of the test above: rebuilding identical rows
+    /// publishes nothing. This runs on every activation *and* on every loader
+    /// update, so it's the hotter of the two.
+    @Test @MainActor
+    func `Bookmarks section does not republish when the rows are unchanged`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        try #require(model.rows.count == 2)
+
+        let counter = ChangeCounter()
+        let cancellable = model.objectWillChange.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        model.refreshSelection()
+        model.refreshSelection()
+        #expect(counter.count == 0, "An unchanged rebuild must not invalidate observers")
+
+        _ = try seedBookmarks(count: 1, application: application, startingAt: 2)
+        model.refreshSelection()
+        #expect(counter.count == 1, "A changed selection must still publish")
+    }
+
+    /// Thread-safe counter — `objectWillChange` delivery isn't actor-isolated.
+    private final class ChangeCounter {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var count: Int = 0
+
+        nonisolated func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+        }
     }
 
     /// A changed selection re-fetches even inside the staleness window —

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -155,11 +155,14 @@ final class HomeSectionModelTests: OBATestCase {
         // Added oldest-first; the store inserts each at index 0, so the last
         // one added is the first one out.
         for stop in stops.prefix(6) {
+            // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+            // fixture stops bypass that path, so we assign it here to match production state.
+            stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
             application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
         }
 
         try #require(application.currentRegion != nil)
-        try #require(Fixtures.pugetSoundRegion.regionIdentifier == application.currentRegion!.regionIdentifier, "Region mismatch: fixture ID \(Fixtures.pugetSoundRegion.regionIdentifier) != app current ID \(application.currentRegion!.regionIdentifier)")
+        try #require(!application.userDataStore.recentStops(in: application.currentRegion).isEmpty)
         let model = HomeRecentStopsSectionModel(application: application, limit: 4)
 
         #expect(model.stops.count == 4)
@@ -182,7 +185,11 @@ final class HomeSectionModelTests: OBATestCase {
         #expect(model.stops.isEmpty)
 
         let stop = try #require(stops.first)
+        // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+        // fixture stops bypass that path, so we assign it here to match production state.
+        stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
         application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        try #require(!application.userDataStore.recentStops(in: application.currentRegion).isEmpty)
         model.reload()
 
         #expect(model.stops.map(\.id) == [stop.id])

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -111,4 +111,46 @@ final class HomeSectionModelTests: OBATestCase {
 
         #expect(model.stops.map(\.id) == observer.stops.prefix(4).map(\.id))
     }
+
+    // MARK: - Recent
+
+    /// The section caps at its limit and preserves the store's MRU ordering.
+    @Test @MainActor
+    func `Recent section caps at the limit in most recently used order`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // Added oldest-first; the store inserts each at index 0, so the last
+        // one added is the first one out.
+        for stop in stops.prefix(6) {
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        let model = HomeRecentStopsSectionModel(application: application, limit: 4)
+
+        #expect(model.stops.count == 4)
+        let expected = application.userDataStore
+            .recentStops(in: application.currentRegion)
+            .prefix(4)
+            .map(\.id)
+        #expect(model.stops.map(\.id) == Array(expected))
+    }
+
+    /// `reload()` picks up a stop added after construction.
+    @Test @MainActor
+    func `Recent section reload picks up newly added stops`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        let model = HomeRecentStopsSectionModel(application: application, limit: 4)
+        #expect(model.stops.isEmpty)
+
+        let stop = try #require(stops.first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        model.reload()
+
+        #expect(model.stops.map(\.id) == [stop.id])
+    }
 }

--- a/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
@@ -295,4 +295,30 @@ final class HomeSectionModelTests: OBATestCase {
 
         #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30))
     }
+
+    /// Posting `.bookmarksDidChange` causes the section to pick up a newly
+    /// added bookmark. The notification is delivered asynchronously via a
+    /// main-actor hop, so we poll until the rows are updated.
+    @Test @MainActor
+    func `Bookmarks section updates when bookmarks did change notification is posted`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplicationWithRegion(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        try #require(application.currentRegion != nil)
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let initialRowCount = model.rows.count
+        #expect(initialRowCount == 2)
+
+        // Add a new bookmark, then post the notification
+        _ = try seedBookmarks(count: 1, application: application)
+        NotificationCenter.default.post(name: .bookmarksDidChange, object: nil)
+
+        // Poll until the rows are updated with the new bookmark
+        await poll(until: {
+            model.rows.count == initialRowCount + 1
+        }, "Bookmarks section did not pick up the newly added bookmark after notification")
+
+        #expect(model.rows.count == 3)
+    }
 }

--- a/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
@@ -1,0 +1,146 @@
+//
+//  HomeSheetViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class HomeSheetViewModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(application: Application) -> HomeSheetViewModel {
+        HomeSheetViewModel(
+            application: application,
+            stopsObserver: MapStopsObserver(application: application)
+        )
+    }
+
+    /// With no data at all, every section is omitted — the view renders the
+    /// all-empty state rather than three empty headers.
+    @Test @MainActor
+    func `Visible sections is empty when every section is empty`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let viewModel = makeViewModel(application: application)
+
+        #expect(viewModel.visibleSections.isEmpty)
+    }
+
+    /// An empty earlier section does not promote a later one — order is fixed.
+    @Test @MainActor
+    func `Visible sections keeps a fixed order when an earlier section is empty`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // Seed recents only — nearby stays empty (no map settle) and bookmarks
+        // stay empty (none stored).
+        let stop = try #require(stops.first)
+        // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+        // fixture stops bypass that path, so we assign it here to match production state.
+        stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        let viewModel = makeViewModel(application: application)
+        viewModel.activate()
+
+        #expect(viewModel.visibleSections == [.recent])
+    }
+
+    /// Both populated sections appear, nearby-before-recent order intact.
+    @Test @MainActor
+    func `Visible sections lists nearby before recent`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let stops = try Fixtures.loadSomeStops()
+        let stop = try #require(stops.first)
+        // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+        // fixture stops bypass that path, so we assign it here to match production state.
+        stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let viewModel = HomeSheetViewModel(application: application, stopsObserver: observer)
+        viewModel.activate()
+
+        #expect(viewModel.visibleSections == [.nearby, .recent])
+    }
+
+    /// Every section caps at the shared limit.
+    @Test @MainActor
+    func `Sections cap at the shared section limit`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        for stop in stops.prefix(HomeSheetSection.itemLimit + 3) {
+            // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
+            // fixture stops bypass that path, so we assign it here to match production state.
+            stop.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        let viewModel = makeViewModel(application: application)
+        viewModel.activate()
+
+        #expect(viewModel.recent.stops.count == HomeSheetSection.itemLimit)
+    }
+
+    /// Two activations in quick succession issue one bookmark fetch.
+    @Test @MainActor
+    func `Activate twice in quick succession fetches bookmarks once`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        let bookmark = Bookmark(
+            name: "Bookmark",
+            regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+            stop: try #require(stops.first)
+        )
+        application.userDataStore.add(bookmark, to: nil)
+
+        let viewModel = makeViewModel(application: application)
+        let start = Date()
+
+        #expect(viewModel.bookmarks.loadIfNeeded(now: start))
+        #expect(viewModel.bookmarks.loadIfNeeded(now: start.addingTimeInterval(2)) == false)
+    }
+}

--- a/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
@@ -9,6 +9,7 @@
 
 import Foundation
 import MapKit
+import Combine
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -103,13 +104,23 @@ final class HomeSheetViewModelTests: OBATestCase {
         #expect(viewModel.visibleSections == [.nearby, .recent])
     }
 
-    /// Every section caps at the shared limit.
+    /// Nearby and recent both cap at the shared limit when composed through the
+    /// view model, each given more than `itemLimit` to work with.
+    ///
+    /// The bookmarks section's cap is covered by
+    /// `HomeSectionModelTests.Bookmarks section selects by sort order up to the limit`,
+    /// which also pins the sort the cap is applied after.
     @Test @MainActor
-    func `Sections cap at the shared section limit`() throws {
+    func `Nearby and recent sections cap at the shared section limit`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let application = buildApplication(queue: queue, dataLoader: dataLoader)
-        let stops = try Fixtures.loadSomeStops()
+        clearStopCache(for: application)
 
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let stops = try Fixtures.loadSomeStops()
         for stop in stops.prefix(HomeSheetSection.itemLimit + 3) {
             // Production stops receive regionIdentifier from RESTAPIResponse.loadReferences;
             // fixture stops bypass that path, so we assign it here to match production state.
@@ -117,10 +128,77 @@ final class HomeSheetViewModelTests: OBATestCase {
             application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
         }
 
-        let viewModel = makeViewModel(application: application)
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+        try #require(observer.stops.count > HomeSheetSection.itemLimit)
+
+        let viewModel = HomeSheetViewModel(application: application, stopsObserver: observer)
         viewModel.activate()
 
         #expect(viewModel.recent.stops.count == HomeSheetSection.itemLimit)
+        #expect(viewModel.nearby.stops.count == HomeSheetSection.itemLimit)
+    }
+
+    /// A section's own content change has to re-render the sheet.
+    ///
+    /// `HomeSheetView` is handed `viewModel` and reads `viewModel.recent.stops`
+    /// through it, but `recent` is a *nested* `ObservableObject` — SwiftUI
+    /// subscribes only to the object it's given, never to children reached
+    /// through it. So unless the view model republishes its children's changes,
+    /// the only thing that can invalidate the view is `visibleSections`, and that
+    /// is guarded against no-op writes. With the Recent section already on screen,
+    /// viewing another stop updates the model and leaves the sheet showing the
+    /// old rows until something else rebuilds it.
+    @Test @MainActor
+    func `A section content change republishes through the view model`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // One recent stop, so the Recent section is already visible and the
+        // second one can't flip `visibleSections`.
+        let first = try #require(stops.first)
+        first.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(first, region: Fixtures.pugetSoundRegion)
+
+        let viewModel = makeViewModel(application: application)
+        viewModel.activate()
+        try #require(viewModel.visibleSections == [.recent])
+
+        let counter = ChangeCounter()
+        let cancellable = viewModel.objectWillChange.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        // A second stop is viewed — exactly what happens when a stacked
+        // `.stopDetails` sheet records a recent and is then dismissed.
+        let second = try #require(stops.dropFirst().first)
+        second.regionIdentifier = Fixtures.pugetSoundRegion.regionIdentifier
+        application.userDataStore.addRecentStop(second, region: Fixtures.pugetSoundRegion)
+        viewModel.activate()
+
+        // The model saw it...
+        #expect(viewModel.recent.stops.first?.id == second.id)
+        #expect(viewModel.visibleSections == [.recent], "Precondition: visibility must not have changed")
+        // ...so the view must have been given a reason to re-read it.
+        #expect(counter.count > 0, "A section content change did not invalidate the view model")
+    }
+
+    /// Thread-safe counter — `objectWillChange` delivery isn't actor-isolated.
+    private final class ChangeCounter {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var count: Int = 0
+
+        nonisolated func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+        }
     }
 
     /// Two activations in quick succession issue one bookmark fetch.

--- a/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
+++ b/OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
@@ -189,6 +189,51 @@ final class HomeSheetViewModelTests: OBATestCase {
         #expect(counter.count > 0, "A section content change did not invalidate the view model")
     }
 
+    /// The all-empty state is held back until the map has settled once.
+    ///
+    /// Recents and bookmarks are read from the store in the section models'
+    /// initializers, so they're accurate at first body evaluation; nearby isn't,
+    /// because it has nothing until the map settles. Without this gate a cold
+    /// open with nothing saved paints "Nothing Here Yet" for a frame or two and
+    /// then replaces it with the nearby stops.
+    @Test @MainActor
+    func `Initial content is withheld until the map settles`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        let viewModel = HomeSheetViewModel(application: application, stopsObserver: observer)
+
+        #expect(viewModel.visibleSections.isEmpty)
+        #expect(viewModel.hasLoadedInitialContent == false, "Nearby has not had its chance yet")
+
+        observer.updateViewport(MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        ))
+
+        #expect(viewModel.hasLoadedInitialContent)
+    }
+
+    /// A map parked at region-level zoom settles through `reset()`, never
+    /// `updateViewport(_:)` — and that is exactly a case where the empty state is
+    /// the right answer, so it has to open the gate too.
+    @Test @MainActor
+    func `A zoomed out settle also releases the empty state`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        let viewModel = HomeSheetViewModel(application: application, stopsObserver: observer)
+        #expect(viewModel.hasLoadedInitialContent == false)
+
+        observer.reset()
+
+        #expect(viewModel.hasLoadedInitialContent)
+        #expect(viewModel.visibleSections.isEmpty, "Precondition: this is the all-empty case")
+    }
+
     /// Thread-safe counter — `objectWillChange` delivery isn't actor-isolated.
     private final class ChangeCounter {
         private let lock = NSLock()

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -32,14 +32,14 @@ final class MapItemSheetViewTests: OBATestCase {
     }
 
     @MainActor
-    private func makeFactory(application: Application, displayModel: MapSearchDisplayModel = MapSearchDisplayModel()) -> AppSheetViewFactory {
+    private func makeFactory(application: Application) -> AppSheetViewFactory {
         AppSheetViewFactory(
             application: application,
             onPresentTrip: { _ in },
             onPresentVehicleTrip: { _ in },
             presentingController: { nil },
             coordinator: SheetCoordinator(root: .home),
-            searchDisplayModel: displayModel
+            searchDisplayModel: MapSearchDisplayModel()
         )
     }
 
@@ -127,17 +127,13 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let displayModel = MapSearchDisplayModel()
-        let factory = makeFactory(application: application, displayModel: displayModel)
+        let factory = makeFactory(application: application)
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
 
         #expect(view.application === application)
         #expect(view.mapItem === item)
-        // The sheet clears the map marker when it goes away, so it needs the same
-        // display model the map renders.
-        #expect(view.displayModel === displayModel)
     }
 
     @Test @MainActor

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -39,7 +39,8 @@ final class MapItemSheetViewTests: OBATestCase {
             onPresentVehicleTrip: { _ in },
             presentingController: { nil },
             coordinator: SheetCoordinator(root: .home),
-            searchDisplayModel: MapSearchDisplayModel()
+            searchDisplayModel: MapSearchDisplayModel(),
+            stopsObserver: MapStopsObserver(application: application)
         )
     }
 

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -90,7 +90,7 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
@@ -102,7 +102,7 @@ final class MapItemSheetViewTests: OBATestCase {
     @Test @MainActor
     func `Factory builds a nearby stops host for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
         let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
 
         let host = factory.nearbyStopsView(coordinate: coordinate)

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -1,0 +1,113 @@
+//
+//  MapItemSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import UIKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The map-item sheet's wiring: injected actions and the share URL the native
+/// `ShareLink` uses.
+@Suite(.serialized)
+final class MapItemSheetViewTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(actions: MapItemActions) -> MapItemViewModel {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = "Pike Place Market"
+        return MapItemViewModel(
+            mapItem: mapItem,
+            application: application,
+            actions: actions,
+            removePinHandler: nil,
+            planTripHandler: {}
+        )
+    }
+
+    @Test @MainActor
+    func `Dismissing routes through the injected action`() {
+        var dismissed = false
+        let viewModel = makeViewModel(actions: MapItemActions(
+            openWebsite: { _ in },
+            showNearbyStops: { _ in },
+            dismiss: { dismissed = true }
+        ))
+
+        viewModel.dismissView()
+
+        #expect(dismissed == true)
+    }
+
+    @Test @MainActor
+    func `Nearby stops routes through the injected action with the item coordinate`() {
+        var received: CLLocationCoordinate2D?
+        let viewModel = makeViewModel(actions: MapItemActions(
+            openWebsite: { _ in },
+            showNearbyStops: { received = $0 },
+            dismiss: { }
+        ))
+
+        viewModel.showNearbyStops()
+
+        let coordinate = try? #require(received)
+        #expect(coordinate?.latitude == 47.6)
+    }
+
+    /// The sheet header uses a native `ShareLink`, so the view model exposes the URL
+    /// rather than presenting a `UIActivityViewController` itself.
+    @Test @MainActor
+    func `Share URL falls back to a query and coordinates link`() throws {
+        let viewModel = makeViewModel(actions: MapItemActions(openWebsite: { _ in }, showNearbyStops: { _ in }, dismiss: { }))
+
+        let url = try #require(viewModel.shareURL)
+
+        #expect(url.absoluteString.contains("maps.apple.com"))
+        #expect(url.absoluteString.contains("47.6"))
+    }
+
+    @Test @MainActor
+    func `Factory builds a map item sheet for the route`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+
+        let view = factory.mapItemView(mapItem: item)
+
+        #expect(view.application === application)
+        #expect(view.mapItem === item)
+    }
+
+    @Test @MainActor
+    func `Factory builds a nearby stops host for the route`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in })
+        let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+
+        let host = factory.nearbyStopsView(coordinate: coordinate)
+
+        #expect(host.application === application)
+        #expect(host.coordinate.latitude == coordinate.latitude)
+    }
+}

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -32,7 +32,19 @@ final class MapItemSheetViewTests: OBATestCase {
     }
 
     @MainActor
-    private func makeViewModel(actions: MapItemActions) -> MapItemViewModel {
+    private func makeFactory(application: Application, displayModel: MapSearchDisplayModel = MapSearchDisplayModel()) -> AppSheetViewFactory {
+        AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in },
+            onPresentVehicleTrip: { _ in },
+            presentingController: { nil },
+            coordinator: SheetCoordinator(root: .home),
+            searchDisplayModel: displayModel
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(actions: MapItemActions, planTripHandler: (() -> Void)? = {}) -> MapItemViewModel {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
         let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
         let mapItem = MKMapItem(placemark: placemark)
@@ -42,9 +54,11 @@ final class MapItemSheetViewTests: OBATestCase {
             application: application,
             actions: actions,
             removePinHandler: nil,
-            planTripHandler: {}
+            planTripHandler: planTripHandler
         )
     }
+
+    private static let noopActions = MapItemActions(openWebsite: { _ in }, showNearbyStops: { _ in }, dismiss: { })
 
     @Test @MainActor
     func `Dismissing routes through the injected action`() {
@@ -87,22 +101,49 @@ final class MapItemSheetViewTests: OBATestCase {
         #expect(url.absoluteString.contains("47.6"))
     }
 
+    /// The sheet has no trip-planner destination to hand off to, so it passes a `nil`
+    /// handler — which must hide the button rather than render one that no-ops.
+    @Test @MainActor
+    func `A nil plan trip handler hides the plan trip button`() {
+        let viewModel = makeViewModel(actions: Self.noopActions, planTripHandler: nil)
+
+        #expect(viewModel.showPlanTripButton == false)
+
+        // Tapping it anyway (the button is gone, but the method is reachable) must
+        // not trap on a force-unwrapped handler.
+        viewModel.planTrip()
+    }
+
+    @Test @MainActor
+    func `A supplied plan trip handler is invoked`() {
+        var planned = false
+        let viewModel = makeViewModel(actions: Self.noopActions, planTripHandler: { planned = true })
+
+        viewModel.planTrip()
+
+        #expect(planned == true)
+    }
+
     @Test @MainActor
     func `Factory builds a map item sheet for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
+        let displayModel = MapSearchDisplayModel()
+        let factory = makeFactory(application: application, displayModel: displayModel)
         let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
 
         let view = factory.mapItemView(mapItem: item)
 
         #expect(view.application === application)
         #expect(view.mapItem === item)
+        // The sheet clears the map marker when it goes away, so it needs the same
+        // display model the map renders.
+        #expect(view.displayModel === displayModel)
     }
 
     @Test @MainActor
     func `Factory builds a nearby stops host for the route`() {
         let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        let factory = AppSheetViewFactory(application: application, onPresentTrip: { _ in }, presentingController: { nil })
+        let factory = makeFactory(application: application)
         let coordinate = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
 
         let host = factory.nearbyStopsView(coordinate: coordinate)

--- a/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
@@ -33,9 +33,14 @@ final class MapSearchDisplayModelTests {
         }
     }
 
+    private func loadStopsForRoute() throws -> StopsForRoute {
+        try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+    }
+
     @Test func `Showing a map item targets its coordinate`() throws {
+        let item = makeMapItem()
         let model = MapSearchDisplayModel()
-        model.show(mapItem: makeMapItem(), animated: true)
+        model.show(mapItem: item, animated: true, owner: .mapItem(item))
 
         guard case .mapItem = model.display else {
             Issue.record("Expected .mapItem, got \(model.display)")
@@ -51,9 +56,9 @@ final class MapSearchDisplayModelTests {
 
     @Test func `Showing a route targets its bounding rect and suppresses ambient stops`() throws {
         let model = MapSearchDisplayModel()
-        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        let stopsForRoute = try loadStopsForRoute()
 
-        model.show(stopsForRoute: stopsForRoute)
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
 
         #expect(model.suppressesAmbientStops == true)
         guard case .route(let display) = model.display else {
@@ -70,8 +75,9 @@ final class MapSearchDisplayModelTests {
     /// The camera target is one-shot: the view applies it and consumes it, so an
     /// unrelated body evaluation later can't yank the map back.
     @Test func `Consuming the camera target clears it without clearing the display`() {
+        let item = makeMapItem()
         let model = MapSearchDisplayModel()
-        model.show(mapItem: makeMapItem(), animated: false)
+        model.show(mapItem: item, animated: false, owner: .mapItem(item))
 
         model.consumeCameraTarget()
 
@@ -81,17 +87,86 @@ final class MapSearchDisplayModelTests {
         }
     }
 
-    @Test func `Clearing resets display and camera target`() throws {
+    @Test func `Clearing resets display, camera target, and owner`() throws {
         let model = MapSearchDisplayModel()
-        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
-        model.show(stopsForRoute: stopsForRoute)
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
 
         model.clear()
 
         #expect(model.cameraTarget == nil)
+        #expect(model.owner == nil)
         #expect(model.suppressesAmbientStops == false)
         if case .none = model.display {} else {
             Issue.record("Expected .none after clear")
+        }
+    }
+
+    // MARK: - Ownership
+
+    @Test func `Showing a result records the sheet route that owns it`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        #expect(model.owner == .routeStops(stopsForRoute))
+    }
+
+    /// The regression this ownership rule exists for: the route sheet's view can be
+    /// torn down and rebuilt by the sheet system without the sheet being dismissed.
+    /// Keying the polyline's lifetime to the view's `onDisappear` wiped the route off
+    /// the map seconds after it was drawn; keying it to the route stack does not.
+    @Test func `The display survives while its owning route is still on the stack`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home, .routeStops(stopsForRoute)])
+
+        #expect(model.suppressesAmbientStops == true)
+        if case .route = model.display {} else {
+            Issue.record("Expected the route to survive, got \(model.display)")
+        }
+    }
+
+    /// Tapping a stop out of the route's list stacks `.stopDetails` over the route
+    /// sheet rather than replacing it, so the polyline has to stay drawn beneath.
+    @Test func `Stacking stop details over the route keeps the route drawn`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        let stopID = try #require(stopsForRoute.stops?.first?.id)
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home, .routeStops(stopsForRoute), .stopDetails(stopID: stopID)])
+
+        if case .route = model.display {} else {
+            Issue.record("Expected the route to survive, got \(model.display)")
+        }
+    }
+
+    @Test func `The display clears once its owning route leaves the stack`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try loadStopsForRoute()
+        model.show(stopsForRoute: stopsForRoute, owner: .routeStops(stopsForRoute))
+
+        model.clearIfOwnerAbsent(from: [.home])
+
+        #expect(model.owner == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none once the owning route was popped")
+        }
+    }
+
+    @Test func `Checking ownership with nothing displayed is a no-op`() {
+        let model = MapSearchDisplayModel()
+
+        model.clearIfOwnerAbsent(from: [])
+
+        #expect(model.owner == nil)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none")
         }
     }
 }

--- a/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/MapSearchDisplayModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  MapSearchDisplayModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Map-side state for a displayed search result: what to draw and where to point
+/// the camera.
+@MainActor
+@Suite(.serialized)
+final class MapSearchDisplayModelTests {
+
+    private func makeMapItem(latitude: Double = 47.6, longitude: Double = -122.3) -> MKMapItem {
+        MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude)))
+    }
+
+    @Test func `Starts with nothing displayed`() {
+        let model = MapSearchDisplayModel()
+
+        #expect(model.cameraTarget == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none, got \(model.display)")
+        }
+    }
+
+    @Test func `Showing a map item targets its coordinate`() throws {
+        let model = MapSearchDisplayModel()
+        model.show(mapItem: makeMapItem(), animated: true)
+
+        guard case .mapItem = model.display else {
+            Issue.record("Expected .mapItem, got \(model.display)")
+            return
+        }
+        guard case .coordinate(let coordinate, let animated) = try #require(model.cameraTarget) else {
+            Issue.record("Expected a coordinate target")
+            return
+        }
+        #expect(coordinate.latitude == 47.6)
+        #expect(animated == true)
+    }
+
+    @Test func `Showing a route targets its bounding rect and suppresses ambient stops`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+
+        model.show(stopsForRoute: stopsForRoute)
+
+        #expect(model.suppressesAmbientStops == true)
+        guard case .route(let display) = model.display else {
+            Issue.record("Expected .route, got \(model.display)")
+            return
+        }
+        #expect(display.polylines.isEmpty == false)
+        guard case .rect = try #require(model.cameraTarget) else {
+            Issue.record("Expected a rect target")
+            return
+        }
+    }
+
+    /// The camera target is one-shot: the view applies it and consumes it, so an
+    /// unrelated body evaluation later can't yank the map back.
+    @Test func `Consuming the camera target clears it without clearing the display`() {
+        let model = MapSearchDisplayModel()
+        model.show(mapItem: makeMapItem(), animated: false)
+
+        model.consumeCameraTarget()
+
+        #expect(model.cameraTarget == nil)
+        if case .mapItem = model.display {} else {
+            Issue.record("Consuming the camera target must not clear the display")
+        }
+    }
+
+    @Test func `Clearing resets display and camera target`() throws {
+        let model = MapSearchDisplayModel()
+        let stopsForRoute = try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+        model.show(stopsForRoute: stopsForRoute)
+
+        model.clear()
+
+        #expect(model.cameraTarget == nil)
+        #expect(model.suppressesAmbientStops == false)
+        if case .none = model.display {} else {
+            Issue.record("Expected .none after clear")
+        }
+    }
+}

--- a/OBAKitTests/Sheet/MapStopsObserverTests.swift
+++ b/OBAKitTests/Sheet/MapStopsObserverTests.swift
@@ -298,4 +298,44 @@ final class MapStopsObserverTests: OBATestCase {
         #expect(observer.bookmarks.count == 1)
         #expect(observer.bookmarks.first?.name == "Second")
     }
+
+    /// The settled viewport's center is published so consumers can sort by it.
+    @Test @MainActor
+    func `Update viewport publishes its center`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        #expect(observer.viewportCenter == nil)
+
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        observer.updateViewport(region)
+
+        #expect(observer.viewportCenter?.latitude == region.center.latitude)
+        #expect(observer.viewportCenter?.longitude == region.center.longitude)
+    }
+
+    /// Zooming out clears the center along with the stops, so a stale center
+    /// can't outlive the render set it was ordering.
+    @Test @MainActor
+    func `Reset clears the viewport center`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        observer.updateViewport(MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        ))
+        #expect(observer.viewportCenter != nil)
+
+        observer.reset()
+
+        #expect(observer.viewportCenter == nil)
+    }
 }

--- a/OBAKitTests/Sheet/MapStopsObserverTests.swift
+++ b/OBAKitTests/Sheet/MapStopsObserverTests.swift
@@ -152,7 +152,7 @@ final class MapStopsObserverTests: OBATestCase {
         let anchor = try #require(allStops.first)
         let farStop = try #require(
             allStops.max {
-                observer.squaredDistance($0, to: anchor.coordinate) < observer.squaredDistance($1, to: anchor.coordinate)
+                Stop.squaredDistance($0, to: anchor.coordinate) < Stop.squaredDistance($1, to: anchor.coordinate)
             }
         )
         try #require(farStop.id != anchor.id, "Need two fixture stops at distinct coordinates")
@@ -198,7 +198,7 @@ final class MapStopsObserverTests: OBATestCase {
         #expect(observer.stops.map(\.id).contains(anchor.id))
         let nearest3 = allStops
             .sorted {
-                observer.squaredDistance($0, to: anchor.coordinate) < observer.squaredDistance($1, to: anchor.coordinate)
+                Stop.squaredDistance($0, to: anchor.coordinate) < Stop.squaredDistance($1, to: anchor.coordinate)
             }
             .prefix(3)
             .map(\.id)

--- a/OBAKitTests/Sheet/MapStopsObserverTests.swift
+++ b/OBAKitTests/Sheet/MapStopsObserverTests.swift
@@ -338,4 +338,55 @@ final class MapStopsObserverTests: OBATestCase {
 
         #expect(observer.viewportCenter == nil)
     }
+
+    /// A re-fired settle at the same center publishes nothing.
+    ///
+    /// `CLLocationCoordinate2D` isn't `Equatable`, so `@Published` won't drop a
+    /// same-value write on its own — without the explicit guard in
+    /// `updateViewport`, every settle would fire `objectWillChange` and invalidate
+    /// `MapPanelRootView`. The map re-serves the same region often enough that the
+    /// rest of this class is built around not republishing on a no-op.
+    @Test @MainActor
+    func `Repeat settle at the same center does not republish`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        observer.updateViewport(region)
+
+        let counter = ChangeCounter()
+        let cancellable = observer.objectWillChange.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        observer.updateViewport(region)
+        #expect(counter.count == 0, "A same-center settle must not invalidate observers")
+
+        // A real move still publishes.
+        observer.updateViewport(MKCoordinateRegion(
+            center: CLLocationCoordinate2D(
+                latitude: region.center.latitude + 0.1,
+                longitude: region.center.longitude
+            ),
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        ))
+        #expect(counter.count == 1, "A moved center must still publish")
+    }
+
+    /// Thread-safe counter — `objectWillChange` delivery isn't actor-isolated.
+    private final class ChangeCounter {
+        private let lock = NSLock()
+        nonisolated(unsafe) private(set) var count: Int = 0
+
+        nonisolated func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+        }
+    }
 }

--- a/OBAKitTests/Sheet/MapStopsObserverTests.swift
+++ b/OBAKitTests/Sheet/MapStopsObserverTests.swift
@@ -378,6 +378,38 @@ final class MapStopsObserverTests: OBATestCase {
         #expect(counter.count == 1, "A moved center must still publish")
     }
 
+    /// A repeated `reset()` publishes nothing.
+    ///
+    /// `MapPanelRootView.onMapCameraChange(frequency: .onEnd)` calls `reset()` on
+    /// the zoomed-out branch of *every* settle, not only on the zoom-out
+    /// transition. `viewportCenter` is `@Published` and `CLLocationCoordinate2D`
+    /// isn't `Equatable`, so without the explicit nil guard each pan while zoomed
+    /// out would fire `objectWillChange` and cascade through
+    /// `HomeNearbyStopsSectionModel` into the home sheet. This is the `reset()`
+    /// counterpart of `Repeat settle at the same center does not republish`.
+    @Test @MainActor
+    func `Repeat reset does not republish`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        observer.updateViewport(MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        ))
+        observer.reset()
+        #expect(observer.viewportCenter == nil)
+
+        let counter = ChangeCounter()
+        let cancellable = observer.objectWillChange.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        observer.reset()
+        observer.reset()
+        #expect(counter.count == 0, "A repeated reset must not invalidate observers")
+    }
+
     /// Thread-safe counter — `objectWillChange` delivery isn't actor-isolated.
     private final class ChangeCounter {
         private let lock = NSLock()

--- a/OBAKitTests/Sheet/MapViewportRecorderTests.swift
+++ b/OBAKitTests/Sheet/MapViewportRecorderTests.swift
@@ -1,0 +1,64 @@
+//
+//  MapViewportRecorderTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// The SwiftUI panel's only writer of `MapRegionManager.lastVisibleMapRect`.
+@Suite(.serialized)
+final class MapViewportRecorderTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @Test @MainActor
+    func `Record persists the rect as the last visible map rect`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let recorder = MapViewportRecorder(application: application)
+        let rect = MKMapRect(
+            origin: MKMapPoint(x: 42_000_000, y: 91_000_000),
+            size: MKMapSize(width: 250_000, height: 180_000)
+        )
+
+        recorder.record(rect)
+
+        let stored = try #require(application.mapRegionManager.lastVisibleMapRect)
+        #expect(stored.origin.x == rect.origin.x)
+        #expect(stored.origin.y == rect.origin.y)
+        #expect(stored.size.width == rect.size.width)
+        #expect(stored.size.height == rect.size.height)
+    }
+
+    @Test @MainActor
+    func `Record overwrites a previously stored rect`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let recorder = MapViewportRecorder(application: application)
+        let first = MKMapRect(origin: MKMapPoint(x: 1, y: 2), size: MKMapSize(width: 3, height: 4))
+        let second = MKMapRect(origin: MKMapPoint(x: 10, y: 20), size: MKMapSize(width: 30, height: 40))
+
+        recorder.record(first)
+        recorder.record(second)
+
+        let stored = try #require(application.mapRegionManager.lastVisibleMapRect)
+        #expect(stored.origin.x == second.origin.x)
+        #expect(stored.size.width == second.size.width)
+    }
+}

--- a/OBAKitTests/Sheet/RouteStopsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/RouteStopsSheetViewTests.swift
@@ -1,0 +1,63 @@
+//
+//  RouteStopsSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Row mapping for the route-stops sheet, asserted without a view host.
+@MainActor
+@Suite(.serialized)
+final class RouteStopsSheetViewTests {
+
+    private func loadStopsForRoute() throws -> StopsForRoute {
+        try Fixtures.loadRESTAPIPayload(type: StopsForRoute.self, fileName: "stops_for_route_1_44.json")
+    }
+
+    @Test func `Rows carry each stop name and id`() throws {
+        let stopsForRoute = try loadStopsForRoute()
+        let rows = RouteStopsRow.rows(from: stopsForRoute)
+
+        #expect(rows.count == (stopsForRoute.stops ?? []).count)
+        let first = try #require(rows.first)
+        let firstStop = try #require(stopsForRoute.stops?.first)
+        #expect(first.title == firstStop.name)
+        #expect(first.stopID == firstStop.id)
+    }
+
+    /// `RouteStopsViewController` renders the adjective form of the stop's cardinal
+    /// direction as its subtitle; the SwiftUI rows must match.
+    @Test func `Rows use the adjective form of the stop direction`() throws {
+        let stopsForRoute = try loadStopsForRoute()
+        let rows = RouteStopsRow.rows(from: stopsForRoute)
+        let firstStop = try #require(stopsForRoute.stops?.first)
+
+        let expected = Formatters.adjectiveFormOfCardinalDirection(firstStop.direction) ?? ""
+        #expect(rows.first?.subtitle == expected)
+    }
+
+    /// `StopsForRoute.stops` is an implicitly-unwrapped optional populated by
+    /// `HasReferences`. `RouteStopsViewController` force-unwraps it; the sheet must
+    /// not.
+    @Test func `Rows are empty when stops have not been resolved`() throws {
+        let stopsForRoute = try Fixtures.dictionaryToModel(
+            type: StopsForRoute.self,
+            dictionary: [
+                "routeId": "1_44",
+                "polylines": [],
+                "stopIds": [],
+                "stopGroupings": []
+            ]
+        )
+
+        #expect(RouteStopsRow.rows(from: stopsForRoute).isEmpty)
+    }
+}

--- a/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
@@ -328,7 +328,14 @@ final class SearchResultsSheetViewTests: OBATestCase {
         await selection.select(route, coordinator: coordinator)
         #expect(selection.error != nil)
 
+        // replaceMappedResponses replaces the *entire* table, so re-register the
+        // regions/agencies mocks that the Application's background tasks rely on.
+        // Dropping them lets the regions refresh land on an unmocked URL, and
+        // MockDataLoader's fatalError takes the whole test host down — attributed to
+        // whichever test happened to be in flight, not this one.
         dataLoader.replaceMappedResponses { loader in
+            stubRegions(dataLoader: loader)
+            stubAgenciesWithCoverage(dataLoader: loader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
             loader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
                 request.url?.path.contains("/api/where/stops-for-route") ?? false
             }

--- a/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
+++ b/OBAKitTests/Sheet/SearchResultsSheetViewTests.swift
@@ -1,0 +1,344 @@
+//
+//  SearchResultsSheetViewTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Everything the disambiguation sheet decides: which rows it builds, which failure
+/// it surfaces inline, and the order in which selecting a row resolves, unwinds, and
+/// presents. Asserted against the extracted pieces rather than a view host, the same
+/// way `RouteStopsSheetViewTests` does.
+@Suite(.serialized)
+final class SearchResultsSheetViewTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeApplication(dataLoader: MockDataLoader) -> Application {
+        buildApplication(queue: queue, dataLoader: dataLoader)
+    }
+
+    @MainActor
+    private func makeSelection(
+        dataLoader: MockDataLoader
+    ) -> (SearchResultsSelection, SheetCoordinator<AppSheetRoute>, MapSearchDisplayModel) {
+        let application = makeApplication(dataLoader: dataLoader)
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        let router = SearchResultRouter(
+            application: application,
+            coordinator: coordinator,
+            displayModel: displayModel,
+            onPresentVehicleTrip: { _ in }
+        )
+        return (SearchResultsSelection(router: router), coordinator, displayModel)
+    }
+
+    private func makeVehicle(id: String?, agency: String = "Metro Transit") throws -> AgencyVehicle {
+        var dictionary: [String: Any] = ["id": "1", "name": agency]
+        if let id { dictionary["vehicle_id"] = id }
+        return try Fixtures.dictionaryToModel(type: AgencyVehicle.self, dictionary: dictionary)
+    }
+
+    // MARK: - Row mapping
+
+    @Test @MainActor
+    func `Rows carry one entry per result, keyed by the model's id`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let stops = try Array(Fixtures.loadSomeStops().prefix(3))
+
+        let rows = SearchResultRow.rows(
+            for: stops,
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.count == 3)
+        #expect(rows.map(\.title) == stops.map(\.name))
+        // Row identity comes from the stop id, not the title: two stops on opposite
+        // sides of one corner share a name, which is exactly the case a
+        // disambiguation list exists to handle.
+        #expect(Set(rows.map(\.id)).count == 3)
+        for (row, stop) in zip(rows, stops) {
+            #expect(row.id.contains(stop.id))
+        }
+    }
+
+    /// A vehicle needs a second request before it can be routed, so its row shows
+    /// progress in place instead of navigating immediately.
+    @Test @MainActor
+    func `The vehicle being fetched becomes a loading row and the others stay tappable`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let vehicles = [try makeVehicle(id: "1_1156"), try makeVehicle(id: "1_1157")]
+
+        let rows = SearchResultRow.rows(
+            for: vehicles,
+            loadingVehicleID: "1_1156",
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.count == 2)
+        if case .loading = rows[0].kind {} else {
+            Issue.record("The vehicle being fetched should render as a loading row")
+        }
+        #expect(rows[0].action == nil)
+
+        if case .loading = rows[1].kind {
+            Issue.record("Only the vehicle being fetched should render as a loading row")
+        }
+        #expect(rows[1].action != nil)
+    }
+
+    @Test @MainActor
+    func `A tapped vehicle row selects by vehicle id rather than by result`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let vehicle = try makeVehicle(id: "1_1156")
+        var selectedVehicleID: String?
+        var selectedResults = 0
+
+        let rows = SearchResultRow.rows(
+            for: [vehicle],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { selectedVehicleID = $0 },
+            onSelect: { _ in selectedResults += 1 }
+        )
+        rows.first?.action?()
+
+        #expect(selectedVehicleID == "1_1156")
+        #expect(selectedResults == 0)
+    }
+
+    /// `AgencyVehicle.vehicleID` is optional, and a vehicle with no id can neither be
+    /// fetched nor routed.
+    @Test @MainActor
+    func `A vehicle with no id produces no row`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+
+        let rows = SearchResultRow.rows(
+            for: [try makeVehicle(id: nil)],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { _ in }
+        )
+
+        #expect(rows.isEmpty)
+    }
+
+    @Test @MainActor
+    func `A tapped non-vehicle row selects the result itself`() throws {
+        let application = makeApplication(dataLoader: MockDataLoader(testName: name))
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var selected: Stop?
+
+        let rows = SearchResultRow.rows(
+            for: [stop],
+            loadingVehicleID: nil,
+            application: application,
+            onSelectVehicle: { _ in },
+            onSelect: { selected = $0 as? Stop }
+        )
+        rows.first?.action?()
+
+        #expect(selected === stop)
+    }
+
+    // MARK: - Inline error row
+
+    @Test @MainActor
+    func `No failure produces no error row`() {
+        #expect(SearchResultRow.inlineErrorRow(
+            vehicleError: nil,
+            failedVehicleID: nil,
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ) == nil)
+    }
+
+    @Test @MainActor
+    func `A vehicle failure offers a retry for that vehicle`() throws {
+        var retried: String?
+
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: "1_1156",
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { retried = $0 },
+            onRetrySelect: { _ in }
+        ))
+        row.action?()
+
+        #expect(row.title == SearchError.noTripsAvailable.localizedDescription)
+        #expect(retried == "1_1156")
+    }
+
+    /// `selectVehicle` reports a missing API service without ever naming a vehicle, so
+    /// there's nothing to retry — the row still has to say what went wrong.
+    @Test @MainActor
+    func `A vehicle failure with no vehicle id has no retry action`() throws {
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: nil,
+            selectionError: nil,
+            failedResult: nil,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ))
+
+        #expect(row.action == nil)
+    }
+
+    /// The regression this sheet shipped with: a failed resolve was dropped on the
+    /// floor, so the tapped row simply did nothing — no error, no spinner, no
+    /// navigation. It has to reach the same inline row a vehicle failure does.
+    @Test @MainActor
+    func `A failed resolve produces an error row that retries the same result`() throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        var retried: Stop?
+
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: nil,
+            failedVehicleID: nil,
+            selectionError: UnstructuredError("boom"),
+            failedResult: stop,
+            onRetryVehicle: { _ in },
+            onRetrySelect: { retried = $0 as? Stop }
+        ))
+        row.action?()
+
+        #expect(row.title == UnstructuredError("boom").localizedDescription)
+        #expect(retried === stop)
+    }
+
+    /// Only one row is ever shown. A vehicle failure is the more specific of the two,
+    /// and `selectVehicle` clears its own error before retrying, so it wins.
+    @Test @MainActor
+    func `A vehicle failure takes precedence over a resolve failure`() throws {
+        let row = try #require(SearchResultRow.inlineErrorRow(
+            vehicleError: SearchError.noTripsAvailable,
+            failedVehicleID: "1_1156",
+            selectionError: UnstructuredError("boom"),
+            failedResult: "anything",
+            onRetryVehicle: { _ in },
+            onRetrySelect: { _ in }
+        ))
+
+        #expect(row.title == SearchError.noTripsAvailable.localizedDescription)
+    }
+
+    // MARK: - Selecting a row
+
+    /// Resolve, then unwind, then present — and `popToRoot()` rather than a `pop()`
+    /// per layer, because both the stacked results sheet and the `.search` route
+    /// beneath it have to come off.
+    @Test @MainActor
+    func `Selecting a result unwinds to root and presents it`() async throws {
+        let (selection, coordinator, displayModel) = makeSelection(dataLoader: MockDataLoader(testName: name))
+        coordinator.push(.search)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        coordinator.push(.searchResults(SearchResponse(
+            request: SearchRequest(query: "1", type: .stopNumber),
+            results: [stop],
+            boundingRegion: nil,
+            error: nil
+        )))
+
+        await selection.select(stop, coordinator: coordinator)
+
+        #expect(selection.error == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes == [.stopDetails(stopID: stop.id)])
+        #expect(displayModel.owner == .stopDetails(stopID: stop.id))
+    }
+
+    /// The Critical: `stops-for-route` fails, so there is nothing to show. The sheet
+    /// has to stay up and say so rather than leave the row silently dead.
+    @Test @MainActor
+    func `A failed resolve keeps the sheet up and records the error and the result`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (selection, coordinator, _) = makeSelection(dataLoader: dataLoader)
+        coordinator.push(.search)
+        let route = try Fixtures.createRoute(id: "1_100002")
+
+        await selection.select(route, coordinator: coordinator)
+
+        #expect(selection.error != nil)
+        #expect((selection.failedResult as? Route) === route)
+        #expect(coordinator.currentRoute == .search, "The results sheet must stay up to show the failure")
+        #expect(coordinator.stackedRoutes.isEmpty)
+    }
+
+    /// `SearchResultRouter.resolve` returns nil with no `lastError` for a result type
+    /// it doesn't handle. That's a programming error rather than anything the user
+    /// did, but the row still can't be a no-op.
+    @Test @MainActor
+    func `An unhandled result type still reports an error`() async {
+        let (selection, coordinator, _) = makeSelection(dataLoader: MockDataLoader(testName: name))
+
+        await selection.select("not a search result", coordinator: coordinator)
+
+        #expect(selection.error?.localizedDescription == SearchResultsSelection.unresolvableText)
+        #expect(selection.failedResult != nil)
+    }
+
+    /// Retrying has to clear the previous failure, or the error row outlives the
+    /// error and the sheet reports a failure that no longer happened.
+    @Test @MainActor
+    func `A successful retry clears the recorded failure`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: "not json".data(using: .utf8)!) { request in
+            request.url?.path.contains("/api/where/stops-for-route") ?? false
+        }
+        let (selection, coordinator, _) = makeSelection(dataLoader: dataLoader)
+        coordinator.push(.search)
+        let route = try Fixtures.createRoute(id: "1_100002")
+
+        await selection.select(route, coordinator: coordinator)
+        #expect(selection.error != nil)
+
+        dataLoader.replaceMappedResponses { loader in
+            loader.mock(data: Fixtures.loadData(file: "stops-for-route-1_100002.json")) { request in
+                request.url?.path.contains("/api/where/stops-for-route") ?? false
+            }
+        }
+
+        await selection.select(route, coordinator: coordinator)
+
+        #expect(selection.error == nil)
+        #expect(selection.failedResult == nil)
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes.contains { if case .routeStops = $0 { return true } else { return false } })
+    }
+}

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -8,6 +8,7 @@
 //
 
 import Testing
+import MapKit
 @testable import OBAKit
 
 /// Behavior tests for `SheetCoordinator`'s content-swap and stacked navigation,
@@ -238,5 +239,33 @@ final class SheetCoordinatorTests {
 
         coordinator.push(.tripPlanner) // stacked — must not alter currentDetents
         #expect(coordinator.currentDetents == AppSheetRoute.search.detentConfiguration.detents)
+    }
+
+    // MARK: - Search navigation shape
+
+    /// Search content-swaps the base sheet; disambiguation stacks *over* it, so the
+    /// search screen stays alive underneath and its query survives a Close.
+    @Test func `Search results stack over the search route rather than replacing it`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let response = SearchResponse(request: SearchRequest(query: "44", type: .route), results: [], boundingRegion: nil, error: nil)
+
+        coordinator.push(.search)
+        coordinator.push(.searchResults(response))
+
+        #expect(coordinator.currentRoute == .search)
+        #expect(coordinator.stackedRoutes.count == 1)
+    }
+
+    /// Picking a result unwinds search before opening the detail, so Close on the
+    /// detail lands on home — not on a stale search screen.
+    @Test func `Popping search after a result leaves home beneath the detail sheet`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+
+        coordinator.push(.search)
+        coordinator.pop()
+        coordinator.push(.stopDetails(stopID: "1_75403"))
+
+        #expect(coordinator.currentRoute == .home)
+        #expect(coordinator.stackedRoutes == [.stopDetails(stopID: "1_75403")])
     }
 }

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -21,7 +21,12 @@ import Testing
 final class LocalizationTests {
 
     /// Keys whose plural forms come from `Localizable.stringsdict` rather than
-    /// `Localizable.strings`. Every one of these is called with `String(format:)` and a count.
+    /// `Localizable.strings`. Each is called with a count.
+    ///
+    /// Note that `String(format:)` expands `%#@…@` but always resolves it against the root
+    /// plural rule, so only `one`/`other` are ever reachable through it — the call site has to
+    /// use `String.localizedStringWithFormat` for a locale's `few`/`many`/`zero`/`two` entries
+    /// to mean anything. Nothing here can catch that; it's a call-site property.
     private static let pluralKeys: Set<String> = [
         "stop_page.service_alerts.summary_fmt",
         "stop_page.service_alerts.show_all_fmt",
@@ -30,7 +35,8 @@ final class LocalizationTests {
         "stop_controller.transfer_show_earlier_departures_fmt",
         "stop_page.empty.no_departures_fmt",
         "data_migration_bulletin.report_summary_number_of_failures",
-        "data_migration_bulletin.report_summary_number_of_successes"
+        "data_migration_bulletin.report_summary_number_of_successes",
+        "search_results_sheet.result_count_fmt"
     ]
 
     /// `%@`, `%d`, `%1$@`, `%2$d`, … and the escaped `%%`.

--- a/docs/superpowers/plans/2026-08-14-home-sheet-sections.md
+++ b/docs/superpowers/plans/2026-08-14-home-sheet-sections.md
@@ -1,0 +1,2603 @@
+# Home Sheet Sections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate the SwiftUI home sheet with Nearby Stops, Recent Stops, and Bookmarks preview sections — four items each, each header's chevron pushing the corresponding index route.
+
+**Architecture:** `HomeSheetViewModel` composes three purpose-built section models, each wired to the data source the UIKit experience already uses. Five shared utilities are extracted first (Tasks 1–5), each additive and defaulted so existing callers are untouched. Nearby and Recent cost zero network requests; Bookmarks costs at most four, once per activation, with no polling timer.
+
+**Tech Stack:** Swift 6 language mode, SwiftUI, Combine, MapKit, Swift Testing (`@Suite(.serialized)`), XcodeGen.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-home-sheet-sections-design.md`
+
+## Global Constraints
+
+- **Do not build any index screen.** `.nearbyAll`, `.recentStopsAll`, `.bookmarksAll` render the existing "coming soon" placeholder. Out of scope.
+- **Regenerate the project after adding files:** `scripts/generate_project OneBusAway`. XcodeGen picks new files up by directory glob; a new file is invisible to the build until this runs.
+- **Build/test destination is `platform=iOS Simulator,name=iPhone 16,OS=26.0`** — not iPhone 17 Pro.
+- **Never erase or reset the simulator.**
+- **Swift 6 language mode with main-actor default isolation.** The five concurrency diagnostic groups are escalated to errors — a data-race warning fails the build. CI fails PRs that add strict-concurrency warnings. `OBAKitCore` pins `SWIFT_DEFAULT_ACTOR_ISOLATION` back to `nonisolated`, so anything added there needs explicit isolation.
+- **Tests are Swift Testing**, not XCTest: `@Suite(.serialized)`, `final class X: OBATestCase`, `override init() async throws`, teardown in `isolated deinit`, `#expect`. Test names are backtick-quoted sentences.
+- **Section item limit is 4**, defined once as `HomeSheetSection.itemLimit`.
+- **Section order is fixed:** Nearby → Recent → Bookmarks, with no promotion or reflow when an earlier section is empty.
+- **Commit messages are a single line, imperative mood.** No `Co-Authored-By`, no Claude/AI attribution anywhere — not in commits, PR bodies, or code comments.
+- **Do not run `git push`, open PRs, or file issues.** Committing locally per task is expected; anything outward-facing is not.
+
+## Reference Commands
+
+```bash
+# Regenerate the Xcode project (required after adding any file)
+scripts/generate_project OneBusAway
+
+# Build for testing
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+
+# Run one suite
+xcodebuild test-without-building -only-testing:OBAKitTests/SUITE_NAME \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+
+# Lint
+scripts/swiftlint.sh
+```
+
+---
+
+## File Structure
+
+**Created**
+
+| File | Responsibility |
+|---|---|
+| `OBAKitCore/Models/REST/References/Stop+Distance.swift` | Cosine-scaled squared distance + nearest-N selection |
+| `OBAKit/Sheet/Content/Home/HomeSheetSection.swift` | Section identity + the shared item limit |
+| `OBAKit/Sheet/Content/Home/HomeSectionHeader.swift` | Title + chevron header, one button |
+| `OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift` | Nearest-4 from `MapStopsObserver` |
+| `OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift` | First 4 region-filtered recent stops |
+| `OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift` | First 4 bookmarks by `sortOrder` + scoped arrivals |
+| `OBAKitTests/Modeling/StopDistanceTests.swift` | Task 1 tests |
+| `OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift` | Task 4 tests |
+| `OBAKitTests/Sheet/Home/HomeSectionModelTests.swift` | Tasks 9–11 tests |
+| `OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift` | Task 12 tests |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `OBAKit/Sheet/Root/MapStopsObserver.swift` | Prune folds onto `Stop.nearest`; publishes `viewportCenter` |
+| `OBAKitCore/Models/UserData/UserDataStore.swift` | Adds `recentStops(in:)` |
+| `OBAKit/Recent/RecentStopsViewModel.swift` | Refactored onto `recentStops(in:)` |
+| `OBAKitCore/Strings/Strings.swift` | Adds `nearbyStops`, `bookmarks` |
+| `OBAKit/Mapping/NearbyStopsListViewController.swift` | Uses `Strings.nearbyStops` |
+| `OBAKit/Search/SearchInteractor.swift` | Uses `Strings.bookmarks` |
+| `OBAKitCore/Bookmarks/BookmarkDataLoader.swift` | `bookmarkProvider` + `autoRefreshes` seams |
+| `OBAKit/Search/SearchList/Models/SearchListRow.swift` | `.nearbyStop(id:)` kind + `stop(...)` factory |
+| `OBAKit/Search/SearchList/SearchListRowView.swift` | Renders `.nearbyStop` |
+| `OBAKit/Sheet/Content/Search/SearchResultRow.swift` | Stop branch delegates to the factory |
+| `OBAKit/Sheet/Root/MapPanelRootController.swift` | Owns `MapStopsObserver` |
+| `OBAKit/Sheet/Root/MapPanelRootView.swift` | Takes observer as `@ObservedObject` |
+| `OBAKit/Sheet/DI/AppSheetViewFactory.swift` | Holds observer; index-route assert exemption |
+| `OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift` | Composes the three sections |
+| `OBAKit/Sheet/Content/Home/HomeSheetView.swift` | Renders the three sections |
+| `OBAKitTests/Sheet/MapStopsObserverTests.swift` | `observer.squaredDistance` → `Stop.squaredDistance` |
+| `OBAKitTests/Search/SearchResultRowTests.swift` | Factory + kind-collision tests |
+| `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift` | Index-route placeholder tests |
+| `OBAKitTests/Modeling/UserData/RecentStopsTests.swift` | `recentStops(in:)` tests (create if absent) |
+
+---
+
+## Task 1: `Stop.nearest` distance utility
+
+Extracts `MapStopsObserver`'s private ordering formula to `OBAKitCore` so the nearby section and the observer's cap-eviction share one definition.
+
+**Files:**
+- Create: `OBAKitCore/Models/REST/References/Stop+Distance.swift`
+- Create: `OBAKitTests/Modeling/StopDistanceTests.swift`
+- Modify: `OBAKit/Sheet/Root/MapStopsObserver.swift:181-221` (prune + `squaredDistance`)
+- Modify: `OBAKitTests/Sheet/MapStopsObserverTests.swift:155,201`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Stop.squaredDistance(_ stop: Stop, to center: CLLocationCoordinate2D) -> Double` and `Stop.nearest(_ stops: [Stop], to center: CLLocationCoordinate2D, limit: Int) -> [Stop]`, both `public static` on `Stop`, both `nonisolated`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Modeling/StopDistanceTests.swift`:
+
+```swift
+//
+//  StopDistanceTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+import Testing
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class StopDistanceTests: OBATestCase {
+
+    /// Stops are returned nearest-first, and the list is truncated to `limit`.
+    @Test func `Nearest returns the closest stops in order`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        let nearest = Stop.nearest(stops, to: anchor, limit: 3)
+
+        #expect(nearest.count == 3)
+        // The anchor stop is zero distance from itself, so it must come first.
+        #expect(nearest.first?.id == stops.first?.id)
+
+        let distances = nearest.map { Stop.squaredDistance($0, to: anchor) }
+        #expect(distances == distances.sorted())
+    }
+
+    /// A limit larger than the input returns everything, still ordered.
+    @Test func `Nearest returns everything when the limit exceeds the input`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        let nearest = Stop.nearest(stops, to: anchor, limit: stops.count + 10)
+
+        #expect(nearest.count == stops.count)
+    }
+
+    /// Degenerate inputs return empty rather than trapping.
+    @Test func `Nearest returns empty for empty input or a non positive limit`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let anchor = try #require(stops.first).location.coordinate
+
+        #expect(Stop.nearest([], to: anchor, limit: 4).isEmpty)
+        #expect(Stop.nearest(stops, to: anchor, limit: 0).isEmpty)
+        #expect(Stop.nearest(stops, to: anchor, limit: -1).isEmpty)
+    }
+
+    /// Longitude is scaled by cos(latitude), so a degree of longitude counts
+    /// for less than a degree of latitude away from the equator. Without the
+    /// scaling these two would compare equal.
+    @Test func `Squared distance scales longitude by latitude`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let reference = try #require(stops.first)
+        let anchor = reference.location.coordinate
+
+        let latOffset = CLLocationCoordinate2D(latitude: anchor.latitude + 1, longitude: anchor.longitude)
+        let lonOffset = CLLocationCoordinate2D(latitude: anchor.latitude, longitude: anchor.longitude + 1)
+
+        let latDistance = Stop.squaredDistance(reference, to: latOffset)
+        let lonDistance = Stop.squaredDistance(reference, to: lonOffset)
+
+        // Seattle is well north of the equator, so cos(lat) < 1.
+        #expect(lonDistance < latDistance)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS with "type 'Stop' has no member 'nearest'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKitCore/Models/REST/References/Stop+Distance.swift`:
+
+```swift
+//
+//  Stop+Distance.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+
+public extension Stop {
+
+    /// Squared distance with longitude scaled by `cos(latitude)` so lat/lon
+    /// degrees compare on a common metric scale. Ordering only — no sqrt, and
+    /// the result is not meaningful as a real-world distance.
+    nonisolated static func squaredDistance(_ stop: Stop, to center: CLLocationCoordinate2D) -> Double {
+        let coordinate = stop.location.coordinate
+        let dLat = coordinate.latitude - center.latitude
+        let dLon = (coordinate.longitude - center.longitude) * cos(center.latitude * .pi / 180)
+        return dLat * dLat + dLon * dLon
+    }
+
+    /// The `limit` stops closest to `center`, nearest first.
+    ///
+    /// Shared by `MapStopsObserver`'s cap eviction and the home sheet's nearby
+    /// section so both order stops by exactly the same metric.
+    nonisolated static func nearest(_ stops: [Stop], to center: CLLocationCoordinate2D, limit: Int) -> [Stop] {
+        guard limit > 0 else { return [] }
+        return stops
+            .sorted { squaredDistance($0, to: center) < squaredDistance($1, to: center) }
+            .prefix(limit)
+            .map { $0 }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+xcodebuild test-without-building -only-testing:OBAKitTests/StopDistanceTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Fold `MapStopsObserver`'s prune onto the shared helper**
+
+In `OBAKit/Sheet/Root/MapStopsObserver.swift`, delete the `squaredDistance(_:to:)` method entirely (it currently sits just below `pruneAccumulated`, documented as internal "so the cap-eviction tests can assert against this exact ordering" — that reason now lives on `Stop`). Replace the cap-eviction block inside `pruneAccumulated()`:
+
+```swift
+        // Count cap: keep the `renderCap` nearest to center, evict the rest.
+        if accumulated.count > renderCap {
+            let nearest = Stop.nearest(Array(accumulated.values), to: center, limit: renderCap)
+            accumulated = Dictionary(nearest.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        }
+```
+
+- [ ] **Step 6: Update the observer's tests to the new call site**
+
+In `OBAKitTests/Sheet/MapStopsObserverTests.swift`, at both line 155 and line 201, replace `observer.squaredDistance(` with `Stop.squaredDistance(`. The expression shape is otherwise unchanged, e.g.:
+
+```swift
+                Stop.squaredDistance($0, to: anchor.coordinate) < Stop.squaredDistance($1, to: anchor.coordinate)
+```
+
+- [ ] **Step 7: Run both suites to verify no regression**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/StopDistanceTests \
+  -only-testing:OBAKitTests/MapStopsObserverTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS. The cap-eviction tests are the regression signal — they assert the exact ordering the observer used before.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add OBAKitCore/Models/REST/References/Stop+Distance.swift \
+        OBAKitTests/Modeling/StopDistanceTests.swift \
+        OBAKit/Sheet/Root/MapStopsObserver.swift \
+        OBAKitTests/Sheet/MapStopsObserverTests.swift
+git commit -m "refactor: extract nearest-N stop selection to a shared Stop helper"
+```
+
+---
+
+## Task 2: `UserDataStore.recentStops(in:)`
+
+**Files:**
+- Modify: `OBAKitCore/Models/UserData/UserDataStore.swift` (protocol ~line 130, implementation ~line 666)
+- Modify: `OBAKit/Recent/RecentStopsViewModel.swift:28-47`
+- Create or modify: `OBAKitTests/Modeling/UserData/RecentStopsTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `UserDataStore.recentStops(in region: Region?) -> [Stop]`, returning `[]` for a nil region.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Modeling/UserData/RecentStopsTests.swift` (if the file already exists, append the two `@Test` methods to the existing suite instead of recreating it):
+
+```swift
+//
+//  RecentStopsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class RecentStopsTests: OBATestCase {
+
+    /// Only stops belonging to the supplied region come back, and the store's
+    /// most-recently-used ordering is preserved.
+    @Test func `Recent stops in region filters by region identifier`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let first = try #require(stops.first)
+        let second = try #require(stops.dropFirst().first)
+
+        let store = UserDefaultsStore(userDefaults: userDefaults)
+        store.addRecentStop(first, region: Fixtures.pugetSoundRegion)
+        store.addRecentStop(second, region: Fixtures.pugetSoundRegion)
+
+        let recents = store.recentStops(in: Fixtures.pugetSoundRegion)
+
+        // addRecentStop inserts at index 0, so the newest is first.
+        #expect(recents.map(\.id) == [second.id, first.id])
+    }
+
+    /// A nil region yields an empty list rather than every stored stop.
+    @Test func `Recent stops in region returns empty for a nil region`() throws {
+        let stops = try Fixtures.loadSomeStops()
+        let first = try #require(stops.first)
+
+        let store = UserDefaultsStore(userDefaults: userDefaults)
+        store.addRecentStop(first, region: Fixtures.pugetSoundRegion)
+
+        #expect(store.recentStops(in: nil).isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS with "value of type 'UserDefaultsStore' has no member 'recentStops(in:)'".
+
+- [ ] **Step 3: Add the protocol requirement and implementation**
+
+In `OBAKitCore/Models/UserData/UserDataStore.swift`, add to the protocol next to the existing `var recentStops: [Stop] { get }` (~line 130):
+
+```swift
+    /// Recent stops belonging to `region`, most-recently-used first.
+    /// Returns `[]` when `region` is nil.
+    func recentStops(in region: Region?) -> [Stop]
+```
+
+And add the implementation next to the existing `recentStops` property (~line 666), mirroring `findBookmarks(in:)`:
+
+```swift
+    public func recentStops(in region: Region?) -> [Stop] {
+        guard let region = region else { return [] }
+        return recentStops.filter { $0.regionIdentifier == region.regionIdentifier }
+    }
+```
+
+- [ ] **Step 4: Refactor `RecentStopsViewModel` onto it**
+
+In `OBAKit/Recent/RecentStopsViewModel.swift`, replace the body of `loadData()` below the alarms lines. The nil-region warning stays here — it tracks view-model lifecycle (`didWarnNilRegion`), not store state:
+
+```swift
+    func loadData() {
+        application.userDataStore.deleteExpiredAlarms()
+        alarms = application.userDataStore.alarms
+        guard let currentRegion = application.currentRegion else {
+            // No current region (mid-region-change, first launch race, denied location).
+            // The user sees a generic empty state — log once per VM so the condition is
+            // observable without spamming on every viewWillAppear.
+            if !didWarnNilRegion {
+                Logger.warn("RecentStopsViewModel.loadData: currentRegion is nil; returning empty recent stops.")
+                didWarnNilRegion = true
+            }
+            recentStops = []
+            return
+        }
+        // Region resolved — re-arm the warn so a *later* region loss is still observable.
+        didWarnNilRegion = false
+        recentStops = application.userDataStore.recentStops(in: currentRegion)
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/RecentStopsTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add OBAKitCore/Models/UserData/UserDataStore.swift \
+        OBAKit/Recent/RecentStopsViewModel.swift \
+        OBAKitTests/Modeling/UserData/RecentStopsTests.swift
+git commit -m "refactor: add UserDataStore.recentStops(in:) and adopt it in RecentStopsViewModel"
+```
+
+---
+
+## Task 3: Shared section title strings
+
+Two section titles are currently inline `OBALoc` calls. Moving them to `Strings` keeps the existing keys, so no translation is lost.
+
+**Files:**
+- Modify: `OBAKitCore/Strings/Strings.swift` (near `recentStops`, ~line 71)
+- Modify: `OBAKit/Mapping/NearbyStopsListViewController.swift:42`
+- Modify: `OBAKit/Search/SearchInteractor.swift:130`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Strings.nearbyStops: String`, `Strings.bookmarks: String`.
+
+- [ ] **Step 1: Add the constants**
+
+In `OBAKitCore/Strings/Strings.swift`, immediately after the existing `recentStops` declaration, add — keeping the keys, values, and comments byte-identical to the inline call sites so the `.strings` entries keep matching:
+
+```swift
+    public static let nearbyStops = OBALoc("nearby_stops_controller.title", value: "Nearby Stops", comment: "The title of the Nearby Stops controller.")
+
+    public static let bookmarks = OBALoc("search_controller.bookmarks.header", value: "Bookmarks", comment: "Title of the Bookmarks search header")
+```
+
+- [ ] **Step 2: Update the nearby call site**
+
+In `OBAKit/Mapping/NearbyStopsListViewController.swift`, in `Section.localizedTitle`, replace the `.nearbyStops` arm's inline `OBALoc(...)` with:
+
+```swift
+            case .nearbyStops:
+                return Strings.nearbyStops
+```
+
+- [ ] **Step 3: Update the bookmarks call site**
+
+In `OBAKit/Search/SearchInteractor.swift`, in `buildBookmarksSection(searchText:)`, replace the section's `title:` argument with `Strings.bookmarks`:
+
+```swift
+        return .init(
+            id: .bookmarks,
+            title: Strings.bookmarks,
+            content: bookmarks
+        )
+```
+
+- [ ] **Step 4: Verify the localization tests still pass**
+
+`OBAKitTests/Strings/LocalizationTests.swift` guards that declared keys resolve. Run it plus the search suite:
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/LocalizationTests \
+  -only-testing:OBAKitTests/SearchInteractorTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS. A failure here means a key or default value drifted from the original — re-diff against the inline versions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Strings/Strings.swift \
+        OBAKit/Mapping/NearbyStopsListViewController.swift \
+        OBAKit/Search/SearchInteractor.swift
+git commit -m "refactor: move nearby stops and bookmarks section titles into Strings"
+```
+
+---
+
+## Task 4: `BookmarkDataLoader` scoping seam
+
+Lets the home sheet reuse the loader for four bookmarks with no polling, while the Bookmarks tab keeps today's behaviour exactly.
+
+**Files:**
+- Modify: `OBAKitCore/Bookmarks/BookmarkDataLoader.swift:66-130`
+- Create: `OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `BookmarkDataLoader.init(application:delegate:bookmarkProvider:autoRefreshes:)` where `bookmarkProvider` is `(@MainActor () -> [Bookmark])?` defaulting to `nil` and `autoRefreshes` is `Bool` defaulting to `true`. Existing members are unchanged: `loadData()`, `loadDataAndWait() async`, `cancelUpdates()`, `dataForKey(_: TripBookmarkKey) -> [ArrivalDeparture]`, `hasFetchedData(forStopID: StopID) -> Bool`, `isLoading`, `lastBatchHadError`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift`:
+
+```swift
+//
+//  BookmarkDataLoaderTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class BookmarkDataLoaderTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    /// Counts arrivals requests so the scoped-provider test can assert the
+    /// loader fetched only the bookmarks it was handed.
+    @MainActor
+    private final class RecordingDelegate: NSObject, BookmarkDataDelegate {
+        var updateCount = 0
+        func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) { updateCount += 1 }
+    }
+
+    /// Builds real *trip* bookmarks — `isTripBookmark` requires a route short
+    /// name, route id, and trip headsign, which only a decoded `ArrivalDeparture`
+    /// supplies. A bookmark that isn't a trip bookmark is skipped by the loader
+    /// without a request, which would silently zero out the counts below.
+    @MainActor
+    private func makeTripBookmarks(count: Int, application: Application) throws -> [Bookmark] {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
+
+        return (0..<count).map { index in
+            let bookmark = Bookmark(
+                name: "Bookmark \(index)",
+                regionIdentifier: pugetSoundRegionIdentifier,
+                arrivalDeparture: arrivalDeparture
+            )
+            bookmark.sortOrder = index
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+    }
+
+    /// The provider — not the whole store — decides what gets fetched.
+    @Test @MainActor
+    func `Bookmark provider scopes fetches to the supplied bookmarks`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        var requestCount = 0
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            let matches = request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            if matches { requestCount += 1 }
+            return matches
+        }
+
+        let all = try makeTripBookmarks(count: 6, application: application)
+        let scoped = Array(all.prefix(2))
+
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(
+            application: application,
+            delegate: delegate,
+            bookmarkProvider: { scoped },
+            autoRefreshes: false
+        )
+
+        await loader.loadDataAndWait()
+
+        // Six bookmarks exist; only the two handed to the provider are fetched.
+        #expect(requestCount == 2)
+    }
+
+    /// With auto-refresh off, the loader installs no repeating timer.
+    @Test @MainActor
+    func `Auto refresh disabled installs no timer`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let bookmarks = try makeTripBookmarks(count: 1, application: application)
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(
+            application: application,
+            delegate: delegate,
+            bookmarkProvider: { bookmarks },
+            autoRefreshes: false
+        )
+
+        await loader.loadDataAndWait()
+
+        #expect(loader.hasScheduledRefresh == false)
+    }
+
+    /// The Bookmarks tab's construction is untouched: every region bookmark is
+    /// fetched and the repeating timer is installed.
+    @Test @MainActor
+    func `Default initializer fetches all region bookmarks and schedules refresh`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        var requestCount = 0
+        dataLoader.mock(data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_75414.json")) { request in
+            let matches = request.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            if matches { requestCount += 1 }
+            return matches
+        }
+
+        _ = try makeTripBookmarks(count: 3, application: application)
+
+        let delegate = RecordingDelegate()
+        let loader = BookmarkDataLoader(application: application, delegate: delegate)
+
+        await loader.loadDataAndWait()
+
+        #expect(requestCount == 3)
+        #expect(loader.hasScheduledRefresh)
+
+        loader.cancelUpdates()
+    }
+}
+```
+
+> Every bookmark here shares one stop id. That is fine: `BookmarkDataLoader.startBatch`
+> issues one fetch per *bookmark*, not per distinct stop, so the request counts below
+> still measure what they claim to.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — the initializer has no `bookmarkProvider` argument, and `hasScheduledRefresh` does not exist.
+
+- [ ] **Step 3: Add the seams**
+
+In `OBAKitCore/Bookmarks/BookmarkDataLoader.swift`, add two stored properties beside the existing ones and replace the initializer (~line 66):
+
+```swift
+    /// When set, supplies the bookmarks a batch should fetch instead of every
+    /// bookmark in the current region. Lets a caller that only displays a few
+    /// bookmarks — the home sheet's preview section — reuse this loader without
+    /// paying for the whole set.
+    private let bookmarkProvider: (@MainActor () -> [Bookmark])?
+
+    /// When `false`, `startRefreshTimer()` is a no-op, so the loader fetches
+    /// only when explicitly asked. Callers that display a handful of bookmarks
+    /// outside a dedicated screen don't want a background 30-second cycle.
+    private let autoRefreshes: Bool
+
+    public init(
+        application: CoreApplication,
+        delegate: BookmarkDataDelegate,
+        bookmarkProvider: (@MainActor () -> [Bookmark])? = nil,
+        autoRefreshes: Bool = true
+    ) {
+        self.application = application
+        self.delegate = delegate
+        self.bookmarkProvider = bookmarkProvider
+        self.autoRefreshes = autoRefreshes
+    }
+```
+
+Guard the timer inside `startRefreshTimer()` rather than at its two call sites, so the invariant holds no matter who calls it (the method is `public`):
+
+```swift
+    public func startRefreshTimer() {
+        timer?.invalidate()
+
+        guard autoRefreshes else {
+            timer = nil
+            return
+        }
+
+        timer = Timer.scheduledMainActorTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] in
+            self?.loadData()
+        }
+    }
+
+    /// Whether a repeating refresh is currently armed. Exposed so callers that
+    /// opted out of auto-refresh can assert they really did.
+    @MainActor public var hasScheduledRefresh: Bool {
+        timer?.isValid ?? false
+    }
+```
+
+And route `eligibleBookmarks()` through the provider (~line 126):
+
+```swift
+    private func eligibleBookmarks() -> [Bookmark] {
+        if let bookmarkProvider {
+            return bookmarkProvider()
+        }
+        return application.userDataStore.bookmarks.filter {
+            $0.regionIdentifier == application.regionsService.currentRegion?.id
+        }
+    }
+```
+
+`loadData()` and `loadDataAndWait()` are otherwise unchanged — they still call `startRefreshTimer()`, which now no-ops when auto-refresh is off.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/BookmarkDataLoaderTests \
+  -only-testing:OBAKitTests/BookmarksViewModelTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS. `BookmarksViewModelTests` passing unchanged is the proof the tab's behaviour did not shift.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKitCore/Bookmarks/BookmarkDataLoader.swift \
+        OBAKitTests/Bookmarks/BookmarkDataLoaderTests.swift
+git commit -m "feat: allow BookmarkDataLoader to scope fetches and skip auto-refresh"
+```
+
+---
+
+## Task 5: Shared stop-row builder
+
+Promotes the `Stop` branch buried in `SearchResultRow` to a named factory the home sections can call, and adds the one row kind they need.
+
+**Files:**
+- Modify: `OBAKit/Search/SearchList/Models/SearchListRow.swift:18-68` (Kind), plus a new extension
+- Modify: `OBAKit/Search/SearchList/SearchListRowView.swift:26` (the `actionRow` arm)
+- Modify: `OBAKit/Sheet/Content/Search/SearchResultRow.swift:90-154`
+- Modify: `OBAKitTests/Search/SearchResultRowTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SearchListRow.Kind.nearbyStop(id: String)` and `SearchListRow.stop(_ stop: Stop, application: Application, kind: Kind, onSelect: @escaping () -> Void) -> SearchListRow`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the suite in `OBAKitTests/Search/SearchResultRowTests.swift`:
+
+```swift
+    /// The shared factory reproduces what the inline `Stop` branch produced,
+    /// for whichever kind the caller asks for.
+    @Test @MainActor
+    func `Stop factory builds a row with the requested kind`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let row = SearchListRow.stop(
+            stop,
+            application: application,
+            kind: .nearbyStop(id: stop.id),
+            onSelect: {}
+        )
+
+        #expect(row.title == stop.name)
+        #expect(row.accessory == .disclosureIndicator)
+        if case .nearbyStop(let id) = row.kind {
+            #expect(id == stop.id)
+        } else {
+            Issue.record("Expected a .nearbyStop kind, got \(row.kind)")
+        }
+    }
+
+    /// A stop shown in both the nearby and recent sections must not produce two
+    /// rows with the same `id`, or `ForEach` collapses them.
+    @Test @MainActor
+    func `Nearby and recent kinds yield distinct identifiers for one stop`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+
+        let nearby = SearchListRow.stop(stop, application: application, kind: .nearbyStop(id: stop.id), onSelect: {})
+        let recent = SearchListRow.stop(stop, application: application, kind: .recentStop(id: stop.id), onSelect: {})
+
+        #expect(nearby.id != recent.id)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `.nearbyStop` case and no `SearchListRow.stop(...)`.
+
+- [ ] **Step 3: Add the kind**
+
+In `OBAKit/Search/SearchList/Models/SearchListRow.swift`, add to `enum Kind` beside `recentStop`:
+
+```swift
+        /// Carries the stop's id for the same reason `recentStop` does: two
+        /// stops on opposite sides of a corner share a name.
+        case nearbyStop(id: String)
+```
+
+and the matching arm in `stableIdentifier`:
+
+```swift
+            case .nearbyStop(let id):
+                return "nearbyStop-\(id)"
+```
+
+- [ ] **Step 4: Add the factory**
+
+Add to `SearchListRow.swift`, below the existing `// MARK: - Placemark Row Building` extension:
+
+```swift
+// MARK: - Stop Row Building
+
+extension SearchListRow {
+
+    /// The standard stop row: stop glyph, name, and a "distance • direction"
+    /// subtitle. Shared by the search results sheet and the home sheet's nearby
+    /// and recent sections so all three render stops identically.
+    ///
+    /// `kind` is a parameter rather than fixed because the caller owns row
+    /// identity — the same stop can legitimately appear in two sections at once.
+    @MainActor
+    static func stop(
+        _ stop: Stop,
+        application: Application,
+        kind: Kind,
+        onSelect: @escaping () -> Void
+    ) -> SearchListRow {
+        SearchListRow(
+            kind: kind,
+            title: stop.name,
+            subtitle: stopSubtitle(application, stop),
+            icon: .uiImage(Icons.stop),
+            accessory: .disclosureIndicator,
+            action: onSelect
+        )
+    }
+
+    /// Direction plus distance from the user, mirroring what the placemark rows
+    /// in the search list already show. Distance is dropped when there's no fix.
+    @MainActor
+    static func stopSubtitle(_ application: Application, _ stop: Stop) -> String? {
+        var parts: [String] = []
+
+        if let currentLocation = application.locationService.currentLocation {
+            let distance = currentLocation.distance(from: stop.location)
+            parts.append(application.formatters.distanceFormatter.string(fromDistance: distance))
+        }
+
+        if let direction = Formatters.adjectiveFormOfCardinalDirection(stop.direction), !direction.isEmpty {
+            parts.append(direction)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " • ")
+    }
+}
+```
+
+- [ ] **Step 5: Delegate the search-results branch to the factory**
+
+In `OBAKit/Sheet/Content/Search/SearchResultRow.swift`, replace the `case let stop as Stop:` arm of `row(for:application:onSelect:)` with:
+
+```swift
+        case let stop as Stop:
+            return SearchListRow.stop(
+                stop,
+                application: application,
+                kind: .searchResult(id: stop.id),
+                onSelect: onSelect
+            )
+```
+
+and delete the now-unused `private static func stopSubtitle(_:_:)` from the bottom of the file — it moved onto `SearchListRow`.
+
+- [ ] **Step 6: Render the new kind**
+
+In `OBAKit/Search/SearchList/SearchListRowView.swift`, add `.nearbyStop` to the `actionRow` arm of the `switch row.kind`:
+
+```swift
+        case .quickSearch, .recentStop, .nearbyStop, .bookmark, .placemark, .searchResult:
+            actionRow
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/SearchResultRowTests \
+  -only-testing:OBAKitTests/SearchResultsSheetViewTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS. `SearchResultsSheetViewTests` passing unchanged proves the delegation preserved the old row output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add OBAKit/Search/SearchList/Models/SearchListRow.swift \
+        OBAKit/Search/SearchList/SearchListRowView.swift \
+        OBAKit/Sheet/Content/Search/SearchResultRow.swift \
+        OBAKitTests/Search/SearchResultRowTests.swift
+git commit -m "refactor: extract a shared stop row builder and add a nearby stop kind"
+```
+
+---
+
+## Task 6: `MapStopsObserver` viewport center and ownership move
+
+The riskiest task in the plan — it touches the map root's construction path. Isolated deliberately so it can be reviewed and reverted on its own.
+
+**Files:**
+- Modify: `OBAKit/Sheet/Root/MapStopsObserver.swift:64-120`
+- Modify: `OBAKit/Sheet/Root/MapPanelRootController.swift:26-48`
+- Modify: `OBAKit/Sheet/Root/MapPanelRootView.swift:25,89-116`
+- Modify: `OBAKit/Sheet/DI/AppSheetViewFactory.swift:26-49`
+- Modify: `OBAKitTests/Sheet/MapStopsObserverTests.swift`
+- Modify: `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift` (factory helper gains the observer)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `MapStopsObserver.viewportCenter: CLLocationCoordinate2D?` (`@Published private(set)`); `AppSheetViewFactory.stopsObserver: MapStopsObserver` and a new required `stopsObserver:` initializer parameter; `MapPanelRootView.init(application:factory:coordinator:searchDisplayModel:stopsObserver:)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `OBAKitTests/Sheet/MapStopsObserverTests.swift`:
+
+```swift
+    /// The settled viewport's center is published so consumers can sort by it.
+    @Test @MainActor
+    func `Update viewport publishes its center`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        #expect(observer.viewportCenter == nil)
+
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        observer.updateViewport(region)
+
+        #expect(observer.viewportCenter?.latitude == region.center.latitude)
+        #expect(observer.viewportCenter?.longitude == region.center.longitude)
+    }
+
+    /// Zooming out clears the center along with the stops, so a stale center
+    /// can't outlive the render set it was ordering.
+    @Test @MainActor
+    func `Reset clears the viewport center`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let observer = MapStopsObserver(application: application)
+        observer.updateViewport(MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        ))
+        #expect(observer.viewportCenter != nil)
+
+        observer.reset()
+
+        #expect(observer.viewportCenter == nil)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `viewportCenter` member.
+
+- [ ] **Step 3: Publish the viewport center**
+
+In `OBAKit/Sheet/Root/MapStopsObserver.swift`, add beside the private `viewport` property:
+
+```swift
+    /// Center of the last settled viewport, published so the home sheet's
+    /// nearby section can order stops by it. Nil until the first settle, and
+    /// cleared on `reset()` so a stale center never outlives its render set.
+    @Published private(set) var viewportCenter: CLLocationCoordinate2D?
+```
+
+Set it in `updateViewport(_:)`:
+
+```swift
+    func updateViewport(_ region: MKCoordinateRegion) {
+        viewport = region
+        viewportCenter = region.center
+        if pruneAccumulated() {
+            publish()
+        }
+    }
+```
+
+and clear it in `reset()`:
+
+```swift
+    func reset() {
+        accumulated.removeAll()
+        viewport = nil
+        viewportCenter = nil
+        guard !stops.isEmpty else { return }
+        stops = []
+    }
+```
+
+- [ ] **Step 4: Move ownership to the controller**
+
+In `OBAKit/Sheet/DI/AppSheetViewFactory.swift`, add the stored property beside `searchDisplayModel` and extend the initializer. Extend the existing initializer doc-comment to cover it — the same "must be the instance the hosting view observes" reasoning applies:
+
+```swift
+    let stopsObserver: MapStopsObserver
+```
+
+```swift
+    init(
+        application: Application,
+        onPresentTrip: @escaping (ArrivalDeparture) -> Void,
+        onPresentVehicleTrip: @escaping (VehicleStatus) -> Void,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel,
+        stopsObserver: MapStopsObserver
+    ) {
+        self.application = application
+        self.onPresentTrip = onPresentTrip
+        self.onPresentVehicleTrip = onPresentVehicleTrip
+        self.coordinator = coordinator
+        self.searchDisplayModel = searchDisplayModel
+        self.stopsObserver = stopsObserver
+    }
+```
+
+In `OBAKit/Sheet/Root/MapPanelRootController.swift`, build the observer before the factory and thread it into both:
+
+```swift
+        let bridge = TripPresentationBridge()
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let displayModel = MapSearchDisplayModel()
+        // Built here, not inside `MapPanelRootView`, because the factory is
+        // constructed first and the home sheet's nearby section must observe
+        // the same instance the map renders from. Same reasoning as
+        // `displayModel` above.
+        let stopsObserver = MapStopsObserver(application: application)
+        let factory = AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { [weak bridge] arrival in bridge?.present(arrival) },
+            onPresentVehicleTrip: { [weak bridge] vehicleStatus in bridge?.present(vehicleStatus: vehicleStatus) },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver
+        )
+        let rootView = MapPanelRootView(
+            application: application,
+            factory: factory,
+            coordinator: coordinator,
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver
+        )
+```
+
+In `OBAKit/Sheet/Root/MapPanelRootView.swift`, change the property wrapper and the initializer, mirroring how `searchDisplay` is already handled:
+
+```swift
+    @ObservedObject private var stopsObserver: MapStopsObserver
+```
+
+```swift
+    init(
+        application: Application,
+        factory: AppSheetViewFactory,
+        coordinator: SheetCoordinator<AppSheetRoute>,
+        searchDisplayModel: MapSearchDisplayModel,
+        stopsObserver: MapStopsObserver
+    ) {
+        _coordinator = StateObject(wrappedValue: coordinator)
+        _searchDisplay = ObservedObject(wrappedValue: searchDisplayModel)
+        _stopsObserver = ObservedObject(wrappedValue: stopsObserver)
+```
+
+and delete the old `_stopsObserver = StateObject(wrappedValue: MapStopsObserver(application: application))` line. Everything else in the initializer is unchanged.
+
+- [ ] **Step 5: Update the factory test helper**
+
+In `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`, extend `makeFactory` so every existing test keeps compiling:
+
+```swift
+    @MainActor
+    private func makeFactory(
+        application: Application,
+        coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
+        displayModel: MapSearchDisplayModel = MapSearchDisplayModel(),
+        stopsObserver: MapStopsObserver? = nil
+    ) -> AppSheetViewFactory {
+        AppSheetViewFactory(
+            application: application,
+            onPresentTrip: { _ in },
+            onPresentVehicleTrip: { _ in },
+            coordinator: coordinator,
+            searchDisplayModel: displayModel,
+            stopsObserver: stopsObserver ?? MapStopsObserver(application: application)
+        )
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/MapStopsObserverTests \
+  -only-testing:OBAKitTests/AppSheetViewFactoryTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify the map still works on device**
+
+Launch the app on the iPhone 16 simulator, confirm stop pins still appear when zoomed in, disappear when zoomed out, and that bookmark pins render at all zoom levels. The unit tests do not cover the SwiftUI wiring this task changed, so this manual check is the real gate.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add OBAKit/Sheet/Root/MapStopsObserver.swift \
+        OBAKit/Sheet/Root/MapPanelRootController.swift \
+        OBAKit/Sheet/Root/MapPanelRootView.swift \
+        OBAKit/Sheet/DI/AppSheetViewFactory.swift \
+        OBAKitTests/Sheet/MapStopsObserverTests.swift \
+        OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+git commit -m "refactor: hoist MapStopsObserver to the panel root and publish its viewport center"
+```
+
+---
+
+## Task 7: Index-route assert exemption
+
+**Files:**
+- Modify: `OBAKit/Sheet/DI/AppSheetViewFactory.swift:64-103,173-205`
+- Modify: `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`
+
+**Interfaces:**
+- Consumes: `makeFactory(...)` from Task 6.
+- Produces: `AppSheetViewFactory.indexPlaceholderView(for:) -> some View`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`:
+
+```swift
+    /// The three index routes are wired for navigation before their screens
+    /// exist, so they must render a placeholder instead of tripping the
+    /// debug assertion that guards genuinely unwired routes.
+    @Test @MainActor
+    func `Index routes render a placeholder without asserting`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let factory = makeFactory(application: application)
+
+        // Reaching `unimplementedView` would call assertionFailure and trap the
+        // test run, so simply building each view is the assertion.
+        for route in [AppSheetRoute.nearbyAll, .recentStopsAll, .bookmarksAll] {
+            _ = factory.indexPlaceholderView(for: route)
+        }
+
+        #expect(Bool(true))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `indexPlaceholderView(for:)`.
+
+- [ ] **Step 3: Split the placeholder out of the assert path**
+
+In `AppSheetViewFactory`, move the three routes out of the `unimplementedView` arm of `view(for:)`:
+
+```swift
+        case .nearbyAll, .recentStopsAll, .bookmarksAll:
+            indexPlaceholderView(for: route)
+
+        // Wiring a push for one of these routes before its view exists will
+        // trip the debug assertion in `unimplementedView(for:)` — register the
+        // view here before reaching for `SheetCoordinator.push(...)`.
+        case .tripPlanner, .tripDetails, .transitAlert, .settings:
+            unimplementedView(for: route)
+```
+
+and add the placeholder builder beside `unimplementedView`:
+
+```swift
+    /// The home sheet's section headers navigate to these three routes before
+    /// their index screens exist, so they render the "coming soon" placeholder
+    /// in every configuration rather than asserting. `unimplementedView` stays
+    /// armed for routes nobody has wired a push for yet — remove a route from
+    /// here once its real view is registered above.
+    func indexPlaceholderView(for route: AppSheetRoute) -> some View {
+        VStack(spacing: 4) {
+            Text(OBALoc(
+                "app_sheet.unimplemented_route.placeholder",
+                value: "This screen is coming soon.",
+                comment: "Placeholder shown in release builds when a sheet route is pushed but has no view registered."
+            ))
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            Text(route.id)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding()
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/AppSheetViewFactoryTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Sheet/DI/AppSheetViewFactory.swift \
+        OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+git commit -m "feat: render a placeholder for the three index routes instead of asserting"
+```
+
+---
+
+## Task 8: `HomeSheetSection` and `HomeSectionHeader`
+
+Defines the section identity and its shared item limit **before** the section
+models, so Tasks 9–12 all reference one already-existing constant rather than
+forward-declaring each other's symbols.
+
+**Files:**
+- Create: `OBAKit/Sheet/Content/Home/HomeSheetSection.swift`
+- Create: `OBAKit/Sheet/Content/Home/HomeSectionHeader.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `enum HomeSheetSection: Hashable { case nearby, recent, bookmarks }` with `static let itemLimit = 4`; `HomeSectionHeader(title: String, onSeeAll: () -> Void)`.
+
+- [ ] **Step 1: Define the section identity and limit**
+
+Create `OBAKit/Sheet/Content/Home/HomeSheetSection.swift`:
+
+```swift
+//
+//  HomeSheetSection.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// The home sheet's content sections, in the order they render.
+///
+/// Order is fixed: an empty earlier section is omitted, never replaced by a
+/// later one. Declared as its own type — rather than inline in the view model —
+/// so each section model can reference `itemLimit` without depending on the
+/// view model that composes them.
+enum HomeSheetSection: Hashable {
+    case nearby
+    case recent
+    case bookmarks
+
+    /// How many items each section previews before the header's chevron takes
+    /// over. Defined once so the three sections can't drift apart.
+    static let itemLimit = 4
+}
+```
+
+- [ ] **Step 2: Write the header view**
+
+The header has no unit test — it is a pure layout view with no logic worth asserting, and the repo does not snapshot-test SwiftUI views. Its behaviour is covered where it is used, in Task 13.
+
+Create `OBAKit/Sheet/Content/Home/HomeSectionHeader.swift`:
+
+```swift
+//
+//  HomeSectionHeader.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// A home sheet section header: title on the left, chevron on the right, the
+/// whole row acting as one button into that section's full index.
+///
+/// One button rather than a label plus a separate chevron button, so the tap
+/// target matches what the row looks like and VoiceOver reads one element.
+struct HomeSectionHeader: View {
+    let title: String
+    let onSeeAll: () -> Void
+
+    private let brandColor = Color(uiColor: ThemeColors.shared.brand)
+
+    var body: some View {
+        Button(action: onSeeAll) {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(brandColor)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityHint(OBALoc(
+            "home_sheet.section_header.a11y_hint",
+            value: "Shows all items in this section.",
+            comment: "VoiceOver hint for a home sheet section header, which opens that section's full list."
+        ))
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+#if DEBUG
+#Preview {
+    HomeSectionHeader(title: "Nearby Stops") { }
+        .padding()
+}
+#endif
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeSheetSection.swift \
+        OBAKit/Sheet/Content/Home/HomeSectionHeader.swift
+git commit -m "feat: add the home sheet section identity and header"
+```
+
+---
+
+## Task 9: `HomeNearbyStopsSectionModel`
+
+**Files:**
+- Create: `OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift`
+- Create: `OBAKitTests/Sheet/Home/HomeSectionModelTests.swift`
+
+**Interfaces:**
+- Consumes: `Stop.nearest(_:to:limit:)` (Task 1); `MapStopsObserver.viewportCenter` (Task 6).
+- Produces: `HomeNearbyStopsSectionModel(observer:limit:)` with `@Published private(set) var stops: [Stop]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Sheet/Home/HomeSectionModelTests.swift`:
+
+```swift
+//
+//  HomeSectionModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class HomeSectionModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Nearby
+
+    /// The section caps at its limit and orders by the observer's viewport center.
+    @Test @MainActor
+    func `Nearby section publishes the nearest stops up to the limit`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+
+        #expect(model.stops.count == 4)
+        let expected = Stop.nearest(observer.stops, to: region.center, limit: 4).map(\.id)
+        #expect(model.stops.map(\.id) == expected)
+    }
+
+    /// Zooming out resets the observer, and the section empties with it.
+    @Test @MainActor
+    func `Nearby section empties when the observer resets`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+        #expect(!model.stops.isEmpty)
+
+        observer.reset()
+
+        #expect(model.stops.isEmpty)
+    }
+
+    /// Before the first settle there is no center to sort by, so the section
+    /// shows the observer's own ordering rather than nothing at all.
+    @Test @MainActor
+    func `Nearby section falls back to observer order before the first settle`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        // Deliberately no updateViewport — viewportCenter stays nil.
+
+        let model = HomeNearbyStopsSectionModel(observer: observer, limit: 4)
+
+        #expect(model.stops.map(\.id) == observer.stops.prefix(4).map(\.id))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `HomeNearbyStopsSectionModel`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift`:
+
+```swift
+//
+//  HomeNearbyStopsSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Combine
+import CoreLocation
+import OBAKitCore
+
+/// The home sheet's nearby-stops preview: the few stops closest to the map's
+/// center.
+///
+/// Reads `MapStopsObserver` rather than subscribing to `MapRegionManager`
+/// itself. The observer is already that manager's subscriber, and a second
+/// delegate would redo the accumulate-and-prune work on every map settle for
+/// the sake of four rows. This costs no network requests at all — it re-slices
+/// stops the map has already loaded.
+@MainActor
+final class HomeNearbyStopsSectionModel: ObservableObject {
+
+    @Published private(set) var stops: [Stop] = []
+
+    private let observer: MapStopsObserver
+    private let limit: Int
+    private var cancellables = Set<AnyCancellable>()
+
+    init(observer: MapStopsObserver, limit: Int = HomeSheetSection.itemLimit) {
+        self.observer = observer
+        self.limit = limit
+
+        observer.$stops
+            .combineLatest(observer.$viewportCenter)
+            .sink { [weak self] stops, center in
+                self?.rebuild(stops: stops, center: center)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// `combineLatest` emits on subscribe, so the initial state is set by the
+    /// sink above rather than duplicated here.
+    private func rebuild(stops: [Stop], center: CLLocationCoordinate2D?) {
+        guard let center else {
+            // No settle yet. The observer's id ordering is arbitrary but stable,
+            // which beats rendering an empty section for the frame or two before
+            // the first camera settle lands.
+            self.stops = Array(stops.prefix(limit))
+            return
+        }
+        self.stops = Stop.nearest(stops, to: center, limit: limit)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/HomeSectionModelTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeNearbyStopsSectionModel.swift \
+        OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+git commit -m "feat: add the home sheet nearby stops section model"
+```
+
+---
+
+## Task 10: `HomeRecentStopsSectionModel`
+
+**Files:**
+- Create: `OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift`
+- Modify: `OBAKitTests/Sheet/Home/HomeSectionModelTests.swift`
+
+**Interfaces:**
+- Consumes: `UserDataStore.recentStops(in:)` (Task 2).
+- Produces: `HomeRecentStopsSectionModel(application:limit:)` with `@Published private(set) var stops: [Stop]` and `func reload()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `HomeSectionModelTests`:
+
+```swift
+    // MARK: - Recent
+
+    /// The section caps at its limit and preserves the store's MRU ordering.
+    @Test @MainActor
+    func `Recent section caps at the limit in most recently used order`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // Added oldest-first; the store inserts each at index 0, so the last
+        // one added is the first one out.
+        for stop in stops.prefix(6) {
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        let model = HomeRecentStopsSectionModel(application: application, limit: 4)
+
+        #expect(model.stops.count == 4)
+        let expected = application.userDataStore
+            .recentStops(in: application.currentRegion)
+            .prefix(4)
+            .map(\.id)
+        #expect(model.stops.map(\.id) == Array(expected))
+    }
+
+    /// `reload()` picks up a stop added after construction.
+    @Test @MainActor
+    func `Recent section reload picks up newly added stops`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        let model = HomeRecentStopsSectionModel(application: application, limit: 4)
+        #expect(model.stops.isEmpty)
+
+        let stop = try #require(stops.first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        model.reload()
+
+        #expect(model.stops.map(\.id) == [stop.id])
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `HomeRecentStopsSectionModel`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift`:
+
+```swift
+//
+//  HomeRecentStopsSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The home sheet's recent-stops preview.
+///
+/// Backed entirely by `UserDataStore`, so it costs no network requests. Recents
+/// are already stored most-recently-used first, so there is nothing to sort.
+@MainActor
+final class HomeRecentStopsSectionModel: ObservableObject {
+
+    @Published private(set) var stops: [Stop] = []
+
+    private let application: Application
+    private let limit: Int
+
+    init(application: Application, limit: Int = HomeSheetSection.itemLimit) {
+        self.application = application
+        self.limit = limit
+        reload()
+    }
+
+    /// Re-reads the store. Called on activation and on region change — a
+    /// region switch changes which recents are current, and the store posts no
+    /// notification for it.
+    func reload() {
+        stops = Array(
+            application.userDataStore
+                .recentStops(in: application.currentRegion)
+                .prefix(limit)
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/HomeSectionModelTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeRecentStopsSectionModel.swift \
+        OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+git commit -m "feat: add the home sheet recent stops section model"
+```
+
+---
+
+## Task 11: `HomeBookmarksSectionModel`
+
+**Files:**
+- Create: `OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift`
+- Modify: `OBAKitTests/Sheet/Home/HomeSectionModelTests.swift`
+
+**Interfaces:**
+- Consumes: `BookmarkDataLoader.init(application:delegate:bookmarkProvider:autoRefreshes:)` (Task 4).
+- Produces: `HomeBookmarksSectionModel(application:limit:)` with `@Published private(set) var rows: [BookmarkRowViewModel]`, `func refreshSelection()`, and `@discardableResult func loadIfNeeded(now:staleAfter:) -> Bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `HomeSectionModelTests`:
+
+```swift
+    // MARK: - Bookmarks
+
+    @MainActor
+    private func seedBookmarks(count: Int, application: Application) throws -> [Bookmark] {
+        let stops = try Fixtures.loadSomeStops()
+        // sortOrder is assigned in reverse so the test proves the model sorts
+        // rather than accidentally matching insertion order.
+        return (0..<count).map { index in
+            let bookmark = Bookmark(
+                name: "Bookmark \(index)",
+                regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+                stop: stops[index % stops.count]
+            )
+            bookmark.sortOrder = count - index
+            application.userDataStore.add(bookmark, to: nil)
+            return bookmark
+        }
+    }
+
+    /// The four shown are chosen by `sortOrder`, not by insertion order —
+    /// `findBookmarks(in:)` returns raw persisted order, so the model must sort.
+    @Test @MainActor
+    func `Bookmarks section selects by sort order up to the limit`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 6, application: application)
+
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        #expect(model.rows.count == 4)
+        let sortOrders = model.rows.map(\.bookmark.sortOrder)
+        #expect(sortOrders == sortOrders.sorted())
+    }
+
+    /// Whole-stop bookmarks have no trip to fetch, so they never report as
+    /// having loaded arrival data and never carry departures.
+    @Test @MainActor
+    func `Bookmarks section leaves stop bookmarks without arrival data`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+
+        for row in model.rows {
+            #expect(row.isTripBookmark == false)
+            #expect(row.arrivalDepartures.isEmpty)
+            #expect(row.hasLoadedArrivalData == false)
+        }
+    }
+
+    /// A second activation inside the staleness window does not re-fetch.
+    @Test @MainActor
+    func `Bookmarks section skips a repeat load inside the staleness window`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(5), staleAfter: 30) == false)
+    }
+
+    /// Once the window lapses, the next activation re-fetches.
+    @Test @MainActor
+    func `Bookmarks section reloads after the staleness window lapses`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(31), staleAfter: 30))
+    }
+
+    /// A changed selection re-fetches even inside the staleness window —
+    /// otherwise a newly added bookmark would show blank until the window lapsed.
+    @Test @MainActor
+    func `Bookmarks section reloads when the selection changes`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        _ = try seedBookmarks(count: 2, application: application)
+
+        let model = HomeBookmarksSectionModel(application: application, limit: 4)
+        let start = Date()
+        #expect(model.loadIfNeeded(now: start, staleAfter: 30))
+
+        _ = try seedBookmarks(count: 1, application: application)
+
+        #expect(model.loadIfNeeded(now: start.addingTimeInterval(1), staleAfter: 30))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — no `HomeBookmarksSectionModel`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift`:
+
+```swift
+//
+//  HomeBookmarksSectionModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The home sheet's bookmarks preview: the first few bookmarks by the user's
+/// own ordering, with live arrivals for those few only.
+///
+/// Reuses `BookmarkDataLoader` — the same loader the Bookmarks tab uses — but
+/// scoped to the displayed bookmarks and with auto-refresh off, so this screen
+/// costs at most `limit` requests per activation and installs no polling timer.
+///
+/// Subclasses `NSObject` to adopt `BookmarkDataDelegate`.
+@MainActor
+final class HomeBookmarksSectionModel: NSObject, ObservableObject, BookmarkDataDelegate {
+
+    @Published private(set) var rows: [BookmarkRowViewModel] = []
+
+    /// The bookmarks a fetch is scoped to. Read by the loader's provider.
+    private(set) var selection: [Bookmark] = []
+
+    private let application: Application
+    private let limit: Int
+    private var loader: BookmarkDataLoader!
+
+    private var lastFetchDate: Date?
+    private var lastFetchedRegionID: Int?
+
+    init(application: Application, limit: Int = HomeSheetSection.itemLimit) {
+        self.application = application
+        self.limit = limit
+        super.init()
+
+        // The provider reads `selection` at fetch time rather than capturing a
+        // snapshot, so `refreshSelection()` before a load is enough to rescope
+        // the next batch.
+        self.loader = BookmarkDataLoader(
+            application: application,
+            delegate: self,
+            bookmarkProvider: { [weak self] in self?.selection ?? [] },
+            autoRefreshes: false
+        )
+
+        refreshSelection()
+    }
+
+    isolated deinit {
+        loader?.cancelUpdates()
+    }
+
+    /// Re-reads which bookmarks belong on screen and rebuilds the rows.
+    ///
+    /// `findBookmarks(in:)` returns raw persisted order — only `bookmarksInGroup`
+    /// sorts — so the sort here is what makes the four shown match the user's
+    /// Manage Bookmarks ordering.
+    func refreshSelection() {
+        selection = Array(
+            application.userDataStore
+                .findBookmarks(in: application.currentRegion)
+                .sorted { $0.sortOrder < $1.sortOrder }
+                .prefix(limit)
+        )
+        rebuildRows()
+    }
+
+    /// Fetches arrivals for the current selection, but only when something has
+    /// actually changed: the data is stale, the region moved, or the displayed
+    /// bookmarks differ. Returns whether a fetch was started.
+    ///
+    /// The sheet system tears sheet content down and rebuilds it without the
+    /// user navigating anywhere, so activation can fire repeatedly per visit —
+    /// this gate is what keeps that from becoming repeated network traffic.
+    @discardableResult
+    func loadIfNeeded(now: Date = Date(), staleAfter: TimeInterval = 30) -> Bool {
+        let previousIDs = selection.map(\.id)
+        refreshSelection()
+
+        let regionID = application.currentRegion?.regionIdentifier
+        let selectionChanged = previousIDs != selection.map(\.id)
+        let regionChanged = regionID != lastFetchedRegionID
+        let isStale = lastFetchDate.map { now.timeIntervalSince($0) > staleAfter } ?? true
+
+        guard selectionChanged || regionChanged || isStale else { return false }
+
+        lastFetchDate = now
+        lastFetchedRegionID = regionID
+        loader.loadData()
+        return true
+    }
+
+    // MARK: - Row Building
+
+    /// Rebuilds the row snapshots from the loader's current arrival data.
+    ///
+    /// `highlightedTripIDs` is always empty: the flash-on-change affordance
+    /// belongs to the polling Bookmarks tab, and nothing polls here.
+    private func rebuildRows() {
+        rows = selection.map { bookmark in
+            BookmarkRowViewModel(
+                bookmark: bookmark,
+                arrivalDepartures: arrivalDepartures(for: bookmark),
+                highlightedTripIDs: [],
+                hasLoadedArrivalData: loader.hasFetchedData(forStopID: bookmark.stopID)
+            )
+        }
+    }
+
+    private func arrivalDepartures(for bookmark: Bookmark) -> [ArrivalDeparture] {
+        guard let key = TripBookmarkKey(bookmark: bookmark) else { return [] }
+        return loader.dataForKey(key)
+    }
+
+    // MARK: - BookmarkDataDelegate
+
+    func dataLoaderDidUpdate(_ dataLoader: BookmarkDataLoader) {
+        rebuildRows()
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/HomeSectionModelTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeBookmarksSectionModel.swift \
+        OBAKitTests/Sheet/Home/HomeSectionModelTests.swift
+git commit -m "feat: add the home sheet bookmarks section model with scoped arrivals"
+```
+
+---
+
+## Task 12: `HomeSheetViewModel` composition
+
+**Files:**
+- Modify: `OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift` (full rewrite)
+- Create: `OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift`
+
+**Interfaces:**
+- Consumes: `HomeSheetSection` (Task 8) and all three section models (Tasks 9–11).
+- Produces: `HomeSheetViewModel(application:stopsObserver:)`; `nearby`, `recent`, `bookmarks` child models; `func activate()`; `@Published private(set) var visibleSections: [HomeSheetSection]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift`:
+
+```swift
+//
+//  HomeSheetViewModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class HomeSheetViewModelTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @MainActor
+    private func makeViewModel(application: Application) -> HomeSheetViewModel {
+        HomeSheetViewModel(
+            application: application,
+            stopsObserver: MapStopsObserver(application: application)
+        )
+    }
+
+    /// With no data at all, every section is omitted — the view renders the
+    /// all-empty state rather than three empty headers.
+    @Test @MainActor
+    func `Visible sections is empty when every section is empty`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+
+        let viewModel = makeViewModel(application: application)
+
+        #expect(viewModel.visibleSections.isEmpty)
+    }
+
+    /// An empty earlier section does not promote a later one — order is fixed.
+    @Test @MainActor
+    func `Visible sections keeps a fixed order when an earlier section is empty`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        // Seed recents only — nearby stays empty (no map settle) and bookmarks
+        // stay empty (none stored).
+        let stop = try #require(stops.first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        let viewModel = makeViewModel(application: application)
+        viewModel.activate()
+
+        #expect(viewModel.visibleSections == [.recent])
+    }
+
+    /// Both populated sections appear, nearby-before-recent order intact.
+    @Test @MainActor
+    func `Visible sections lists nearby before recent`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        clearStopCache(for: application)
+
+        dataLoader.mock(data: Fixtures.loadData(file: "stops_for_location_seattle.json")) { request in
+            request.url?.path.contains("/api/where/stops-for-location.json") ?? false
+        }
+
+        let stops = try Fixtures.loadSomeStops()
+        let stop = try #require(stops.first)
+        application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+
+        let observer = MapStopsObserver(application: application)
+        let region = MKCoordinateRegion(
+            center: TestData.mockSeattleLocation.coordinate,
+            latitudinalMeters: 5000,
+            longitudinalMeters: 5000
+        )
+        await application.mapRegionManager.requestStops(in: region)
+        observer.updateViewport(region)
+
+        let viewModel = HomeSheetViewModel(application: application, stopsObserver: observer)
+        viewModel.activate()
+
+        #expect(viewModel.visibleSections == [.nearby, .recent])
+    }
+
+    /// Every section caps at the shared limit.
+    @Test @MainActor
+    func `Sections cap at the shared section limit`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        for stop in stops.prefix(HomeSheetSection.itemLimit + 3) {
+            application.userDataStore.addRecentStop(stop, region: Fixtures.pugetSoundRegion)
+        }
+
+        let viewModel = makeViewModel(application: application)
+        viewModel.activate()
+
+        #expect(viewModel.recent.stops.count == HomeSheetSection.itemLimit)
+    }
+
+    /// Two activations in quick succession issue one bookmark fetch.
+    @Test @MainActor
+    func `Activate twice in quick succession fetches bookmarks once`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let stops = try Fixtures.loadSomeStops()
+
+        let bookmark = Bookmark(
+            name: "Bookmark",
+            regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier,
+            stop: try #require(stops.first)
+        )
+        application.userDataStore.add(bookmark, to: nil)
+
+        let viewModel = makeViewModel(application: application)
+        let start = Date()
+
+        #expect(viewModel.bookmarks.loadIfNeeded(now: start))
+        #expect(viewModel.bookmarks.loadIfNeeded(now: start.addingTimeInterval(2)) == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: compile FAILS — `HomeSheetViewModel` has no `stopsObserver:` parameter and no `visibleSections`.
+
+- [ ] **Step 3: Rewrite the view model**
+
+Replace the contents of `OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift`:
+
+```swift
+//
+//  HomeSheetViewModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Combine
+import MapKit
+import OBAKitCore
+
+// MARK: - HomeSheetViewModel
+
+/// Owns the home sheet's reactive content state: the search bar's placeholder
+/// and the three preview sections.
+///
+/// Composes three child section models rather than talking to the data sources
+/// itself, so each section's rules stay separately readable and testable.
+@MainActor
+final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelegate {
+
+    let nearby: HomeNearbyStopsSectionModel
+    let recent: HomeRecentStopsSectionModel
+    let bookmarks: HomeBookmarksSectionModel
+
+    /// Published rather than computed so a region change repaints the search bar.
+    /// The UIKit panel gets this from its own `RegionsServiceDelegate` callback
+    /// (`MapFloatingPanelController.regionsService(_:updatedRegion:)`); a plain
+    /// computed property would leave the placeholder naming the old region until
+    /// something unrelated happened to invalidate the view.
+    @Published private(set) var searchPlaceholder: String
+
+    /// Sections that currently have something to show, in render order. Empty
+    /// sections are dropped entirely — header included.
+    @Published private(set) var visibleSections: [HomeSheetSection] = []
+
+    private let application: Application
+    private var cancellables = Set<AnyCancellable>()
+
+    init(application: Application, stopsObserver: MapStopsObserver) {
+        self.application = application
+        self.searchPlaceholder = SearchPlaceholder.text(for: application)
+        self.nearby = HomeNearbyStopsSectionModel(observer: stopsObserver)
+        self.recent = HomeRecentStopsSectionModel(application: application)
+        self.bookmarks = HomeBookmarksSectionModel(application: application)
+        super.init()
+
+        // `RegionsService` holds delegates weakly, so there's nothing to unregister.
+        application.regionsService.addDelegate(self)
+
+        // Recompute the visible set whenever any child's content changes. The
+        // children publish values, not the section list, so this is the single
+        // place the order and the omission rule live.
+        nearby.$stops
+            .combineLatest(recent.$stops, bookmarks.$rows)
+            .sink { [weak self] nearbyStops, recentStops, bookmarkRows in
+                self?.updateVisibleSections(
+                    hasNearby: !nearbyStops.isEmpty,
+                    hasRecent: !recentStops.isEmpty,
+                    hasBookmarks: !bookmarkRows.isEmpty
+                )
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Called when the sheet's content appears. Idempotent: the sheet system
+    /// tears content down and rebuilds it without the user navigating anywhere,
+    /// so this can fire several times per visit. The store reads are cheap and
+    /// unconditional; only the bookmark fetch is gated.
+    func activate() {
+        recent.reload()
+        bookmarks.loadIfNeeded()
+    }
+
+    private func updateVisibleSections(hasNearby: Bool, hasRecent: Bool, hasBookmarks: Bool) {
+        var sections: [HomeSheetSection] = []
+        if hasNearby { sections.append(.nearby) }
+        if hasRecent { sections.append(.recent) }
+        if hasBookmarks { sections.append(.bookmarks) }
+        guard sections != visibleSections else { return }
+        visibleSections = sections
+    }
+
+    // MARK: - RegionsServiceDelegate
+
+    func regionsService(_ service: RegionsService, updatedRegion region: Region) {
+        searchPlaceholder = SearchPlaceholder.text(for: application)
+        // Which recents and bookmarks are "current" changed, and neither store
+        // posts a notification for it.
+        recent.reload()
+        bookmarks.loadIfNeeded()
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests/HomeSheetViewModelTests \
+  -only-testing:OBAKitTests/HomeSectionModelTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift \
+        OBAKitTests/Sheet/Home/HomeSheetViewModelTests.swift
+git commit -m "feat: compose the three preview sections in HomeSheetViewModel"
+```
+
+---
+
+## Task 13: Render the sections in `HomeSheetView`
+
+**Files:**
+- Modify: `OBAKit/Sheet/Content/Home/HomeSheetView.swift` (full rewrite)
+- Modify: `OBAKit/Sheet/DI/AppSheetViewFactory.swift:107-109` (`homeView()`)
+
+**Interfaces:**
+- Consumes: `HomeSheetViewModel` (Task 12), `HomeSectionHeader` (Task 8), `SearchListRow.stop(...)` (Task 5), `AppSheetViewFactory.stopsObserver` (Task 6), `indexPlaceholderView` routes (Task 7).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Wire the factory**
+
+In `OBAKit/Sheet/DI/AppSheetViewFactory.swift`, pass the observer through:
+
+```swift
+    func homeView() -> HomeSheetView {
+        HomeSheetView(
+            application: self.application,
+            viewModel: HomeSheetViewModel(
+                application: self.application,
+                stopsObserver: self.stopsObserver
+            )
+        )
+    }
+```
+
+- [ ] **Step 2: Rewrite the view**
+
+Replace the contents of `OBAKit/Sheet/Content/Home/HomeSheetView.swift`:
+
+```swift
+//
+//  HomeSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+struct HomeSheetView: View {
+    @StateObject private var viewModel: HomeSheetViewModel
+    @EnvironmentObject var coordinator: SheetCoordinator<AppSheetRoute>
+
+    /// Needed by `SearchListRow.stop(...)` for distance formatting. Passed in
+    /// rather than read from the environment: there is no `Application`
+    /// environment key in this codebase, and adding one for a single consumer
+    /// would be a wider change than this task warrants. `obaFormatters` (used by
+    /// the bookmark rows below) does exist, and is injected from here.
+    private let application: Application
+
+    init(
+        application: Application,
+        viewModel: @autoclosure @escaping () -> HomeSheetViewModel
+    ) {
+        self.application = application
+        _viewModel = StateObject(wrappedValue: viewModel())
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                searchBarRow
+                    .padding(.top, 16)
+
+                if viewModel.visibleSections.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(viewModel.visibleSections, id: \.self) { section in
+                        sectionView(for: section)
+                    }
+                }
+            }
+            .padding(.bottom, 24)
+        }
+        .ignoresSafeArea(.container, edges: .bottom)
+        .task {
+            viewModel.activate()
+        }
+    }
+
+    // MARK: - Search Bar
+
+    private var searchBarRow: some View {
+        Button {
+            coordinator.push(.search)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                Text(viewModel.searchPlaceholder)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background { Capsule().fill(Color(.tertiarySystemFill)) }
+            .contentShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12)
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private func sectionView(for section: HomeSheetSection) -> some View {
+        switch section {
+        case .nearby:
+            stopSection(
+                title: Strings.nearbyStops,
+                stops: viewModel.nearby.stops,
+                destination: .nearbyAll,
+                kind: { .nearbyStop(id: $0.id) }
+            )
+        case .recent:
+            stopSection(
+                title: Strings.recentStops,
+                stops: viewModel.recent.stops,
+                destination: .recentStopsAll,
+                kind: { .recentStop(id: $0.id) }
+            )
+        case .bookmarks:
+            bookmarksSection
+        }
+    }
+
+    /// Nearby and Recent render identically — same row builder, same layout —
+    /// and differ only in title, data, destination, and row kind.
+    private func stopSection(
+        title: String,
+        stops: [Stop],
+        destination: AppSheetRoute,
+        kind: @escaping (Stop) -> SearchListRow.Kind
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HomeSectionHeader(title: title) {
+                coordinator.push(destination)
+            }
+            ForEach(stops, id: \.id) { stop in
+                SearchListRowView(
+                    row: SearchListRow.stop(
+                        stop,
+                        application: application,
+                        kind: kind(stop),
+                        onSelect: { coordinator.push(.stopDetails(stopID: stop.id)) }
+                    )
+                )
+            }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private var bookmarksSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HomeSectionHeader(title: Strings.bookmarks) {
+                coordinator.push(.bookmarksAll)
+            }
+            ForEach(viewModel.bookmarks.rows) { row in
+                Group {
+                    if row.isTripBookmark {
+                        BookmarkCardView(row: row)
+                    } else {
+                        StopBookmarkRow(row: row)
+                    }
+                }
+                .contentShape(.rect)
+                .onTapGesture {
+                    coordinator.push(.stopDetails(stopID: row.stopID))
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .environment(\.obaFormatters, application.formatters)
+    }
+
+    /// Shown only when all three sections are empty — a first launch, or a map
+    /// parked at region-level zoom with no saved data. Reuses the nearby
+    /// controller's copy, minus its "Search Wider Area" button: that drives
+    /// `MapRegionManager.preferredLoadDataRegionFudgeFactor` and a timed reset
+    /// the SwiftUI path has no equivalent plumbing for.
+    private var emptyState: some View {
+        EmptyStateView(
+            title: OBALoc(
+                "nearby_controller.empty_set.title",
+                value: "No Nearby Stops",
+                comment: "Title for the empty set indicator on the Nearby controller"
+            ),
+            description: OBALoc(
+                "nearby_controller.empty_set.body",
+                value: "Zoom out or pan around to find some stops.",
+                comment: "Body for the empty set indicator on the Nearby controller."
+            ),
+            systemImage: "mappin.slash"
+        )
+        .padding(.top, 40)
+    }
+}
+```
+
+> `\.obaFormatters` is declared in `OBAKitCore/SwiftUI/Environment/OBAFormattersKey.swift`
+> and is what `BookmarkCardView` / `StopBookmarkRow` read. There is deliberately no
+> `Application` environment key — do not add one.
+
+- [ ] **Step 3: Build and run the full suite**
+
+```bash
+scripts/generate_project OneBusAway
+xcodebuild clean build-for-testing -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+xcodebuild test-without-building -only-testing:OBAKitTests \
+  -project 'OBAKit.xcodeproj' -scheme 'App' \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0'
+```
+
+Expected: the whole `OBAKitTests` target passes. Any failure outside the new suites is a regression from Tasks 1–7 and must be fixed before committing.
+
+- [ ] **Step 4: Lint**
+
+```bash
+scripts/swiftlint.sh
+```
+
+Expected: no new violations. `HomeSheetView.body` is close to the type-check budget that already forced `buildSheetContent` out of `MapPanelRootView.body` — if the compiler reports "unable to type-check this expression in reasonable time", extract `sectionView(for:)`'s callers into a separate `@ViewBuilder` computed property rather than simplifying the layout.
+
+- [ ] **Step 5: Verify on the simulator**
+
+Launch on the iPhone 16 simulator and confirm:
+- Dragging the home sheet up reveals the sections in order: Nearby, Recent, Bookmarks.
+- Each section shows at most four rows.
+- Tapping a row opens that stop's detail sheet.
+- Tapping a section header opens the "coming soon" placeholder — and does **not** trap in a debug build.
+- Panning the map re-orders the Nearby section.
+- With no bookmarks and no recents, only the empty state shows.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add OBAKit/Sheet/Content/Home/HomeSheetView.swift \
+        OBAKit/Sheet/DI/AppSheetViewFactory.swift
+git commit -m "feat: render nearby, recent, and bookmark sections on the home sheet"
+```
+
+---
+
+## Verification Checklist
+
+Run after Task 13, before considering the work done.
+
+- [ ] Full `OBAKitTests` target passes on iPhone 16 / iOS 26.
+- [ ] `scripts/swiftlint.sh` reports no new violations.
+- [ ] `BookmarksViewModelTests`, `MapStopsObserverTests`, `SearchResultsSheetViewTests`, and `SearchInteractorTests` all pass **unchanged in behaviour** — they are the regression signal that the five extractions preserved the UIKit paths.
+- [ ] Instrument or log-check that opening the home sheet issues **at most four** `arrivals-and-departures-for-stop` requests and **zero** additional `stops-for-location` requests.
+- [ ] Re-opening the home sheet within 30 seconds issues **no** further arrivals requests.
+- [ ] No `Co-Authored-By` or AI attribution in any commit message on the branch.

--- a/docs/superpowers/specs/2026-08-13-home-sheet-sections-design.md
+++ b/docs/superpowers/specs/2026-08-13-home-sheet-sections-design.md
@@ -1,0 +1,369 @@
+# Home Sheet Sections — Design
+
+**Date:** 2026-08-13
+**Branch:** `feature/home-sheet-map-panel`
+**Status:** Approved design, ready for implementation planning
+
+## Summary
+
+Populate the SwiftUI home sheet (`HomeSheetView`) with three preview sections —
+Nearby Stops, Recent Stops, Bookmarks, in that fixed order. Each shows at most
+four items under a header whose trailing chevron pushes the corresponding full
+index route.
+
+The home sheet is the entry point to those full indexes, so it must stay cheap:
+the design budgets **zero** new network requests for Nearby and Recent, and **at
+most four** for Bookmarks, with no polling timer.
+
+**Out of scope:** the three index screens themselves (`.nearbyAll`,
+`.recentStopsAll`, `.bookmarksAll`). Their routes are wired and will render the
+existing "coming soon" placeholder.
+
+## Goals
+
+- Three sections, four items each, fixed order, each with a working header arrow.
+- Reuse the data-loading paths the UIKit experience already uses rather than
+  inventing parallel ones.
+- Extract genuinely shared utilities so the old and new experiences share one
+  implementation.
+- Keep the screen light: no redundant fetches, no background refresh cycle.
+
+## Non-Goals
+
+- Building any index screen.
+- Changing Bookmarks-tab or Map-panel behaviour. Every extraction below is
+  additive and defaults to today's behaviour for existing callers.
+- Pull-to-refresh, reordering, or context menus on the home sheet.
+
+## Current State
+
+| Piece | Today |
+|---|---|
+| `HomeSheetView` | Stub: search bar only, inside a `ScrollView` |
+| `HomeSheetViewModel` | `searchPlaceholder` + a `nearbyStops` TODO |
+| `.nearbyAll` / `.recentStopsAll` / `.bookmarksAll` | Declared in `AppSheetRoute`, stacking, `.large`; mapped to `unimplementedView(for:)` which fires `assertionFailure` in DEBUG |
+| Nearby stops (SwiftUI) | `MapStopsObserver`, `@StateObject` on `MapPanelRootView`, fed by `MapRegionManager` |
+| Nearby stops (UIKit) | `MapPanelViewModel.updateNearbyStops` → `NearbyStopsListViewController` |
+| Recent stops | `RecentStopsViewModel.loadData()` — region filter over `UserDataStore.recentStops` |
+| Bookmarks | `BookmarksViewModel` + `BookmarkDataLoader` — one arrivals request per bookmarked stop on a 30s repeating timer |
+
+## Chosen Approach
+
+`HomeSheetViewModel` composes three purpose-built section models, each wired to
+the data source the old experience already uses. Sections stay independently
+testable; the home view model only composes and caps at four.
+
+Two approaches were rejected:
+
+- **Reuse the full screen view models** (`MapPanelViewModel`,
+  `RecentStopsViewModel`, `BookmarksViewModel`). Zero new model code, but
+  `BookmarksViewModel` brings group/distance sorting, collapse persistence, Live
+  Activity plumbing, and an unconditional 30-second timer, and its `start()`
+  fetches *every* bookmark. Fails the call budget.
+- **One flat view model** conforming to `MapRegionDelegate`,
+  `BookmarkDataDelegate`, and `RegionsServiceDelegate` at once. Fewest files, but
+  three refresh triggers interleave in one object and no section can be tested in
+  isolation.
+
+## Shared Utilities
+
+Each is additive and defaulted so existing callers are untouched.
+
+### 1. `BookmarkDataLoader` scoping seam — `OBAKitCore/Bookmarks/`
+
+Today `eligibleBookmarks()` is private and always reads every region bookmark,
+and both `loadData()` and `loadDataAndWait()` unconditionally call
+`startRefreshTimer()`. Two defaulted parameters open it up:
+
+```swift
+public init(
+    application: CoreApplication,
+    delegate: BookmarkDataDelegate,
+    bookmarkProvider: (() -> [Bookmark])? = nil,   // nil → today's eligibleBookmarks()
+    autoRefreshes: Bool = true                      // false → skip startRefreshTimer()
+)
+```
+
+`eligibleBookmarks()` consults `bookmarkProvider` when non-nil. The Bookmarks tab
+passes neither and behaves exactly as it does today. The home section passes a
+provider returning its four bookmarks and `autoRefreshes: false`.
+
+Batch identity, staleness gating, `fetchedStopIDs`, and continuation handling are
+untouched — the home section inherits all of it.
+
+### 2. Nearest-N stop selection — `OBAKitCore`
+
+`MapStopsObserver.squaredDistance(_:to:)` already implements
+cosine-scaled-longitude ordering, currently only for cap eviction. Promote it to a
+shared helper:
+
+```swift
+extension Stop {
+    static func nearest(_ stops: [Stop], to center: CLLocationCoordinate2D, limit: Int) -> [Stop]
+}
+```
+
+`MapStopsObserver`'s prune path is refactored onto it so one distance formula
+serves both. Its existing cap-eviction tests assert against that exact ordering
+and must keep passing.
+
+### 3. Region-filtered recent stops — `OBAKitCore/Models/UserData/UserDataStore`
+
+The region filter plus nil-region handling currently lives inline in
+`RecentStopsViewModel.loadData()`:
+
+```swift
+public func recentStops(in region: Region?) -> [Stop]
+```
+
+Returns `[]` for a nil region. `RecentStopsViewModel` is refactored onto it,
+keeping its existing log-once-per-view-model nil-region warning at the call site
+(the warning is view-model lifecycle state, not store state, so it does not move).
+
+### 4. Section title strings — `OBAKitCore/Strings/Strings.swift`
+
+`Strings.recentStops` already exists. Two titles are currently inline `OBALoc`
+calls and move next to it, keeping their existing keys so no translation is lost:
+
+- `Strings.nearbyStops` — key `nearby_stops_controller.title`, currently inline in
+  `NearbyStopsListViewController`
+- `Strings.bookmarks` — key `search_controller.bookmarks.header`, currently inline
+  in `SearchInteractor`
+
+Both original call sites are updated to use the constants.
+
+### 5. Shared stop-row builder — `OBAKit/Search/SearchList/`
+
+`SearchResultRow.row(for:application:onSelect:)` already builds a `SearchListRow`
+for a `Stop` — icon, name, and a "distance • direction" subtitle via its private
+`stopSubtitle(_:_:)`. The Nearby and Recent sections want exactly that row. Promote
+the stop branch to a named factory so three call sites share one definition:
+
+```swift
+extension SearchListRow {
+    static func stop(
+        _ stop: Stop,
+        application: Application,
+        kind: Kind,
+        onSelect: @escaping () -> Void
+    ) -> SearchListRow
+}
+```
+
+`SearchResultRow`'s `case let stop as Stop` branch delegates to it, passing
+`.searchResult(id:)`. `stopSubtitle` moves onto the factory.
+
+One new case is added to `SearchListRow.Kind`:
+
+```swift
+/// Carries the stop's id for the same reason `recentStop` does: two stops on
+/// opposite sides of a corner share a name.
+case nearbyStop(id: String)
+```
+
+with the matching `stableIdentifier` arm (`"nearbyStop-\(id)"`) and an
+`actionRow` arm in `SearchListRowView`. Recent rows reuse the existing
+`.recentStop(id:)` kind. Both render through `SearchListRowView` unchanged.
+
+### Reused without change
+
+`SearchListRowView` renders Nearby and Recent rows as-is. `BookmarkRowViewModel`,
+`BookmarkCardView`, and `StopBookmarkRow` are already value-driven and read
+formatters from the environment; the home sheet's bookmark rows use them directly
+and render identically to the Bookmarks tab.
+
+## Components
+
+### `HomeSheetViewModel` (rewritten)
+
+`@MainActor`, `ObservableObject`. Keeps `searchPlaceholder` and its
+`RegionsServiceDelegate` conformance. Gains three child section models and
+composes their output. Exposes `activate()`.
+
+`activate()` is **idempotent**. Per the `MapSearchDisplayModel.owner` comment, the
+sheet system tears sheet content down and rebuilds it without the user navigating
+anywhere, so `.task` / `onAppear` can fire repeatedly per visit. It re-fetches
+bookmark arrivals only when one of these holds:
+
+- more than 30 seconds since the last completed fetch,
+- the current region changed,
+- the four-bookmark selection changed.
+
+Otherwise it returns without touching the network.
+
+### `HomeNearbyStopsSectionModel`
+
+Reads `MapStopsObserver.stops` and republishes
+`Stop.nearest(stops, to: viewportCenter, limit: 4)`. Holds the observer as a
+dependency; adds **no** `MapRegionDelegate` conformance of its own — the observer
+is already the single subscriber and adding a second would double the work on
+every settle.
+
+`MapStopsObserver.viewport` is private today. It gains a read-only
+`viewportCenter: CLLocationCoordinate2D?` accessor, published so a settle in a new
+region re-sorts the section. When it is `nil` (no settle yet), the section renders
+the observer's first four stops in its existing id order rather than showing
+nothing — a brief, stable ordering that the first settle corrects.
+
+Empty when the map is zoomed out past `MapRegionManager.requiredHeightToShowStops`
+(the observer is `reset()` there), which is correct: there is nothing nearby to
+preview.
+
+### `HomeRecentStopsSectionModel`
+
+`userDataStore.recentStops(in: application.currentRegion)`, first four. Recents are
+already stored MRU-first, so no sort. Refreshes on `activate()` and on region
+change. No network.
+
+### `HomeBookmarksSectionModel`
+
+Selection: `userDataStore.findBookmarks(in: currentRegion)`, **sorted by
+`sortOrder`**, first four.
+
+> `findBookmarks(in:)` returns raw persisted order — only `bookmarksInGroup`
+> sorts. Without an explicit sort the four shown would not match the user's
+> Manage Bookmarks ordering.
+
+Owns a `BookmarkDataLoader` built with the scoped provider and
+`autoRefreshes: false`. Conforms to `BookmarkDataDelegate`; on
+`dataLoaderDidUpdate` it rebuilds `[BookmarkRowViewModel]` via
+`loader.dataForKey(_:)` and `loader.hasFetchedData(forStopID:)`, exactly as
+`BookmarksViewModel.rebuildSections()` does.
+
+`highlightedTripIDs` is always empty here — the flash-on-change affordance belongs
+to the polling tab, and there is no polling on this screen.
+
+### `HomeSectionHeader` (new view)
+
+Title + trailing chevron button. Takes a title and an action. Used by all three
+sections. The whole header is one button; the title carries the accessibility
+label and the chevron is decorative.
+
+### `HomeSheetView` (extended)
+
+```
+ScrollView
+├── searchBarRow                          ← unchanged
+├── HomeSectionHeader + nearby rows
+├── HomeSectionHeader + recent rows
+└── HomeSectionHeader + bookmark rows     ← BookmarkCardView / StopBookmarkRow
+```
+
+Nearby and Recent rows are `SearchListRowView`s built by
+`SearchListRow.stop(_:application:kind:onSelect:)`; Bookmarks use
+`BookmarkCardView` / `StopBookmarkRow`.
+
+## Data Flow and Call Budget
+
+| Section | Source | New requests |
+|---|---|---|
+| Nearby | `MapStopsObserver` ← `MapRegionManager` | **0** — piggybacks on stop requests the map already makes |
+| Recent | `UserDataStore` (UserDefaults) | **0** |
+| Bookmarks | scoped `BookmarkDataLoader` | **≤4**, on `activate()` only; fewer when some of the four are stop-only bookmarks, which the loader already skips |
+
+No repeating timer is installed by this screen.
+
+## Ownership Change
+
+`MapStopsObserver` is currently constructed as a `@StateObject` inside
+`MapPanelRootView.init`, but `AppSheetViewFactory` is constructed earlier, in
+`MapPanelRootController.init`, and cannot see it.
+
+The observer moves up to `MapPanelRootController.init` and is passed to both the
+factory and `MapPanelRootView` (as `@ObservedObject`). This mirrors exactly how
+`MapSearchDisplayModel` is already threaded, and the reasoning in
+`AppSheetViewFactory`'s init comment — the factory and the hosting view must share
+one instance — applies unchanged.
+
+## Navigation
+
+- **Row tap** → `coordinator.push(.stopDetails(stopID:))`. Bookmark rows push
+  their `bookmark.stopID`.
+- **Header chevron** → `.nearbyAll`, `.recentStopsAll`, `.bookmarksAll`.
+
+Those three routes are exempted from the DEBUG `assertionFailure` in
+`AppSheetViewFactory.unimplementedView(for:)` and render the release-style
+"coming soon" placeholder in all configurations. The assert stays armed for every
+other unwired route. Registering a real view later is a one-line factory change
+per route, and removing the exemption is the natural cleanup step at that point.
+
+## Empty States
+
+A section with no items is omitted entirely, header included.
+
+When all three are empty, one `EmptyStateView` is shown using the existing
+`nearby_controller.empty_set.title` / `.body` strings. The "Search Wider Area"
+button from `NearbyStopsListViewController` is **not** carried over — it drives
+`MapRegionManager.preferredLoadDataRegionFudgeFactor` and a timed reset that the
+SwiftUI path has no equivalent plumbing for. Adding it is separate work.
+
+## Decisions
+
+- **Nearby means the map viewport**, not the user's location: nearest four to the
+  map's center. Matches the UIKit panel and what is visibly pinned behind the
+  sheet, and works without location permission.
+- **Bookmarks are picked by `sortOrder`**, not by favorite status or distance.
+  Favorites are not hoisted — that rule was not requested, and `isFavorite` remains
+  available if it is wanted later.
+- **Section order is fixed** — Nearby, Recent, Bookmarks — with no promotion or
+  reflow when an earlier section is empty.
+- **Bookmark rows show live arrivals** for the four displayed only, fetched once
+  per activation with no polling.
+
+## Testing
+
+Swift Testing, `@Suite(.serialized)`, per `OBAKitTests` convention.
+
+**`HomeSheetViewModelTests`**
+- Each section caps at four items when more are available.
+- An empty section is omitted from the rendered list.
+- Section order stays Nearby → Recent → Bookmarks when an earlier section is empty.
+- `activate()` called twice in quick succession issues one bookmark fetch.
+- `activate()` after a region change re-fetches.
+
+**`HomeSectionModelTests`**
+- Nearby: nearest-four by map center; empty when the observer has been `reset()`.
+- Recent: region-filtered, MRU order preserved, nil region yields empty.
+- Bookmarks: selection sorted by `sortOrder`; stop-only bookmarks produce rows with
+  no arrival data and never report as loading.
+
+**`BookmarkDataLoaderTests` (extended)**
+- `bookmarkProvider` scopes fetches to exactly the supplied bookmarks.
+- `autoRefreshes: false` installs no timer; `loadData()` twice does not double up.
+- Default init is unchanged: all region bookmarks, timer installed.
+
+**`StopNearestTests`**
+- Ordering matches `MapStopsObserver`'s existing cap-eviction expectations.
+- `limit` larger than the input returns everything; empty input returns empty.
+
+**`SearchResultRowTests` (extended)**
+- `SearchListRow.stop(...)` produces the same title, subtitle, and icon the
+  existing `case let stop as Stop` branch produced, for each `kind` passed.
+- Subtitle drops the distance when there is no location fix.
+- `.nearbyStop(id:)` yields a distinct `stableIdentifier` from `.recentStop(id:)`
+  for the same stop, so a stop appearing in both sections does not collide.
+
+**`AppSheetViewFactoryTests` (extended)**
+- The three index routes render the placeholder without asserting.
+- Every other unwired route still asserts.
+
+**`UserDataStoreTests` (extended)**
+- `recentStops(in:)` filters by region and returns `[]` for nil.
+
+**Regression:** existing `MapStopsObserverTests`, `BookmarksViewModel` tests, and
+`RecentStopsViewModel` tests must pass unchanged — every extraction defaults to
+current behaviour.
+
+## Risks
+
+- **Repeated sheet content teardown** re-triggering fetches. Mitigated by the
+  idempotent `activate()`; the staleness rule is the thing to verify on device,
+  not just in tests.
+- **`MapStopsObserver` ownership move** touches the map root's construction path.
+  It is a mechanical change following the `MapSearchDisplayModel` precedent, but it
+  is the one edit in this design that can regress map behaviour, so it warrants its
+  own step and its own verification.
+- **Strict concurrency.** Every target builds in Swift 6 language mode with the
+  five concurrency diagnostic groups escalated to errors; CI fails PRs that add
+  warnings. New view models are `@MainActor`; the `bookmarkProvider` closure must
+  be main-actor-isolated to match `BookmarkDataLoader`.


### PR DESCRIPTION
Populates the home sheet of the map-panel experience (`OBAUseMapPanelExperience`) with three preview sections — Nearby Stops, Recent Stops, Bookmarks, in that fixed order — each showing four items under a header that opens the section's full index. The classic UIKit path is untouched.

The home sheet is the entry point to those indexes, so the governing constraint was that opening it stay cheap: **zero network requests for Nearby and Recent, one per displayed bookmark, and no polling timer.**

> Bookmarks used to be capped at four requests. Pinning (below) makes the section's size user-controlled, so the bound is now per displayed row rather than a fixed four. The Bookmarks tab already fetches every bookmark in the region, so this stays the cheaper of the two surfaces.

## What's included

**Three section models.** `HomeNearbyStopsSectionModel` re-slices stops `MapStopsObserver` has already accumulated from the map's own loads, ordered by the map's viewport centre. `HomeRecentStopsSectionModel` reads `UserDataStore`. `HomeBookmarksSectionModel` drives a scoped `BookmarkDataLoader`. `HomeSheetViewModel` composes the three and publishes `visibleSections`, which is the single place the fixed order and the empty-section omission rule live.

**A scoped bookmark loader.** `BookmarkDataLoader` gains defaulted `bookmarkProvider` and `autoRefreshes` parameters, so the home sheet fetches arrivals for the bookmarks it displays and installs no timer, while the Bookmarks tab passes neither and keeps its 30-second cycle unchanged.

**Bookmark ordering by creation date.** `Bookmark` gains `dateCreated`, and the preview orders newest-first. `sortOrder` couldn't do this job: it's the manual Manage Bookmarks position, and `UserDataStore.add` appends a new bookmark to the end of its group — so ordering by it put the newest one *last*, past the cut, permanently invisible once you had more than four. It's also renumbered per group, so its values were never comparable in a whole-region sort.

**Pinning.** `Bookmark` gains `isPinned`, with a pin/unpin context menu on both the Bookmarks tab and the home sheet's rows. Pinned bookmarks lead the section and are never squeezed out by a newer bookmark — the item limit becomes a floor rather than a cap, so pinning six shows six. Pinning is placement-only: the Bookmarks tab's grouped/manual ordering is unchanged. Deliberately distinct from `isFavorite`, which despite the name is the "Show in Today View" toggle — reusing it would have silently changed what appears in the widget.

**Shared extractions**, each additive and defaulted: `Stop.nearest(_:to:limit:)` (which `MapStopsObserver`'s cap-eviction now folds onto), `UserDataStore.recentStops(in:)` (adopted by `RecentStopsViewModel`), `Strings.nearbyStops` / `.bookmarks` (adopted by `NearbyStopsListViewController` and `SearchInteractor`), and the loader seams above. `BookmarkRowViewModel`, `BookmarkCardView`, and `StopBookmarkRow` are reused as-is, so bookmark rows render identically to the Bookmarks tab.

**Observer ownership moved up.** `MapStopsObserver` is now built in `MapPanelRootController` and passed to both the sheet factory and `MapPanelRootView`, mirroring how `MapSearchDisplayModel` is already threaded. The factory is constructed first, so leaving the observer as a `@StateObject` on the view would have given the sheet a different instance from the one the map renders — the sheet listing stops the map isn't showing.

**Index routes render placeholders.** `.nearbyAll`, `.recentStopsAll`, and `.bookmarksAll` are wired but the screens are not built; they were exempted from `unimplementedView`'s DEBUG `assertionFailure` so a section header doesn't trap a debug build. Registering a real view later is a one-line factory change each.

## Notable decisions

**Section models republish through the view model.** `HomeSheetViewModel` holds the three section models as nested `ObservableObject`s, and SwiftUI subscribes only to the object a view is handed — never to children reached through it. Without forwarding, a section's own `@Published` write updated the model while the sheet kept rendering stale rows; `visibleSections` couldn't stand in for it, because it's guarded against no-op writes, so viewing a stop while Recent Stops was already on screen published nothing at all. This was reproducible in the app: view a stop from Nearby, dismiss, and it was missing from Recent until the sheet was closed and reopened.

**Sections refresh on data change, not just on activation.** Refreshing only from `.task` looked sufficient and wasn't: `.task` fires once per view identity, and tapping a stop row pushes `.stopDetails` as a *stacked* sheet, so the home sheet underneath is never torn down. Bookmarks observe `.bookmarksDidChange` — scoped to the app's own `UserDataStore`, which is the only poster — and the sheet re-activates when the stacked layer empties. Both paths run through the same staleness/region/selection gate.

**The `.bookmarksDidChange` handler goes straight to `loadIfNeeded()`.** It used to call `refreshSelection()` first, which advanced the selection *before* `loadIfNeeded()` snapshotted it — so a newly created bookmark never registered as a selection change, and its arrivals were never fetched inside the 30-second staleness window. The row appeared blank until something else re-activated the sheet.

**The stacked-layer transition is derived from `onChange`'s previous value, not stored `@State`.** A tracked flag re-seeds when the sheet system rebuilds a sheet's content view without the user leaving — the same rebuild behaviour documented in `SearchSheetViewModel` — which would silently skip the next refresh.

**`viewportCenter` is only written when the centre moves.** `CLLocationCoordinate2D` isn't `Equatable`, so `@Published` can't drop a same-value write; without an explicit guard every map settle fired `objectWillChange` and invalidated `MapPanelRootView`, breaking the no-republish invariant the rest of `MapStopsObserver` is built around.

**The section-title strings live in `OBAKit`, not `OBAKitCore`.** Putting them beside `Strings.recentStops` in Core looked right, but Core's `OBALoc` resolves against the Core bundle and neither key exists there; the titles would have fallen back to English in all 12 localised languages while `LocalizationTests` still passed, because a fallback resolves to a non-empty string.

**Nearby follows the map viewport, not the user's location.** It orders by the map's centre, matching the UIKit panel and what's visibly pinned behind the sheet, and it works with no location permission.

## Persistence

`dateCreated` and `isPinned` are both new keys on a persisted Core model shared with the widget. Both decode with `decodeIfPresent` fallbacks — `.distantPast` and `false` — so bookmarks written by earlier builds still load. `dateCreated` falls back to `.distantPast` rather than "now" on purpose: "now" would make every stored bookmark look freshly created on the first launch after upgrading and scramble the ordering. It's excluded from `isEqual`/`hash`, since `Date` loses sub-second precision through the store's encoder and a round-tripped bookmark would otherwise compare unequal to the one written.

## Verification

- 47 new tests across the branch, covering per-section capping, ordering, nil-region handling, staleness/region/selection gating, the `.bookmarksDidChange` refresh, fixed section order, empty-section omission, `activate()` idempotence, creation-date ordering, pin placement and the uncapped pin case, store persistence of a pin (including that it leaves `sortOrder` and group membership alone), and legacy decodes for both new fields.
- Two of those are regression tests verified against the bugs they guard: re-introducing the `refreshSelection()` call fails the bookmark-arrivals test, and removing the `viewportCenter` guard fails the republish test.
- `BookmarksViewModelTests`, `SearchResultsSheetViewTests`, and `SearchInteractorTests` pass unchanged, which is the evidence the extractions preserved the UIKit paths.
- SwiftLint clean — the four remaining violations are all in files this branch doesn't touch.
- `OBAKitTests` has two failures, `RentalFormatTests.rangeFallbackUsesAbbreviatedUnits` (compares `MKDistanceFormatter`'s abbreviated and spelled-out output, identical under a metric host locale) and `BackgroundAnnotationDeemphasisTests` (passes in isolation; cross-suite pollution). Both reproduce identically on the branch point with every change stashed, so they are pre-existing and unrelated. Note that the run summary prints "Test run … passed" even when suites fail — the exit code is the signal.
- Exercised on the simulator: stop and bookmark pins still render after the observer ownership move, and the sheet opens with its pinned search bar.

## Notes for review

- This branch is stacked on #1280, which is still open, so the diff against `main` includes that PR's work. #1280 needs to land first.
- The strings added for the new keys across the 12 localised languages are machine-assisted and would benefit from a native-speaker pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a redesigned home screen with nearby stops, recent stops, and bookmark previews.
  - Added interactive search with result counts, route and map-item details, nearby stops, and vehicle status handling.
  - Added bookmark pinning and unpinning with visible indicators and accessibility support.
  - Added route-stop views, map-item sharing, website links, and improved map result display.
- **Bug Fixes**
  - Improved loading, retry, cancellation, error messaging, navigation, and localization across search and trip details.
- **Accessibility & Localization**
  - Added translated labels, pluralized result counts, section hints, and empty-state messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->