### PR TITLE
Harden proximity monitoring follow-ups from #1150

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -75,6 +75,10 @@ targets:
           - fb
           - twitter
           - comgooglemaps
+        # Proximity alerts geofence the destination, and Core Location only delivers
+        # region events in the background under Always. Same body as the When In Use
+        # string, matching every InfoPlist.strings translation already in the repo.
+        NSLocationAlwaysAndWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
         NSLocationWhenInUseUsageDescription: See where you are in relation to transit, and help you navigate more easily.
         # HealthKit purpose strings live in Apps/Shared/info_plist.yml (shared by every app).
         NSLocationTemporaryUsageDescriptionDictionary:

--- a/OBAKitCore/Location/Location/LocationManagerProtocol.swift
+++ b/OBAKitCore/Location/Location/LocationManagerProtocol.swift
@@ -17,6 +17,10 @@ public protocol LocationManager {
 
     func requestWhenInUseAuthorization()
 
+    /// Region monitoring only delivers events in the background under
+    /// `.authorizedAlways`, so proximity alerts must be able to ask for it.
+    func requestAlwaysAuthorization()
+
     @available(iOS 14, *)
     func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String)
 
@@ -56,6 +60,13 @@ public protocol LocationManager {
     func startMonitoring(for region: CLRegion)
     func stopMonitoring(for region: CLRegion)
     var monitoredRegions: Set<CLRegion> { get }
+
+    /// The largest radius, in meters, this device will actually monitor.
+    ///
+    /// `CLCircularRegion` silently clamps an oversize radius, so a region built
+    /// past this limit fires at a different distance than the one requested with
+    /// no error to tell anyone. Reading the limit is what makes that detectable.
+    var maximumRegionMonitoringDistance: CLLocationDistance { get }
 }
 
 extension CLLocationManager: LocationManager {

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -24,7 +24,16 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     @objc optional func locationService(_ service: LocationService, headingChanged heading: CLHeading?)
     @objc optional func locationService(_ service: LocationService, errorReceived error: Error)
     @objc optional func locationService(_ service: LocationService, didEnterMonitoredRegion identifier: String)
-    @objc optional func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error)
+    /// Fired when Core Location fails to monitor one of *our* proximity regions.
+    ///
+    /// Failures for regions the app monitors for other reasons are filtered out
+    /// before this point, mirroring the prefix check in `didEnterMonitoredRegion`.
+    /// `identifier` is nil when Core Location could not attribute the failure to a
+    /// region; those are forwarded anyway, since one of ours may be the cause.
+    ///
+    /// `kind` classifies `error` into what the receiver can actually do about it —
+    /// see `RegionMonitoringFailureKind`.
+    @objc optional func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error, kind: RegionMonitoringFailureKind)
 }
 
 // @preconcurrency: CLLocationManager delivers callbacks on the run loop it was
@@ -137,9 +146,9 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         }
     }
 
