### PR TITLE
Add Bike Mode: cycling speed for stop ETAs, plus separate walk/bike header chips

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -50,8 +50,8 @@ targets:
           - twitter
           - comgooglemaps
         NSLocationWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
-        NSHealthShareUsageDescription: OneBusAway uses your walking speed from the Health app to give you more accurate arrival time estimates.
-        NSHealthUpdateUsageDescription: OneBusAway uses your walking speed from the Health app to give you more accurate arrival time estimates.
+        NSHealthShareUsageDescription: OneBusAway uses your walking or cycling speed from the Health app to give you more accurate arrival time estimates.
+        NSHealthUpdateUsageDescription: OneBusAway uses your walking or cycling speed from the Health app to give you more accurate arrival time estimates.
         NSLocationTemporaryUsageDescriptionDictionary:
           MapStatusView: See where you are in relation to transit, and help you navigate more easily.
         UILaunchStoryboardName: LaunchScreen

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -93,6 +93,9 @@ public class Application: CoreApplication, PushServiceDelegate {
     @MainActor
     lazy var walkingSpeedManager = WalkingSpeedManager(userDataStore: userDataStore)
 
+    @MainActor
+    lazy var bikeModeManager = BikeModeManager(userDataStore: userDataStore)
+
     @objc lazy var userActivityBuilder = UserActivityBuilder(application: self)
 
     /// Handles all deep-linking into the app.
@@ -402,6 +405,10 @@ public class Application: CoreApplication, PushServiceDelegate {
 
         if userDataStore.walkingSpeedSource == .healthKit {
             Task { await walkingSpeedManager.refreshFromHealthKitIfPossible() }
+        }
+
+        if userDataStore.bikeModeEnabled && userDataStore.bikeSpeedSource == .healthKit {
+            Task { await bikeModeManager.refreshFromHealthKitIfPossible() }
         }
     }
 

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -41,6 +41,7 @@ class SettingsViewController: FormViewController {
             +++ alertsSection
             +++ accessibilitySection
             +++ walkingSpeedSection
+            +++ bikeModeSection
             +++ surveySection
             +++ debugSection
 
@@ -66,6 +67,7 @@ class SettingsViewController: FormViewController {
             alwaysShowSurveysOnStops: application.userDataStore.alwaysShowSurveysOnStops,
             walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
             walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
+            bikeModeEnabledKey: application.userDataStore.bikeModeEnabled,
             defaultAlarmLeadTimeMinutesKey: application.userDataStore.defaultAlarmLeadTimeMinutes
         ])
     }
@@ -123,6 +125,10 @@ class SettingsViewController: FormViewController {
         }
 
         saveWalkingSpeedValues(values)
+
+        if let bikeModeEnabled = values[bikeModeEnabledKey] as? Bool {
+            application.userDataStore.bikeModeEnabled = bikeModeEnabled
+        }
     }
 
     private func saveExperimentalValues(_ values: [String: Any?]) {
@@ -275,6 +281,40 @@ class SettingsViewController: FormViewController {
                                 using: self.application.toastManager
                             )
                         }
