### PR TITLE
Add a Settings toggle for the transfer arrival banner

### DIFF
--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -70,6 +70,7 @@ class SettingsViewController: FormViewController {
             walkingSpeedMetersPerSecondKey: snapToPreset(application.userDataStore.walkingSpeedMetersPerSecond),
             walkingSpeedUseHealthKitKey: application.userDataStore.walkingSpeedSource == .healthKit,
             stopUIReducedColorsTag: application.userDataStore.stopUIReducedColors,
+            transferBannerTag: application.userDataStore.showTransferArrivalBanner,
             alwaysShowFeedbackPrompt: application.reviewPromptPolicy.alwaysShowPrompt
         ])
     }
@@ -127,6 +128,10 @@ class SettingsViewController: FormViewController {
             application.setArrivalDepartureFilter(filter)
         }
 
+        if let showBanner = values[transferBannerTag] as? Bool {
+            application.userDataStore.showTransferArrivalBanner = showBanner
+        }
+
         saveWalkingSpeedValues(values)
     }
 
@@ -179,10 +184,16 @@ class SettingsViewController: FormViewController {
     // MARK: - Arrival & Departure Display Section
 
     private let arrivalFilterTag = "arrivalDepartureFilter"
+    private let transferBannerTag = UserDefaultsStore.showTransferArrivalBannerKey
 
     private lazy var arrivalDisplaySection: Section = {
         let section = Section(
-            OBALoc("settings_controller.arrival_display_section.title", value: "Arrival & Departure Display", comment: "Settings section title for controlling which arrivals/departures are shown")
+            header: OBALoc("settings_controller.arrival_display_section.title", value: "Arrival & Departure Display", comment: "Settings section title for controlling which arrivals/departures are shown"),
+            footer: OBALoc(
+                "settings_controller.arrival_display_section.transfer_banner.footer",
+                value: "Show transfer arrival banner: when on, opening a stop from a trip shows times relative to when you arrive. Turn that switch off for ordinary clock times and every departure.",
+                comment: "Settings > Arrival & Departure Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter"
+            )
         )
 
         section <<< AlertRow<ArrivalDepartureFilter> {
@@ -192,6 +203,15 @@ class SettingsViewController: FormViewController {
             $0.options = Array(ArrivalDepartureFilter.allCases)
             $0.displayValueFor = { $0?.displayTitle }
             $0.value = self.application.effectiveArrivalDepartureFilter
+        }
+
+        section <<< SwitchRow {
+            $0.tag = transferBannerTag
+            $0.title = OBALoc(
+                "settings_controller.arrival_display_section.transfer_banner",
+                value: "Show transfer arrival banner",
+                comment: "Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip"
+            )
         }
 
         return section

--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -210,7 +210,7 @@ class SettingsViewController: FormViewController {
             $0.title = OBALoc(
                 "settings_controller.arrival_display_section.transfer_banner",
                 value: "Show transfer arrival banner",
-                comment: "Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip"
+                comment: "Settings > Arrival & Departure Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip"
             )
         }
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -96,6 +96,13 @@ public class StopViewController: UIViewController,
         set { viewModel.transferContext = newValue }
     }
 
+    /// Honors Settings > Arrival Display > transfer banner. When the rider
+    /// turns that off, the stop page ignores the trip-sourced transfer context
+    /// so times are wall-clock and the full list is shown (#1277).
+    private var displayedTransferContext: TransferContext? {
+        application.userDataStore.displayedTransferContext(transferContext)
+    }
+
     var stop: Stop? { viewModel.stop }
     var stopArrivals: StopArrivals? { viewModel.stopArrivals }
     var stopPreferences: StopPreferences { viewModel.stopPreferences }
@@ -807,7 +814,7 @@ public class StopViewController: UIViewController,
             arrivalDeparture: arrivalDeparture,
             isAlarmAvailable: alarmAvailable,
             highlightTimeOnDisplay: highlightTimeOnDisplay,
-            transferContext: transferContext,
+            transferContext: displayedTransferContext,
             onSelectAction: onSelectAction,
             alarmAction: addAlarmAction,
             bookmarkAction: bookmarkAction,
@@ -855,7 +862,7 @@ public class StopViewController: UIViewController,
         // Filter departures before transfer arrival time, unless user opted to show all.
         // Only insert the "Show earlier" button when sorting by time (groupRoute == nil)
         // to avoid duplicate item IDs across route groups. See #409.
-        if let transferContext = transferContext, !showAllTransferDepartures {
+        if let transferContext = displayedTransferContext, !showAllTransferDepartures {
             let (visible, hidden) = partitionTransferDepartures(items: items, arrivalTime: transferContext.arrivalTime)
             items = visible
             if !hidden.isEmpty && groupRoute == nil {
@@ -987,7 +994,7 @@ public class StopViewController: UIViewController,
 
     /// Inserts either a transfer arrival banner or the GPS-based walk time row.
     private func addWalkTimeOrTransferBanner(to items: inout [AnyOBAListViewItem]) {
-        if let transferContext = transferContext {
+        if let transferContext = displayedTransferContext {
             let bannerItem = TransferArrivalItem(
                 id: "transfer_arrival_banner",
                 arrivalTime: transferContext.arrivalTime,

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -96,7 +96,7 @@ public class StopViewController: UIViewController,
         set { viewModel.transferContext = newValue }
     }
 
-    /// Honors Settings > Arrival Display > transfer banner. When the rider
+    /// Honors Settings > Arrival & Departure Display > transfer banner. When the rider
     /// turns that off, the stop page ignores the trip-sourced transfer context
     /// so times are wall-clock and the full list is shown (#1277).
     private var displayedTransferContext: TransferContext? {

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "عرض الوصول والمغادرة";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "إظهار شريط وصول التحويلة";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "عند فتح محطة من رحلة تُعرض الأوقات نسبة إلى وصولك. أوقف الخيار لرؤية الساعة وكل المغادرات.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "إظهار المغادرات";
 

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "إظهار شريط وصول التحويلة";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "عند فتح محطة من رحلة تُعرض الأوقات نسبة إلى وصولك. أوقف الخيار لرؤية الساعة وكل المغادرات.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "إظهار شريط وصول التحويلة: عند التشغيل تُعرض الأوقات نسبة إلى وصولك عند فتح محطة من رحلة. أوقف هذا المفتاح لرؤية الساعة وكل المغادرات.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "إظهار المغادرات";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Arrival & Departure Display";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Show transfer arrival banner";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "When you open a stop from a trip, times are shown relative to when you arrive there. Turn this off to see ordinary clock times and every departure.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Show Departures";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Show transfer arrival banner";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "When you open a stop from a trip, times are shown relative to when you arrive there. Turn this off to see ordinary clock times and every departure.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Show transfer arrival banner: when on, opening a stop from a trip shows times relative to when you arrive. Turn that switch off for ordinary clock times and every departure.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Show Departures";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Visualización de llegadas y salidas";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Mostrar banner de llegada de transbordo";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Al abrir una parada desde un viaje, los horarios se muestran respecto a tu llegada. Desactívalo para ver la hora del reloj y todas las salidas.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostrar salidas";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Mostrar banner de llegada de transbordo";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Al abrir una parada desde un viaje, los horarios se muestran respecto a tu llegada. Desactívalo para ver la hora del reloj y todas las salidas.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostrar banner de llegada de transbordo: al activarlo, al abrir una parada desde un viaje los horarios son relativos a tu llegada. Apaga ese interruptor para ver la hora absoluta y todas las salidas.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostrar salidas";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Ipakita ang banner ng pagdating sa transfer";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Kapag magbubukas ng hintuan mula sa biyahe, relative sa pagdating mo ang oras. I-off para sa orasan at lahat ng alis.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Ipakita ang transfer arrival banner: kapag naka-on, ang oras ay relative sa pagdating mo kapag magbubukas ng hintuan mula sa biyahe. I-off ang switch na iyon para sa ordinaryong oras at lahat ng pag-alis.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Ipakita ang mga Pag-alis";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Display ng Pagdating at Pag-alis";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Ipakita ang banner ng pagdating sa transfer";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Kapag magbubukas ng hintuan mula sa biyahe, relative sa pagdating mo ang oras. I-off para sa orasan at lahat ng alis.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Ipakita ang mga Pag-alis";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Ipakita ang banner ng pagdating sa transfer";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Ipakita ang transfer arrival banner: kapag naka-on, ang oras ay relative sa pagdating mo kapag magbubukas ng hintuan mula sa biyahe. I-off ang switch na iyon para sa ordinaryong oras at lahat ng pag-alis.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Ipakita ang banner ng pagdating sa transfer: kapag naka-on, ang oras ay relative sa pagdating mo kapag magbubukas ng hintuan mula sa biyahe. I-off ang switch na iyon para sa ordinaryong oras at lahat ng pag-alis.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Ipakita ang mga Pag-alis";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Affichage des arrivées et départs";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Afficher la bannière d’arrivée de correspondance";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Lorsque vous ouvrez un arrêt depuis un trajet, les horaires sont relatifs à votre arrivée. Désactivez pour voir l’heure réelle et tous les départs.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Afficher les départs";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Afficher la bannière d’arrivée de correspondance";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Lorsque vous ouvrez un arrêt depuis un trajet, les horaires sont relatifs à votre arrivée. Désactivez pour voir l’heure réelle et tous les départs.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Afficher la bannière d’arrivée en correspondance : activée, l’ouverture d’un arrêt depuis un trajet affiche les horaires relatifs à votre arrivée. Désactivez ce commutateur pour l’heure réelle et tous les départs.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Afficher les départs";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Afficher la bannière d’arrivée de correspondance";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Afficher la bannière d’arrivée en correspondance : activée, l’ouverture d’un arrêt depuis un trajet affiche les horaires relatifs à votre arrivée. Désactivez ce commutateur pour l’heure réelle et tous les départs.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Afficher la bannière d’arrivée de correspondance : activée, l’ouverture d’un arrêt depuis un trajet affiche les horaires relatifs à votre arrivée. Désactivez ce commutateur pour l’heure réelle et tous les départs.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Afficher les départs";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Mostra il banner di arrivo della coincidenza";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Aprendo una fermata da una corsa, gli orari sono relativi al tuo arrivo. Disattiva per vedere l’orologio e tutte le partenze.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostra banner arrivo trasferimento: se attivo, aprendo una fermata da una corsa gli orari sono relativi al tuo arrivo. Disattiva quell’interruttore per l’orologio e tutte le partenze.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostra partenze";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Mostra il banner di arrivo della coincidenza";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostra banner arrivo trasferimento: se attivo, aprendo una fermata da una corsa gli orari sono relativi al tuo arrivo. Disattiva quell’interruttore per l’orologio e tutte le partenze.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostra il banner di arrivo della coincidenza: se attivo, aprendo una fermata da una corsa gli orari sono relativi al tuo arrivo. Disattiva quell’interruttore per l’orologio e tutte le partenze.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostra partenze";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Visualizzazione di arrivi e partenze";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Mostra il banner di arrivo della coincidenza";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Aprendo una fermata da una corsa, gli orari sono relativi al tuo arrivo. Disattiva per vedere l’orologio e tutte le partenze.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostra partenze";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "환승 도착 배너 표시";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "여행에서 정류장을 열면 도착 시각 기준으로 시간이 표시됩니다. 끄면 일반 시각과 모든 출발이 보입니다.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "환승 도착 배너 표시: 켜면 여행에서 정류장을 열 때 도착 시각 기준으로 시간이 표시됩니다. 그 스위치를 끄면 일반 시각과 모든 출발이 보입니다.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "출발 표시";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "도착·출발 정보 표시";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "환승 도착 배너 표시";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "여행에서 정류장을 열면 도착 시각 기준으로 시간이 표시됩니다. 끄면 일반 시각과 모든 출발이 보입니다.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "출발 표시";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Pokaż baner przyjazdu przy przesiadce";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Po otwarciu przystanku z kursu czasy są względne wobec Twojego przyjazdu. Wyłącz, aby zobaczyć zegar i wszystkie odjazdy.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Pokaż baner przyjazdu przesiadki: gdy włączony, otwarcie przystanku z kursu pokazuje czasy względem Twojego przyjazdu. Wyłącz ten przełącznik, aby zobaczyć zegar i wszystkie odjazdy.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Pokazuj odjazdy";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Wyświetlanie przyjazdów i odjazdów";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Pokaż baner przyjazdu przy przesiadce";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Po otwarciu przystanku z kursu czasy są względne wobec Twojego przyjazdu. Wyłącz, aby zobaczyć zegar i wszystkie odjazdy.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Pokazuj odjazdy";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Pokaż baner przyjazdu przy przesiadce";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Pokaż baner przyjazdu przesiadki: gdy włączony, otwarcie przystanku z kursu pokazuje czasy względem Twojego przyjazdu. Wyłącz ten przełącznik, aby zobaczyć zegar i wszystkie odjazdy.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Pokaż baner przyjazdu przy przesiadce: gdy włączony, otwarcie przystanku z kursu pokazuje czasy względem Twojego przyjazdu. Wyłącz ten przełącznik, aby zobaczyć zegar i wszystkie odjazdy.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Pokazuj odjazdy";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Mostrar banner de chegada da conexão";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Ao abrir uma parada a partir de uma viagem, os horários são relativos à sua chegada. Desative para ver o relógio e todas as partidas.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostrar banner de chegada da transferência: quando ligado, abrir uma parada a partir de uma viagem mostra horários relativos à sua chegada. Desligue esse interruptor para o relógio e todas as partidas.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostrar partidas";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Exibição de chegadas e partidas";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Mostrar banner de chegada da conexão";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Ao abrir uma parada a partir de uma viagem, os horários são relativos à sua chegada. Desative para ver o relógio e todas as partidas.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostrar partidas";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Mostrar banner de chegada da conexão";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostrar banner de chegada da transferência: quando ligado, abrir uma parada a partir de uma viagem mostra horários relativos à sua chegada. Desligue esse interruptor para o relógio e todas as partidas.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Mostrar banner de chegada da conexão: quando ligado, abrir uma parada a partir de uma viagem mostra horários relativos à sua chegada. Desligue esse interruptor para o relógio e todas as partidas.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Mostrar partidas";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Показывать баннер прибытия при пересадке";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Баннер прибытия пересадки: если включён, при открытии остановки с рейса время относительно вашего прибытия. Выключите этот переключатель, чтобы видеть обычные часы и все отправления.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Показывать баннер прибытия при пересадке: если включён, при открытии остановки с рейса время относительно вашего прибытия. Выключите этот переключатель, чтобы видеть обычные часы и все отправления.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Показывать отправления";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Отображение прибытий и отправлений";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Показывать баннер прибытия при пересадке";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Если открыть остановку с рейса, время показывается относительно вашего прибытия. Выключите, чтобы видеть обычные часы и все отправления.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Показывать отправления";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Показывать баннер прибытия при пересадке";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Если открыть остановку с рейса, время показывается относительно вашего прибытия. Выключите, чтобы видеть обычные часы и все отправления.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Баннер прибытия пересадки: если включён, при открытии остановки с рейса время относительно вашего прибытия. Выключите этот переключатель, чтобы видеть обычные часы и все отправления.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Показывать отправления";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "settings_controller.arrival_display_section.transfer_banner" = "Hiện banner tới lúc chuyển tuyến";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Hiện banner tới điểm trung chuyển: khi bật, mở điểm dừng từ chuyến đi sẽ hiện giờ theo lúc bạn tới. Tắt công tắc đó để xem đồng hồ thường và mọi chuyến.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Hiện banner tới lúc chuyển tuyến: khi bật, mở điểm dừng từ chuyến đi sẽ hiện giờ theo lúc bạn tới. Tắt công tắc đó để xem đồng hồ thường và mọi chuyến.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Hiển thị chuyến khởi hành";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Hiện banner tới lúc chuyển tuyến";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "Khi mở điểm dừng từ chuyến đi, giờ hiện theo lúc bạn tới. Tắt để xem đồng hồ và mọi chuyến.";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Hiện banner tới điểm trung chuyển: khi bật, mở điểm dừng từ chuyến đi sẽ hiện giờ theo lúc bạn tới. Tắt công tắc đó để xem đồng hồ thường và mọi chuyến.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Hiển thị chuyến khởi hành";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Hiển thị giờ đến và khởi hành";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "Hiện banner tới lúc chuyển tuyến";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "Khi mở điểm dừng từ chuyến đi, giờ hiện theo lúc bạn tới. Tắt để xem đồng hồ và mọi chuyến.";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "Hiển thị chuyến khởi hành";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "显示换乘到达横幅";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "从行程打开车站时，时间相对你到达该站显示。关闭后将显示时钟时间和全部出发班次。";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "显示换乘到达横幅：开启后，从行程打开车站时时间相对你到达该站显示。关闭该开关将显示时钟时间和全部出发班次。";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "显示班次";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "到站与离站信息显示";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "显示换乘到达横幅";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "从行程打开车站时，时间相对你到达该站显示。关闭后将显示时钟时间和全部出发班次。";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "显示班次";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1017,6 +1017,12 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "到站與離站資訊顯示";
 
+/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+"settings_controller.arrival_display_section.transfer_banner" = "顯示轉乘到達橫幅";
+
+/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "從行程開啟車站時，時間會相對你到達該站顯示。關閉後將顯示時鐘時間和全部出發班次。";
+
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "顯示班次";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1020,8 +1020,8 @@
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "顯示轉乘到達橫幅";
 
-/* Settings > Arrival Display > Footer explaining the transfer arrival banner toggle */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "從行程開啟車站時，時間會相對你到達該站顯示。關閉後將顯示時鐘時間和全部出發班次。";
+/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+"settings_controller.arrival_display_section.transfer_banner.footer" = "顯示轉乘到達橫幅：開啟後，從行程開啟車站時時間會相對你到達該站顯示。關閉該開關將顯示時鐘時間和全部出發班次。";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "顯示班次";

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -9,6 +9,7 @@
 
 import ActivityKit
 import Combine
+import CoreLocation
 import SwiftUI
 import OBAKitCore
 

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -103,15 +103,18 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     ///   one and moves its chrome into a bottom toolbar. Ignored when the flag or a transfer
     ///   context routes to the legacy `StopViewController`, which has only the pushed layout.
     public func makeStopController(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil, showToolbarOnBottom: Bool = false) -> UIViewController {
-        // TransferContext UX (arrival-relative filtering, transfer banner) is not yet built on the new stop page — route transfers to the legacy screen until it is.
+        // Transfer UX is not on the new stop page yet. The banner toggle can
+        // drop the context — use the same helper the page will, or a trip→stop
+        // tap with the toggle off lands on the legacy screen for nothing.
+        let effective = application.userDataStore.displayedTransferContext(transferContext)
         let stopController: StopContextConfigurable
-        if transferContext == nil, FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+        if effective == nil, FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
             stopController = StopPageViewController(application: application, stop: stop, showToolbarOnBottom: showToolbarOnBottom)
         } else {
             stopController = StopViewController(application: application, stop: stop)
         }
         stopController.bookmarkContext = bookmark
-        stopController.transferContext = transferContext
+        stopController.transferContext = effective
         return stopController
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -41,6 +41,11 @@ public protocol UserDataStore: NSObjectProtocol {
     /// Settings > Accessibility.
     var stopUIReducedColors: Bool { get set }
 
+    /// Whether opening a stop from a trip applies transfer-relative times
+    /// and the "Arriving at XX:XX via ###" banner. Default `true` so existing
+    /// riders keep current behavior; Settings > Arrival Display can turn it off.
+    var showTransferArrivalBanner: Bool { get set }
+
     // MARK: - Bookmark Groups
 
     /// Retrieves a list of `BookmarkGroup` objects.
@@ -332,6 +337,16 @@ public protocol UserDataStore: NSObjectProtocol {
 
 }
 
+extension UserDataStore {
+    /// Drops `context` when the rider has turned the transfer banner off, so
+    /// the stop page shows ordinary clock times and the full departure list.
+    /// Lives on the protocol extension rather than the `@objc` protocol:
+    /// `TransferContext` is a Swift struct and cannot appear in an ObjC requirement.
+    public func displayedTransferContext(_ context: TransferContext?) -> TransferContext? {
+        showTransferArrivalBanner ? context : nil
+    }
+}
+
 // MARK: - Survey Tracking Data Models
 
 /// Represents a completed survey entry
@@ -426,6 +441,7 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         static let walkingSpeedSource = "UserDataStore.walkingSpeedSource"
         static let defaultAlarmLeadTimeMinutes = "UserDataStore.defaultAlarmLeadTimeMinutes"
         static let stopUIReducedColors = UserDefaultsStore.stopUIReducedColorsKey
+        static let showTransferArrivalBanner = UserDefaultsStore.showTransferArrivalBannerKey
     }
 
     /// The defaults key backing `stopUIReducedColors`, public so the stop
@@ -436,12 +452,17 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
     /// docs/superpowers/specs/2026-07-20-stop-ui-accessibility-design.md §3.
     public static let stopUIReducedColorsKey = "stopUIReducedColors"
 
+    /// Defaults key for `showTransferArrivalBanner`. Dot-free so a future
+    /// `@AppStorage` reader can observe it; see `stopUIReducedColorsKey`.
+    public static let showTransferArrivalBannerKey = "showTransferArrivalBanner"
+
     public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
 
         self.userDefaults.register(defaults: [
             UserDefaultsKeys.debugMode: false,
             UserDefaultsKeys.stopUIReducedColors: false,
+            UserDefaultsKeys.showTransferArrivalBanner: true,
             UserDefaultsKeys.walkingSpeedMetersPerSecond: WalkingSpeed.defaultMetersPerSecond,
             UserDefaultsKeys.walkingSpeedSource: WalkingSpeedSource.manual.rawValue
         ])
@@ -470,6 +491,17 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
         }
         set {
             userDefaults.set(newValue, forKey: UserDefaultsKeys.stopUIReducedColors)
+        }
+    }
+
+    // MARK: - Transfer Arrival Banner
+
+    public var showTransferArrivalBanner: Bool {
+        get {
+            return userDefaults.bool(forKey: UserDefaultsKeys.showTransferArrivalBanner)
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsKeys.showTransferArrivalBanner)
         }
     }
 

--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -43,7 +43,7 @@ public protocol UserDataStore: NSObjectProtocol {
 
     /// Whether opening a stop from a trip applies transfer-relative times
     /// and the "Arriving at XX:XX via ###" banner. Default `true` so existing
-    /// riders keep current behavior; Settings > Arrival Display can turn it off.
+    /// riders keep current behavior; Settings > Arrival & Departure Display can turn it off.
     var showTransferArrivalBanner: Bool { get set }
 
     // MARK: - Bookmark Groups

--- a/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
+++ b/OBAKitTests/Modeling/UserData/UserDataStoreTests.swift
@@ -214,6 +214,31 @@ final class UserDefaultsStoreTests: OBATestCase {
         #expect(self.userDefaultsStore.userDefaults.bool(forKey: UserDefaultsStore.stopUIReducedColorsKey))
     }
 
+    // MARK: - Transfer Arrival Banner
+
+    @Test func `Transfer arrival banner defaults on`() {
+        #expect(self.userDefaultsStore.showTransferArrivalBanner)
+        #expect(UserDefaultsStore.showTransferArrivalBannerKey == "showTransferArrivalBanner")
+    }
+
+    @Test func `Transfer arrival banner off persists and drops displayed context`() {
+        let context = TransferContext(
+            arrivalTime: Date(timeIntervalSince1970: 1_700_000_000),
+            fromRouteShortName: "10",
+            fromTripHeadsign: "Capitol Hill"
+        )
+        #expect(self.userDefaultsStore.displayedTransferContext(context) == context)
+
+        userDefaultsStore.showTransferArrivalBanner = false
+        #expect(!self.userDefaultsStore.showTransferArrivalBanner)
+        #expect(self.userDefaultsStore.displayedTransferContext(context) == nil)
+
+        let reloaded = UserDefaultsStore(userDefaults: userDefaults)
+        #expect(!reloaded.showTransferArrivalBanner)
+        #expect(reloaded.displayedTransferContext(context) == nil)
+        #expect(self.userDefaultsStore.userDefaults.bool(forKey: UserDefaultsStore.showTransferArrivalBannerKey) == false)
+    }
+
     // MARK: - Survey Properties
 
     @Test func `Survey user identifier generates UUID`() {

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -132,6 +132,25 @@ final class LocalizationTests {
         }
     }
 
+    /// The footer names the switch. A locale that leaves the English phrase in
+    /// the footer while translating the title makes the two unrecognizable as
+    /// the same control.
+    @Test func `Transfer banner footer names the switch title in every locale`() {
+        let bundle = Bundle(for: DonationCell.self)
+        let titleKey = "settings_controller.arrival_display_section.transfer_banner"
+        let footerKey = "settings_controller.arrival_display_section.transfer_banner.footer"
+
+        for localization in bundle.localizations where localization != "Base" {
+            guard let table = strings(in: bundle, localization: localization),
+                  let title = table[titleKey],
+                  let footer = table[footerKey] else {
+                Issue.record("\(localization): missing transfer banner strings")
+                continue
+            }
+            #expect(footer.hasPrefix(title), "\(localization): footer must start with the switch title \"\(title)\"")
+        }
+    }
+
     /// The plural keys exist in *both* `Localizable.strings` (as the `value:` fallback) and
     /// `Localizable.stringsdict`. If the stringsdict resource ever stops being bundled, lookup
     /// silently falls back to the bare `%d` form and English renders "1 stops". Assert the

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -834,6 +834,26 @@ final class StopViewModelTests: OBATestCase {
         #expect(plainController is StopPageViewController)
     }
 
+    /// The banner toggle drops the effective transfer context. Routing must use
+    /// that same helper: a raw non-nil context with the toggle off is ordinary
+    /// stop UX, so it belongs on the new page (flag default ON). Leave the
+    /// router on the raw value and this fails — legacy screen, no banner.
+    @Test @MainActor
+    func `Make stop controller ignores transfer context when the banner toggle is off`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
+        #expect(FeatureFlags.isNewStopPageEnabled(userDefaults: app.userDefaults))
+
+        app.userDataStore.showTransferArrivalBanner = false
+
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        let transfer = TransferContext(arrivalTime: Date(), fromRouteShortName: "1", fromTripHeadsign: "Downtown")
+        let controller = app.viewRouter.makeStopController(stop: stop, transferContext: transfer)
+
+        #expect(controller is StopPageViewController)
+        #expect((controller as? StopPageViewController)?.transferContext == nil)
+    }
+
     // MARK: - Alarm Lead Time
 
     /// `alarmLeadTimeMinutes` derives the displayed lead time from the alarm's

--- a/docs/transfer-arrival-banner.md
+++ b/docs/transfer-arrival-banner.md
@@ -1,0 +1,24 @@
+# Transfer arrival banner
+
+When a rider taps a stop on a trip, the stop page can treat that stop as a
+transfer: it shows an **Arriving at HH:MM via ROUTENAME** banner, hides
+departures that already left before the rider arrives, and prints remaining
+times relative to that arrival instead of the clock.
+
+That is useful for connections. It is also the behavior #1277 asked to turn
+off — relative "NOW" / "-5m" times and a filtered list are easy to misread as
+the live stop.
+
+## Setting
+
+Settings → Arrival Display → **Show transfer arrival banner**. Default **on**,
+so existing riders keep the current trip-to-stop flow.
+
+When the switch is off, `UserDataStore.displayedTransferContext(_:)` (a Swift
+protocol extension — `TransferContext` cannot appear on the `@objc` protocol)
+returns `nil` and `StopViewController` renders the stop as a normal stop:
+wall-clock times, walk-time row, full departure list.
+
+The new stop page still does not implement transfer UX
+(`Router.makeStopController` sends transfers to the legacy screen). This
+toggle only affects that legacy path.

--- a/docs/transfer-arrival-banner.md
+++ b/docs/transfer-arrival-banner.md
@@ -19,6 +19,7 @@ protocol extension — `TransferContext` cannot appear on the `@objc` protocol)
 returns `nil` and `StopViewController` renders the stop as a normal stop:
 wall-clock times, walk-time row, full departure list.
 
-The new stop page still does not implement transfer UX
-(`Router.makeStopController` sends transfers to the legacy screen). This
-toggle only affects that legacy path.
+The new stop page still does not implement transfer UX. With the toggle **on**,
+`Router.makeStopController` sends a real transfer to the legacy screen. With it
+**off**, `displayedTransferContext` is nil at the routing boundary too, so a
+trip→stop tap uses the new stop page like any other stop.

--- a/docs/transfer-arrival-banner.md
+++ b/docs/transfer-arrival-banner.md
@@ -11,8 +11,9 @@ the live stop.
 
 ## Setting
 
-Settings → Arrival Display → **Show transfer arrival banner**. Default **on**,
-so existing riders keep the current trip-to-stop flow.
+Settings → Arrival & Departure Display → **Show transfer arrival banner**.
+Default **on**, so existing riders keep the current trip-to-stop flow. The
+footer in every locale starts with that switch title verbatim.
 
 When the switch is off, `UserDataStore.displayedTransferContext(_:)` (a Swift
 protocol extension — `TransferContext` cannot appear on the `@objc` protocol)


### PR DESCRIPTION
## Summary
- Settings → Arrival Display → **Show transfer arrival banner** (default **on**) so riders can turn off transfer-relative times when they open a stop from a trip.
- When off, `UserDataStore.displayedTransferContext(_:)` returns `nil` and the legacy stop page shows wall-clock times, the walk-time row, and the full departure list.
- New keys in all 13 localization catalogs. `displayedTransferContext` lives on a Swift protocol extension because `TransferContext` cannot appear on the `@objc` `UserDataStore` protocol.

Does not replace the banner with trip highlighting, and does not change the new stop page (transfers still route to the legacy screen). **Refs #1277**.

## Test plan
- [ ] Settings → Arrival Display: switch defaults on; turning it off persists after leaving Settings.
- [ ] Open a stop from a trip with the switch **on**: Arriving-at banner, relative times, earlier departures hidden.
- [ ] Same path with the switch **off**: ordinary clock times, walk-time row, full list, no banner.
- [ ] `UserDefaultsStoreTests` — transfer banner defaults on; off persists and drops displayed context.
- [ ] `LocalizationTests` — every locale has the new keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Arrival & Departure Display setting to show or hide transfer-arrival banners.
  * The setting is enabled by default and persists across app launches.
  * Disabling it removes transfer-specific arrival and departure details from stop displays.
  * Improved departure filtering, menu accessibility states, and time-sorted arrival sections.
* **Localization**
  * Added translated labels, explanations, and related stop-display text across supported languages.
* **Documentation**
  * Documented banner behavior, relative-time formatting, and setting limitations.
* **Tests**
  * Added coverage for persistence, disabled-state behavior, and localization completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->