-    private func notifyDelegatesMonitoringDidFail(_ identifier: String?, error: Error) {
+    private func notifyDelegatesMonitoringDidFail(_ identifier: String?, error: Error, kind: RegionMonitoringFailureKind) {
         for delegate in delegates.allObjects {
-            delegate.locationService?(self, monitoringDidFailFor: identifier, error: error)
+            delegate.locationService?(self, monitoringDidFailFor: identifier, error: error, kind: kind)
         }
     }
 
@@ -243,6 +252,34 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     /// Prompts the user for permission to access location services. (e.g. GPS.)
     @objc public func requestInUseAuthorization() {
         locationManager.requestWhenInUseAuthorization()
+    }
+
+    /// Prompts the user to upgrade to Always authorization, which region
+    /// monitoring requires to deliver geofence events in the background.
+    ///
+    /// Apple only surfaces this prompt once, and only from `.authorizedWhenInUse`
+    /// or `.notDetermined` — calling it from `.denied` or `.restricted` does
+    /// nothing at all. Callers should therefore treat it as a one-shot upgrade
+    /// path and fall back to deep-linking Settings when it no-ops.
+    ///
+    /// - Important: This also requires `NSLocationAlwaysAndWhenInUseUsageDescription`
+    ///   in the host app's Info.plist; without it iOS ignores the call entirely.
+    ///   `Apps/Shared/app_shared.yml` declares it for every white-label app, and
+    ///   KiedyBus overrides the body with its own. A new app that skips both will
+    ///   never reach `.authorizedAlways`, and this method will silently do nothing.
+    @objc public func requestAlwaysAuthorization() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    /// Whether the app can actually run proximity geofences.
+    ///
+    /// Deliberately stricter than `isLocationUseAuthorized`, which also accepts
+    /// `.authorizedWhenInUse`. Region monitoring started under When In Use is
+    /// accepted by Core Location but only delivers while the app is in use — which
+    /// defeats the entire purpose of a proximity alert, since the user is watching
+    /// the road, not the screen.
+    public var isProximityMonitoringAuthorized: Bool {
+        authorizationStatus == .authorizedAlways
     }
 
     @available(iOS 14, *)
@@ -483,26 +520,72 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     static let proximityRegionPrefix = "oba.proximity."
 
+    /// The number of regions iOS will monitor for a single app, across every
+    /// feature that asks for one.
+    ///
+    /// Core Location does not expose this as a constant, and it enforces the cap
+    /// asynchronously: the call that exceeds it returns normally, then fails via
+    /// `monitoringDidFailFor` carrying no region at all. Checking up front is the
+    /// only way to tell the caller *which* alert failed to arm.
+    public static let maximumMonitoredRegions = 20
+
+    static func proximityRegionIdentifier(for alert: ProximityAlert) -> String {
+        proximityRegionPrefix + alert.id.uuidString
+    }
+
+    /// The regions currently monitored on behalf of proximity alerts, excluding
+    /// any the app monitors for other reasons.
+    public var monitoredProximityRegions: Set<CLRegion> {
+        locationManager.monitoredRegions.filter { $0.identifier.hasPrefix(Self.proximityRegionPrefix) }
+    }
+
     /// Starts monitoring a geofence region for the given proximity alert.
     ///
-    /// - Note: Region monitoring requires `.authorizedAlways` for background delivery.
-    ///   The caller (e.g. ProximityAlertManager) is responsible for ensuring appropriate authorization.
-    public func startMonitoringProximity(for alert: ProximityAlert) {
-        guard isLocationUseAuthorized else { return }
+    /// The result is deliberately *not* `@discardableResult`. Region monitoring
+    /// has no self-healing re-arm — nothing retries it when authorization or the
+    /// region count later changes — so a caller that drops a failure on the floor
+    /// ships an alert that will never fire and never explains why.
+    public func startMonitoringProximity(for alert: ProximityAlert) -> ProximityMonitoringResult {
+        guard isProximityMonitoringAuthorized else {
+            Logger.warn("Not monitoring proximity alert \(alert.id): needs authorizedAlways, have \(authorizationStatus).")
+            return .insufficientAuthorization(authorizationStatus)
+        }
 
-        let region = CLCircularRegion(
-            center: alert.coordinate,
-            radius: alert.radiusMeters,
-            identifier: Self.proximityRegionPrefix + alert.id.uuidString
-        )
+        let identifier = Self.proximityRegionIdentifier(for: alert)
+
+        // Re-arming an alert already being monitored replaces its region instead
+        // of adding one — `CLRegion` hashes on identifier — so it can't push the
+        // app over the cap and must not be rejected by this check.
+        let isReplacement = locationManager.monitoredRegions.contains { $0.identifier == identifier }
+        if !isReplacement, locationManager.monitoredRegions.count >= Self.maximumMonitoredRegions {
+            Logger.warn("Not monitoring proximity alert \(alert.id): already at the \(Self.maximumMonitoredRegions)-region limit.")
+            return .regionLimitReached(limit: Self.maximumMonitoredRegions)
+        }
+
+        // `CLCircularRegion` clamps an oversize radius without reporting it, so
+        // the alert would fire at a distance the user never chose. Clamp
+        // deliberately and say so. A non-positive device maximum means the value
+        // is unavailable rather than zero, so honor the request in that case.
+        let requestedRadius = alert.radiusMeters
+        let deviceMaximum = locationManager.maximumRegionMonitoringDistance
+        let radius = deviceMaximum > 0 ? min(requestedRadius, deviceMaximum) : requestedRadius
+
+        let region = CLCircularRegion(center: alert.coordinate, radius: radius, identifier: identifier)
         region.notifyOnEntry = true
         region.notifyOnExit = false
         locationManager.startMonitoring(for: region)
+
+        guard radius == requestedRadius else {
+            Logger.warn("Proximity alert \(alert.id) radius \(requestedRadius)m exceeds the device maximum \(deviceMaximum)m; monitoring at \(radius)m.")
+            return .startedWithClampedRadius(requested: requestedRadius, monitored: radius)
+        }
+
+        return .started
     }
 
     /// Stops monitoring the geofence region for the given proximity alert.
     public func stopMonitoringProximity(for alert: ProximityAlert) {
-        let identifier = Self.proximityRegionPrefix + alert.id.uuidString
+        let identifier = Self.proximityRegionIdentifier(for: alert)
         guard let matchingRegion = locationManager.monitoredRegions.first(where: {
             $0.identifier == identifier
         }) else {
@@ -514,18 +597,47 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Stops monitoring all proximity alert regions without affecting other monitored regions.
     public func stopMonitoringAllProximityAlerts() {
-        for region in locationManager.monitoredRegions where region.identifier.hasPrefix(Self.proximityRegionPrefix) {
+        for region in monitoredProximityRegions {
             locationManager.stopMonitoring(for: region)
         }
     }
 
     public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        guard region is CLCircularRegion, region.identifier.hasPrefix(Self.proximityRegionPrefix) else { return }
+        guard region.identifier.hasPrefix(Self.proximityRegionPrefix) else { return }
+
+        // Every region registered under this prefix is created as a
+        // `CLCircularRegion` a few lines above, so one that isn't means either a
+        // bug here or something else writing into our identifier namespace.
+        // Returning silently would strand the alert with nothing to debug from.
+        guard region is CLCircularRegion else {
+            Logger.error("Entered region \(region.identifier) carrying the proximity prefix but typed \(type(of: region)) rather than CLCircularRegion. Ignoring.")
+            return
+        }
+
         notifyDelegatesDidEnterMonitoredRegion(region.identifier)
     }
 
     public func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
-        Logger.error("Region monitoring failed for \(region?.identifier ?? "unknown"): \(error)")
-        notifyDelegatesMonitoringDidFail(region?.identifier, error: error)
+        let kind = RegionMonitoringFailureKind(error: error)
+
+        guard let identifier = region?.identifier else {
+            // Core Location reports the region-count cap, and some setup
+            // failures, with no region attached. Unattributable, but plausibly
+            // one of ours, so it still goes to the delegates.
+            Logger.error("Region monitoring failed with no region attached (\(kind)): \(error)")
+            notifyDelegatesMonitoringDidFail(nil, error: error, kind: kind)
+            return
+        }
+
+        // Mirrors the prefix filter in `didEnterRegion`. Without it, proximity
+        // delegates receive every monitoring failure in the app — including ones
+        // they can neither attribute nor act on.
+        guard identifier.hasPrefix(Self.proximityRegionPrefix) else {
+            Logger.error("Region monitoring failed for non-proximity region \(identifier) (\(kind)): \(error)")
+            return
+        }
+
+        Logger.error("Region monitoring failed for proximity region \(identifier) (\(kind)): \(error)")
+        notifyDelegatesMonitoringDidFail(identifier, error: error, kind: kind)
     }
 }

--- a/OBAKitCore/Location/Location/ProximityMonitoring.swift
+++ b/OBAKitCore/Location/Location/ProximityMonitoring.swift
@@ -1,0 +1,117 @@
+//
+//  ProximityMonitoring.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+
+/// The outcome of a request to begin monitoring a proximity alert's geofence.
+///
+/// Region monitoring has no self-healing re-arm: unlike location updates, which
+/// `LocationService` restarts when authorization changes, a geofence that never
+/// started stays dead for the life of the alert. So "did not start" cannot be a
+/// silent no-op — every case below `started` is a condition the caller is
+/// expected to surface rather than swallow.
+public enum ProximityMonitoringResult: Equatable, Sendable {
+    /// Monitoring began with the radius the alert asked for.
+    case started
+
+    /// Monitoring began, but at a smaller radius than requested, because the
+    /// device will not monitor one that large. Core Location clamps an oversize
+    /// radius silently, so this is the only signal that the alert will fire at a
+    /// different distance than the user chose.
+    case startedWithClampedRadius(requested: CLLocationDistance, monitored: CLLocationDistance)
+
+    /// Monitoring did not begin: delivering geofence events in the background
+    /// requires `.authorizedAlways`, and the app holds the status carried here.
+    case insufficientAuthorization(CLAuthorizationStatus)
+
+    /// Monitoring did not begin: the app already monitors `limit` regions, which
+    /// is all iOS allows. A slot must be freed before this alert can arm.
+    case regionLimitReached(limit: Int)
+
+    /// Whether a geofence is now armed, at whatever radius.
+    public var isMonitoring: Bool {
+        switch self {
+        case .started, .startedWithClampedRadius:
+            return true
+        case .insufficientAuthorization, .regionLimitReached:
+            return false
+        }
+    }
+}
+
+/// A region-monitoring failure classified by what the caller can do about it.
+///
+/// Core Location funnels every monitoring failure through one delegate callback
+/// carrying a bare `Error`. Some are permanent and need the user to act in
+/// Settings; others are the OS deferring work that resolves on its own. The
+/// distinction matters in both directions: retrying a permanent failure burns
+/// battery forever, and giving up on a transient one drops an alert that would
+/// have armed a moment later.
+@objc(OBARegionMonitoringFailureKind)
+public enum RegionMonitoringFailureKind: Int, Sendable {
+    /// Permanent until the user changes location authorization in Settings.
+    case authorizationDenied
+
+    /// The region itself was rejected — the app exceeded the OS limit on
+    /// simultaneously monitored regions, or asked for a radius this device will
+    /// not monitor. Permanent until the app changes what it asks for.
+    case regionRejected
+
+    /// The OS delayed the request rather than refusing it. Expected to resolve
+    /// without intervention, so the alert is safe to leave armed.
+    case transient
+
+    /// An error Core Location does not document for this path. Treated as
+    /// permanent, because retrying an unrecognized failure forever is the worse
+    /// of the two ways to be wrong.
+    case unknown
+
+    public init(error: Error) {
+        guard let clError = error as? CLError else {
+            self = .unknown
+            return
+        }
+
+        switch clError.code {
+        case .denied, .regionMonitoringDenied:
+            self = .authorizationDenied
+        case .regionMonitoringFailure:
+            self = .regionRejected
+        case .regionMonitoringSetupDelayed, .regionMonitoringResponseDelayed, .network:
+            self = .transient
+        default:
+            self = .unknown
+        }
+    }
+
+    /// Whether leaving the alert armed and waiting is the right response.
+    ///
+    /// Nothing in OBAKitCore consumes this yet — it exists for the retry decision
+    /// `ProximityAlertManager` has to make, which is the whole reason failures are
+    /// classified at all. Keep it when wiring that up rather than re-deriving
+    /// `== .transient` at the call site.
+    public var isTransient: Bool {
+        self == .transient
+    }
+}
+
+/// `@objc` enums interpolate as `RegionMonitoringFailureKind(rawValue: 1)`,
+/// which tells whoever is reading a device log nothing at all. Matches how
+/// `CLAuthorizationStatus` is given a description in `CoreLocationExtensions`.
+extension RegionMonitoringFailureKind: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .authorizationDenied: return "authorizationDenied"
+        case .regionRejected: return "regionRejected"
+        case .transient: return "transient"
+        case .unknown: return "unknown"
+        }
+    }
+}