+                    }
+                }
+            }
+        }
+
+        return section
+    }()
+
+    // MARK: - Bike Mode
+
+    private let bikeModeEnabledKey = "bikeModeEnabled"
+
+    private lazy var bikeModeSection: Section = {
+        let section = Section(
+            header: OBALoc("settings_controller.bike_mode_section.title", value: "Bike Mode", comment: "Settings > Bike Mode section title"),
+            footer: OBALoc("settings_controller.bike_mode_section.footer", value: "Uses a faster travel speed for walk-time estimates, arrival ETAs, and the Stop page.", comment: "Settings > Bike Mode section footer")
+        )
+
+        section <<< SwitchRow {
+            $0.tag = bikeModeEnabledKey
+            $0.title = OBALoc("settings_controller.bike_mode.title", value: "Bike Mode", comment: "Settings > Bike Mode > on/off toggle")
+            $0.onChange { [weak self] row in
+                guard let self, row.value == true, HKHealthStore.isHealthDataAvailable() else { return }
+                Task {
+                    let granted = await self.application.bikeModeManager.requestHealthKitAuthorizationAndSync()
+                    if !granted {
+                        self.showErrorToast(
+                            OBALoc(
+                                "settings_controller.bike_mode.healthkit_unavailable",
+                                value: "Couldn't sync cycling speed from Health. Using a standard biking speed instead.",
+                                comment: "Settings > Bike Mode > HealthKit denial or no-data toast"
+                            ),
+                            using: self.application.toastManager
+                        )
                     }
                 }
             }

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -95,13 +95,13 @@ struct StopPageHeaderView: View {
                 HStack(spacing: 8) {
                     if let walkTime {
                         Button(action: onWalkingDirections) {
-                            travelChip(walkChipText(walkTime), systemImage: "figure.walk")
+                            travelChip(walkChipText(walkTime), systemImage: "figure.walk", background: ThemeColors.shared.departureOnTime)
                         }
                         .buttonStyle(.plain)
                         .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
                     }
                     if let bikeTime {
-                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle")
+                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle", background: ThemeColors.shared.blue)
                     }
                 }
             }
@@ -154,14 +154,15 @@ struct StopPageHeaderView: View {
             .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
-    /// Shared capsule styling for the walk and bike chips. The icon is a
-    /// placeholder for now; distinct iconography can come later.
-    private func travelChip(_ text: String, systemImage: String) -> some View {
+    /// Shared capsule styling for the walk and bike chips. Each mode gets its own
+    /// background color (walk: on-time green, bike: system blue) so the two
+    /// estimates read as distinct at a glance, not just by their icon.
+    private func travelChip(_ text: String, systemImage: String, background: UIColor) -> some View {
         Label(text, systemImage: systemImage)
             .font(.footnote.weight(.heavy))
             .foregroundStyle(.white)
             .padding(.horizontal, 12).padding(.vertical, 6)
-            .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+            .background(Color(uiColor: background), in: Capsule())
             .contentShape(Capsule())
     }
 

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -14,8 +14,9 @@ import OBAKitCore
 /// dark scrim, with the identity block bottom-left in white — the "last
 /// updated" status line, stop name, the code/direction subtitle with inline
 /// route chips (wrapping onto as many lines as needed, never truncated), and
-/// the walk pill (the single visual source of walk time, §4.5). Tapping the
-/// walk pill opens walking directions in an external maps app.
+/// the travel pills — a walk estimate and a bike estimate, each at the user's
+/// respective speed and always shown regardless of Bike Mode (§4.5). Tapping
+/// the walk pill opens walking directions in an external maps app.
 ///
 /// A plain-value view: it never touches `StopViewModel`. The map snapshot is
 /// produced by a `snapshotLoader` closure supplied by the hosting VC, so the
@@ -24,7 +25,10 @@ import OBAKitCore
 /// `UIScreen.main`.
 struct StopPageHeaderView: View {
     let stop: Stop
+    /// Walk time at the user's walking speed — always shown, independent of Bike Mode.
     let walkTime: WalkTimeInfo?
+    /// Bike time at the user's cycling speed — always shown, independent of Bike Mode.
+    let bikeTime: WalkTimeInfo?
     /// The "Updated: …" line; empty hides it.
     let statusText: String
     let snapshotLoader: (CGSize) async -> UIImage?
@@ -84,17 +88,22 @@ struct StopPageHeaderView: View {
             // button below stays separate so it remains individually
             // focusable and activatable.
             .accessibilityElement(children: .combine)
-            if let walkTime {
-                Button(action: onWalkingDirections) {
-                    Label(walkChipText(walkTime), systemImage: "figure.walk")
-                        .font(.footnote.weight(.heavy))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 12).padding(.vertical, 6)
-                        .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
-                        .contentShape(Capsule())
+            // Two independent estimates: the walk chip (tappable, opens walking
+            // directions) and the bike chip. Both are always shown when
+            // available — Bike Mode only affects the arrival split, not these.
+            if walkTime != nil || bikeTime != nil {
+                HStack(spacing: 8) {
+                    if let walkTime {
+                        Button(action: onWalkingDirections) {
+                            travelChip(walkChipText(walkTime), systemImage: "figure.walk")
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
+                    }
+                    if let bikeTime {
+                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle")
+                    }
                 }
-                .buttonStyle(.plain)
-                .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
             }
         }
         .padding(16)
@@ -145,11 +154,31 @@ struct StopPageHeaderView: View {
             .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
+    /// Shared capsule styling for the walk and bike chips. The icon is a
+    /// placeholder for now; distinct iconography can come later.
+    private func travelChip(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.footnote.weight(.heavy))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12).padding(.vertical, 6)
+            .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+            .contentShape(Capsule())
+    }
+
     private func walkChipText(_ info: WalkTimeInfo) -> String {
         let fmt = OBALoc(
             "stop_page.walk_chip_minutes_fmt",
             value: "%d min walk",
             comment: "Walk chip on the header card. %d is the walk time in minutes."
+        )
+        return String(format: fmt, info.walkMinutes)
+    }
+
+    private func bikeChipText(_ info: WalkTimeInfo) -> String {
+        let fmt = OBALoc(
+            "stop_page.bike_chip_minutes_fmt",
+            value: "%d min bike",
+            comment: "Bike chip on the header card. %d is the bike time in minutes."
         )
         return String(format: fmt, info.walkMinutes)
     }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -153,8 +153,9 @@ struct StopPageView: View {
     }
 
     var body: some View {
-        // Hoist the single computed walk value so the header chip, the
-        // chronological partition, and the divider all read one snapshot of it.
+        // Hoist the mode-aware walk value so the chronological partition and the
+        // divider read one snapshot of it. The header shows its own always-on
+        // walk and bike estimates, independent of Bike Mode.
         let walkTime = viewModel.walkTime
         let departures = filteredDepartures
         let departureIDs = Set(departures.map(\.id))
@@ -170,7 +171,7 @@ struct StopPageView: View {
         List {
             if let stop = viewModel.stop {
                 Section {
-                    StopPageHeaderView(stop: stop, walkTime: walkTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader, onWalkingDirections: navigation.showWalkingDirections)
+                    StopPageHeaderView(stop: stop, walkTime: viewModel.headerWalkTime, bikeTime: viewModel.headerBikeTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader, onWalkingDirections: navigation.showWalkingDirections)
                         .listRowInsets(EdgeInsets(top: 0, leading: Self.horizontalRowInset, bottom: 0, trailing: Self.horizontalRowInset))
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -964,7 +964,7 @@ public class StopViewController: UIViewController,
         guard items.count > 0,
               let currentLocation = application.locationService.currentLocation,
               let stopLocation = stop?.location,
-              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.walkingSpeedMetersPerSecond)
+              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.effectiveTravelVelocityMetersPerSecond)
         else { return }
 
         if let insertionIndex = findInsertionIndexForWalkTime(walkingTime, items: items) {

--- a/OBAKit/TripPlanning/BikeModeManager.swift
+++ b/OBAKit/TripPlanning/BikeModeManager.swift
@@ -1,0 +1,82 @@
+//
+//  BikeModeManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Resolves the user's cycling speed from HealthKit (if authorized) or falls back to
+/// `BikeSpeed.defaultMetersPerSecond`. Does not own whether Bike Mode itself is enabled —
+/// that's `UserDataStore.bikeModeEnabled`, set directly by the Settings UI. This manager only
+/// owns `bikeSpeedMetersPerSecond` / `bikeSpeedSource`.
+@MainActor
+final class BikeModeManager {
+    private let healthKit: BikeSpeedHealthKitProviding
+    private let userDataStore: UserDataStore
+
+    init(userDataStore: UserDataStore, healthKit: BikeSpeedHealthKitProviding = HKHealthStoreBikeSpeedProvider()) {
+        self.userDataStore = userDataStore
+        self.healthKit = healthKit
+    }
+
+    /// Requests HealthKit authorization and attempts to sync the latest cycling speed.
+    ///
+    /// Apple's HealthKit privacy model does not surface read-permission denials: the
+    /// authorization request succeeds even when the user taps "Don't Allow", and a
+    /// subsequent query just returns no samples. To avoid leaving the source stuck on
+    /// HealthKit for a denying user, success here is defined as "actually retrieved a usable
+    /// sample". A user who genuinely granted access but has no recent cycling-speed samples
+    /// (e.g. no Apple Watch) is also routed to `.manual` — that's intentional.
+    @discardableResult
+    func requestHealthKitAuthorizationAndSync() async -> Bool {
+        guard healthKit.isAvailable else {
+            userDataStore.bikeSpeedSource = .manual
+            return false
+        }
+
+        do {
+            try await healthKit.requestAuthorization()
+        } catch {
+            Logger.error("BikeModeManager: HealthKit requestAuthorization failed: \(error)")
+            userDataStore.bikeSpeedSource = .manual
+            return false
+        }
+
+        let didSync = await syncLatestBikeSpeed()
+        if !didSync {
+            userDataStore.bikeSpeedSource = .manual
+        }
+        return didSync
+    }
+
+    /// Passive refresh used at launch when the user already opted into HealthKit previously.
+    /// Updates `bikeSpeedMetersPerSecond` if a fresh sample is available, but never flips
+    /// `bikeSpeedSource` to `.manual` — an idle user keeps their previously-synced value and
+    /// their stated intent. Only the active sync path in Settings can downgrade the source.
+    func refreshFromHealthKitIfPossible() async {
+        guard healthKit.isAvailable else { return }
+        await syncLatestBikeSpeed()
+    }
+
+    /// Fetches the latest cycling-speed sample and writes it to the store if it's in `BikeSpeed.validRange`.
+    /// Returns `true` on a successful write; otherwise leaves the stored speed and source untouched
+    /// and returns `false`. Callers decide how to react to a `false` result.
+    @discardableResult
+    private func syncLatestBikeSpeed() async -> Bool {
+        guard let mps = await healthKit.fetchLatestBikeSpeed(),
+              BikeSpeed.validRange.contains(mps)
+        else {
+            return false
+        }
+
+        userDataStore.bikeSpeedMetersPerSecond = mps
+        userDataStore.bikeSpeedSource = .healthKit
+        return true
+    }
+}

--- a/OBAKit/TripPlanning/BikeSpeedHealthKitProviding.swift
+++ b/OBAKit/TripPlanning/BikeSpeedHealthKitProviding.swift
@@ -1,0 +1,74 @@
+//
+//  BikeSpeedHealthKitProviding.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Narrow seam around the two HealthKit operations `BikeModeManager` needs.
+/// Exists so the manager's denial/sync state machine can be tested without a live `HKHealthStore`.
+protocol BikeSpeedHealthKitProviding {
+    /// `true` when HealthKit is usable on this device and the cycling-speed quantity type is available.
+    var isAvailable: Bool { get }
+
+    /// Requests read authorization for cycling-speed samples.
+    /// May complete successfully even when the user denies — denial is detected by the absence of samples.
+    func requestAuthorization() async throws
+
+    /// Returns the most recent cycling-speed sample (m/s) from the last 30 days, or `nil` if none exists or the query fails.
+    /// Does not apply range validation; the caller decides what counts as a usable sample.
+    func fetchLatestBikeSpeed() async -> Double?
+}
+
+struct HKHealthStoreBikeSpeedProvider: BikeSpeedHealthKitProviding {
+    private let healthStore = HKHealthStore()
+
+    private static var cyclingSpeedType: HKQuantityType? {
+        HKQuantityType.quantityType(forIdentifier: .cyclingSpeed)
+    }
+
+    var isAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable() && Self.cyclingSpeedType != nil
+    }
+
+    func requestAuthorization() async throws {
+        guard let type = Self.cyclingSpeedType else { return }
+        try await healthStore.requestAuthorization(toShare: [], read: [type])
+    }
+
+    func fetchLatestBikeSpeed() async -> Double? {
+        guard let type = Self.cyclingSpeedType else { return nil }
+
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? .distantPast
+        let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    Logger.error("BikeModeManager: HealthKit sample query failed: \(error)")
+                    continuation.resume(returning: nil)
+                    return
+                }
+                guard let sample = samples?.first as? HKQuantitySample else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let mps = sample.quantity.doubleValue(for: HKUnit.meter().unitDivided(by: .second()))
+                continuation.resume(returning: mps)
+            }
+            healthStore.execute(query)
+        }
+    }
+}

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -556,14 +556,33 @@ class StopViewModel: ObservableObject {
 
     // MARK: - Stop Page: Walk Time
 
-    /// Walk time from the user's current location to this stop; the single
-    /// source for the header chip and the chronological walk line (§4.5).
-    var walkTime: WalkTimeInfo? {
+    /// Travel time to this stop at an arbitrary speed. Shared by the header's
+    /// walk/bike chips and the mode-aware chronological split.
+    private func travelTime(atSpeed speed: Double) -> WalkTimeInfo? {
         WalkTimeInfo.compute(
             from: application.locationService.currentLocation,
             to: stop?.location,
-            speedMetersPerSecond: application.userDataStore.effectiveTravelVelocityMetersPerSecond
+            speedMetersPerSecond: speed
         )
+    }
+
+    /// Travel time using the mode the user has selected — Bike Mode swaps in the
+    /// cycling speed. Drives the chronological reachable/missed split and the
+    /// walk-line divider (§4.5).
+    var walkTime: WalkTimeInfo? {
+        travelTime(atSpeed: application.userDataStore.effectiveTravelVelocityMetersPerSecond)
+    }
+
+    /// Walk time at the user's walking speed — always shown on the header's walk
+    /// chip, independent of whether Bike Mode is enabled.
+    var headerWalkTime: WalkTimeInfo? {
+        travelTime(atSpeed: application.userDataStore.walkingSpeedMetersPerSecond)
+    }
+
+    /// Bike time at the user's cycling speed — always shown on the header's bike
+    /// chip, independent of whether Bike Mode is enabled.
+    var headerBikeTime: WalkTimeInfo? {
+        travelTime(atSpeed: application.userDataStore.bikeSpeedMetersPerSecond)
     }
 
     // MARK: - Stop Page: Alarms

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -562,7 +562,7 @@ class StopViewModel: ObservableObject {
         WalkTimeInfo.compute(
             from: application.locationService.currentLocation,
             to: stop?.location,
-            speedMetersPerSecond: application.userDataStore.walkingSpeedMetersPerSecond
+            speedMetersPerSecond: application.userDataStore.effectiveTravelVelocityMetersPerSecond
         )
     }
 

--- a/OBAKitCore/Models/UserData/BikeSpeed.swift
+++ b/OBAKitCore/Models/UserData/BikeSpeed.swift
@@ -1,0 +1,26 @@
+//
+//  BikeSpeed.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+// Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
+@objc public enum BikeSpeedSource: Int {
+    case manual = 0    // fixed fallback constant in effect
+    case healthKit = 1 // synced from HealthKit
+}
+
+/// Shared constants for bike mode speed handling.
+public enum BikeSpeed {
+    /// Fallback cycling speed when HealthKit is unavailable, denied, or has no samples (≈15 km/h).
+    public static let defaultMetersPerSecond: Double = 4.2
+
+    /// Acceptable range for a stored bike speed, in meters per second (≈3.6–72 km/h).
+    /// Values outside this range are treated as invalid (divide-hostile or implausible).
+    public static let validRange: ClosedRange<Double> = 1.0...20.0
+}

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -299,12 +299,35 @@ public protocol UserDataStore: NSObjectProtocol {
     /// The source of the walking speed value (manual preset or HealthKit).
     var walkingSpeedSource: WalkingSpeedSource { get set }
 
+    // MARK: - Bike Mode
+
+    /// Whether Bike Mode is enabled. When `true`, walk-time-to-stop calculations
+    /// app-wide should use `bikeSpeedMetersPerSecond` instead of `walkingSpeedMetersPerSecond`.
+    var bikeModeEnabled: Bool { get set }
+
+    /// The user's effective cycling speed in meters per second (HealthKit-synced value,
+    /// or `BikeSpeed.defaultMetersPerSecond` when no sync has ever succeeded).
+    var bikeSpeedMetersPerSecond: Double { get set }
+
+    /// The source of the bike speed value (fixed fallback constant or HealthKit).
+    var bikeSpeedSource: BikeSpeedSource { get set }
+
     // MARK: - Alarm Lead Time
 
     /// The user's preferred alarm lead time in minutes for one-tap alarms on
     /// the Stop page. Adjustable per-alarm afterward. Defaults to 5.
     var defaultAlarmLeadTimeMinutes: Int { get set }
 
+}
+
+public extension UserDataStore {
+    /// The velocity (m/s) that all walk-time-to-stop calculations should use.
+    /// Bike Mode, when enabled, takes priority over the walking speed. This is the
+    /// single place call sites should read from instead of branching on
+    /// `bikeModeEnabled` themselves.
+    var effectiveTravelVelocityMetersPerSecond: Double {
+        bikeModeEnabled ? bikeSpeedMetersPerSecond : walkingSpeedMetersPerSecond
+    }
 }
 
 // MARK: - Survey Tracking Data Models
@@ -399,6 +422,9 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let alwaysShowSurveysOnStops = "UserDataStore.alwaysShowSurveysOnStops"
         static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
+        static let bikeModeEnabled = "UserDataStore.bikeModeEnabled"
+        static let bikeSpeedMetersPerSecond = "UserDataStore.bikeSpeedMetersPerSecond"
+        static let bikeSpeedSource = "UserDataStore.bikeSpeedSource"
         static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
     }
 
@@ -409,6 +435,9 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             UserDefaultsKeys.debugMode: false,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
             UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue,
+            UserDefaultsKeys.bikeModeEnabled: false,
+            UserDefaultsKeys.bikeSpeedMetersPerSecond: BikeSpeed.defaultMetersPerSecond,
+            UserDefaultsKeys.bikeSpeedSource: BikeSpeedSource.manual.rawValue,
             UserDefaultsKeys.defaultAlarmLeadTimeMinutes: UserDataStoreDefaults.alarmLeadTimeMinutes
         ])
     }
@@ -1088,6 +1117,33 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.walkingSpeedSource)
+        }
+    }
+
+    // MARK: - Bike Mode
+
+    public var bikeModeEnabled: Bool {
+        get { userDefaults.bool(forKey: UserDefaultsKeys.bikeModeEnabled) }
+        set { userDefaults.set(newValue, forKey: UserDefaultsKeys.bikeModeEnabled) }
+    }
+
+    public var bikeSpeedMetersPerSecond: Double {
+        get {
+            let stored = userDefaults.double(forKey: UserDefaultsKeys.bikeSpeedMetersPerSecond)
+            return min(max(stored, BikeSpeed.validRange.lowerBound), BikeSpeed.validRange.upperBound)
+        }
+        set {
+            let clamped = min(max(newValue, BikeSpeed.validRange.lowerBound), BikeSpeed.validRange.upperBound)
+            userDefaults.set(clamped, forKey: UserDefaultsKeys.bikeSpeedMetersPerSecond)
+        }
+    }
+
+    public var bikeSpeedSource: BikeSpeedSource {
+        get {
+            BikeSpeedSource(rawValue: userDefaults.integer(forKey: UserDefaultsKeys.bikeSpeedSource)) ?? .manual
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.bikeSpeedSource)
         }
     }
 

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -307,6 +307,70 @@ class UserDefaultsStoreTests: OBATestCase {
         expect(self.userDefaultsStore.walkingSpeedMetersPerSecond).to(beCloseTo(WalkingSpeed.validRange.upperBound))
     }
 
