### PR TITLE
Add Bike Mode: cycling speed for stop ETAs, plus separate walk/bike header chips

### DIFF
--- a/Apps/KiedyBus/pl.lproj/InfoPlist.strings
+++ b/Apps/KiedyBus/pl.lproj/InfoPlist.strings
@@ -12,6 +12,6 @@
 
 "NSLocationWhenInUseUsageDescription" = "Pokaż swoją lokalizację na mapie";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
-"NSHealthUpdateUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia lub jazdy rowerem z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
+"NSHealthUpdateUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia lub jazdy rowerem z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";

--- a/Apps/OneBusAway/ar.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/ar.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "لمعرفة مكانك بالنسبة إلى وسائل النقل العام ومساعدتك على التنقل بسهولة أكبر.";
 "NSLocationWhenInUseUsageDescription" = "لمعرفة مكانك بالنسبة إلى وسائل النقل العام ومساعدتك على التنقل بسهولة أكبر.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "يستخدم سرعة مشيك من تطبيق «صحتي» لمنحك تقديرات أدق لأوقات الوصول.";
-"NSHealthUpdateUsageDescription" = "يستخدم سرعة مشيك من تطبيق «صحتي» لمنحك تقديرات أدق لأوقات الوصول.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "يستخدم سرعة المشي أو ركوب الدراجة من تطبيق «صحتي» لمنحك تقديرات أدق لأوقات الوصول.";
+"NSHealthUpdateUsageDescription" = "يستخدم سرعة المشي أو ركوب الدراجة من تطبيق «صحتي» لمنحك تقديرات أدق لأوقات الوصول.";

--- a/Apps/OneBusAway/es.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/es.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Vea dónde se encuentra en relación con el transporte público y navegue con mayor facilidad.";
 "NSLocationWhenInUseUsageDescription" = "Vea dónde se encuentra en relación con el transporte público y navegue con mayor facilidad.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Usa su velocidad al caminar de la app Salud para ofrecerle estimaciones más precisas de la hora de llegada.";
-"NSHealthUpdateUsageDescription" = "Usa su velocidad al caminar de la app Salud para ofrecerle estimaciones más precisas de la hora de llegada.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Usa su velocidad al caminar o en bicicleta de la app Salud para ofrecerle estimaciones más precisas de la hora de llegada.";
+"NSHealthUpdateUsageDescription" = "Usa su velocidad al caminar o en bicicleta de la app Salud para ofrecerle estimaciones más precisas de la hora de llegada.";

--- a/Apps/OneBusAway/fil.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/fil.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Makikita kung nasaan ka kaugnay ng transit, at matutulungan kang mag-navigate nang mas madali.";
 "NSLocationWhenInUseUsageDescription" = "Makikita kung nasaan ka kaugnay ng transit, at matutulungan kang mag-navigate nang mas madali.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Ginagamit ang bilis ng paglalakad mo mula sa Health app para bigyan ka ng mas tumpak na tantiya ng oras ng pagdating.";
-"NSHealthUpdateUsageDescription" = "Ginagamit ang bilis ng paglalakad mo mula sa Health app para bigyan ka ng mas tumpak na tantiya ng oras ng pagdating.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Ginagamit ang bilis ng paglalakad o pagbibisikleta mo mula sa Health app para bigyan ka ng mas tumpak na tantiya ng oras ng pagdating.";
+"NSHealthUpdateUsageDescription" = "Ginagamit ang bilis ng paglalakad o pagbibisikleta mo mula sa Health app para bigyan ka ng mas tumpak na tantiya ng oras ng pagdating.";

--- a/Apps/OneBusAway/fr.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/fr.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Voyez où vous vous trouvez par rapport aux transports en commun et déplacez-vous plus facilement.";
 "NSLocationWhenInUseUsageDescription" = "Voyez où vous vous trouvez par rapport aux transports en commun et déplacez-vous plus facilement.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Utilise votre vitesse de marche issue de l'app Santé pour vous donner des estimations d'heure d'arrivée plus précises.";
-"NSHealthUpdateUsageDescription" = "Utilise votre vitesse de marche issue de l'app Santé pour vous donner des estimations d'heure d'arrivée plus précises.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Utilise votre vitesse de marche ou à vélo issue de l'app Santé pour vous donner des estimations d'heure d'arrivée plus précises.";
+"NSHealthUpdateUsageDescription" = "Utilise votre vitesse de marche ou à vélo issue de l'app Santé pour vous donner des estimations d'heure d'arrivée plus précises.";

--- a/Apps/OneBusAway/it.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/it.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Vedi dove ti trovi rispetto ai trasporti pubblici e spostati più facilmente.";
 "NSLocationWhenInUseUsageDescription" = "Vedi dove ti trovi rispetto ai trasporti pubblici e spostati più facilmente.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Usa la tua velocità di camminata dall'app Salute per fornirti stime più precise dell'orario di arrivo.";
-"NSHealthUpdateUsageDescription" = "Usa la tua velocità di camminata dall'app Salute per fornirti stime più precise dell'orario di arrivo.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Usa la tua velocità di camminata o in bici dall'app Salute per fornirti stime più precise dell'orario di arrivo.";
+"NSHealthUpdateUsageDescription" = "Usa la tua velocità di camminata o in bici dall'app Salute per fornirti stime più precise dell'orario di arrivo.";

--- a/Apps/OneBusAway/ko.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/ko.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "대중교통과 관련된 현재 위치를 확인하고 더 쉽게 이동할 수 있도록 도와줍니다.";
 "NSLocationWhenInUseUsageDescription" = "대중교통과 관련된 현재 위치를 확인하고 더 쉽게 이동할 수 있도록 도와줍니다.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "건강 앱의 보행 속도를 사용하여 더 정확한 예상 도착 시각을 알려드립니다.";
-"NSHealthUpdateUsageDescription" = "건강 앱의 보행 속도를 사용하여 더 정확한 예상 도착 시각을 알려드립니다.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "건강 앱의 보행 또는 자전거 속도를 사용하여 더 정확한 예상 도착 시각을 알려드립니다.";
+"NSHealthUpdateUsageDescription" = "건강 앱의 보행 또는 자전거 속도를 사용하여 더 정확한 예상 도착 시각을 알려드립니다.";

--- a/Apps/OneBusAway/pl.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/pl.lproj/InfoPlist.strings
@@ -10,6 +10,6 @@
 
 "NSLocationWhenInUseUsageDescription" = "Pokaż swoją lokalizację na mapie";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
-"NSHealthUpdateUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia lub jazdy rowerem z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";
+"NSHealthUpdateUsageDescription" = "Wykorzystuje Twoją prędkość chodzenia lub jazdy rowerem z aplikacji Zdrowie, aby dokładniej szacować godziny przyjazdu.";

--- a/Apps/OneBusAway/pt-BR.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/pt-BR.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Veja onde você está em relação ao transporte público e navegue com mais facilidade.";
 "NSLocationWhenInUseUsageDescription" = "Veja onde você está em relação ao transporte público e navegue com mais facilidade.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Usa sua velocidade de caminhada do app Saúde para oferecer estimativas de horário de chegada mais precisas.";
-"NSHealthUpdateUsageDescription" = "Usa sua velocidade de caminhada do app Saúde para oferecer estimativas de horário de chegada mais precisas.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Usa sua velocidade de caminhada ou de bicicleta do app Saúde para oferecer estimativas de horário de chegada mais precisas.";
+"NSHealthUpdateUsageDescription" = "Usa sua velocidade de caminhada ou de bicicleta do app Saúde para oferecer estimativas de horário de chegada mais precisas.";

--- a/Apps/OneBusAway/ru.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/ru.lproj/InfoPlist.strings
@@ -2,6 +2,6 @@
 
 "NSLocationWhenInUseUsageDescription" = "Показывает, где вы находитесь относительно общественного транспорта, и помогает вам проще ориентироваться.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Использует вашу скорость ходьбы из приложения «Здоровье», чтобы точнее прогнозировать время прибытия.";
-"NSHealthUpdateUsageDescription" = "Использует вашу скорость ходьбы из приложения «Здоровье», чтобы точнее прогнозировать время прибытия.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Использует вашу скорость ходьбы или езды на велосипеде из приложения «Здоровье», чтобы точнее прогнозировать время прибытия.";
+"NSHealthUpdateUsageDescription" = "Использует вашу скорость ходьбы или езды на велосипеде из приложения «Здоровье», чтобы точнее прогнозировать время прибытия.";

--- a/Apps/OneBusAway/vi.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/vi.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "Xem vị trí của bạn so với mạng lưới giao thông công cộng và giúp bạn di chuyển dễ dàng hơn.";
 "NSLocationWhenInUseUsageDescription" = "Xem vị trí của bạn so với mạng lưới giao thông công cộng và giúp bạn di chuyển dễ dàng hơn.";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "Dùng tốc độ đi bộ của bạn từ ứng dụng Sức khỏe để ước tính giờ đến chính xác hơn.";
-"NSHealthUpdateUsageDescription" = "Dùng tốc độ đi bộ của bạn từ ứng dụng Sức khỏe để ước tính giờ đến chính xác hơn.";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "Dùng tốc độ đi bộ hoặc đạp xe của bạn từ ứng dụng Sức khỏe để ước tính giờ đến chính xác hơn.";
+"NSHealthUpdateUsageDescription" = "Dùng tốc độ đi bộ hoặc đạp xe của bạn từ ứng dụng Sức khỏe để ước tính giờ đến chính xác hơn.";

--- a/Apps/OneBusAway/zh-Hans.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/zh-Hans.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "查看您与公共交通的相对位置，帮助您更轻松地出行。";
 "NSLocationWhenInUseUsageDescription" = "查看您与公共交通的相对位置，帮助您更轻松地出行。";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "使用“健康”App中的步行速度，为您提供更准确的到站时间预估。";
-"NSHealthUpdateUsageDescription" = "使用“健康”App中的步行速度，为您提供更准确的到站时间预估。";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "使用“健康”App中的步行或骑行速度，为您提供更准确的到站时间预估。";
+"NSHealthUpdateUsageDescription" = "使用“健康”App中的步行或骑行速度，为您提供更准确的到站时间预估。";

--- a/Apps/OneBusAway/zh-Hant.lproj/InfoPlist.strings
+++ b/Apps/OneBusAway/zh-Hant.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "查看您與大眾運輸的相對位置，協助您更輕鬆地前往目的地。";
 "NSLocationWhenInUseUsageDescription" = "查看您與大眾運輸的相對位置，協助您更輕鬆地前往目的地。";
 
-/* Purpose string shown when the app requests HealthKit access to your walking speed. */
-"NSHealthShareUsageDescription" = "使用「健康」App 中的步行速度，為您提供更準確的到站時間預估。";
-"NSHealthUpdateUsageDescription" = "使用「健康」App 中的步行速度，為您提供更準確的到站時間預估。";
+/* Purpose string shown when the app requests HealthKit access to your walking and cycling speed. */
+"NSHealthShareUsageDescription" = "使用「健康」App 中的步行或騎乘速度，為您提供更準確的到站時間預估。";
+"NSHealthUpdateUsageDescription" = "使用「健康」App 中的步行或騎乘速度，為您提供更準確的到站時間預估。";

--- a/Apps/Shared/info_plist.yml
+++ b/Apps/Shared/info_plist.yml
@@ -14,5 +14,5 @@ targets:
   App:
     info:
       properties:
-        NSHealthShareUsageDescription: Uses your walking speed from the Health app to give you more accurate arrival time estimates.
-        NSHealthUpdateUsageDescription: Uses your walking speed from the Health app to give you more accurate arrival time estimates.
+        NSHealthShareUsageDescription: Uses your walking or cycling speed from the Health app to give you more accurate arrival time estimates.
+        NSHealthUpdateUsageDescription: Uses your walking or cycling speed from the Health app to give you more accurate arrival time estimates.

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -118,6 +118,9 @@ public class Application: CoreApplication, PushServiceDelegate {
         regionIDProvider: { [weak self] in self?.regionsService.currentRegion?.regionIdentifier }
     )
 
+    @MainActor
+    lazy var bikeModeManager = BikeModeManager(userDataStore: userDataStore)
+
     @objc lazy var userActivityBuilder = UserActivityBuilder(application: self)
 
     /// Handles all deep-linking into the app.
@@ -534,6 +537,10 @@ public class Application: CoreApplication, PushServiceDelegate {
 
         if userDataStore.walkingSpeedSource == .healthKit {
             Task { await walkingSpeedManager.refreshFromHealthKitIfPossible() }
+        }
+
+        if userDataStore.bikeModeEnabled && userDataStore.bikeSpeedSource == .healthKit {
+            Task { await bikeModeManager.refreshFromHealthKitIfPossible() }
         }
     }
 

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -539,7 +539,11 @@ public class Application: CoreApplication, PushServiceDelegate {
             Task { await walkingSpeedManager.refreshFromHealthKitIfPossible() }
         }
 