--- a/OBAKitCore/Models/UserData/ProximityAlert.swift
+++ b/OBAKitCore/Models/UserData/ProximityAlert.swift
@@ -28,14 +28,72 @@ public class ProximityAlert: NSObject, Codable {
     /// The maximum age (in seconds) before a proximity alert is considered stale and should be removed.
     public static let expirationInterval: TimeInterval = 24 * 60 * 60 // 24 hours
 
-    public init(stop: Stop, radiusMeters: Double = 200.0, createdAt: Date = Date()) {
+    // MARK: - Radius
+
+    /// The geofence radius used when a caller doesn't choose one.
+    public static let defaultRadiusMeters: CLLocationDistance = 200
+
+    /// The tightest geofence worth arming. Core Location's own accuracy floor
+    /// means anything smaller fires late, early, or not at all.
+    public static let minimumRadiusMeters: CLLocationDistance = 50
+
+    /// A conservative ceiling for a radius, applied where the device's real limit
+    /// isn't reachable.
+    ///
+    /// `LocationManager.maximumRegionMonitoringDistance` is the authoritative
+    /// value and varies with hardware and current resource constraints, so this
+    /// model can't consult it. `LocationService` clamps a second time against the
+    /// live value when it actually arms the region.
+    public static let maximumRadiusMeters: CLLocationDistance = 10_000
+
+    /// Brings `radius` into the monitorable range, logging whenever it has to.
+    ///
+    /// An out-of-range radius can't simply be passed along: `CLCircularRegion`
+    /// clamps it silently, so the alert would fire at a distance nobody asked for
+    /// with nothing anywhere recording that it had changed.
+    static func clampedRadius(_ radius: CLLocationDistance) -> CLLocationDistance {
+        guard radius.isFinite else {
+            Logger.warn("ProximityAlert radius \(radius) is not a finite number; using the \(defaultRadiusMeters)m default.")
+            return defaultRadiusMeters
+        }
+
+        let clamped = min(max(radius, minimumRadiusMeters), maximumRadiusMeters)
+        if clamped != radius {
+            Logger.warn("ProximityAlert radius \(radius)m falls outside \(minimumRadiusMeters)m–\(maximumRadiusMeters)m; clamped to \(clamped)m.")
+        }
+
+        return clamped
+    }
+
+    public init(stop: Stop, radiusMeters: CLLocationDistance = ProximityAlert.defaultRadiusMeters, createdAt: Date = Date()) {
         self.id = UUID()
         self.stopID = stop.id
         self.stopName = stop.name
         self.latitude = stop.location.coordinate.latitude
         self.longitude = stop.location.coordinate.longitude
-        self.radiusMeters = radiusMeters
+        self.radiusMeters = ProximityAlert.clampedRadius(radiusMeters)
         self.createdAt = createdAt
+    }
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case id, stopID, stopName, latitude, longitude, radiusMeters, createdAt
+    }
+
+    /// Re-applies the radius clamp on the way in, so the invariant also holds for
+    /// alerts persisted by a build that predates it. Keys match the property
+    /// names the synthesized conformance used, keeping stored alerts readable.
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(UUID.self, forKey: .id)
+        stopID = try container.decode(StopID.self, forKey: .stopID)
+        stopName = try container.decode(String.self, forKey: .stopName)
+        latitude = try container.decode(Double.self, forKey: .latitude)
+        longitude = try container.decode(Double.self, forKey: .longitude)
+        radiusMeters = ProximityAlert.clampedRadius(try container.decode(CLLocationDistance.self, forKey: .radiusMeters))
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
 
     /// Whether this alert has expired based on `expirationInterval`.

--- a/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
+++ b/OBAKitTests/Helpers/Mocks/LocationServiceMocks.swift
@@ -31,7 +31,14 @@ public class LocationManagerMock: NSObject, LocationManager {
         monitoredRegions.remove(region)
     }
 
+    /// Settable so tests can drive the radius-clamping path. The default is far
+    /// larger than any radius `ProximityAlert` will hand over, so a test that
+    /// doesn't care about clamping never trips it by accident.
+    public var maximumRegionMonitoringDistance: CLLocationDistance = 100_000
+
     public func requestWhenInUseAuthorization() { }
+
+    public func requestAlwaysAuthorization() { }
 
     @available(iOS 14, *)
     public func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String) {
@@ -118,6 +125,14 @@ public class AuthorizableLocationManagerMock: LocationManagerMock {
         _authorizationStatus = .authorizedWhenInUse
     }
 
+    /// Mirrors the real prompt's one rule that matters here: Always can only be
+    /// granted from `.notDetermined` or `.authorizedWhenInUse`. From `.denied` or
+    /// `.restricted` the system shows nothing, so neither does this.
+    public override func requestAlwaysAuthorization() {
+        guard _authorizationStatus == .notDetermined || _authorizationStatus == .authorizedWhenInUse else { return }
+        _authorizationStatus = .authorizedAlways
+    }
+
     public override var authorizationStatus: CLAuthorizationStatus {
         return _authorizationStatus
     }
@@ -186,6 +201,10 @@ class LocDelegate: NSObject, LocationServiceDelegate {
     var enteredRegionIdentifier: String?
     var monitoringFailedIdentifier: String?
     var monitoringFailedError: Error?
+    var monitoringFailedKind: RegionMonitoringFailureKind?
+    /// Distinguishes "not notified at all" from "notified with a nil identifier",
+    /// which the prefix-filtering tests turn on.
+    var monitoringFailedCallCount = 0
 
     func locationService(_ service: LocationService, locationChanged location: CLLocation) {
         self.location = location
@@ -207,8 +226,10 @@ class LocDelegate: NSObject, LocationServiceDelegate {
         self.enteredRegionIdentifier = identifier
     }
 
-    func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error) {
+    func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error, kind: RegionMonitoringFailureKind) {
         self.monitoringFailedIdentifier = identifier
         self.monitoringFailedError = error
+        self.monitoringFailedKind = kind
+        self.monitoringFailedCallCount += 1
     }
 }

--- a/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
+++ b/OBAKitTests/Helpers/Mocks/MockAuthorizedLocationManager.swift
@@ -31,6 +31,10 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
         // nop, already authorized.
     }
 