+    // MARK: - Bike Mode
+
+    func test_bikeModeEnabled_defaultValue() {
+        expect(self.userDefaultsStore.bikeModeEnabled) == false
+    }
+
+    func test_bikeModeEnabled_roundTrip() {
+        userDefaultsStore.bikeModeEnabled = true
+        expect(self.userDefaultsStore.bikeModeEnabled) == true
+
+        userDefaultsStore.bikeModeEnabled = false
+        expect(self.userDefaultsStore.bikeModeEnabled) == false
+    }
+
+    func test_bikeSpeed_defaultValue() {
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+
+    func test_bikeSpeed_roundTrip() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+
+        let newStore = UserDefaultsStore(userDefaults: userDefaults)
+        expect(newStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+    }
+
+    func test_bikeSpeedSource_defaultValue() {
+        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+    }
+
+    func test_bikeSpeedSource_roundTrip() {
+        userDefaultsStore.bikeSpeedSource = .healthKit
+        expect(self.userDefaultsStore.bikeSpeedSource) == .healthKit
+
+        userDefaultsStore.bikeSpeedSource = .manual
+        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+    }
+
+    func test_bikeSpeedMetersPerSecond_clampsBelowRange() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 0.1
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.lowerBound))
+    }
+
+    func test_bikeSpeedMetersPerSecond_clampsAboveRange() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 30.0
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.upperBound))
+    }
+
+    func test_effectiveTravelVelocity_whenBikeModeDisabled_returnsWalkingSpeed() {
+        userDefaultsStore.bikeModeEnabled = false
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+
+        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(1.6))
+    }
+
+    func test_effectiveTravelVelocity_whenBikeModeEnabled_returnsBikeSpeed() {
+        userDefaultsStore.bikeModeEnabled = true
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+
+        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(5.0))
+    }
+
     // MARK: - Default Alarm Lead Time
 
     func test_defaultAlarmLeadTime_defaultValueAndRoundTrip() {

--- a/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
@@ -1,0 +1,168 @@
+//
+//  BikeModeManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+@MainActor
+final class BikeModeManagerTests: OBATestCase {
+
+    private struct FakeProvider: BikeSpeedHealthKitProviding {
+        var isAvailable: Bool = true
+        var authorizationError: Error?
+        var sampleSpeed: Double?
+
+        func requestAuthorization() async throws {
+            if let authorizationError {
+                throw authorizationError
+            }
+        }
+
+        func fetchLatestBikeSpeed() async -> Double? {
+            sampleSpeed
+        }
+    }
+
+    private struct DummyError: Error {}
+
+    private var store: UserDefaultsStore {
+        UserDefaultsStore(userDefaults: userDefaults)
+    }
+
+    // MARK: - requestHealthKitAuthorizationAndSync
+
+    func test_requestAndSync_whenSampleMissing_returnsFalseAndForcesManual() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.5
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+        // Speed left untouched even on failure.
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.5))
+    }
+
+    func test_requestAndSync_whenSampleInRange_writesValueAndMarksHealthKit() async {
+        store.bikeSpeedSource = .manual
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 5.5)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == true
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+    }
+
+    func test_requestAndSync_whenSampleOutOfRange_doesNotWriteAndForcesManual() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        // 30 m/s sits well outside BikeSpeed.validRange (1.0...20.0).
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 30.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+        // Stored speed unchanged — the out-of-range sample must not leak in.
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+
+    func test_requestAndSync_whenAuthorizationThrows_forcesManual() async {
+        store.bikeSpeedSource = .healthKit
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(authorizationError: DummyError(), sampleSpeed: 5.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+    }
+
+    func test_requestAndSync_whenHealthKitUnavailable_forcesManual() async {
+        store.bikeSpeedSource = .healthKit
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(isAvailable: false, sampleSpeed: 5.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+    }
+
+    // MARK: - refreshFromHealthKitIfPossible
+
+    func test_passiveRefresh_withNoSample_leavesSourceAndSpeedUntouched() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 5.5
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        // The asymmetry: passive refresh must never downgrade source to .manual.
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+    }
+
+    func test_passiveRefresh_withInRangeSample_updatesSpeed() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 6.0)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(6.0))
+    }
+
+    func test_passiveRefresh_withOutOfRangeSample_isNoOp() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 0.5)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+}

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -882,4 +882,37 @@ class StopViewModelTests: OBATestCase {
         expect(viewModel.alarm(for: departure)).toNot(beNil())
         expect(app.userDataStore.alarms).toNot(beEmpty())
     }
