### PR TITLE
Coalesce bookmark list writes on move and delete

### DIFF
--- a/OBAKitCore/Models/UserData/UserDataStore.swift
+++ b/OBAKitCore/Models/UserData/UserDataStore.swift
@@ -570,60 +570,52 @@ public class UserDefaultsStore: NSObject, UserDataStore, StopPreferencesStore {
 
         bookmark.groupID = group?.id ?? nil
 
-        if let existing = findBookmark(id: bookmark.id) {
-            delete(bookmark: existing, reorderGroup: true)
-        }
+        // Decode once, mutate in memory, encode once. The previous loop called
+        // `bookmarks` get/set (full plist round-trip) per row, which froze the
+        // UI for several seconds with a dozen bookmarks. See #548.
+        var all = bookmarks.filter { $0.id != bookmark.id }
+        let newGroupID = bookmark.groupID
 
-        var newGroupBookmarks = bookmarksInGroup(group)
-        newGroupBookmarks.insert(bookmark, at: min(index, newGroupBookmarks.count))
-
-        for (idx, elt) in newGroupBookmarks.enumerated() {
-            if let existing = findBookmark(id: elt.id) {
-                delete(bookmark: existing, reorderGroup: false)
-            }
-
+        var destination = all
+            .filter { $0.groupID == newGroupID }
+            .sorted { $0.sortOrder < $1.sortOrder }
+        destination.insert(bookmark, at: min(index, destination.count))
+        for (idx, elt) in destination.enumerated() {
             elt.sortOrder = idx
-
-            bookmarks.append(elt)
         }
 
-        if oldGroupID != bookmark.groupID {
-            let oldGroupBookmarks = bookmarksInGroup(findGroup(id: oldGroupID))
-            for (idx, elt) in oldGroupBookmarks.enumerated() {
-                if let existing = findBookmark(id: elt.id) {
-                    delete(bookmark: existing, reorderGroup: false)
-                }
+        let destinationIDs = Set(destination.map(\.id))
+        all.removeAll { destinationIDs.contains($0.id) }
+        all.append(contentsOf: destination)
 
+        if oldGroupID != newGroupID {
+            let remaining = all
+                .filter { $0.groupID == oldGroupID }
+                .sorted { $0.sortOrder < $1.sortOrder }
+            for (idx, elt) in remaining.enumerated() {
                 elt.sortOrder = idx
-                bookmarks.append(elt)
             }
         }
 
+        bookmarks = all
         NotificationCenter.default.post(name: .bookmarksDidChange, object: self)
     }
 
     public func delete(bookmark: Bookmark) {
-        delete(bookmark: bookmark, reorderGroup: true)
-        NotificationCenter.default.post(name: .bookmarksDidChange, object: self)
-    }
+        var all = bookmarks
+        guard let stored = all.first(where: { $0.id == bookmark.id }) else { return }
+        let groupID = stored.groupID
+        all.removeAll { $0.id == bookmark.id }
 
-    private func delete(bookmark: Bookmark, reorderGroup: Bool) {
-        let bookmark = findBookmark(id: bookmark.id, defaultValue: bookmark)
-        guard let index = bookmarks.firstIndex(of: bookmark) else { return }
-
-        let groupID = bookmark.groupID
-
-        bookmarks.remove(at: index)
-
-        if reorderGroup {
-            for (idx, elt) in bookmarksInGroup(findGroup(id: groupID)).enumerated() {
-                if let existing = findBookmark(id: elt.id) {
-                    delete(bookmark: existing, reorderGroup: false)
-                }
-                elt.sortOrder = idx
-                bookmarks.append(elt)
-            }
+        let remaining = all
+            .filter { $0.groupID == groupID }
+            .sorted { $0.sortOrder < $1.sortOrder }
+        for (idx, elt) in remaining.enumerated() {
+            elt.sortOrder = idx
         }
+
+        bookmarks = all
+        NotificationCenter.default.post(name: .bookmarksDidChange, object: self)
     }
 
     /// Finds the specified `Bookmark` by `id` or returns the `defaultValue`. Useful for upserts and the like.

--- a/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
@@ -417,7 +417,10 @@ final class UserDefaultsStore_BookmarksTests: OBATestCase {
 
 /// Counts `UserDataStore.bookmarks` encodes. Subclassing `UserDefaults` is the
 /// seam: `Bookmark` is a production type and should not grow test-only hooks.
-private final class BookmarkWriteCountingDefaults: UserDefaults {
+///
+/// `nonisolated` because OBAKitTests defaults to `@MainActor` and
+/// `UserDefaults.set(_:forKey:)` / `init(suiteName:)` are not.
+nonisolated private final class BookmarkWriteCountingDefaults: UserDefaults {
     var bookmarkWrites = 0
 
     override func set(_ value: Any?, forKey defaultName: String) {

--- a/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
+++ b/OBAKitTests/Modeling/UserData/Bookmarks/UserDataStore_BookmarksTests.swift
@@ -369,4 +369,61 @@ final class UserDefaultsStore_BookmarksTests: OBATestCase {
         #expect(self.userDefaultsStore.findBookmark(id: g1b2.id)!.sortOrder == 0)
         #expect(self.userDefaultsStore.findBookmark(id: g1b3.id)!.sortOrder == 1)
     }
+
+    // MARK: - Bookmark plist write coalescing (#548)
+
+    /// Revert `add(_:to:index:)` to the per-row `bookmarks` get/set loop and
+    /// this fails: that path wrote the full bookmark plist once per member.
+    @Test func `Moving a bookmark encodes the bookmark list once`() {
+        let defaults = BookmarkWriteCountingDefaults(suiteName: "bookmark-writes-move-\(UUID().uuidString)")!
+        let store = UserDefaultsStore(userDefaults: defaults)
+        let stop = stops[0]
+
+        for i in 0..<12 {
+            store.add(Bookmark(name: "Bookmark \(i)", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop))
+        }
+
+        defaults.bookmarkWrites = 0
+        let inserted = Bookmark(name: "Inserted", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
+        store.add(inserted, to: nil, index: 3)
+
+        #expect(defaults.bookmarkWrites == 1)
+        #expect(store.bookmarks.map(\.name)[3] == "Inserted")
+        #expect(store.bookmarks.count == 13)
+    }
+
+    /// Same coalescing guarantee on delete: one plist write, remaining
+    /// sortOrder values compacted. Restoring the per-row rewrite fails this.
+    @Test func `Deleting a bookmark encodes the bookmark list once`() {
+        let defaults = BookmarkWriteCountingDefaults(suiteName: "bookmark-writes-delete-\(UUID().uuidString)")!
+        let store = UserDefaultsStore(userDefaults: defaults)
+        let stop = stops[0]
+
+        var bookmarks: [Bookmark] = []
+        for i in 0..<12 {
+            let bookmark = Bookmark(name: "Bookmark \(i)", regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier, stop: stop)
+            store.add(bookmark)
+            bookmarks.append(bookmark)
+        }
+
+        defaults.bookmarkWrites = 0
+        store.delete(bookmark: bookmarks[4])
+
+        #expect(defaults.bookmarkWrites == 1)
+        #expect(store.bookmarks.count == 11)
+        #expect(store.bookmarks.map(\.sortOrder) == Array(0..<11))
+    }
+}
+
+/// Counts `UserDataStore.bookmarks` encodes. Subclassing `UserDefaults` is the
+/// seam: `Bookmark` is a production type and should not grow test-only hooks.
+private final class BookmarkWriteCountingDefaults: UserDefaults {
+    var bookmarkWrites = 0
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        if defaultName == "UserDataStore.bookmarks" {
+            bookmarkWrites += 1
+        }
+        super.set(value, forKey: defaultName)
+    }
 }

--- a/docs/bookmark-edit-performance.md
+++ b/docs/bookmark-edit-performance.md
@@ -1,0 +1,13 @@
+# Bookmark edit performance
+
+Editing the Bookmarks list used to freeze the UI for several seconds once a
+rider had more than about ten bookmarks (#548). Moving or deleting one item
+rewrote the whole bookmark plist once per remaining row: `bookmarks` get
+decodes the array, `bookmarks` set encodes it, and `add(_:to:index:)` /
+`delete(bookmark:)` looped that round-trip.
+
+Those methods now decode once, reorder in memory, and encode once.
+
+Existing sort-order tests in `UserDefaultsStore_BookmarksTests` still define
+the grouping and `sortOrder` contract. Two new tests count writes to the
+`UserDataStore.bookmarks` key and fail if the per-row loop is restored.


### PR DESCRIPTION
## Summary
- `add(_:to:index:)` and `delete(bookmark:)` used to decode and encode the full bookmark plist once per remaining row. That is the 5–8 second freeze in #548.
- Both methods now mutate an in-memory `[Bookmark]` and write the plist once.
- Existing sort-order tests still define grouping/`sortOrder`. Two new tests count writes to `UserDataStore.bookmarks` and fail if the per-row loop is restored.

**Closes #548.** (The comment asking for a per-group edit mode is a separate feature.)

## Test plan
- [ ] Seed ~12 bookmarks. Drag one to a new index: list order is correct, no multi-second freeze.
- [ ] Delete one: remaining `sortOrder` values compact, no multi-second freeze.
- [ ] Move a bookmark between groups: source and destination groups reindex independently.
- [ ] `UserDefaultsStore_BookmarksTests` — existing sort-order tests plus the two write-count tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bookmark insertion and deletion reliability, including safe handling of missing bookmarks.
  * Preserved bookmark ordering when moving or deleting items.
* **Performance**
  * Bookmark edits now save changes more efficiently, reducing unnecessary storage operations.
* **Tests**
  * Added coverage for bookmark order, deletion behavior, item counts, and save frequency.
* **Documentation**
  * Documented bookmark editing performance improvements and ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->