+    func requestAlwaysAuthorization() {
+        authorizationStatus = .authorizedAlways
+    }
+
     @available(iOS 14, *)
     func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String) {
         // nop.
@@ -96,4 +100,8 @@ class MockAuthorizedLocationManager: NSObject, LocationManager {
     func stopMonitoring(for region: CLRegion) {
         monitoredRegions.remove(region)
     }
+
+    /// Large enough that no radius this mock is handed gets clamped by accident;
+    /// the clamping path has dedicated coverage against `LocationManagerMock`.
+    var maximumRegionMonitoringDistance: CLLocationDistance = 100_000
 }

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -28,11 +28,25 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
 
         let location = CLLocation(latitude: 47.0, longitude: -122.0)
         locationManagerMock = AuthorizableLocationManagerMock(updateLocation: location, updateHeading: OBAMockHeading(heading: 0.0))
-        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        // Always, not When In Use: geofences only deliver in the background under
+        // Always, and `startMonitoringProximity` now refuses anything less.
+        locationManagerMock._authorizationStatus = .authorizedAlways
         service = LocationService(userDefaults: userDefaults, locationManager: locationManagerMock)
         delegate = LocDelegate()
         service.addDelegate(delegate)
         stop = try! Fixtures.loadSomeStops().first!
+    }
+
+    /// Fills the manager with regions the service did not create, standing in for
+    /// the rest of the app's monitoring. The OS cap is per-app, not per-feature.
+    private func fillMonitoredRegions(count: Int) {
+        for index in 0..<count {
+            locationManagerMock.startMonitoring(for: CLCircularRegion(
+                center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
+                radius: 100,
+                identifier: "filler-region-\(index)"
+            ))
+        }
     }
 
     // MARK: - Start Monitoring