-        if userDataStore.bikeModeEnabled && userDataStore.bikeSpeedSource == .healthKit {
+        // Matches the walking-speed refresh above: gated on the sync source alone, not
+        // on whether Bike Mode is currently toggled on. The header's bike chip is always
+        // shown regardless of mode, so a rider who synced once and later turned Bike Mode
+        // off would otherwise keep a frozen cycling-speed ETA on every stop header forever.
+        if userDataStore.bikeSpeedSource == .healthKit {
             Task { await bikeModeManager.refreshFromHealthKitIfPossible() }
         }
     }

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -418,7 +418,7 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc("settings_controller.bike_mode.title", value: "Bike Mode", comment: "Settings > Bike Mode > on/off toggle")
             $0.onChange { [weak self] row in
                 guard let self, row.value == true, HKHealthStore.isHealthDataAvailable() else { return }
-                Task {
+                Task { @MainActor in
                     let granted = await self.application.bikeModeManager.requestHealthKitAuthorizationAndSync()
                     if !granted {
                         self.showErrorToast(

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -41,6 +41,7 @@ class SettingsViewController: FormViewController {
             +++ experimentalSection
             +++ accessibilitySection
             +++ walkingSpeedSection
+            +++ bikeModeSection
             +++ surveySection
             +++ feedbackSection
             +++ debugSection
@@ -71,7 +72,8 @@ class SettingsViewController: FormViewController {
             walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
             stopUIReducedColorsTag: application.userDataStore.stopUIReducedColors,
             transferBannerTag: application.userDataStore.showTransferArrivalBanner,
-            alwaysShowFeedbackPrompt: application.reviewPromptPolicy.alwaysShowPrompt
+            alwaysShowFeedbackPrompt: application.reviewPromptPolicy.alwaysShowPrompt,
+            bikeModeEnabledKey: application.userDataStore.bikeModeEnabled
         ])
     }
 
@@ -133,6 +135,10 @@ class SettingsViewController: FormViewController {
         }
 
         saveWalkingSpeedValues(values)
+
+        if let bikeModeEnabled = values[bikeModeEnabledKey] as? Bool {
+            application.userDataStore.bikeModeEnabled = bikeModeEnabled
+        }
     }
 
     private func saveAccessibilityValues(_ values: [String: Any?]) {
@@ -396,6 +402,41 @@ class SettingsViewController: FormViewController {
 
         return section
     }()
+
+    // MARK: - Bike Mode
+
+    private let bikeModeEnabledKey = "bikeModeEnabled"
+
+    private lazy var bikeModeSection: Section = {
+        let section = Section(
+            header: OBALoc("settings_controller.bike_mode_section.title", value: "Bike Mode", comment: "Settings > Bike Mode section title"),
+            footer: OBALoc("settings_controller.bike_mode_section.footer", value: "Uses a faster travel speed for walk-time estimates, arrival ETAs, and the Stop page.", comment: "Settings > Bike Mode section footer")
+        )
+
+        section <<< SwitchRow {
+            $0.tag = bikeModeEnabledKey
+            $0.title = OBALoc("settings_controller.bike_mode.title", value: "Bike Mode", comment: "Settings > Bike Mode > on/off toggle")
+            $0.onChange { [weak self] row in
+                guard let self, row.value == true, HKHealthStore.isHealthDataAvailable() else { return }
+                Task {
+                    let granted = await self.application.bikeModeManager.requestHealthKitAuthorizationAndSync()
+                    if !granted {
+                        self.showErrorToast(
+                            OBALoc(
+                                "settings_controller.bike_mode.healthkit_unavailable",
+                                value: "Couldn't sync cycling speed from Health. Using a standard biking speed instead.",
+                                comment: "Settings > Bike Mode > HealthKit denial or no-data toast"
+                            ),
+                            using: self.application.toastManager
+                        )
+                    }
+                }
+            }
+        }
+
+        return section
+    }()
+
 
    // MARK: - Privacy
 

--- a/OBAKit/Sheet/Content/Stop/Details/StopDetailsSheetView.swift
+++ b/OBAKit/Sheet/Content/Stop/Details/StopDetailsSheetView.swift
@@ -382,7 +382,8 @@ struct StopDetailsSheetView: View {
                 if let stop = viewModel.stop {
                     StopPageSheetHeaderView(
                         stop: stop,
-                        walkTime: viewModel.walkTime,
+                        walkTime: viewModel.headerWalkTime,
+                        bikeTime: viewModel.headerBikeTime,
                         onWalkingDirections: navigation.showWalkingDirections,
                         onClose: { coordinator.pop() },
                         showsCloseButton: false,

--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalWalkItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalWalkItem.swift
@@ -10,7 +10,7 @@ import CoreLocation
 
 nonisolated struct StopArrivalWalkItem: OBAListViewItem {
     var configuration: OBAListViewItemConfiguration {
-        return .custom(StopArrivalWalkContentConfiguration(distance: distance, timeToWalk: timeToWalk))
+        return .custom(StopArrivalWalkContentConfiguration(distance: distance, timeToWalk: timeToWalk, isBikeMode: isBikeMode))
     }
 
     static var customCellType: OBAListViewCell.Type? {
@@ -26,11 +26,15 @@ nonisolated struct StopArrivalWalkItem: OBAListViewItem {
     let id: String
     let distance: CLLocationDistance
     let timeToWalk: TimeInterval
+    /// Whether `timeToWalk` was computed at bike speed — Bike Mode swaps the
+    /// row's icon and wording from walk to bike to match.
+    var isBikeMode: Bool = false
 
     static func == (lhs: StopArrivalWalkItem, rhs: StopArrivalWalkItem) -> Bool {
         return lhs.id == rhs.id &&
             lhs.distance == rhs.distance &&
-            lhs.timeToWalk == rhs.timeToWalk
+            lhs.timeToWalk == rhs.timeToWalk &&
+            lhs.isBikeMode == rhs.isBikeMode
     }
 
     func hash(into hasher: inout Hasher) {
@@ -41,6 +45,7 @@ nonisolated struct StopArrivalWalkItem: OBAListViewItem {
 nonisolated struct StopArrivalWalkContentConfiguration: OBAContentConfiguration {
     var distance: CLLocationDistance
     var timeToWalk: TimeInterval
+    var isBikeMode: Bool = false
     var formatters: Formatters?
 
     var obaContentView: (OBAContentView & ReuseIdentifierProviding).Type {
@@ -65,6 +70,6 @@ class StopArrivalWalkCell: OBAListViewCell {
     override func apply(_ config: OBAContentConfiguration) {
         guard let config = config as? StopArrivalWalkContentConfiguration else { return }
         walkTimeView.formatters = config.formatters
-        walkTimeView.set(distance: config.distance, timeToWalk: config.timeToWalk)
+        walkTimeView.set(distance: config.distance, timeToWalk: config.timeToWalk, isBikeMode: config.isBikeMode)
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -16,6 +16,9 @@ import OBAKitCore
 struct ChronologicalListView: View {
     let partition: StopPageListBuilder.ChronologicalPartition<ArrivalDeparture>
     let walkMinutes: Int?
+    /// Whether `walkMinutes` was computed at bike speed — Bike Mode swaps the
+    /// divider's wording/icon/color from walk to bike to match.
+    var isBikeMode: Bool = false
     let showPast: Bool
     let highlightedTripID: TripIdentifier?
     let statusProvider: (ArrivalDeparture) -> DepartureStatus
@@ -40,7 +43,7 @@ struct ChronologicalListView: View {
             }
             // Walk divider escapes the card chrome (out-of-card row rules).
             Section {
-                WalkLineDivider(walkMinutes: walkMinutes)
+                WalkLineDivider(walkMinutes: walkMinutes, isBikeMode: isBikeMode)
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesBuilder.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesBuilder.swift
@@ -49,6 +49,11 @@ struct StopDeparturesBuilder {
             serviceAlerts: viewModel.stopArrivals?.serviceAlerts ?? [],
             sortType: viewModel.stopPreferences.sortType,
             walkMinutes: walkTime?.walkMinutes,
+            // Read straight off the view model, unlike `walkTime`: it has no
+            // location-drift-within-one-render-pass concern to guard against,
+            // so there's no snapshot-consistency reason to thread it through
+            // the caller too.
+            isBikeMode: viewModel.isBikeModeEnabled,
             minutesAfter: viewModel.minutesAfter,
             isBrokenBookmark: viewModel.isBrokenBookmark,
             errorText: viewModel.operationErrorMessage,

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -28,6 +28,9 @@ struct StopDeparturesSections: View {
     let serviceAlerts: [ServiceAlert]
     let sortType: StopSort
     let walkMinutes: Int?
+    /// Whether `walkMinutes` was computed at bike speed — the chronological
+    /// divider's wording/icon/color has to match what actually produced it.
+    var isBikeMode: Bool = false
     let minutesAfter: UInt
     let isBrokenBookmark: Bool
     let errorText: String?
@@ -216,6 +219,7 @@ struct StopDeparturesSections: View {
                 // there is anything to disclose.
                 partition: chronologicalPartition,
                 walkMinutes: walkMinutes,
+                isBikeMode: isBikeMode,
                 showPast: !pastCollapsed,
                 highlightedTripID: highlightedTripID,
                 statusProvider: statusProvider,

--- a/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkLineDivider.swift
@@ -8,17 +8,36 @@ import SwiftUI
 import OBAKitCore
 
 /// The dashed reachability divider in chronological mode: everything above is
-/// "just missed", everything below is catchable on foot (§4.5).
+/// "just missed", everything below is catchable at the user's current travel
+/// mode (§4.5). `walkMinutes` is mode-aware — it's already bike time when Bike
+/// Mode is on — so the label and icon have to say so too, or the divider would
+/// tell a cyclist they have an implausibly fast "walk".
 struct WalkLineDivider: View {
     let walkMinutes: Int
+    var isBikeMode: Bool = false
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-    /// Matches the walk pill on the header card (§4.5).
-    private let lineColor = Color(uiColor: ThemeColors.shared.departureOnTime)
+    /// Matches the walk/bike pill on the header card (§4.5).
+    private var lineColor: Color {
+        Color(uiColor: isBikeMode ? ThemeColors.shared.blue : ThemeColors.shared.departureOnTime)
+    }
+
+    private var systemImage: String {
+        isBikeMode ? "bicycle" : "figure.walk"
+    }
 
     private var text: String {
-        let fmt = OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
+        let fmt = isBikeMode
+            ? OBALoc("stop_page.bike_divider_fmt", value: "%d MIN BIKE — CATCH BELOW", comment: "Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes.")
+            : OBALoc("stop_page.walk_divider_fmt", value: "%d MIN WALK — CATCH BELOW", comment: "Divider between departures you'd miss on foot and ones you can still catch. %d is the walk time in minutes.")
+        return String(format: fmt, walkMinutes)
+    }
+
+    private var accessibilityText: String {
+        let fmt = isBikeMode
+            ? OBALoc("stop_page.bike_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute bike ride to the stop", comment: "VoiceOver description of the bike divider. %d is bike minutes.")
+            : OBALoc("stop_page.walk_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute walk to the stop", comment: "VoiceOver description of the walk divider. %d is walk minutes.")
         return String(format: fmt, walkMinutes)
     }
 
@@ -29,7 +48,7 @@ struct WalkLineDivider: View {
         // Dynamic Type strategy; the text must grow, not the row squeeze it).
         HStack(spacing: 10) {
             if dynamicTypeSize.isAccessibilitySize {
-                Label(text, systemImage: "figure.walk")
+                Label(text, systemImage: systemImage)
                     .font(.caption.weight(.heavy))
                     .foregroundStyle(lineColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -41,7 +60,7 @@ struct WalkLineDivider: View {
                     )
             } else {
                 dash
-                Label(text, systemImage: "figure.walk")
+                Label(text, systemImage: systemImage)
                     .font(.caption.weight(.heavy))
                     .foregroundStyle(lineColor)
                     .lineLimit(1)
@@ -54,7 +73,7 @@ struct WalkLineDivider: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(String(format: OBALoc("stop_page.walk_divider_a11y_fmt", value: "Departures above this point leave sooner than your %d minute walk to the stop", comment: "VoiceOver description of the walk divider. %d is walk minutes."), walkMinutes))
+        .accessibilityLabel(accessibilityText)
     }
 
     private var dash: some View {
@@ -79,5 +98,6 @@ struct WalkLineDivider: View {
     List {
         WalkLineDivider(walkMinutes: 104)
         WalkLineDivider(walkMinutes: 8)
+        WalkLineDivider(walkMinutes: 3, isBikeMode: true)
     }
 }

--- a/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
+++ b/OBAKit/Stops/StopPage/Shared/WalkTimeInfo.swift
@@ -7,10 +7,17 @@
 import Foundation
 import CoreLocation
 
-/// The single source of walk time on the Stop page (§4.5): the header chip
-/// and the chronological walk line must both read from the same instance.
+/// A travel-time estimate at a given speed (§4.5) — walking or cycling, whichever
+/// `compute(...)` was called with. `StopViewModel` computes three independent
+/// instances from this one type: `headerWalkTime` and `headerBikeTime` (always
+/// their own fixed speed, for the header's two chips) and the mode-aware `walkTime`
+/// (walking or cycling speed depending on Bike Mode, for the chronological
+/// partition and divider) — so unlike this type's single-source origin, the header
+/// chips and the divider do NOT necessarily share one instance anymore; they only
+/// have to agree when Bike Mode is off, or the header and the divider would show
+/// different rounded minutes for what should read as the same walk-speed estimate.
 struct WalkTimeInfo: Equatable {
-    /// Rounded up — never promise a shorter walk than reality.
+    /// Rounded up — never promise a shorter walk (or bike ride) than reality.
     let walkMinutes: Int
     let distance: CLLocationDistance
 

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -98,13 +98,13 @@ struct StopPageHeaderView: View {
                 HStack(spacing: 8) {
                     if let walkTime {
                         Button(action: onWalkingDirections) {
-                            travelChip(walkChipText(walkTime), systemImage: "figure.walk")
+                            travelChip(walkChipText(walkTime), systemImage: "figure.walk", background: ThemeColors.shared.departureOnTime)
                         }
                         .buttonStyle(.plain)
                         .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
                     }
                     if let bikeTime {
-                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle")
+                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle", background: ThemeColors.shared.blue)
                     }
                 }
             }
@@ -157,14 +157,15 @@ struct StopPageHeaderView: View {
             .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
-    /// Shared capsule styling for the walk and bike chips. The icon is a
-    /// placeholder for now; distinct iconography can come later.
-    private func travelChip(_ text: String, systemImage: String) -> some View {
+    /// Shared capsule styling for the walk and bike chips. Each mode gets its own
+    /// background color (walk: on-time green, bike: system blue) so the two
+    /// estimates read as distinct at a glance, not just by their icon.
+    private func travelChip(_ text: String, systemImage: String, background: UIColor) -> some View {
         Label(text, systemImage: systemImage)
             .font(.footnote.weight(.heavy))
             .foregroundStyle(.white)
             .padding(.horizontal, 12).padding(.vertical, 6)
-            .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+            .background(Color(uiColor: background), in: Capsule())
             .contentShape(Capsule())
     }
 

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -94,8 +94,11 @@ struct StopPageHeaderView: View {
             // Two independent estimates: the walk chip (tappable, opens walking
             // directions) and the bike chip. Both are always shown when
             // available — Bike Mode only affects the arrival split, not these.
+            // FlowLayout, not HStack: the subtitle/route chips above never
+            // compress or drop at accessibility sizes, and two side-by-side
+            // pills with no wrap would be the one thing on this card that does.
             if walkTime != nil || bikeTime != nil {
-                HStack(spacing: 8) {
+                FlowLayout(hSpacing: 8, vSpacing: 8) {
                     if let walkTime {
                         Button(action: onWalkingDirections) {
                             travelChip(walkChipText(walkTime), systemImage: "figure.walk", background: ThemeColors.shared.departureOnTime)

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -14,8 +14,9 @@ import OBAKitCore
 /// dark scrim, with the identity block bottom-left in white — the "last
 /// updated" status line, stop name, the code/direction subtitle with inline
 /// route chips (wrapping onto as many lines as needed, never truncated), and
-/// the walk pill (the single visual source of walk time, §4.5). Tapping the
-/// walk pill opens walking directions in an external maps app.
+/// the travel pills — a walk estimate and a bike estimate, each at the user's
+/// respective speed and always shown regardless of Bike Mode (§4.5). Tapping
+/// the walk pill opens walking directions in an external maps app.
 ///
 /// A plain-value view: it never touches `StopViewModel`. The map snapshot is
 /// produced by a `snapshotLoader` closure supplied by the hosting VC, so the
@@ -24,7 +25,10 @@ import OBAKitCore
 /// `UIScreen.main`.
 struct StopPageHeaderView: View {
     let stop: Stop
+    /// Walk time at the user's walking speed — always shown, independent of Bike Mode.
     let walkTime: WalkTimeInfo?
+    /// Bike time at the user's cycling speed — always shown, independent of Bike Mode.
+    let bikeTime: WalkTimeInfo?
     /// The "Updated: …" line; empty hides it.
     let statusText: String
     let snapshotLoader: (CGSize) async -> UIImage?
@@ -87,17 +91,22 @@ struct StopPageHeaderView: View {
             // The screen's title: mark it a heading so it anchors VoiceOver's
             // Headings rotor for quick top-of-page navigation.
             .accessibilityAddTraits(.isHeader)
-            if let walkTime {
-                Button(action: onWalkingDirections) {
-                    Label(walkChipText(walkTime), systemImage: "figure.walk")
-                        .font(.footnote.weight(.heavy))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 12).padding(.vertical, 6)
-                        .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
-                        .contentShape(Capsule())
+            // Two independent estimates: the walk chip (tappable, opens walking
+            // directions) and the bike chip. Both are always shown when
+            // available — Bike Mode only affects the arrival split, not these.
+            if walkTime != nil || bikeTime != nil {
+                HStack(spacing: 8) {
+                    if let walkTime {
+                        Button(action: onWalkingDirections) {
+                            travelChip(walkChipText(walkTime), systemImage: "figure.walk")
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
+                    }
+                    if let bikeTime {
+                        travelChip(bikeChipText(bikeTime), systemImage: "bicycle")
+                    }
                 }
-                .buttonStyle(.plain)
-                .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
             }
         }
         .padding(16)
@@ -148,11 +157,31 @@ struct StopPageHeaderView: View {
             .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
+    /// Shared capsule styling for the walk and bike chips. The icon is a
+    /// placeholder for now; distinct iconography can come later.
+    private func travelChip(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.footnote.weight(.heavy))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12).padding(.vertical, 6)
+            .background(Color(uiColor: ThemeColors.shared.departureOnTime), in: Capsule())
+            .contentShape(Capsule())
+    }
+
     private func walkChipText(_ info: WalkTimeInfo) -> String {
         let fmt = OBALoc(
             "stop_page.walk_chip_minutes_fmt",
             value: "%d min walk",
             comment: "Walk chip on the header card. %d is the walk time in minutes."
+        )
+        return String(format: fmt, info.walkMinutes)
+    }
+
+    private func bikeChipText(_ info: WalkTimeInfo) -> String {
+        let fmt = OBALoc(
+            "stop_page.bike_chip_minutes_fmt",
+            value: "%d min bike",
+            comment: "Bike chip on the header card. %d is the bike time in minutes."
         )
         return String(format: fmt, info.walkMinutes)
     }
@@ -271,6 +300,7 @@ private struct HeaderStatusLine: View {
         StopPageHeaderView(
             stop: stop,
             walkTime: WalkTimeInfo(walkMinutes: 7, distance: 520),
+            bikeTime: WalkTimeInfo(walkMinutes: 3, distance: 520),
             statusText: "Updated: 2 min ago",
             snapshotLoader: { _ in nil },
             onWalkingDirections: {}
@@ -278,6 +308,7 @@ private struct HeaderStatusLine: View {
         StopPageHeaderView(
             stop: stop,
             walkTime: nil,
+            bikeTime: nil,
             statusText: "",
             snapshotLoader: { _ in nil },
             onWalkingDirections: {}

--- a/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
@@ -50,7 +50,7 @@ struct StopPageSheetHeaderView: View {
     /// Walk time at the user's walking speed — always shown, independent of Bike Mode.
     let walkTime: WalkTimeInfo?
     /// Bike time at the user's cycling speed — always shown, independent of Bike Mode.
-    var bikeTime: WalkTimeInfo? = nil
+    var bikeTime: WalkTimeInfo?
     /// Opens walking directions to the stop (VC-owned; disambiguates between maps apps when more
     /// than one is available).
     let onWalkingDirections: () -> Void
@@ -169,7 +169,7 @@ struct StopPageSheetHeaderView: View {
                         if let bikeTime {
                             bikePill(bikeTime)
                         }
-                        if (walkTime != nil || bikeTime != nil), !chips.isEmpty {
+                        if (walkTime != nil || bikeTime != nil) && !chips.isEmpty {
                             rowSeparator
                         }
                         ForEach(chips) { chip in

--- a/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageSheetHeaderView.swift
@@ -47,7 +47,10 @@ nonisolated enum StopSheetHeaderMetrics {
 /// A plain-value view except for `mapFocus` — it never touches `StopViewModel`.
 struct StopPageSheetHeaderView: View {
     let stop: Stop
+    /// Walk time at the user's walking speed — always shown, independent of Bike Mode.
     let walkTime: WalkTimeInfo?
+    /// Bike time at the user's cycling speed — always shown, independent of Bike Mode.
+    var bikeTime: WalkTimeInfo? = nil
     /// Opens walking directions to the stop (VC-owned; disambiguates between maps apps when more
     /// than one is available).
     let onWalkingDirections: () -> Void
@@ -149,21 +152,24 @@ struct StopPageSheetHeaderView: View {
                     }
                 }
 
-                if !isCollapsed, walkTime != nil || !chips.isEmpty {
-                    // Walk pill and chips share one flowing row, per the design — the pill
-                    // leads, a hairline separates it from the routes, and everything wraps
-                    // together.
+                if !isCollapsed, walkTime != nil || bikeTime != nil || !chips.isEmpty {
+                    // Walk pill, bike pill, and chips share one flowing row, per the design —
+                    // the pills lead, a hairline separates them from the routes, and everything
+                    // wraps together.
                     //
                     // `FlowLayout` sizes subviews with an unspecified proposal, which a
                     // `Button` answers with a greedy height — that is what once stretched the
                     // walk pill down the whole sheet. So nothing in this row is a `Button`;
-                    // the pill and the chips are `Text`-shaped tappable views instead. See
+                    // the pills and the chips are `Text`-shaped tappable views instead. See
                     // `chipView(_:)`.
                     FlowLayout(hSpacing: 6, vSpacing: 6) {
                         if let walkTime {
                             walkPill(walkTime)
                         }
-                        if walkTime != nil, !chips.isEmpty {
+                        if let bikeTime {
+                            bikePill(bikeTime)
+                        }
+                        if (walkTime != nil || bikeTime != nil), !chips.isEmpty {
                             rowSeparator
                         }
                         ForEach(chips) { chip in
@@ -236,6 +242,28 @@ struct StopPageSheetHeaderView: View {
         .accessibilityLabel(text)
         .accessibilityAddTraits(.isButton)
         .accessibilityHint(OBALoc("stop_page.header.walk_a11y_hint", value: "Opens walking directions to this stop.", comment: "VoiceOver hint on the header card's walk-time button."))
+    }
+
+    /// The bike-time pill: same shape as `walkPill(_:)`, tinted blue (matching the pushed
+    /// header's bike chip) instead of on-time green. Not tappable — there's no cycling-directions
+    /// deep link to open (see the walk pill's `onWalkingDirections`; Apple's Maps URL scheme has
+    /// no documented bike mode), so unlike the walk pill this is a static value, not a button.
+    private func bikePill(_ info: WalkTimeInfo) -> some View {
+        let text = bikePillText(info)
+        return HStack(spacing: 4) {
+            Image(systemName: "bicycle")
+                .accessibilityHidden(true) // the text below carries the meaning
+            Text(text)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .font(chipFont)
+        .foregroundStyle(Color(uiColor: ThemeColors.shared.blue))
+        .padding(.horizontal, chipHorizontalPadding)
+        .padding(.vertical, chipVerticalPadding)
+        .background(Color(uiColor: ThemeColors.shared.blue).opacity(0.14), in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(text)
     }
 
     // MARK: - Shared pill metrics
@@ -322,6 +350,17 @@ struct StopPageSheetHeaderView: View {
             "stop_page.walk_chip_minutes_fmt",
             value: "%d min walk",
             comment: "Walk chip on the header card. %d is the walk time in minutes."
+        )
+        return String(format: fmt, info.walkMinutes)
+    }
+
+    /// Shares its localization key with `StopPageHeaderView`'s bike chip — same wording,
+    /// different chrome, same string.
+    private func bikePillText(_ info: WalkTimeInfo) -> String {
+        let fmt = OBALoc(
+            "stop_page.bike_chip_minutes_fmt",
+            value: "%d min bike",
+            comment: "Bike chip on the header card. %d is the bike time in minutes."
         )
         return String(format: fmt, info.walkMinutes)
     }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -228,7 +228,7 @@ struct StopPageView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             if showToolbarOnBottom {
                 if let stop = viewModel.stop {
-                    StopPageSheetHeaderView(stop: stop, walkTime: walkTime, onWalkingDirections: navigation.showWalkingDirections, onClose: navigation.closeSheet, isCollapsed: isCollapsed, mapFocus: mapFocus)
+                    StopPageSheetHeaderView(stop: stop, walkTime: viewModel.headerWalkTime, bikeTime: viewModel.headerBikeTime, onWalkingDirections: navigation.showWalkingDirections, onClose: navigation.closeSheet, isCollapsed: isCollapsed, mapFocus: mapFocus)
                 } else {
                     // Unconditional, unlike the pushed presentation's header: with no navigation
                     // bar behind the sheet, this strip carries the only close button, so a stop

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -174,8 +174,9 @@ struct StopPageView: View {
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     var body: some View {
-        // Hoist the single computed walk value so the header chip, the
-        // chronological partition, and the divider all read one snapshot of it.
+        // Hoist the mode-aware walk value so the chronological partition and the
+        // divider read one snapshot of it. The header shows its own always-on
+        // walk and bike estimates, independent of Bike Mode.
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
 
@@ -187,7 +188,7 @@ struct StopPageView: View {
             if let stop = viewModel.stop {
                 if !showToolbarOnBottom {
                     Section {
-                        StopPageHeaderView(stop: stop, walkTime: walkTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader, onWalkingDirections: navigation.showWalkingDirections)
+                        StopPageHeaderView(stop: stop, walkTime: viewModel.headerWalkTime, bikeTime: viewModel.headerBikeTime, statusText: viewModel.statusText, snapshotLoader: snapshotLoader, onWalkingDirections: navigation.showWalkingDirections)
                             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                             .listRowBackground(Color.clear)
                             .listRowSeparator(.hidden)

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1049,7 +1049,7 @@ public class StopViewController: UIViewController,
 
         if let insertionIndex = findInsertionIndexForWalkTime(walkingTime, items: items) {
             let distance = currentLocation.distance(from: stopLocation)
-            let walkItem = StopArrivalWalkItem(id: "walk_item", distance: distance, timeToWalk: walkingTime)
+            let walkItem = StopArrivalWalkItem(id: "walk_item", distance: distance, timeToWalk: walkingTime, isBikeMode: application.userDataStore.bikeModeEnabled)
             items.insert(walkItem.typeErased, at: insertionIndex)
         }
     }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -1044,7 +1044,7 @@ public class StopViewController: UIViewController,
         guard items.count > 0,
               let currentLocation = application.locationService.currentLocation,
               let stopLocation = stop?.location,
-              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.walkingSpeedMetersPerSecond)
+              let walkingTime = WalkingDirections.travelTime(from: currentLocation, to: stopLocation, velocity: application.userDataStore.effectiveTravelVelocityMetersPerSecond)
         else { return }
 
         if let insertionIndex = findInsertionIndexForWalkTime(walkingTime, items: items) {

--- a/OBAKit/Stops/WalkTimeView.swift
+++ b/OBAKit/Stops/WalkTimeView.swift
@@ -87,7 +87,7 @@ class WalkTimeView: UIView {
         NotificationCenter.default.removeObserver(self)
     }
 
-    public func set(distance: CLLocationDistance, timeToWalk: TimeInterval) {
+    public func set(distance: CLLocationDistance, timeToWalk: TimeInterval, isBikeMode: Bool = false) {
         // bail out if the distance is 40 meters or less. Just don't show anything because
         // it suggests the user is essentially at the stop and showing '100 feet arriving in 1
         // min' looks weird.
@@ -97,25 +97,33 @@ class WalkTimeView: UIView {
             return
         }
 
-        walkerImageView.image = Icons.walkTransport
+        // No dedicated bike glyph asset exists yet (matches `walkTransport`'s vector PDF); the
+        // SF Symbol used by the SwiftUI stop page's bike chip is a reasonable stand-in here too.
+        walkerImageView.image = isBikeMode ? UIImage(systemName: "bicycle") : Icons.walkTransport
 
         let distanceString = formatters.distanceFormatter.string(fromDistance: distance)
         let arrivalTime = formatters.timeFormatter.string(from: Date().addingTimeInterval(timeToWalk))
 
         if let timeString = formatters.positionalTimeFormatter.string(from: timeToWalk) {
-            let fmt = OBALoc("walk_time_view.distance_time_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M.")
+            let fmt = isBikeMode
+                ? OBALoc("walk_time_view.distance_time_bike_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles, 6m: arriving at 09:41 A.M.")
+                : OBALoc("walk_time_view.distance_time_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M.")
             label.text = String(format: fmt, distanceString, timeString, arrivalTime)
         }
         else {
             label.text = distanceString
         }
 
-        accessibilityLabel = OBALoc("walk_time_view.accessibility_label", value: "Time to walk to stop", comment: "A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop.")
+        accessibilityLabel = isBikeMode
+            ? OBALoc("walk_time_view.accessibility_label_bike", value: "Time to bike to stop", comment: "A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop.")
+            : OBALoc("walk_time_view.accessibility_label", value: "Time to walk to stop", comment: "A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop.")
         accessibilityTraits = [.staticText]
         isAccessibilityElement = true
 
         if let timeString = formatters.accessibilityPositionalTimeFormatter.string(from: timeToWalk) {
-            let fmt = OBALoc("walk_time_view.accessibility_value", value: "%@. Takes %@ to walk, arriving at %@", comment: "Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am")
+            let fmt = isBikeMode
+                ? OBALoc("walk_time_view.accessibility_value_bike", value: "%@. Takes %@ to bike, arriving at %@", comment: "Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am")
+                : OBALoc("walk_time_view.accessibility_value", value: "%@. Takes %@ to walk, arriving at %@", comment: "Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am")
             accessibilityValue = String(format: fmt, distanceString, timeString, arrivalTime)
         }
         else {

--- a/OBAKit/Stops/WalkTimeView.swift
+++ b/OBAKit/Stops/WalkTimeView.swift
@@ -93,6 +93,10 @@ class WalkTimeView: UIView {
         // min' looks weird.
         guard distance > 40 else {
             label.text = nil
+            // This view is reused across list cells; without clearing it, a cell that
+            // previously showed the bike icon (or vice versa) would keep it here even
+            // though no text renders alongside it.
+            walkerImageView.image = nil
             isAccessibilityElement = false
             return
         }

--- a/OBAKit/Stops/WalkTimeView.swift
+++ b/OBAKit/Stops/WalkTimeView.swift
@@ -109,9 +109,10 @@ class WalkTimeView: UIView {
         let arrivalTime = formatters.timeFormatter.string(from: Date().addingTimeInterval(timeToWalk))
 
         if let timeString = formatters.positionalTimeFormatter.string(from: timeToWalk) {
-            let fmt = isBikeMode
-                ? OBALoc("walk_time_view.distance_time_bike_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles, 6m: arriving at 09:41 A.M.")
-                : OBALoc("walk_time_view.distance_time_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M.")
+            // Mode-neutral by construction — "1.2 miles, 6m: arriving at 09:41" reads the same
+            // whether those minutes were walked or ridden, so both modes share one string
+            // rather than making translators maintain two identical ones.
+            let fmt = OBALoc("walk_time_view.distance_time_fmt", value: "%@, %@: arriving at %@", comment: "Format string with placeholders for distance from stop, travel time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M.")
             label.text = String(format: fmt, distanceString, timeString, arrivalTime)
         }
         else {

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "إظهار المغادرات";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "وضع الدراجة";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "يستخدم سرعة تنقّل أسرع لتقديرات وقت الوصول إلى الموقف ومواعيد الوصول وصفحة الموقف.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "وضع الدراجة";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "تعذّرت مزامنة سرعة ركوب الدراجة من تطبيق «صحتي». سيتم استخدام سرعة قياسية للدراجة بدلًا من ذلك.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "تحديث المناطق عند كل تشغيل";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "الإشعارات متوقفة";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d د بالدراجة — يمكنك اللحاق بما بالأسفل";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "المغادرات فوق هذه النقطة تغادر قبل أن تصل إلى الموقف بالدراجة خلال %d دقيقة";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d د بالدراجة";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "الآن";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "وقت المشي إلى الموقف";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "وقت الوصول إلى الموقف بالدراجة";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. يستغرق المشي %2$@، والوصول عند %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. يستغرق ركوب الدراجة %2$@، والوصول عند %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@، %2$@: الوصول عند %3$@";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1259,6 +1259,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Show Departures";
 
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Couldn't sync cycling speed from Health. Using a standard biking speed instead.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Bike Mode";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Uses a faster travel speed for walk-time estimates, arrival ETAs, and the Stop page.";
+
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Bike Mode";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Refresh regions on every launch";
 
@@ -1426,6 +1438,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Notifications Are Off";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min bike";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Departures above this point leave sooner than your %d minute bike ride to the stop";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN BIKE — CATCH BELOW";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NOW";
@@ -1931,10 +1952,16 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Time to walk to stop";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Time to bike to stop";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Takes %2$@ to walk, arriving at %3$@";
 
-/* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Takes %2$@ to bike, arriving at %3$@";
+
+/* Format string with placeholders for distance from stop, travel time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: arriving at %3$@";
 
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Mostrar salidas";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Modo Bicicleta";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Usa una velocidad de desplazamiento más rápida para las estimaciones de tiempo hasta la parada, las horas de llegada y la página de la parada.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Modo bicicleta";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "No se pudo sincronizar la velocidad en bicicleta desde Salud. Se usará una velocidad en bicicleta estándar.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Actualizar las regiones al inicio";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Las notificaciones están desactivadas";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN EN BICI — ALCANZABLES ABAJO";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Las salidas que aparecen por encima de este punto se van antes de que llegue a la parada, a %d minutos en bicicleta.";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min en bici";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "AHORA";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Tiempo para llegar a la parada";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Tiempo para llegar a la parada en bicicleta";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Toma %2$@ para caminar, llegando a las %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Toma %2$@ en bicicleta, llegando a las %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: llegando a las %3$@";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Ipakita ang mga Pag-alis";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Mode ng Bisikleta";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Gumagamit ng mas mabilis na bilis ng paglalakbay para sa mga tantiya ng oras papunta sa hintuan, mga oras ng pagdating, at sa pahina ng Hintuan.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Mode ng Bisikleta";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Hindi ma-sync ang bilis ng pagbibisikleta mula sa Health. Gagamit na lang ng karaniwang bilis ng bisikleta.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "I-refresh ang mga rehiyon sa bawat paglunsad";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Naka-off ang Mga Notification";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN BISIKLETA — ABUTAN SA IBABA";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Ang mga pag-alis sa itaas ng puntong ito ay aalis nang mas maaga kaysa sa %d minutong pagbibisikleta mo papunta sa hintuan";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min bisikleta";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NGAYON";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Oras ng paglalakad papunta sa hintuan";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Oras ng pagbibisikleta papunta sa hintuan";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Aabutin ng %2$@ ang paglalakad, darating sa %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Aabutin ng %2$@ ang pagbibisikleta, darating sa %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: darating sa %3$@";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Afficher les départs";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Mode vélo";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Utilise une vitesse de déplacement plus rapide pour les estimations de temps jusqu'à l'arrêt, les heures d'arrivée et la page de l'arrêt.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Mode vélo";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Impossible de synchroniser la vitesse à vélo depuis Santé. Une vitesse à vélo standard sera utilisée.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Actualiser les régions à chaque lancement";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Notifications désactivées";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN À VÉLO — À PRENDRE CI-DESSOUS";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Les départs situés au-dessus partent avant la fin de vos %d minutes de vélo jusqu'à l'arrêt";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min à vélo";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "MAINT.";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Temps de marche jusqu'à l'arrêt";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Temps de trajet à vélo jusqu'à l'arrêt";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. %2$@ de marche, arrivée à %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. %2$@ à vélo, arrivée à %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@ : arrivée à %3$@";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Mostra partenze";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Modalità bici";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Usa una velocità di spostamento più elevata per le stime dei tempi verso la fermata, gli orari di arrivo e la pagina della fermata.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Modalità bici";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Impossibile sincronizzare la velocità in bici da Salute. Verrà usata una velocità in bici standard.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Aggiorna area a ogni avvio";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Notifiche disattivate";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN IN BICI — DA QUI IN GIÙ LE PRENDI";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Le partenze sopra questo punto avvengono prima dei %d minuti necessari per raggiungere la fermata in bici";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min in bici";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "ADESSO";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Tempo necessario per raggiungere la fermata";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Tempo necessario per raggiungere la fermata in bici";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Camminando arriverai in %2$@, giungendo a destinazione alle ore %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. In bici arriverai in %2$@, giungendo a destinazione alle ore %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: arriverai alle %3$@";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "출발 표시";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "자전거 모드";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "정류장까지의 소요 시간 추정, 도착 예정 시간, 정류장 화면에 더 빠른 이동 속도를 사용합니다.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "자전거 모드";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "건강 앱에서 자전거 속도를 동기화할 수 없습니다. 표준 자전거 속도를 사용합니다.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "실행할 때마다 지역 새로고침";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "알림이 꺼져 있음";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "자전거 %d분 — 아래부터 탑승 가능";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "이 지점 위의 출발편은 정류장까지 자전거 %d분보다 먼저 출발합니다";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "자전거 %d분";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "지금";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "정류장까지 도보 시간";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "정류장까지 자전거 이동 시간";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. 도보로 %2$@ 걸리며, %3$@에 도착합니다";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. 자전거로 %2$@ 걸리며, %3$@에 도착합니다";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: %3$@ 도착";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Pokazuj odjazdy";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Tryb rowerowy";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Używa większej prędkości przemieszczania się do szacowania czasu dojazdu na przystanek, godzin przyjazdu i na stronie przystanku.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Tryb rowerowy";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Nie udało się zsynchronizować prędkości jazdy rowerem z aplikacją Zdrowie. Zostanie użyta standardowa prędkość roweru.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Odśwież regiony przy każdym uruchomieniu";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Powiadomienia są wyłączone";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN ROWEREM — PONIŻEJ ZDĄŻYSZ";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Odjazdy powyżej tego miejsca nastąpią, zanim dojedziesz na przystanek. Dojazd rowerem zajmuje %d min.";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min rowerem";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "TERAZ";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Czas spaceru do przystanku";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Czas dojazdu rowerem do przystanku";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Potrzeba%2$@ spacerem, przyjazd o %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Potrzeba %2$@ rowerem, przyjazd o %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: przyjedzie %3$@";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Mostrar partidas";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Modo Bicicleta";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Usa uma velocidade de deslocamento maior para as estimativas de tempo até a parada, os horários de chegada e a página da parada.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Modo bicicleta";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Não foi possível sincronizar a velocidade de bicicleta com o app Saúde. Será usada uma velocidade de bicicleta padrão.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Atualizar regiões a cada inicialização";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Notificações Desativadas";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d MIN DE BICICLETA — DÁ PARA PEGAR ABAIXO";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "As partidas acima deste ponto saem antes dos seus %d minutos de bicicleta até a parada";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d min de bicicleta";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "AGORA";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Tempo de caminhada até a parada";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Tempo de bicicleta até a parada";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Leva %2$@ a pé, chegando às %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Leva %2$@ de bicicleta, chegando às %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: chegando às %3$@";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Показывать отправления";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Режим велосипеда";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Использует более высокую скорость передвижения для оценки времени до остановки, времени прибытия и на странице остановки.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Режим велосипеда";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Не удалось синхронизировать скорость езды на велосипеде из приложения «Здоровье». Будет использована стандартная скорость велосипеда.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Обновлять регионы при каждом запуске";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Уведомления отключены";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "%d МИН. НА ВЕЛОСИПЕДЕ — НИЖЕ УСПЕЕТЕ";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Отправления выше этой линии произойдут раньше, чем вы доедете до остановки за %d мин.";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "%d мин. на велосипеде";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "СЕЙЧАС";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Время пешком до остановки";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Время на велосипеде до остановки";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Идти пешком %2$@, прибытие в %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Ехать на велосипеде %2$@, прибытие в %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: прибытие в %3$@";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "Hiển thị chuyến khởi hành";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "Chế độ xe đạp";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "Dùng tốc độ di chuyển nhanh hơn cho ước tính thời gian đến điểm dừng, giờ đến dự kiến và trang Điểm dừng.";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "Chế độ xe đạp";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "Không thể đồng bộ tốc độ đạp xe từ Sức khỏe. Sẽ dùng tốc độ đạp xe tiêu chuẩn.";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "Làm mới khu vực mỗi lần khởi chạy";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "Thông báo đang tắt";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "ĐẠP XE %d PHÚT — BẮT XE BÊN DƯỚI";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "Các chuyến phía trên vạch này khởi hành trước khi bạn kịp đạp xe %d phút đến điểm dừng";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "Đạp xe %d phút";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NGAY";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "Thời gian đi bộ đến điểm dừng";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "Thời gian đạp xe đến điểm dừng";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@. Mất %2$@ đi bộ, đến nơi lúc %3$@";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@. Mất %2$@ đạp xe, đến nơi lúc %3$@";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@, %2$@: đến nơi lúc %3$@";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "显示班次";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "骑行模式";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "在到站时间估算、预计到达时间和车站页面中使用更快的出行速度。";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "骑行模式";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "无法从“健康”App同步骑行速度。将使用标准骑行速度。";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "启动应用时刷新地区信息";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "通知已关闭";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "骑行%d分钟 — 以下班次可赶上";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "此分隔线以上的班次会在您骑行%d分钟到达车站之前离站";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "骑行%d分钟";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "现在";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "步行到车站的时间";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "骑行到车站的时间";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "距离车站%1$@。需要步行%2$@，可以在%3$@抵达车站。";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "距离车站%1$@。需要骑行%2$@，可以在%3$@抵达车站。";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "距离车站%1$@，需要步行%2$@：预计在%3$@抵达车站。";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1079,6 +1079,18 @@
 /* Title for the departure filter setting row */
 "settings_controller.arrival_filter.title" = "顯示班次";
 
+/* Settings > Bike Mode section title */
+"settings_controller.bike_mode_section.title" = "騎乘模式";
+
+/* Settings > Bike Mode section footer */
+"settings_controller.bike_mode_section.footer" = "在到站時間估算、預計抵達時間與站牌頁面中使用較快的移動速度。";
+
+/* Settings > Bike Mode > on/off toggle */
+"settings_controller.bike_mode.title" = "騎乘模式";
+
+/* Settings > Bike Mode > HealthKit denial or no-data toast */
+"settings_controller.bike_mode.healthkit_unavailable" = "無法從「健康」同步騎乘速度。將使用標準騎乘速度。";
+
 /* Settings > Debug section > Refresh regions on every launch */
 "settings_controller.debug_section.always_refresh_regions" = "每次啟動時重新整理區域";
 
@@ -1216,6 +1228,15 @@
 
 /* Title of the alert shown when the user tries to set a departure alarm but notifications are denied in Settings. */
 "stop_page.alarm_permission_denied.title" = "通知已關閉";
+
+/* Divider between departures you'd miss on a bike and ones you can still catch. %d is the bike time in minutes. */
+"stop_page.bike_divider_fmt" = "騎乘 %d 分鐘 — 以下可搭乘";
+
+/* VoiceOver description of the bike divider. %d is bike minutes. */
+"stop_page.bike_divider_a11y_fmt" = "此分隔線以上的班次，會在您騎乘 %d 分鐘抵達站牌之前離站";
+
+/* Bike chip on the header card. %d is the bike time in minutes. */
+"stop_page.bike_chip_minutes_fmt" = "騎乘 %d 分鐘";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "現在";
@@ -1638,8 +1659,14 @@
 /* A label for blind or low-vision users on the UI element that describes how long it takes to walk to the stop. */
 "walk_time_view.accessibility_label" = "步行至站牌所需時間";
 
+/* A label for blind or low-vision users on the UI element that describes how long it takes to bike to the stop. */
+"walk_time_view.accessibility_label_bike" = "騎乘至站牌所需時間";
+
 /* Accessibility string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 17 minutes to walk, arriving at 9:41 am */
 "walk_time_view.accessibility_value" = "%1$@。步行需 %2$@，將於 %3$@ 抵達";
+
+/* Accessibility string with placeholders for distance from stop, biking time to stop, and predicted arrival time. e.g. 1.2 miles. Takes 6 minutes to bike, arriving at 9:41 am */
+"walk_time_view.accessibility_value_bike" = "%1$@。騎乘需 %2$@，將於 %3$@ 抵達";
 
 /* Format string with placeholders for distance from stop, walking time to stop, and predicted arrival time. e.g. 1.2 miles, 17m: arriving at 09:41 A.M. */
 "walk_time_view.distance_time_fmt" = "%1$@，%2$@：%3$@ 抵達";

--- a/OBAKit/TripPlanning/BikeModeManager.swift
+++ b/OBAKit/TripPlanning/BikeModeManager.swift
@@ -1,0 +1,82 @@
+//
+//  BikeModeManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Resolves the user's cycling speed from HealthKit (if authorized) or falls back to
+/// `BikeSpeed.defaultMetersPerSecond`. Does not own whether Bike Mode itself is enabled —
+/// that's `UserDataStore.bikeModeEnabled`, set directly by the Settings UI. This manager only
+/// owns `bikeSpeedMetersPerSecond` / `bikeSpeedSource`.
+@MainActor
+final class BikeModeManager {
+    private let healthKit: BikeSpeedHealthKitProviding
+    private let userDataStore: UserDataStore
+
+    init(userDataStore: UserDataStore, healthKit: BikeSpeedHealthKitProviding = HKHealthStoreBikeSpeedProvider()) {
+        self.userDataStore = userDataStore
+        self.healthKit = healthKit
+    }
+
+    /// Requests HealthKit authorization and attempts to sync the latest cycling speed.
+    ///
+    /// Apple's HealthKit privacy model does not surface read-permission denials: the
+    /// authorization request succeeds even when the user taps "Don't Allow", and a
+    /// subsequent query just returns no samples. To avoid leaving the source stuck on
+    /// HealthKit for a denying user, success here is defined as "actually retrieved a usable
+    /// sample". A user who genuinely granted access but has no recent cycling-speed samples
+    /// (e.g. no Apple Watch) is also routed to `.manual` — that's intentional.
+    @discardableResult
+    func requestHealthKitAuthorizationAndSync() async -> Bool {
+        guard healthKit.isAvailable else {
+            userDataStore.bikeSpeedSource = .manual
+            return false
+        }
+
+        do {
+            try await healthKit.requestAuthorization()
+        } catch {
+            Logger.error("BikeModeManager: HealthKit requestAuthorization failed: \(error)")
+            userDataStore.bikeSpeedSource = .manual
+            return false
+        }
+
+        let didSync = await syncLatestBikeSpeed()
+        if !didSync {
+            userDataStore.bikeSpeedSource = .manual
+        }
+        return didSync
+    }
+
+    /// Passive refresh used at launch when the user already opted into HealthKit previously.
+    /// Updates `bikeSpeedMetersPerSecond` if a fresh sample is available, but never flips
+    /// `bikeSpeedSource` to `.manual` — an idle user keeps their previously-synced value and
+    /// their stated intent. Only the active sync path in Settings can downgrade the source.
+    func refreshFromHealthKitIfPossible() async {
+        guard healthKit.isAvailable else { return }
+        await syncLatestBikeSpeed()
+    }
+
+    /// Fetches the latest cycling-speed sample and writes it to the store if it's in `BikeSpeed.validRange`.
+    /// Returns `true` on a successful write; otherwise leaves the stored speed and source untouched
+    /// and returns `false`. Callers decide how to react to a `false` result.
+    @discardableResult
+    private func syncLatestBikeSpeed() async -> Bool {
+        guard let mps = await healthKit.fetchLatestBikeSpeed(),
+              BikeSpeed.validRange.contains(mps)
+        else {
+            return false
+        }
+
+        userDataStore.bikeSpeedMetersPerSecond = mps
+        userDataStore.bikeSpeedSource = .healthKit
+        return true
+    }
+}

--- a/OBAKit/TripPlanning/BikeSpeedHealthKitProviding.swift
+++ b/OBAKit/TripPlanning/BikeSpeedHealthKitProviding.swift
@@ -1,0 +1,74 @@
+//
+//  BikeSpeedHealthKitProviding.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import HealthKit
+import OBAKitCore
+
+/// Narrow seam around the two HealthKit operations `BikeModeManager` needs.
+/// Exists so the manager's denial/sync state machine can be tested without a live `HKHealthStore`.
+protocol BikeSpeedHealthKitProviding {
+    /// `true` when HealthKit is usable on this device and the cycling-speed quantity type is available.
+    var isAvailable: Bool { get }
+
+    /// Requests read authorization for cycling-speed samples.
+    /// May complete successfully even when the user denies — denial is detected by the absence of samples.
+    func requestAuthorization() async throws
+
+    /// Returns the most recent cycling-speed sample (m/s) from the last 30 days, or `nil` if none exists or the query fails.
+    /// Does not apply range validation; the caller decides what counts as a usable sample.
+    func fetchLatestBikeSpeed() async -> Double?
+}
+
+struct HKHealthStoreBikeSpeedProvider: BikeSpeedHealthKitProviding {
+    private let healthStore = HKHealthStore()
+
+    private static var cyclingSpeedType: HKQuantityType? {
+        HKQuantityType.quantityType(forIdentifier: .cyclingSpeed)
+    }
+
+    var isAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable() && Self.cyclingSpeedType != nil
+    }
+
+    func requestAuthorization() async throws {
+        guard let type = Self.cyclingSpeedType else { return }
+        try await healthStore.requestAuthorization(toShare: [], read: [type])
+    }
+
+    func fetchLatestBikeSpeed() async -> Double? {
+        guard let type = Self.cyclingSpeedType else { return nil }
+
+        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? .distantPast
+        let predicate = HKQuery.predicateForSamples(withStart: thirtyDaysAgo, end: Date())
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    Logger.error("BikeModeManager: HealthKit sample query failed: \(error)")
+                    continuation.resume(returning: nil)
+                    return
+                }
+                guard let sample = samples?.first as? HKQuantitySample else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let mps = sample.quantity.doubleValue(for: HKUnit.meter().unitDivided(by: .second()))
+                continuation.resume(returning: mps)
+            }
+            healthStore.execute(query)
+        }
+    }
+}

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -711,7 +711,7 @@ class StopViewModel: ObservableObject {
         WalkTimeInfo.compute(
             from: environment.currentUserLocation,
             to: stop?.location,
-            speedMetersPerSecond: environment.walkingSpeedMetersPerSecond
+            speedMetersPerSecond: environment.effectiveTravelVelocityMetersPerSecond
         )
     }
 

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -705,14 +705,33 @@ class StopViewModel: ObservableObject {
 
     // MARK: - Stop Page: Walk Time
 
-    /// Walk time from the user's current location to this stop; the single
-    /// source for the header chip and the chronological walk line (§4.5).
-    var walkTime: WalkTimeInfo? {
+    /// Travel time to this stop at an arbitrary speed. Shared by the header's
+    /// walk/bike chips and the mode-aware chronological split.
+    private func travelTime(atSpeed speed: Double) -> WalkTimeInfo? {
         WalkTimeInfo.compute(
             from: environment.currentUserLocation,
             to: stop?.location,
-            speedMetersPerSecond: environment.effectiveTravelVelocityMetersPerSecond
+            speedMetersPerSecond: speed
         )
+    }
+
+    /// Travel time using the mode the user has selected — Bike Mode swaps in the
+    /// cycling speed. Drives the chronological reachable/missed split and the
+    /// walk-line divider (§4.5).
+    var walkTime: WalkTimeInfo? {
+        travelTime(atSpeed: environment.effectiveTravelVelocityMetersPerSecond)
+    }
+
+    /// Walk time at the user's walking speed — always shown on the header's walk
+    /// chip, independent of whether Bike Mode is enabled.
+    var headerWalkTime: WalkTimeInfo? {
+        travelTime(atSpeed: environment.walkingSpeedMetersPerSecond)
+    }
+
+    /// Bike time at the user's cycling speed — always shown on the header's bike
+    /// chip, independent of whether Bike Mode is enabled.
+    var headerBikeTime: WalkTimeInfo? {
+        travelTime(atSpeed: environment.bikeSpeedMetersPerSecond)
     }
 
     // MARK: - Stop Page: Alarms

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -171,6 +171,16 @@ class StopViewModel: ObservableObject {
     private var alarmFiredCancellable: AnyCancellable?
     private var userDefaultsCancellable: AnyCancellable?
 
+    /// Snapshot of the three values behind the header's walk/bike chips and the
+    /// chronological divider, so `syncBikeStateFromDefaults()` can tell a real
+    /// change from an unrelated settings write.
+    private struct BikeState: Equatable {
+        let walkingSpeed: Double
+        let bikeSpeed: Double
+        let bikeModeEnabled: Bool
+    }
+    private var lastBikeState: BikeState?
+
     // MARK: - Init Context
 
     /// Optional bookmark that opened this stop view.
@@ -238,10 +248,22 @@ class StopViewModel: ObservableObject {
         // Settings is presented modally from More, so this VM can outlive a
         // filter change. Re-read the persisted value; skip the write path so
         // we don't echo defaults back at ourselves (#1273).
+        //
+        // The header's walk/bike chips and the chronological divider are plain
+        // computed properties, not `@Published` — a Bike Mode toggle in Settings
+        // needs the same fan-out to reach them. `syncBikeStateFromDefaults()`
+        // shares this one subscription rather than adding a second, and is a
+        // no-op unless one of the three bike-relevant values actually moved —
+        // same shape as `syncArrivalDepartureFilterFromDefaults`'s guard, so an
+        // unrelated settings write doesn't invalidate the stop page.
         userDefaultsCancellable = NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification, object: environment.userDefaults)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.syncArrivalDepartureFilterFromDefaults() }
+            .sink { [weak self] _ in
+                self?.syncArrivalDepartureFilterFromDefaults()
+                self?.syncBikeStateFromDefaults()
+            }
+        lastBikeState = currentBikeState
     }
 
     /// Backward-compatible entry point for existing callers that pass `Application` directly.
@@ -557,6 +579,28 @@ class StopViewModel: ObservableObject {
         }
     }
 
+    private var currentBikeState: BikeState {
+        BikeState(
+            walkingSpeed: environment.walkingSpeedMetersPerSecond,
+            bikeSpeed: environment.bikeSpeedMetersPerSecond,
+            bikeModeEnabled: environment.bikeModeEnabled
+        )
+    }
+
+    /// `headerWalkTime`/`headerBikeTime`/`walkTime` are plain computed properties,
+    /// not `@Published`, so a Bike Mode toggle (or a speed re-sync) made in
+    /// Settings needs an explicit nudge to reach the stop page on this same
+    /// `UserDefaults.didChangeNotification` fan-out. No-op unless one of the
+    /// three values actually moved, so an unrelated settings write — same hot
+    /// path as `syncArrivalDepartureFilterFromDefaults` — doesn't invalidate it.
+    private func syncBikeStateFromDefaults() {
+        let current = currentBikeState
+        if current != lastBikeState {
+            lastBikeState = current
+            objectWillChange.send()
+        }
+    }
+
     /// `true` when the user has never saved preferences for this stop, so the
     /// page may seed its sort mode from the app-wide last-used mode. A stop whose
     /// preferences were saved — including one deliberately set back to
@@ -732,6 +776,12 @@ class StopViewModel: ObservableObject {
     /// chip, independent of whether Bike Mode is enabled.
     var headerBikeTime: WalkTimeInfo? {
         travelTime(atSpeed: environment.bikeSpeedMetersPerSecond)
+    }
+
+    /// Whether `walkTime` above is currently reading bike speed — the chronological
+    /// divider's wording ("walk" vs. "bike") must match what actually produced its minutes.
+    var isBikeModeEnabled: Bool {
+        environment.bikeModeEnabled
     }
 
     // MARK: - Stop Page: Alarms

--- a/OBAKit/ViewModels/StopViewModelEnvironment.swift
+++ b/OBAKit/ViewModels/StopViewModelEnvironment.swift
@@ -35,6 +35,12 @@ protocol StopViewModelEnvironment: AnyObject {
     func recordRecentStop(_ stop: Stop, region: Region)
     var defaultAlarmLeadTimeMinutes: Int { get }
     var walkingSpeedMetersPerSecond: CLLocationSpeed { get }
+    /// The user's cycling speed, independent of whether Bike Mode is enabled —
+    /// the header's bike chip is always shown regardless of mode.
+    var bikeSpeedMetersPerSecond: CLLocationSpeed { get }
+    /// `userDataStore.effectiveTravelVelocityMetersPerSecond` — walking speed, or
+    /// cycling speed when Bike Mode is enabled. Drives the mode-aware split.
+    var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { get }
 
     // MARK: - Stop preferences (individual operations, not the full StopPreferencesStore)
 
@@ -95,6 +101,8 @@ extension Application: StopViewModelEnvironment {
     func recordRecentStop(_ stop: Stop, region: Region) { userDataStore.addRecentStop(stop, region: region) }
     var defaultAlarmLeadTimeMinutes: Int { userDataStore.defaultAlarmLeadTimeMinutes }
     var walkingSpeedMetersPerSecond: CLLocationSpeed { userDataStore.walkingSpeedMetersPerSecond }
+    var bikeSpeedMetersPerSecond: CLLocationSpeed { userDataStore.bikeSpeedMetersPerSecond }
+    var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { userDataStore.effectiveTravelVelocityMetersPerSecond }
 
     func stopPreferences(stopID: StopID, region: Region) -> StopPreferences {
         stopPreferencesDataStore.preferences(stopID: stopID, region: region)
@@ -147,6 +155,8 @@ final class PreviewStopViewModelEnvironment: StopViewModelEnvironment {
     func recordRecentStop(_ stop: Stop, region: Region) {}
     var defaultAlarmLeadTimeMinutes: Int { 2 }
     var walkingSpeedMetersPerSecond: CLLocationSpeed { 1.4 }
+    var bikeSpeedMetersPerSecond: CLLocationSpeed { 4.2 }
+    var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { 1.4 }
 
     func stopPreferences(stopID: StopID, region: Region) -> StopPreferences { .init() }
     func setStopPreferences(_ prefs: StopPreferences, stop: Stop, region: Region) {}

--- a/OBAKit/ViewModels/StopViewModelEnvironment.swift
+++ b/OBAKit/ViewModels/StopViewModelEnvironment.swift
@@ -41,6 +41,9 @@ protocol StopViewModelEnvironment: AnyObject {
     /// `userDataStore.effectiveTravelVelocityMetersPerSecond` — walking speed, or
     /// cycling speed when Bike Mode is enabled. Drives the mode-aware split.
     var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { get }
+    /// Whether the mode-aware split above is currently reading bike speed —
+    /// drives the "walk" vs. "bike" wording on the chronological divider.
+    var bikeModeEnabled: Bool { get }
 
     // MARK: - Stop preferences (individual operations, not the full StopPreferencesStore)
 
@@ -103,6 +106,7 @@ extension Application: StopViewModelEnvironment {
     var walkingSpeedMetersPerSecond: CLLocationSpeed { userDataStore.walkingSpeedMetersPerSecond }
     var bikeSpeedMetersPerSecond: CLLocationSpeed { userDataStore.bikeSpeedMetersPerSecond }
     var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { userDataStore.effectiveTravelVelocityMetersPerSecond }
+    var bikeModeEnabled: Bool { userDataStore.bikeModeEnabled }
 
     func stopPreferences(stopID: StopID, region: Region) -> StopPreferences {
         stopPreferencesDataStore.preferences(stopID: stopID, region: region)
@@ -157,6 +161,7 @@ final class PreviewStopViewModelEnvironment: StopViewModelEnvironment {
     var walkingSpeedMetersPerSecond: CLLocationSpeed { 1.4 }
     var bikeSpeedMetersPerSecond: CLLocationSpeed { 4.2 }
     var effectiveTravelVelocityMetersPerSecond: CLLocationSpeed { 1.4 }
+    var bikeModeEnabled: Bool { false }
 
     func stopPreferences(stopID: StopID, region: Region) -> StopPreferences { .init() }
     func setStopPreferences(_ prefs: StopPreferences, stop: Stop, region: Region) {}

--- a/OBAKitCore/Models/UserData/BikeSpeed.swift
+++ b/OBAKitCore/Models/UserData/BikeSpeed.swift
@@ -11,7 +11,12 @@ import Foundation
 
 // Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
 @objc public enum BikeSpeedSource: Int {
-    case manual = 0    // fixed fallback constant in effect
+    // Not currently HealthKit-driven — covers both "never synced" (the stored speed is
+    // `BikeSpeed.defaultMetersPerSecond`) and "a sync attempt fell back to manual"
+    // (`BikeModeManager` leaves the last-synced speed in place rather than resetting it;
+    // see its `requestHealthKitAuthorizationAndSync` doc comment). There is no manual
+    // speed-entry UI — this case name means "not HealthKit", not "user-entered".
+    case manual = 0
     case healthKit = 1 // synced from HealthKit
 }
 

--- a/OBAKitCore/Models/UserData/BikeSpeed.swift
+++ b/OBAKitCore/Models/UserData/BikeSpeed.swift
@@ -1,0 +1,26 @@
+//
+//  BikeSpeed.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+// Raw values are persisted to UserDefaults — do not reorder or renumber existing cases.
+@objc public enum BikeSpeedSource: Int {
+    case manual = 0    // fixed fallback constant in effect
+    case healthKit = 1 // synced from HealthKit
+}
+
+/// Shared constants for bike mode speed handling.
+public enum BikeSpeed {
+    /// Fallback cycling speed when HealthKit is unavailable, denied, or has no samples (≈15 km/h).
+    public static let defaultMetersPerSecond: Double = 4.2
+
+    /// Acceptable range for a stored bike speed, in meters per second (≈3.6–72 km/h).
+    /// Values outside this range are treated as invalid (divide-hostile or implausible).
+    public static let validRange: ClosedRange<Double> = 1.0...20.0
+}

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -329,6 +329,19 @@ public protocol UserDataStore: NSObjectProtocol {
     /// The source of the walking speed value (manual preset or HealthKit).
     var walkingSpeedSource: WalkingSpeedSource { get set }
 
+    // MARK: - Bike Mode
+
+    /// Whether Bike Mode is enabled. When `true`, walk-time-to-stop calculations
+    /// app-wide should use `bikeSpeedMetersPerSecond` instead of `walkingSpeedMetersPerSecond`.
+    var bikeModeEnabled: Bool { get set }
+
+    /// The user's effective cycling speed in meters per second (HealthKit-synced value,
+    /// or `BikeSpeed.defaultMetersPerSecond` when no sync has ever succeeded).
+    var bikeSpeedMetersPerSecond: Double { get set }
+
+    /// The source of the bike speed value (fixed fallback constant or HealthKit).
+    var bikeSpeedSource: BikeSpeedSource { get set }
+
     // MARK: - Alarm Lead Time
 
     /// The alarm lead time in minutes for one-tap alarms on the Stop page.
@@ -344,6 +357,16 @@ extension UserDataStore {
     /// `TransferContext` is a Swift struct and cannot appear in an ObjC requirement.
     public func displayedTransferContext(_ context: TransferContext?) -> TransferContext? {
         showTransferArrivalBanner ? context : nil
+    }
+}
+
+public extension UserDataStore {
+    /// The velocity (m/s) that all walk-time-to-stop calculations should use.
+    /// Bike Mode, when enabled, takes priority over the walking speed. This is the
+    /// single place call sites should read from instead of branching on
+    /// `bikeModeEnabled` themselves.
+    var effectiveTravelVelocityMetersPerSecond: Double {
+        bikeModeEnabled ? bikeSpeedMetersPerSecond : walkingSpeedMetersPerSecond
     }
 }
 
@@ -439,6 +462,9 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let alwaysShowSurveysOnStops = "UserDataStore.alwaysShowSurveysOnStops"
         static let walkingSpeedMetersPerSecond = "UserDataStore.walkingSpeedMetersPerSecond"
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
+        static let bikeModeEnabled = "UserDataStore.bikeModeEnabled"
+        static let bikeSpeedMetersPerSecond = "UserDataStore.bikeSpeedMetersPerSecond"
+        static let bikeSpeedSource = "UserDataStore.bikeSpeedSource"
         static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
         static let stopUIReducedColors = UserDefaultsStore.stopUIReducedColorsKey
         static let showTransferArrivalBanner = UserDefaultsStore.showTransferArrivalBannerKey
@@ -464,7 +490,10 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
             UserDefaultsKeys.stopUIReducedColors: false,
             UserDefaultsKeys.showTransferArrivalBanner: true,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
-            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
+            UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue,
+            UserDefaultsKeys.bikeModeEnabled: false,
+            UserDefaultsKeys.bikeSpeedMetersPerSecond: BikeSpeed.defaultMetersPerSecond,
+            UserDefaultsKeys.bikeSpeedSource: BikeSpeedSource.manual.rawValue
         ])
 
         // The alarm lead time used to be user-configurable; the setting has been removed
@@ -1202,6 +1231,33 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.walkingSpeedSource)
+        }
+    }
+
+    // MARK: - Bike Mode
+
+    public var bikeModeEnabled: Bool {
+        get { userDefaults.bool(forKey: UserDefaultsKeys.bikeModeEnabled) }
+        set { userDefaults.set(newValue, forKey: UserDefaultsKeys.bikeModeEnabled) }
+    }
+
+    public var bikeSpeedMetersPerSecond: Double {
+        get {
+            let stored = userDefaults.double(forKey: UserDefaultsKeys.bikeSpeedMetersPerSecond)
+            return min(max(stored, BikeSpeed.validRange.lowerBound), BikeSpeed.validRange.upperBound)
+        }
+        set {
+            let clamped = min(max(newValue, BikeSpeed.validRange.lowerBound), BikeSpeed.validRange.upperBound)
+            userDefaults.set(clamped, forKey: UserDefaultsKeys.bikeSpeedMetersPerSecond)
+        }
+    }
+
+    public var bikeSpeedSource: BikeSpeedSource {
+        get {
+            BikeSpeedSource(rawValue: userDefaults.integer(forKey: UserDefaultsKeys.bikeSpeedSource)) ?? .manual
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: UserDefaultsKeys.bikeSpeedSource)
         }
     }
 

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -347,66 +347,66 @@ final class UserDefaultsStoreTests: OBATestCase {
 
     // MARK: - Bike Mode
 
-    func test_bikeModeEnabled_defaultValue() {
-        expect(self.userDefaultsStore.bikeModeEnabled) == false
+    @Test func `Bike mode enabled default value`() {
+        #expect(self.userDefaultsStore.bikeModeEnabled == false)
     }
 
-    func test_bikeModeEnabled_roundTrip() {
+    @Test func `Bike mode enabled round trip`() {
         userDefaultsStore.bikeModeEnabled = true
-        expect(self.userDefaultsStore.bikeModeEnabled) == true
+        #expect(UserDefaultsStore(userDefaults: userDefaults).bikeModeEnabled == true)
 
         userDefaultsStore.bikeModeEnabled = false
-        expect(self.userDefaultsStore.bikeModeEnabled) == false
+        #expect(UserDefaultsStore(userDefaults: userDefaults).bikeModeEnabled == false)
     }
 
-    func test_bikeSpeed_defaultValue() {
-        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    @Test func `Bike speed default value`() {
+        expectClose(self.userDefaultsStore.bikeSpeedMetersPerSecond, 4.2)
     }
 
-    func test_bikeSpeed_roundTrip() {
+    @Test func `Bike speed round trip`() {
         userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
-        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+        expectClose(self.userDefaultsStore.bikeSpeedMetersPerSecond, 5.0)
 
         let newStore = UserDefaultsStore(userDefaults: userDefaults)
-        expect(newStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+        expectClose(newStore.bikeSpeedMetersPerSecond, 5.0)
     }
 
-    func test_bikeSpeedSource_defaultValue() {
-        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+    @Test func `Bike speed source default value`() {
+        #expect(self.userDefaultsStore.bikeSpeedSource == .manual)
     }
 
-    func test_bikeSpeedSource_roundTrip() {
+    @Test func `Bike speed source round trip`() {
         userDefaultsStore.bikeSpeedSource = .healthKit
-        expect(self.userDefaultsStore.bikeSpeedSource) == .healthKit
+        #expect(UserDefaultsStore(userDefaults: userDefaults).bikeSpeedSource == .healthKit)
 
         userDefaultsStore.bikeSpeedSource = .manual
-        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+        #expect(UserDefaultsStore(userDefaults: userDefaults).bikeSpeedSource == .manual)
     }
 
-    func test_bikeSpeedMetersPerSecond_clampsBelowRange() {
+    @Test func `Bike speed meters per second clamps below range`() {
         userDefaultsStore.bikeSpeedMetersPerSecond = 0.1
-        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.lowerBound))
+        expectClose(self.userDefaultsStore.bikeSpeedMetersPerSecond, BikeSpeed.validRange.lowerBound)
     }
 
-    func test_bikeSpeedMetersPerSecond_clampsAboveRange() {
+    @Test func `Bike speed meters per second clamps above range`() {
         userDefaultsStore.bikeSpeedMetersPerSecond = 30.0
-        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.upperBound))
+        expectClose(self.userDefaultsStore.bikeSpeedMetersPerSecond, BikeSpeed.validRange.upperBound)
     }
 
-    func test_effectiveTravelVelocity_whenBikeModeDisabled_returnsWalkingSpeed() {
+    @Test func `Effective travel velocity when bike mode disabled returns walking speed`() {
         userDefaultsStore.bikeModeEnabled = false
         userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
         userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
 
-        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(1.6))
+        expectClose(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond, 1.6)
     }
 
-    func test_effectiveTravelVelocity_whenBikeModeEnabled_returnsBikeSpeed() {
+    @Test func `Effective travel velocity when bike mode enabled returns bike speed`() {
         userDefaultsStore.bikeModeEnabled = true
         userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
         userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
 
-        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(5.0))
+        expectClose(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond, 5.0)
     }
 
     // MARK: - Default Alarm Lead Time

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -345,6 +345,70 @@ final class UserDefaultsStoreTests: OBATestCase {
         expectClose(self.userDefaultsStore.walkingSpeedMetersPerSecond, WalkingSpeed.validRange.upperBound)
     }
 
+    // MARK: - Bike Mode
+
+    func test_bikeModeEnabled_defaultValue() {
+        expect(self.userDefaultsStore.bikeModeEnabled) == false
+    }
+
+    func test_bikeModeEnabled_roundTrip() {
+        userDefaultsStore.bikeModeEnabled = true
+        expect(self.userDefaultsStore.bikeModeEnabled) == true
+
+        userDefaultsStore.bikeModeEnabled = false
+        expect(self.userDefaultsStore.bikeModeEnabled) == false
+    }
+
+    func test_bikeSpeed_defaultValue() {
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+
+    func test_bikeSpeed_roundTrip() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+
+        let newStore = UserDefaultsStore(userDefaults: userDefaults)
+        expect(newStore.bikeSpeedMetersPerSecond).to(beCloseTo(5.0))
+    }
+
+    func test_bikeSpeedSource_defaultValue() {
+        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+    }
+
+    func test_bikeSpeedSource_roundTrip() {
+        userDefaultsStore.bikeSpeedSource = .healthKit
+        expect(self.userDefaultsStore.bikeSpeedSource) == .healthKit
+
+        userDefaultsStore.bikeSpeedSource = .manual
+        expect(self.userDefaultsStore.bikeSpeedSource) == .manual
+    }
+
+    func test_bikeSpeedMetersPerSecond_clampsBelowRange() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 0.1
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.lowerBound))
+    }
+
+    func test_bikeSpeedMetersPerSecond_clampsAboveRange() {
+        userDefaultsStore.bikeSpeedMetersPerSecond = 30.0
+        expect(self.userDefaultsStore.bikeSpeedMetersPerSecond).to(beCloseTo(BikeSpeed.validRange.upperBound))
+    }
+
+    func test_effectiveTravelVelocity_whenBikeModeDisabled_returnsWalkingSpeed() {
+        userDefaultsStore.bikeModeEnabled = false
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+
+        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(1.6))
+    }
+
+    func test_effectiveTravelVelocity_whenBikeModeEnabled_returnsBikeSpeed() {
+        userDefaultsStore.bikeModeEnabled = true
+        userDefaultsStore.walkingSpeedMetersPerSecond = 1.6
+        userDefaultsStore.bikeSpeedMetersPerSecond = 5.0
+
+        expect(self.userDefaultsStore.effectiveTravelVelocityMetersPerSecond).to(beCloseTo(5.0))
+    }
+
     // MARK: - Default Alarm Lead Time
 
     @Test func `Default alarm lead time is 10 minutes`() {

--- a/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
@@ -7,12 +7,11 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
-import Nimble
+import Testing
 @testable import OBAKit
 @testable import OBAKitCore
 
-@MainActor
+@Suite(.serialized)
 final class BikeModeManagerTests: OBATestCase {
 
     private struct FakeProvider: BikeSpeedHealthKitProviding {
@@ -39,7 +38,7 @@ final class BikeModeManagerTests: OBATestCase {
 
     // MARK: - requestHealthKitAuthorizationAndSync
 
-    func test_requestAndSync_whenSampleMissing_returnsFalseAndForcesManual() async {
+    @Test func `Request and sync when sample missing returns false and forces manual`() async {
         store.bikeSpeedSource = .healthKit
         store.bikeSpeedMetersPerSecond = 4.5
 
@@ -50,13 +49,13 @@ final class BikeModeManagerTests: OBATestCase {
 
         let result = await manager.requestHealthKitAuthorizationAndSync()
 
-        expect(result) == false
-        expect(self.store.bikeSpeedSource) == .manual
+        #expect(result == false)
+        #expect(self.store.bikeSpeedSource == .manual)
         // Speed left untouched even on failure.
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.5))
+        expectClose(self.store.bikeSpeedMetersPerSecond, 4.5)
     }
 
-    func test_requestAndSync_whenSampleInRange_writesValueAndMarksHealthKit() async {
+    @Test func `Request and sync when sample in range writes value and marks health kit`() async {
         store.bikeSpeedSource = .manual
         store.bikeSpeedMetersPerSecond = 4.2
 
@@ -67,12 +66,12 @@ final class BikeModeManagerTests: OBATestCase {
 
         let result = await manager.requestHealthKitAuthorizationAndSync()
 
-        expect(result) == true
-        expect(self.store.bikeSpeedSource) == .healthKit
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+        #expect(result == true)
+        #expect(self.store.bikeSpeedSource == .healthKit)
+        expectClose(self.store.bikeSpeedMetersPerSecond, 5.5)
     }
 
-    func test_requestAndSync_whenSampleOutOfRange_doesNotWriteAndForcesManual() async {
+    @Test func `Request and sync when sample out of range does not write and forces manual`() async {
         store.bikeSpeedSource = .healthKit
         store.bikeSpeedMetersPerSecond = 4.2
 
@@ -84,13 +83,13 @@ final class BikeModeManagerTests: OBATestCase {
 
         let result = await manager.requestHealthKitAuthorizationAndSync()
 
-        expect(result) == false
-        expect(self.store.bikeSpeedSource) == .manual
+        #expect(result == false)
+        #expect(self.store.bikeSpeedSource == .manual)
         // Stored speed unchanged — the out-of-range sample must not leak in.
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+        expectClose(self.store.bikeSpeedMetersPerSecond, 4.2)
     }
 
-    func test_requestAndSync_whenAuthorizationThrows_forcesManual() async {
+    @Test func `Request and sync when authorization throws forces manual`() async {
         store.bikeSpeedSource = .healthKit
 
         let manager = BikeModeManager(
@@ -100,11 +99,11 @@ final class BikeModeManagerTests: OBATestCase {
 
         let result = await manager.requestHealthKitAuthorizationAndSync()
 
-        expect(result) == false
-        expect(self.store.bikeSpeedSource) == .manual
+        #expect(result == false)
+        #expect(self.store.bikeSpeedSource == .manual)
     }
 
-    func test_requestAndSync_whenHealthKitUnavailable_forcesManual() async {
+    @Test func `Request and sync when health kit unavailable forces manual`() async {
         store.bikeSpeedSource = .healthKit
 
         let manager = BikeModeManager(
@@ -114,13 +113,13 @@ final class BikeModeManagerTests: OBATestCase {
 
         let result = await manager.requestHealthKitAuthorizationAndSync()
 
-        expect(result) == false
-        expect(self.store.bikeSpeedSource) == .manual
+        #expect(result == false)
+        #expect(self.store.bikeSpeedSource == .manual)
     }
 
     // MARK: - refreshFromHealthKitIfPossible
 
-    func test_passiveRefresh_withNoSample_leavesSourceAndSpeedUntouched() async {
+    @Test func `Passive refresh with no sample leaves source and speed untouched`() async {
         store.bikeSpeedSource = .healthKit
         store.bikeSpeedMetersPerSecond = 5.5
 
@@ -132,11 +131,11 @@ final class BikeModeManagerTests: OBATestCase {
         await manager.refreshFromHealthKitIfPossible()
 
         // The asymmetry: passive refresh must never downgrade source to .manual.
-        expect(self.store.bikeSpeedSource) == .healthKit
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+        #expect(self.store.bikeSpeedSource == .healthKit)
+        expectClose(self.store.bikeSpeedMetersPerSecond, 5.5)
     }
 
-    func test_passiveRefresh_withInRangeSample_updatesSpeed() async {
+    @Test func `Passive refresh with in range sample updates speed`() async {
         store.bikeSpeedSource = .healthKit
         store.bikeSpeedMetersPerSecond = 4.2
 
@@ -147,11 +146,11 @@ final class BikeModeManagerTests: OBATestCase {
 
         await manager.refreshFromHealthKitIfPossible()
 
-        expect(self.store.bikeSpeedSource) == .healthKit
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(6.0))
+        #expect(self.store.bikeSpeedSource == .healthKit)
+        expectClose(self.store.bikeSpeedMetersPerSecond, 6.0)
     }
 
-    func test_passiveRefresh_withOutOfRangeSample_isNoOp() async {
+    @Test func `Passive refresh with out of range sample is no op`() async {
         store.bikeSpeedSource = .healthKit
         store.bikeSpeedMetersPerSecond = 4.2
 
@@ -162,7 +161,7 @@ final class BikeModeManagerTests: OBATestCase {
 
         await manager.refreshFromHealthKitIfPossible()
 
-        expect(self.store.bikeSpeedSource) == .healthKit
-        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+        #expect(self.store.bikeSpeedSource == .healthKit)
+        expectClose(self.store.bikeSpeedMetersPerSecond, 4.2)
     }
 }

--- a/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
+++ b/OBAKitTests/Modeling/WalkingDirections/BikeModeManagerTests.swift
@@ -1,0 +1,168 @@
+//
+//  BikeModeManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+import Nimble
+@testable import OBAKit
+@testable import OBAKitCore
+
+@MainActor
+final class BikeModeManagerTests: OBATestCase {
+
+    private struct FakeProvider: BikeSpeedHealthKitProviding {
+        var isAvailable: Bool = true
+        var authorizationError: Error?
+        var sampleSpeed: Double?
+
+        func requestAuthorization() async throws {
+            if let authorizationError {
+                throw authorizationError
+            }
+        }
+
+        func fetchLatestBikeSpeed() async -> Double? {
+            sampleSpeed
+        }
+    }
+
+    private struct DummyError: Error {}
+
+    private var store: UserDefaultsStore {
+        UserDefaultsStore(userDefaults: userDefaults)
+    }
+
+    // MARK: - requestHealthKitAuthorizationAndSync
+
+    func test_requestAndSync_whenSampleMissing_returnsFalseAndForcesManual() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.5
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+        // Speed left untouched even on failure.
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.5))
+    }
+
+    func test_requestAndSync_whenSampleInRange_writesValueAndMarksHealthKit() async {
+        store.bikeSpeedSource = .manual
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 5.5)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == true
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+    }
+
+    func test_requestAndSync_whenSampleOutOfRange_doesNotWriteAndForcesManual() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        // 30 m/s sits well outside BikeSpeed.validRange (1.0...20.0).
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 30.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+        // Stored speed unchanged — the out-of-range sample must not leak in.
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+
+    func test_requestAndSync_whenAuthorizationThrows_forcesManual() async {
+        store.bikeSpeedSource = .healthKit
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(authorizationError: DummyError(), sampleSpeed: 5.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+    }
+
+    func test_requestAndSync_whenHealthKitUnavailable_forcesManual() async {
+        store.bikeSpeedSource = .healthKit
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(isAvailable: false, sampleSpeed: 5.0)
+        )
+
+        let result = await manager.requestHealthKitAuthorizationAndSync()
+
+        expect(result) == false
+        expect(self.store.bikeSpeedSource) == .manual
+    }
+
+    // MARK: - refreshFromHealthKitIfPossible
+
+    func test_passiveRefresh_withNoSample_leavesSourceAndSpeedUntouched() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 5.5
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: nil)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        // The asymmetry: passive refresh must never downgrade source to .manual.
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(5.5))
+    }
+
+    func test_passiveRefresh_withInRangeSample_updatesSpeed() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 6.0)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(6.0))
+    }
+
+    func test_passiveRefresh_withOutOfRangeSample_isNoOp() async {
+        store.bikeSpeedSource = .healthKit
+        store.bikeSpeedMetersPerSecond = 4.2
+
+        let manager = BikeModeManager(
+            userDataStore: store,
+            healthKit: FakeProvider(sampleSpeed: 0.5)
+        )
+
+        await manager.refreshFromHealthKitIfPossible()
+
+        expect(self.store.bikeSpeedSource) == .healthKit
+        expect(self.store.bikeSpeedMetersPerSecond).to(beCloseTo(4.2))
+    }
+}

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -1160,8 +1160,8 @@ final class StopViewModelTests: OBATestCase {
     /// `headerWalkTime` and `headerBikeTime` must stay fixed at their respective speeds
     /// regardless of Bike Mode, while the mode-aware `walkTime` is the one that switches —
     /// the contract the header chips and the chronological split each depend on.
-    @MainActor
-    func test_headerWalkAndBikeTime_areIndependentOfBikeModeWhileWalkTimeSwitches() async {
+    @Test @MainActor
+    func `Header walk and bike time stay fixed across Bike Mode while the mode-aware value switches`() async throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -1169,22 +1169,20 @@ final class StopViewModelTests: OBATestCase {
         await viewModel.refresh()
 
         app.userDataStore.bikeModeEnabled = false
-        let headerWalkBefore = viewModel.headerWalkTime
-        let headerBikeBefore = viewModel.headerBikeTime
+        let headerWalkBefore = try #require(viewModel.headerWalkTime)
+        let headerBikeBefore = try #require(viewModel.headerBikeTime)
 
-        expect(headerWalkBefore).toNot(beNil())
-        expect(headerBikeBefore).toNot(beNil())
         // Cycling speed is faster than walking speed, so the bike estimate must be shorter.
-        expect(headerBikeBefore?.walkMinutes).to(beLessThan(headerWalkBefore?.walkMinutes))
+        #expect(headerBikeBefore.walkMinutes < headerWalkBefore.walkMinutes)
         // Bike Mode off: the mode-aware value tracks the walking speed.
-        expect(viewModel.walkTime) == headerWalkBefore
+        #expect(viewModel.walkTime == headerWalkBefore)
 
         app.userDataStore.bikeModeEnabled = true
 
         // The header chips must not move when Bike Mode toggles...
-        expect(viewModel.headerWalkTime) == headerWalkBefore
-        expect(viewModel.headerBikeTime) == headerBikeBefore
+        #expect(viewModel.headerWalkTime == headerWalkBefore)
+        #expect(viewModel.headerBikeTime == headerBikeBefore)
         // ...but the mode-aware value now tracks the cycling speed instead.
-        expect(viewModel.walkTime) == headerBikeBefore
+        #expect(viewModel.walkTime == headerBikeBefore)
     }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -1154,4 +1154,37 @@ final class StopViewModelTests: OBATestCase {
         let message = try #require(viewModel.operationErrorMessage)
         #expect(!message.contains("404"))
     }
+
+    // MARK: - Stop Page: Walk/Bike Time
+
+    /// `headerWalkTime` and `headerBikeTime` must stay fixed at their respective speeds
+    /// regardless of Bike Mode, while the mode-aware `walkTime` is the one that switches —
+    /// the contract the header chips and the chronological split each depend on.
+    @MainActor
+    func test_headerWalkAndBikeTime_areIndependentOfBikeModeWhileWalkTimeSwitches() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        app.userDataStore.bikeModeEnabled = false
+        let headerWalkBefore = viewModel.headerWalkTime
+        let headerBikeBefore = viewModel.headerBikeTime
+
+        expect(headerWalkBefore).toNot(beNil())
+        expect(headerBikeBefore).toNot(beNil())
+        // Cycling speed is faster than walking speed, so the bike estimate must be shorter.
+        expect(headerBikeBefore?.walkMinutes).to(beLessThan(headerWalkBefore?.walkMinutes))
+        // Bike Mode off: the mode-aware value tracks the walking speed.
+        expect(viewModel.walkTime) == headerWalkBefore
+
+        app.userDataStore.bikeModeEnabled = true
+
+        // The header chips must not move when Bike Mode toggles...
+        expect(viewModel.headerWalkTime) == headerWalkBefore
+        expect(viewModel.headerBikeTime) == headerBikeBefore
+        // ...but the mode-aware value now tracks the cycling speed instead.
+        expect(viewModel.walkTime) == headerBikeBefore
+    }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -1185,4 +1185,69 @@ final class StopViewModelTests: OBATestCase {
         // ...but the mode-aware value now tracks the cycling speed instead.
         #expect(viewModel.walkTime == headerBikeBefore)
     }
+
+    /// A Bike Mode toggle made in Settings — not through this view model — must
+    /// still refresh the stop page immediately, or the header chips and the
+    /// chronological divider would show stale minutes until the next periodic
+    /// poll. Mirrors `Arrival departure filter syncs from an external Settings
+    /// change` above: `syncBikeStateFromDefaults` shares that test's subscription
+    /// (#1273) rather than a second one.
+    @Test @MainActor
+    func `Bike Mode toggle from an external Settings change emits objectWillChange`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        var emissions = 0
+        let cancellable = viewModel.objectWillChange.sink { emissions += 1 }
+        defer { cancellable.cancel() }
+
+        // `refresh()` above has its own async side effects (e.g. recording this
+        // stop as recently viewed) that can still be landing on the main queue
+        // here, each a legitimate `objectWillChange` in its own right. Let that
+        // settle before measuring, so the assertion below isolates this write's
+        // effect from that unrelated background noise, not just its raw count.
+        for _ in 0..<5 { await Task.yield() }
+        let baseline = emissions
+
+        // Settings' write path.
+        app.userDataStore.bikeModeEnabled = true
+
+        // `UserDefaults.didChangeNotification` fan-out is `receive(on: main)`,
+        // so give the runloop a few hops to deliver.
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(emissions > baseline)
+    }
+
+    /// The no-op guard on the same path: re-persisting an unchanged bike setting
+    /// must not emit beyond baseline — pins `syncBikeStateFromDefaults`'s
+    /// `current != lastBikeState` check so a rider isn't paying a re-render on
+    /// every unrelated Settings write.
+    @Test @MainActor
+    func `Unrelated Settings write does not emit a bike state refresh`() async {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+        await viewModel.refresh()
+
+        var emissions = 0
+        let cancellable = viewModel.objectWillChange.sink { emissions += 1 }
+        defer { cancellable.cancel() }
+
+        // See the sibling test above for why this settles against a baseline
+        // rather than an absolute count.
+        for _ in 0..<5 { await Task.yield() }
+        let baseline = emissions
+
+        // Re-writing the already-current value: nothing bike-related actually changed.
+        app.userDataStore.bikeModeEnabled = app.userDataStore.bikeModeEnabled
+
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(emissions == baseline)
+    }
 }


### PR DESCRIPTION
## Summary

Adds a standalone **Bike Mode** to speed up walk-time-to-stop estimates for cyclists, without disturbing the existing walking-speed path:

- **Bike Mode toggle** (Settings) swaps the travel velocity used for stop ETAs, arrival estimates, and the reachable/missed departure split from walking speed to cycling speed. Speed syncs from HealthKit cycling data when available (mirroring the existing \`WalkingSpeedManager\` pattern as an independent mechanism), falling back to a fixed ~15 km/h constant otherwise.
- **Stop header** shows two independent, always-visible chips — a walk estimate and a bike estimate, each computed at its own fixed speed — instead of a single pill that silently followed Bike Mode while still reading "walk". Bike Mode drives only the reachable/missed arrival split, not these header chips.
- **Chronological divider** ("N MIN WALK — CATCH BELOW") now switches to bike wording/icon/color when Bike Mode is on, so it matches the mode-aware minutes it's actually showing.
- **Settings round-trip**: toggling Bike Mode now refreshes the stop page immediately (previously waited for the next periodic poll, since the affected properties aren't \`@Published\`).
- **Chip styling**: walk (green) and bike (blue) chips use distinct background colors so the two estimates read as different at a glance, not just by icon.

### Known limitation

The bike chip isn't tappable — no "open cycling directions" action to match the walk chip's \`onWalkingDirections\`. Apple's documented Maps URL scheme only supports \`dirflg=d/w/r\`; there's no officially supported bike value, so wiring that up would mean relying on undocumented behavior. Left as a deliberate follow-up rather than guessing.

## Test plan

- [x] Full unit suite: 1952/1952, 0 failures (includes new/converted bike-mode suites in Swift Testing style, matching the rest of the migrated suite)
- [x] \`BikeModeManagerTests\` — HealthKit auth success/failure/exception, sample present/absent/out-of-range, active-vs-passive sync asymmetry
- [x] \`UserDataStoreTests\` — bike speed/mode/source defaults, roundtrip against a fresh store instance, clamping, \`effectiveTravelVelocityMetersPerSecond\` in both Bike Mode states
- [x] \`StopViewModelTests\` — \`headerWalkTime\`/\`headerBikeTime\` stay fixed across the Bike Mode toggle while the mode-aware \`walkTime\` (driving the chronological split) switches between them
- [x] Live-data simulator walkthrough (Puget Sound): both header chips render with correct minutes and distinct colors on a real stop
- [ ] **Needs a human/device pass** (not exercisable in Simulator): live HealthKit authorization + a real \`cyclingSpeed\` sample round-trip, and the denial toast on a physical device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bike Mode with manual or HealthKit-based cycling speed detection.
  * Stop pages now show separate walking and cycling estimates with mode-specific icons, labels, and accessibility text.
  * Added Settings controls for Bike Mode and transfer-arrival banners.
* **Bug Fixes**
  * Travel times now update when travel-mode settings change.
  * Improved stop deep-link navigation across regions.
  * Updated HealthKit messaging to cover walking and cycling speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->