+
+    // MARK: - Stop Page: Walk/Bike Time
+
+    /// `headerWalkTime` and `headerBikeTime` must stay fixed at their respective speeds
+    /// regardless of Bike Mode, while the mode-aware `walkTime` is the one that switches —
+    /// the contract the header chips and the chronological split each depend on.
+    @MainActor
+    func test_headerWalkAndBikeTime_areIndependentOfBikeModeWhileWalkTimeSwitches() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        app.userDataStore.bikeModeEnabled = false
+        let headerWalkBefore = viewModel.headerWalkTime
+        let headerBikeBefore = viewModel.headerBikeTime
+
+        expect(headerWalkBefore).toNot(beNil())
+        expect(headerBikeBefore).toNot(beNil())
+        // Cycling speed is faster than walking speed, so the bike estimate must be shorter.
+        expect(headerBikeBefore?.walkMinutes).to(beLessThan(headerWalkBefore?.walkMinutes))
+        // Bike Mode off: the mode-aware value tracks the walking speed.
+        expect(viewModel.walkTime) == headerWalkBefore
+
+        app.userDataStore.bikeModeEnabled = true
+
+        // The header chips must not move when Bike Mode toggles...
+        expect(viewModel.headerWalkTime) == headerWalkBefore
+        expect(viewModel.headerBikeTime) == headerBikeBefore
+        // ...but the mode-aware value now tracks the cycling speed instead.
+        expect(viewModel.walkTime) == headerBikeBefore
+    }
 }