@@ -40,13 +54,15 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
     @Test func `Start monitoring proximity creates region with correct properties`() {
         let alert = ProximityAlert(stop: stop, radiusMeters: 300.0)
 
-        service.startMonitoringProximity(for: alert)
+        let result = service.startMonitoringProximity(for: alert)
 
+        #expect(result == .started)
+        #expect(result.isMonitoring)
         #expect(self.locationManagerMock.monitoredRegions.count == 1)
 
         let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
         #expect(region != nil)
-        #expect(region?.identifier == "oba.proximity.\(alert.id.uuidString)")
+        #expect(region?.identifier == LocationService.proximityRegionIdentifier(for: alert))
         #expect(region?.center.latitude == stop.location.coordinate.latitude)
         #expect(region?.center.longitude == stop.location.coordinate.longitude)
         #expect(region?.radius == 300.0)
@@ -54,34 +70,24 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(region?.notifyOnExit == false)
     }
 
-    @Test func `Start monitoring proximity unauthorized does not monitor`() {
-        let unauthorizedMock = LocationManagerMock()
-        let unauthorizedService = LocationService(userDefaults: userDefaults, locationManager: unauthorizedMock)
-        let alert = ProximityAlert(stop: stop)
-
-        unauthorizedService.startMonitoringProximity(for: alert)
-
-        #expect(unauthorizedMock.monitoredRegions.isEmpty)
-    }
-
     @Test func `Start monitoring proximity default radius`() {
         let alert = ProximityAlert(stop: stop)
 
-        service.startMonitoringProximity(for: alert)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
 
         let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
-        #expect(region?.radius == 200.0)
+        #expect(region?.radius == ProximityAlert.defaultRadiusMeters)
     }
 
     @Test func `Start monitoring proximity duplicate alert replaces region`() {
         let alert = ProximityAlert(stop: stop)
 
-        service.startMonitoringProximity(for: alert)
-        service.startMonitoringProximity(for: alert)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
 
         // CLRegion uses identifier for equality in Set, so duplicate insert replaces
         #expect(self.locationManagerMock.monitoredRegions.count == 1)
-        #expect(self.locationManagerMock.monitoredRegions.first?.identifier == "oba.proximity.\(alert.id.uuidString)")
+        #expect(self.locationManagerMock.monitoredRegions.first?.identifier == LocationService.proximityRegionIdentifier(for: alert))
     }
 
     @Test func `Start monitoring proximity multiple alerts`() {
@@ -89,10 +95,138 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
 
-        service.startMonitoringProximity(for: alert1)
-        service.startMonitoringProximity(for: alert2)
+        #expect(service.startMonitoringProximity(for: alert1) == .started)
+        #expect(service.startMonitoringProximity(for: alert2) == .started)
 
         #expect(self.locationManagerMock.monitoredRegions.count == 2)
+    }
+
+    // MARK: - Start Monitoring: Authorization
+
+    @Test func `Start monitoring proximity when in use is insufficient`() {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let alert = ProximityAlert(stop: stop)
+
+        let result = service.startMonitoringProximity(for: alert)
+
+        // When In Use passes `isLocationUseAuthorized`, which is exactly why this
+        // path needs its own check: monitoring started under it never fires in the
+        // background, which is the only time a proximity alert is useful.
+        #expect(result == .insufficientAuthorization(.authorizedWhenInUse))
+        #expect(!result.isMonitoring)
+        #expect(self.locationManagerMock.monitoredRegions.isEmpty)
+    }
+
+    @Test func `Start monitoring proximity unauthorized does not monitor`() {
+        let unauthorizedMock = LocationManagerMock()
+        let unauthorizedService = LocationService(userDefaults: userDefaults, locationManager: unauthorizedMock)
+        let alert = ProximityAlert(stop: stop)
+
+        let result = unauthorizedService.startMonitoringProximity(for: alert)
+
+        #expect(result == .insufficientAuthorization(.notDetermined))
+        #expect(unauthorizedMock.monitoredRegions.isEmpty)
+    }
+
+    @Test func `Is proximity monitoring authorized requires always`() {
+        locationManagerMock._authorizationStatus = .authorizedAlways
+        #expect(self.service.isProximityMonitoringAuthorized)
+
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        #expect(!self.service.isProximityMonitoringAuthorized)
+        // Still authorized for ordinary location use — the two questions differ.
+        #expect(self.service.isLocationUseAuthorized)
+    }
+
+    @Test func `Request always authorization upgrades from when in use`() {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+
+        service.requestAlwaysAuthorization()
+
+        #expect(self.service.isProximityMonitoringAuthorized)
+    }
+
+    @Test func `Request always authorization does nothing when denied`() {
+        locationManagerMock._authorizationStatus = .denied
+
+        service.requestAlwaysAuthorization()
+
+        #expect(!self.service.isProximityMonitoringAuthorized)
+    }
+
+    // MARK: - Start Monitoring: Region Limit
+
+    @Test func `Start monitoring proximity at region limit is refused`() {
+        fillMonitoredRegions(count: LocationService.maximumMonitoredRegions)
+        let alert = ProximityAlert(stop: stop)
+
+        let result = service.startMonitoringProximity(for: alert)
+
+        #expect(result == .regionLimitReached(limit: LocationService.maximumMonitoredRegions))
+        #expect(!result.isMonitoring)
+        #expect(self.locationManagerMock.monitoredRegions.count == LocationService.maximumMonitoredRegions)
+        #expect(self.service.monitoredProximityRegions.isEmpty)
+    }
+
+    @Test func `Start monitoring proximity counts regions the app monitors elsewhere`() {
+        // The cap is per-app, so non-proximity regions consume slots too.
+        fillMonitoredRegions(count: LocationService.maximumMonitoredRegions - 1)
+        let alert1 = ProximityAlert(stop: stop)
+        let alert2 = ProximityAlert(stop: stop)
+
+        #expect(service.startMonitoringProximity(for: alert1) == .started)
+        #expect(service.startMonitoringProximity(for: alert2) == .regionLimitReached(limit: LocationService.maximumMonitoredRegions))
+    }
+
+    @Test func `Start monitoring proximity re arms existing alert at region limit`() {
+        let alert = ProximityAlert(stop: stop)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+
+        fillMonitoredRegions(count: LocationService.maximumMonitoredRegions - 1)
+        #expect(self.locationManagerMock.monitoredRegions.count == LocationService.maximumMonitoredRegions)
+
+        // Re-arming replaces a region rather than adding one, so being at the cap
+        // must not block it — otherwise a full slate would freeze every alert.
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+        #expect(self.locationManagerMock.monitoredRegions.count == LocationService.maximumMonitoredRegions)
+    }
+
+    // MARK: - Start Monitoring: Radius Clamping
+
+    @Test func `Start monitoring proximity clamps radius to device maximum`() {
+        locationManagerMock.maximumRegionMonitoringDistance = 150
+        let alert = ProximityAlert(stop: stop, radiusMeters: 400)
+
+        let result = service.startMonitoringProximity(for: alert)
+
+        // Core Location would have clamped this silently and fired the alert 250m
+        // closer than the user asked for, with nothing recording the difference.
+        #expect(result == .startedWithClampedRadius(requested: 400, monitored: 150))
+        #expect(result.isMonitoring)
+
+        let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
+        #expect(region?.radius == 150)
+    }
+
+    @Test func `Start monitoring proximity keeps radius within device maximum`() {
+        locationManagerMock.maximumRegionMonitoringDistance = 5_000
+        let alert = ProximityAlert(stop: stop, radiusMeters: 300)
+
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+
+        let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
+        #expect(region?.radius == 300)
+    }
+
+    @Test func `Start monitoring proximity ignores unavailable device maximum`() {
+        // A non-positive maximum means "unknown", not "monitor nothing".
+        locationManagerMock.maximumRegionMonitoringDistance = 0
+        let alert = ProximityAlert(stop: stop, radiusMeters: 300)
+
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+
+        let region = locationManagerMock.monitoredRegions.first as? CLCircularRegion
+        #expect(region?.radius == 300)
     }
 
     // MARK: - Stop Monitoring
