### PR TITLE
Tighten a few Swift 6 concurrency escape hatches

### DIFF
--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -50,7 +50,7 @@ public final class ArrivalDeparture: NSObject, Identifiable, Decodable, HasRefer
     public let routeID: RouteID
 
     /// the route for the arriving vehicle
-    public var route: Route!
+    public private(set) var route: Route!
 
     /// the route long name that potentially overrides the route long name in the referenced `Route` element
     private let _routeLongName: String?
@@ -79,7 +79,7 @@ public final class ArrivalDeparture: NSObject, Identifiable, Decodable, HasRefer
     public let stopID: StopID
 
     /// The stop the vehicle is arriving at
-    public var stop: Stop!
+    public private(set) var stop: Stop!
 
     /// The index of the stop into the sequence of stops that make up the trip for this arrival
     public let stopSequence: Int
@@ -94,7 +94,7 @@ public final class ArrivalDeparture: NSObject, Identifiable, Decodable, HasRefer
     public let tripID: TripIdentifier
 
     /// The Trip for the arriving vehicle
-    public var trip: Trip!
+    public private(set) var trip: Trip!
 
     /// Trip-specific status for the arriving transit vehicle
     public let tripStatus: TripStatus?

--- a/OBAKitCore/Models/REST/StopArrivals.swift
+++ b/OBAKitCore/Models/REST/StopArrivals.swift
@@ -51,7 +51,7 @@ public class StopArrivals: NSObject, Identifiable, Decodable, HasReferences {
     let stopID: StopID
 
     /// The stop to which this object refers.
-    public var stop: Stop!
+    public private(set) var stop: Stop!
 
     public private(set) var regionIdentifier: Int?
 

--- a/OBAKitCore/Utilities/DecodingErrorReporter.swift
+++ b/OBAKitCore/Utilities/DecodingErrorReporter.swift
@@ -8,16 +8,17 @@
 //
 
 import Foundation
+import Synchronization
 
 public enum DecodingErrorReporter {
 
-    private static let lock = NSLock()
-    // nonisolated(unsafe): every access goes through `lock` via the computed property below.
-    nonisolated(unsafe) private static var _reportHandler: (@Sendable (_ error: DecodingError, _ url: URL, _ httpMethod: String, _ message: String) -> Void)?
+    // Mutex is compiler-checked. The previous `nonisolated(unsafe)` + `NSLock`
+    // pair encoded the same exclusive-access invariant by comment only (#1198).
+    private static let handler = Mutex<(@Sendable (_ error: DecodingError, _ url: URL, _ httpMethod: String, _ message: String) -> Void)?>(nil)
 
     public static var reportHandler: (@Sendable (_ error: DecodingError, _ url: URL, _ httpMethod: String, _ message: String) -> Void)? {
-        get { lock.withLock { _reportHandler } }
-        set { lock.withLock { _reportHandler = newValue } }
+        get { handler.withLock { $0 } }
+        set { handler.withLock { $0 = newValue } }
     }
 
     public static func message(from error: DecodingError) -> String {

--- a/docs/swift6-escape-hatches.md
+++ b/docs/swift6-escape-hatches.md
@@ -1,0 +1,26 @@
+# Swift 6 escape hatches unwound in #1198
+
+Follow-up to the Swift 6 migration plan (`docs/swift6-migration-plan.md`) and
+issue #1198. This change only takes hatches that are compiler-checked today
+without new factories or Apple annotations.
+
+## Done
+
+- `ArrivalDeparture.route`, `.stop`, and `.trip` are `public private(set)`.
+  `loadReferences` remains the only writer, which is the HasReferences
+  "read-only after handoff" contract. Covered by
+  `ArrivalDepartureTests` `Load references`.
+- `StopArrivals.stop` is the same.
+- `DecodingErrorReporter.reportHandler` is a `Mutex` instead of
+  `nonisolated(unsafe)` plus `NSLock`. Existing
+  `DecodingErrorReporterTests` still drive get/set/`report`.
+
+## Left alone on purpose
+
+- `Trip.route` stays a public `var`. `TripTests` assign it because `References`
+  has no public memberwise factory.
+- `UncheckedSendableBox` stays. MapKit's `MKDirections.Request` /
+  `MKLookAroundSceneRequest` still need a sole-owner hop at
+  `MapRegionManager.handleMapFeatureSelection` and `MapItemViewModel.fetchScene`.
+- `AnalyticsOrchestrator.userDefaults`, `Icons.iconCache`, and other
+  `NSCache` / `UserDefaults` marks wait on Apple `Sendable` annotations.


### PR DESCRIPTION
## Summary
- `ArrivalDeparture.route`, `.stop`, and `.trip`, plus `StopArrivals.stop`, are `public private(set)`. `loadReferences` remains the only writer.
- `DecodingErrorReporter.reportHandler` is a compiler-checked `Mutex` instead of `nonisolated(unsafe)` plus `NSLock`.
- Left alone on purpose: `Trip.route` (tests assign it; `References` has no public factory), `UncheckedSendableBox` (MapKit hops), `UserDefaults` / `NSCache` marks waiting on Apple.

Does not finish the whole audit. **Refs #1198.**

## Test plan
- [ ] `ArrivalDepartureTests` `Load references` still wires route/stop/trip.
- [ ] `DecodingErrorReporterTests` still set and invoke `reportHandler`.
- [ ] App builds in the Swift 6 language mode.