### PR DESCRIPTION
## Summary

Adds a standalone **Bike Mode** to speed up walk-time-to-stop estimates for cyclists, without disturbing the existing walking-speed path:

- **Bike Mode toggle** (Settings) swaps the travel velocity used for stop ETAs, arrival estimates, and the reachable/missed departure split from walking speed to cycling speed. Speed syncs from HealthKit cycling data when available (mirroring the existing \`WalkingSpeedManager\` pattern as an independent mechanism), falling back to a fixed ~15 km/h constant otherwise.
- **Stop header** now shows two independent, always-visible chips — a walk estimate and a bike estimate, each computed at its own fixed speed — instead of a single pill that silently followed Bike Mode while still reading "walk". Bike Mode continues to drive only the reachable/missed arrival split, not these header chips.
- **Chip styling**: walk (green) and bike (blue) chips now use distinct background colors so the two estimates read as different at a glance, not just by icon.

### Known limitation

The bike chip isn't tappable — there's no "open cycling directions" action to match the walk chip's \`onWalkingDirections\`. Apple's documented Maps URL scheme only supports \`dirflg=d/w/r\`; there's no officially supported bike value, so wiring that up would mean relying on undocumented behavior. Left as a deliberate follow-up rather than guessing.

## Test plan

- [x] Full unit suite on iPhone 17 Pro simulator: 1254/1254, 0 failures
- [x] \`BikeModeManagerTests\` — HealthKit auth success/failure/exception, sample present/absent/out-of-range, active-vs-passive sync asymmetry (passive refresh never downgrades source to \`.manual\`)
- [x] \`UserDataStoreTests\` — bike speed/mode/source defaults, roundtrip, clamping, \`effectiveTravelVelocityMetersPerSecond\` in both Bike Mode states
- [x] \`StopViewModelTests\` — new coverage asserting \`headerWalkTime\`/\`headerBikeTime\` stay fixed across the Bike Mode toggle while the mode-aware \`walkTime\` (driving the chronological split) switches between them
- [x] Live-data simulator walkthrough (Puget Sound): both chips render with correct minutes and distinct colors on a real stop
- [ ] **Needs a human/device pass** (not exercisable in Simulator): live HealthKit authorization + a real \`cyclingSpeed\` sample round-trip, and the denial toast on a physical device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bike Mode, allowing cycling speed to be used for arrival-time estimates.
  - Added optional HealthKit synchronization for cycling speed, with manual fallback.
  - Settings now includes a Bike Mode toggle and synchronization feedback.
  - Stop pages display separate walking and cycling travel-time estimates.
  - Updated HealthKit messaging to clarify that walking or cycling speed may be used.

- **Bug Fixes**
  - Improved travel-time calculations when Bike Mode is enabled.
  - Preserved walking and cycling estimates independently when switching modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->