@@ -100,7 +234,7 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
     @Test func `Stop monitoring proximity removes correct region`() {
         let alert = ProximityAlert(stop: stop)
 
-        service.startMonitoringProximity(for: alert)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
         #expect(self.locationManagerMock.monitoredRegions.count == 1)
 
         service.stopMonitoringProximity(for: alert)
@@ -111,7 +245,7 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let alert1 = ProximityAlert(stop: stop)
         let alert2 = ProximityAlert(stop: stop)
 
-        service.startMonitoringProximity(for: alert1)
+        #expect(service.startMonitoringProximity(for: alert1) == .started)
 
         service.stopMonitoringProximity(for: alert2)
 
@@ -123,14 +257,14 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
 
-        service.startMonitoringProximity(for: alert1)
-        service.startMonitoringProximity(for: alert2)
+        #expect(service.startMonitoringProximity(for: alert1) == .started)
+        #expect(service.startMonitoringProximity(for: alert2) == .started)
 
         service.stopMonitoringProximity(for: alert1)
 
         #expect(self.locationManagerMock.monitoredRegions.count == 1)
         let remaining = self.locationManagerMock.monitoredRegions.first
-        #expect(remaining?.identifier == "oba.proximity.\(alert2.id.uuidString)")
+        #expect(remaining?.identifier == LocationService.proximityRegionIdentifier(for: alert2))
     }
 
     // MARK: - Stop All Monitoring
@@ -140,8 +274,8 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let alert1 = ProximityAlert(stop: stops[0])
         let alert2 = ProximityAlert(stop: stops[1])
 
-        service.startMonitoringProximity(for: alert1)
-        service.startMonitoringProximity(for: alert2)
+        #expect(service.startMonitoringProximity(for: alert1) == .started)
+        #expect(service.startMonitoringProximity(for: alert2) == .started)
 
         service.stopMonitoringAllProximityAlerts()
 
@@ -150,7 +284,7 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
 
     @Test func `Stop monitoring all proximity alerts preserves non prefixed regions`() {
         let alert = ProximityAlert(stop: stop)
-        service.startMonitoringProximity(for: alert)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
 
         let otherRegion = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
@@ -175,6 +309,18 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.locationManagerMock.monitoredRegions.isEmpty)
     }
 
+    // MARK: - Monitored Proximity Regions
+
+    @Test func `Monitored proximity regions excludes regions the app monitors elsewhere`() {
+        let alert = ProximityAlert(stop: stop)
+        #expect(service.startMonitoringProximity(for: alert) == .started)
+        fillMonitoredRegions(count: 3)
+
+        #expect(self.locationManagerMock.monitoredRegions.count == 4)
+        #expect(self.service.monitoredProximityRegions.count == 1)
+        #expect(self.service.monitoredProximityRegions.first?.identifier == LocationService.proximityRegionIdentifier(for: alert))
+    }
+
     // MARK: - Delegate: didEnterRegion
 
     @Test func `Did enter region notifies delegate`() {
@@ -182,12 +328,12 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let region = CLCircularRegion(
             center: alert.coordinate,
             radius: alert.radiusMeters,
-            identifier: "oba.proximity.\(alert.id.uuidString)"
+            identifier: LocationService.proximityRegionIdentifier(for: alert)
         )
 
         service.locationManager(CLLocationManager(), didEnterRegion: region)
 
-        #expect(self.delegate.enteredRegionIdentifier == "oba.proximity.\(alert.id.uuidString)")
+        #expect(self.delegate.enteredRegionIdentifier == LocationService.proximityRegionIdentifier(for: alert))
     }
 
     @Test func `Did enter region non prefixed circular region does not notify`() {
@@ -203,9 +349,14 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
     }
 
     @Test func `Did enter region non circular region does not notify`() {
+        // A beacon region wearing our prefix is a "should never happen" state:
+        // everything registered under it is created as a CLCircularRegion.
         let beaconRegion = CLBeaconRegion(
             uuid: UUID(),
-            identifier: "oba.proximity.beacon-test"
+            // No alert to derive this from, but the prefix still comes from the
+            // one place that defines it — that's what puts the region in our
+            // namespace, and so what the guard under test keys off.
+            identifier: LocationService.proximityRegionPrefix + "beacon-test"
         )
 
         service.locationManager(CLLocationManager(), didEnterRegion: beaconRegion)
@@ -215,27 +366,92 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
 
     // MARK: - Delegate: monitoringDidFail
 
-    @Test func `Monitoring did fail notifies delegate`() {
+    @Test func `Monitoring did fail notifies delegate for proximity region`() {
+        let alert = ProximityAlert(stop: stop)
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: LocationService.proximityRegionIdentifier(for: alert)
+        )
+
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: CLError(.regionMonitoringFailure))
+
+        #expect(self.delegate.monitoringFailedCallCount == 1)
+        #expect(self.delegate.monitoringFailedIdentifier == region.identifier)
+        #expect(self.delegate.monitoringFailedKind == .regionRejected)
+    }
+
+    @Test func `Monitoring did fail ignores non proximity region`() {
         let region = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
             radius: 200,
-            identifier: UUID().uuidString
+            identifier: "some-other-region"
         )
-        let error = NSError(domain: "CLError", code: 5, userInfo: nil)
 
-        service.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: error)
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: CLError(.regionMonitoringFailure))
 
-        #expect(self.delegate.monitoringFailedIdentifier == region.identifier)
-        #expect((self.delegate.monitoringFailedError as? NSError)?.code == 5)
+        // Proximity delegates used to receive every monitoring failure in the app,
+        // including ones they could neither attribute nor act on.
+        #expect(self.delegate.monitoringFailedCallCount == 0)
+        #expect(self.delegate.monitoringFailedIdentifier == nil)
+        #expect(self.delegate.monitoringFailedError == nil)
     }
 
     @Test func `Monitoring did fail nil region notifies delegate`() {
-        let error = NSError(domain: "CLError", code: 5, userInfo: nil)
+        // Core Location reports the region cap with no region attached. It can't
+        // be attributed, but it may well be ours, so it still gets forwarded.
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: nil, withError: CLError(.regionMonitoringFailure))
 
-        service.locationManager(CLLocationManager(), monitoringDidFailFor: nil, withError: error)
-
+        #expect(self.delegate.monitoringFailedCallCount == 1)
         #expect(self.delegate.monitoringFailedIdentifier == nil)
         #expect(self.delegate.monitoringFailedError != nil)
+        #expect(self.delegate.monitoringFailedKind == .regionRejected)
+    }
+
+    @Test func `Monitoring did fail forwards denial kind`() {
+        let alert = ProximityAlert(stop: stop)
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: LocationService.proximityRegionIdentifier(for: alert)
+        )
+
+        service.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: CLError(.regionMonitoringDenied))
+
+        #expect(self.delegate.monitoringFailedKind == .authorizationDenied)
+    }
+
+    // MARK: - Failure Classification
+
+    @Test func `Failure kind classifies denials as authorization denied`() {
+        #expect(RegionMonitoringFailureKind(error: CLError(.denied)) == .authorizationDenied)
+        #expect(RegionMonitoringFailureKind(error: CLError(.regionMonitoringDenied)) == .authorizationDenied)
+    }
+
+    @Test func `Failure kind classifies monitoring failure as region rejected`() {
+        let kind = RegionMonitoringFailureKind(error: CLError(.regionMonitoringFailure))
+
+        #expect(kind == .regionRejected)
+        // Retrying this one forever would never succeed: the app has to change
+        // what it asks for first.
+        #expect(!kind.isTransient)
+    }
+
+    @Test func `Failure kind classifies delays as transient`() {
+        #expect(RegionMonitoringFailureKind(error: CLError(.regionMonitoringSetupDelayed)) == .transient)
+        #expect(RegionMonitoringFailureKind(error: CLError(.regionMonitoringResponseDelayed)) == .transient)
+        #expect(RegionMonitoringFailureKind(error: CLError(.network)) == .transient)
+        #expect(RegionMonitoringFailureKind(error: CLError(.network)).isTransient)
+    }
+
+    @Test func `Failure kind classifies non core location error as unknown`() {
+        let error = NSError(domain: "SomeOtherDomain", code: 5, userInfo: nil)
+        let kind = RegionMonitoringFailureKind(error: error)
+
+        #expect(kind == .unknown)
+        // Unknown is treated as permanent: retrying an unrecognized failure
+        // forever is the worse of the two ways to be wrong.
+        #expect(!kind.isTransient)
     }
 
     // MARK: - Multiple Delegates
@@ -248,13 +464,12 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         let region = CLCircularRegion(
             center: alert.coordinate,
             radius: alert.radiusMeters,
-            identifier: "oba.proximity.\(alert.id.uuidString)"
+            identifier: LocationService.proximityRegionIdentifier(for: alert)
         )
 
         service.locationManager(CLLocationManager(), didEnterRegion: region)
 
-        #expect(self.delegate.enteredRegionIdentifier == "oba.proximity.\(alert.id.uuidString)")
-        #expect(delegate2.enteredRegionIdentifier == "oba.proximity.\(alert.id.uuidString)")
+        #expect(self.delegate.enteredRegionIdentifier == LocationService.proximityRegionIdentifier(for: alert))
+        #expect(delegate2.enteredRegionIdentifier == LocationService.proximityRegionIdentifier(for: alert))
     }
 }
-

--- a/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
+++ b/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
@@ -44,6 +44,61 @@ final class ProximityAlertTests: OBATestCase {
         #expect(alert.radiusMeters == 500.0)
     }
 
+    // MARK: - Radius Clamping
+
+    @Test func `Init clamps radius below the minimum`() {
+        let alert = ProximityAlert(stop: stop, radiusMeters: 5)
+
+        #expect(alert.radiusMeters == ProximityAlert.minimumRadiusMeters)
+    }
+
+    @Test func `Init clamps radius above the maximum`() {
+        // `CLCircularRegion` would accept this and silently monitor something
+        // else, firing the alert at a distance the user never chose.
+        let alert = ProximityAlert(stop: stop, radiusMeters: 50_000)
+
+        #expect(alert.radiusMeters == ProximityAlert.maximumRadiusMeters)
+    }
+
+    @Test func `Init leaves an in range radius alone`() {
+        let alert = ProximityAlert(stop: stop, radiusMeters: 750)
+
+        #expect(alert.radiusMeters == 750)
+    }
+
+    @Test func `Init accepts the range boundaries`() {
+        let atMinimum = ProximityAlert(stop: stop, radiusMeters: ProximityAlert.minimumRadiusMeters)
+        let atMaximum = ProximityAlert(stop: stop, radiusMeters: ProximityAlert.maximumRadiusMeters)
+
+        #expect(atMinimum.radiusMeters == ProximityAlert.minimumRadiusMeters)
+        #expect(atMaximum.radiusMeters == ProximityAlert.maximumRadiusMeters)
+    }
+
+    @Test func `Init replaces a non finite radius with the default`() {
+        // Clamping alone wouldn't save this: `min`/`max` propagate NaN rather
+        // than bounding it, leaving a radius Core Location cannot interpret.
+        #expect(ProximityAlert(stop: stop, radiusMeters: .nan).radiusMeters == ProximityAlert.defaultRadiusMeters)
+        #expect(ProximityAlert(stop: stop, radiusMeters: .infinity).radiusMeters == ProximityAlert.defaultRadiusMeters)
+    }
+
+    @Test func `Decoding clamps an out of range persisted radius`() throws {
+        let alert = ProximityAlert(stop: stop, radiusMeters: 300)
+        let encoded = try JSONEncoder().encode(alert)
+
+        guard var dictionary = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+            Issue.record("Encoded proximity alert was not a JSON object.")
+            return
+        }
+
+        // Stands in for an alert written by a build that predates the clamp.
+        dictionary["radiusMeters"] = 50_000
+
+        let tampered = try JSONSerialization.data(withJSONObject: dictionary)
+        let decoded = try JSONDecoder().decode(ProximityAlert.self, from: tampered)
+
+        #expect(decoded.radiusMeters == ProximityAlert.maximumRadiusMeters)
+    }
+
     @Test func `Coordinate returns correct value`() {
         let alert = ProximityAlert(stop: stop)
 


### PR DESCRIPTION

## Summary
- `startMonitoringProximity` returns a non-discardable `ProximityMonitoringResult` instead of no-oping silently. Region monitoring never self-heals, so a dropped failure is a permanently dead alert.
- Requires `.authorizedAlways` rather than `isLocationUseAuthorized`, and adds the missing `NSLocationAlwaysAndWhenInUseUsageDescription` to `app_shared.yml` — all twelve locales already carried the translation.
- Filters `monitoringDidFailFor` by the `oba.proximity.` prefix, mirroring `didEnterRegion`, and classifies `CLError` into `RegionMonitoringFailureKind`.
- Guards the 20-region cap up front (exempting re-arms, which replace rather than add) and clamps the radius against `maximumRegionMonitoringDistance` and on the model.
- Logs a prefixed region that is not a `CLCircularRegion` instead of returning silently.
- Refs #1150. The user-facing half of items 1 and 2 belongs to `ProximityAlertManager`, which does not exist yet; this lands the signals it will need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Always location authorization for background proximity alerts.
  * Improved proximity monitoring with authorization checks, region limits, radius adjustment, and monitoring status results.
  * Added clearer reporting and classification of region-monitoring failures.
  * Added validation and safe defaults for proximity alert radii.

* **Bug Fixes**
  * Prevented unsupported, oversized, invalid, or unrelated regions from being monitored.
  * Ensured persisted proximity alerts are validated when restored.

* **Tests**
  * Expanded coverage for authorization, region limits, radius handling, monitoring results, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->