### PR TITLE
Fix and restyle the inline stop-page survey card

### DIFF
--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -64,6 +64,11 @@ struct StopDeparturesSections: View {
     /// matching the inset-grouped card margin.
     private static let horizontalRowInset: CGFloat = 0
 
+    /// The survey card draws its own rounded background, so unlike the other
+    /// card rows it needs a margin: flush with the screen edges, its corners fall
+    /// off-screen and the card reads as a stray hairline band.
+    private static let surveyRowInset: CGFloat = 16
+
     var body: some View {
         // Hoisted for the same reason `walkMinutes` is passed in rather than
         // recomputed: the header row's Past count and the list's past section
@@ -82,7 +87,7 @@ struct StopDeparturesSections: View {
                     onDismiss: onSurveyDismiss,
                     onOpenExternalSurvey: onSurveyExternal
                 )
-                .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
+                .listRowInsets(EdgeInsets(top: 8, leading: Self.surveyRowInset, bottom: 8, trailing: Self.surveyRowInset))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
             }

--- a/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
+++ b/OBAKit/Stops/StopPage/SurveyCardRepresentable.swift
@@ -68,3 +68,61 @@ struct SurveyCardRepresentable: UIViewRepresentable {
         }
     }
 }
+
+// MARK: - Previews
+
+/// Builds a one-question survey whose hero question is `type`, so the previews
+/// below can show every shape of card the Stop page can render.
+private func previewSurvey(type: QuestionType, labelText: String, options: [String]? = nil) -> Survey {
+    Survey(
+        id: 1,
+        name: "Preview Survey",
+        createdAt: Date(),
+        updatedAt: Date(),
+        showOnMap: false,
+        showOnStops: true,
+        startDate: nil,
+        endDate: nil,
+        visibleStopsList: nil,
+        visibleRoutesList: nil,
+        allowsMultipleResponses: false,
+        alwaysVisible: true,
+        study: Study(id: 1, name: "Preview Study", description: nil),
+        // `heroQuestion` is the question at position 1.
+        questions: [
+            SurveyQuestion(
+                id: 1,
+                position: 1,
+                required: false,
+                content: QuestionContent(labelText: labelText, type: type, options: options)
+            )
+        ]
+    )
+}
+
+private func previewCard(_ survey: Survey) -> some View {
+    SurveyCardRepresentable(
+        survey: survey,
+        stopID: "1_11370",
+        onNext: { _ in },
+        onDismiss: {},
+        onOpenExternalSurvey: {}
+    )
+    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+    .listRowBackground(Color.clear)
+    .listRowSeparator(.hidden)
+}
+
+#Preview("Survey card variants") {
+    List {
+        // A label hero collects no answer, so Next is actionable immediately.
+        previewCard(previewSurvey(type: .label, labelText: "Share your transit story"))
+        previewCard(previewSurvey(
+            type: .radio,
+            labelText: "How was your trip today?",
+            options: ["Great", "Fine", "Not great"]
+        ))
+        previewCard(previewSurvey(type: .externalSurvey, labelText: "Help us plan future service"))
+    }
+    .listStyle(.plain)
+}

--- a/OBAKit/Surveys/SurveyCell.swift
+++ b/OBAKit/Surveys/SurveyCell.swift
@@ -16,6 +16,20 @@ class SurveyCell: OBAListViewCell {
     private var optionButtons: [UIButton] = []
     private var currentSelection: String?
 
+    /// Whether the hero question collects an answer inside the card. A `.label`
+    /// hero is display-only — no option to pick, no field to fill in — so it is
+    /// answerable without a selection.
+    private var heroCollectsAnswer = true
+
+    /// The answer a Next tap would submit, or `nil` while the hero question is
+    /// still unanswered. A display-only hero answers with an empty string;
+    /// without that, `Next` was gated on a selection that could never arrive and
+    /// stayed permanently disabled.
+    private var pendingAnswer: String? {
+        if let currentSelection { return currentSelection }
+        return heroCollectsAnswer ? nil : ""
+    }
+
     public override func apply(_ config: OBAContentConfiguration) {
         super.apply(config)
 
@@ -28,38 +42,104 @@ class SurveyCell: OBAListViewCell {
         updateUI()
     }
 
+    // MARK: - Metrics
+
+    private enum Metrics {
+        /// Matches `SurveyLauncherCardView`'s grouped card so the two survey
+        /// surfaces read as the same component.
+        static let cardRadius: CGFloat = 16.0
+        static let cardPadding: CGFloat = 16.0
+        static let optionRadius: CGFloat = 10.0
+        static let hairline: CGFloat = 1.0
+
+        // Icon tile, also lifted from `SurveyLauncherCardView`.
+        static let tileSize: CGFloat = 42.0
+        static let tileRadius: CGFloat = 10.0
+        static let tileGlyphPointSize: CGFloat = 20.0
+        static let tileTextGap: CGFloat = 14.0
+        /// Ceilings for the scaled tile. Left uncapped, an AX5 tile is wide
+        /// enough to leave the question a single word per line.
+        static let maxTileSize: CGFloat = 72.0
+        static let maxTileGlyphPointSize: CGFloat = 34.0
+    }
+
     // MARK: - UI Components
+
+    /// The rounded card the content sits in. The cell itself stays transparent:
+    /// it spans the full row width, so drawing the card chrome on the cell drew
+    /// a hairline across the whole screen instead of a card.
+    private lazy var cardView: UIView = {
+        let view = UIView.autolayoutNew()
+        view.backgroundColor = .secondarySystemBackground
+        view.layer.cornerRadius = Metrics.cardRadius
+        view.layer.cornerCurve = .continuous
+        return view
+    }()
+
+    /// Brand-filled tile carrying the survey glyph. Decorative — the question
+    /// text alongside it already says what the card is.
+    private let iconTile: UIView = {
+        let view = UIView.autolayoutNew()
+        view.backgroundColor = ThemeColors.shared.brand
+        view.layer.cornerRadius = Metrics.tileRadius
+        view.layer.cornerCurve = .continuous
+        return view
+    }()
+
+    private let tileGlyph: UIImageView = {
+        let symbol = UIImage(
+            systemName: "questionmark.bubble",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: Metrics.tileGlyphPointSize, weight: .semibold)
+        )
+        let imageView = UIImageView(image: symbol)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
 
     lazy var questionLabel: UILabel = {
         let label = UILabel.autolayoutNew()
         label.numberOfLines = 0
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = .preferredFont(forTextStyle: .headline)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .label
         return label
     }()
 
-    lazy var optionsStack: UIStackView = {
-        let stack = UIStackView.verticalStack(arrangedSubviews: [])
-        stack.spacing = 8
+    /// Held so `updateTileSize()` can rescale the tile when the user's text size
+    /// changes; the tile is square, so both constraints share one constant.
+    private lazy var tileSizeConstraints: [NSLayoutConstraint] = [
+        iconTile.widthAnchor.constraint(equalToConstant: Metrics.tileSize),
+        iconTile.heightAnchor.constraint(equalToConstant: Metrics.tileSize)
+    ]
+
+    /// Tile and question side by side. The tile keeps its square footprint while
+    /// the question takes the rest of the width and wraps.
+    private lazy var headerRow: UIStackView = {
+        let stack = UIStackView.horizontalStack(arrangedSubviews: [iconTile, questionLabel])
+        stack.spacing = Metrics.tileTextGap
+        stack.alignment = .center
         return stack
     }()
 
+    lazy var optionsStack: UIStackView = {
+        let stack = UIStackView.verticalStack(arrangedSubviews: [])
+        stack.spacing = ThemeMetrics.padding
+        return stack
+    }()
+
+    /// Borderless and secondary: dismissing is the low-emphasis action, and the
+    /// bordered half-width box it used to be competed with `Next`.
     lazy var dismissButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.title = OBALoc("survey_cell.dismiss_button", value: "Dismiss", comment: "Button to dismiss the survey")
-        config.baseForegroundColor = .label
-        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
-            var outgoing = incoming
-            outgoing.font = .systemFont(ofSize: incoming.font?.pointSize ?? UIFont.labelFontSize, weight: .medium)
-            return outgoing
-        }
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
+        config.baseForegroundColor = .secondaryLabel
+        config.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 12)
 
         let button = UIButton(configuration: config)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 8
-        button.layer.borderWidth = 1
-        button.layer.borderColor = UIColor.systemGray4.cgColor
+        button.setContentHuggingPriority(.required, for: .horizontal)
 
         let action = UIAction { [weak self] _ in
             guard let viewModel = self?.viewModel else { return }
@@ -70,38 +150,24 @@ class SurveyCell: OBAListViewCell {
     }()
 
     lazy var nextButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.title = OBALoc("survey_cell.next_button", value: "Next", comment: "Button to proceed to next survey question")
-        config.baseBackgroundColor = .systemGreen
-        config.baseForegroundColor = .white
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
-
-        let button = UIButton(configuration: config)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 8
-        button.clipsToBounds = true
+        let button = SurveyCell.prominentButton(
+            title: OBALoc("survey_cell.next_button", value: "Next", comment: "Button to proceed to next survey question")
+        )
 
         let action = UIAction { [weak self] _ in
             guard let self,
                   let viewModel = self.viewModel,
-                  let selectedOption = self.currentSelection else { return }
-            viewModel.onNext(selectedOption)
+                  let answer = self.pendingAnswer else { return }
+            viewModel.onNext(answer)
         }
         button.addAction(action, for: .touchUpInside)
         return button
     }()
 
     lazy var externalSurveyButton: UIButton = {
-        var config = UIButton.Configuration.filled()
-        config.title = OBALoc("survey_cell.open_external_survey_button", value: "Open Survey", comment: "Button that opens an external survey in the browser")
-        config.baseBackgroundColor = .systemGreen
-        config.baseForegroundColor = .white
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
-
-        let button = UIButton(configuration: config)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 8
-        button.clipsToBounds = true
+        let button = SurveyCell.prominentButton(
+            title: OBALoc("survey_cell.open_external_survey_button", value: "Open Survey", comment: "Button that opens an external survey in the browser")
+        )
         button.isHidden = true
 
         let action = UIAction { [weak self] _ in
@@ -111,22 +177,27 @@ class SurveyCell: OBAListViewCell {
         return button
     }()
 
+    /// Dismiss trailing-aligned next to the call to action rather than splitting
+    /// the card in half: the spacer takes the slack so both buttons keep their
+    /// intrinsic width. `Next` and `Open Survey` are mutually exclusive, so they
+    /// share the slot and every question type gets the same single action row.
     lazy var actionButtonsStack: UIStackView = {
-        let stack = UIStackView.horizontalStack(arrangedSubviews: [dismissButton, nextButton])
+        let spacer = UIView.autolayoutNew()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let stack = UIStackView.horizontalStack(arrangedSubviews: [spacer, dismissButton, nextButton, externalSurveyButton])
         stack.spacing = ThemeMetrics.compactPadding
-        stack.distribution = .fillEqually
+        stack.alignment = .center
         return stack
     }()
 
     lazy var contentStack: UIStackView = {
         let stack = UIStackView.verticalStack(arrangedSubviews: [
-            questionLabel,
+            headerRow,
             optionsStack,
-            externalSurveyButton,
-            UIView.spacerView(height: 8.0),
             actionButtonsStack
         ])
-        stack.spacing = 8.0
+        stack.spacing = ThemeMetrics.padding
         return stack
     }()
 
@@ -142,22 +213,70 @@ class SurveyCell: OBAListViewCell {
     }
 
     private func setupView() {
-        backgroundColor = .systemBackground
-        layer.cornerRadius = 12
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.systemGray4.cgColor
+        backgroundColor = .clear
 
-        // Add content stack with padding
-        addSubview(contentStack)
-        contentStack.pinToSuperview(.edges, insets: NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: -12, trailing: -12))
+        addSubview(cardView)
+        cardView.pinToSuperview(.edges)
+
+        let padding = Metrics.cardPadding
+        iconTile.addSubview(tileGlyph)
+        cardView.addSubview(contentStack)
+        contentStack.pinToSuperview(.edges, insets: NSDirectionalEdgeInsets(top: padding, leading: padding, bottom: -padding, trailing: -padding))
+
+        NSLayoutConstraint.activate(tileSizeConstraints + [
+            tileGlyph.centerXAnchor.constraint(equalTo: iconTile.centerXAnchor),
+            tileGlyph.centerYAnchor.constraint(equalTo: iconTile.centerYAnchor)
+        ])
+        updateTileSize()
 
         registerForTraitChanges([UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self]) { (self: SurveyCell, _: UITraitCollection) in
-            self.layer.borderColor = UIColor.systemGray4.cgColor
-            self.dismissButton.layer.borderColor = UIColor.systemGray4.cgColor
             for button in self.optionButtons {
-                button.layer.borderColor = button.isSelected ? UIColor.systemGreen.cgColor : UIColor.systemGray4.cgColor
+                button.layer.borderColor = SurveyCell.optionBorderColor(isSelected: button.isSelected)
             }
         }
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: SurveyCell, _: UITraitCollection) in
+            self.updateTileSize()
+        }
+    }
+
+    /// Grows the tile alongside the question text. A fixed 42pt tile shrinks into
+    /// a bullet next to accessibility-size text, which reads as a rendering bug.
+    private func updateTileSize() {
+        let metrics = UIFontMetrics(forTextStyle: .headline)
+        let side = min(metrics.scaledValue(for: Metrics.tileSize, compatibleWith: traitCollection), Metrics.maxTileSize)
+        for constraint in tileSizeConstraints {
+            constraint.constant = side
+        }
+
+        let glyphPointSize = min(
+            metrics.scaledValue(for: Metrics.tileGlyphPointSize, compatibleWith: traitCollection),
+            Metrics.maxTileGlyphPointSize
+        )
+        tileGlyph.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: glyphPointSize, weight: .semibold)
+    }
+
+    // MARK: - Factories
+
+    /// The card's filled call-to-action buttons. `UIButton.Configuration` rounds
+    /// its own background, so the buttons carry no `layer.cornerRadius` — setting
+    /// both left the configuration's radius fighting the layer's.
+    private static func prominentButton(title: String) -> UIButton {
+        var config = UIButton.Configuration.filled()
+        config.title = title
+        config.baseBackgroundColor = ThemeColors.shared.brand
+        config.baseForegroundColor = .white
+        config.cornerStyle = .large
+        config.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20)
+
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        return button
+    }
+
+    private static func optionBorderColor(isSelected: Bool) -> CGColor {
+        isSelected ? ThemeColors.shared.brand.cgColor : UIColor.separator.cgColor
     }
 
     // MARK: - UI Updates
@@ -189,6 +308,7 @@ class SurveyCell: OBAListViewCell {
 
         externalSurveyButton.isHidden = true
         nextButton.isHidden = false
+        heroCollectsAnswer = true
 
         switch question.content.type {
         case .radio:
@@ -207,6 +327,7 @@ class SurveyCell: OBAListViewCell {
 
         case .label:
             optionsStack.isHidden = true
+            heroCollectsAnswer = false
 
         case .externalSurvey:
             optionsStack.isHidden = true
@@ -244,12 +365,14 @@ class SurveyCell: OBAListViewCell {
         let iconName = isRadio ? "circle" : "square"
         let selectedIconName = isRadio ? "circle.fill" : "checkmark.square.fill"
 
+        let brand = ThemeColors.shared.brand
+
         var config = UIButton.Configuration.plain()
         config.title = title
         config.baseForegroundColor = .label
-        config.image = UIImage(systemName: iconName)?.withTintColor(.systemGreen, renderingMode: .alwaysOriginal)
-        config.imagePadding = 8
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
+        config.image = UIImage(systemName: iconName)?.withTintColor(brand, renderingMode: .alwaysOriginal)
+        config.imagePadding = ThemeMetrics.padding
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 14, bottom: 12, trailing: 14)
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
             outgoing.font = .preferredFont(forTextStyle: .body)
@@ -260,14 +383,17 @@ class SurveyCell: OBAListViewCell {
         button.configurationUpdateHandler = { btn in
             var updatedConfig = btn.configuration
             let name = btn.isSelected ? selectedIconName : iconName
-            updatedConfig?.image = UIImage(systemName: name)?.withTintColor(.systemGreen, renderingMode: .alwaysOriginal)
+            updatedConfig?.image = UIImage(systemName: name)?.withTintColor(brand, renderingMode: .alwaysOriginal)
             btn.configuration = updatedConfig
         }
         button.contentHorizontalAlignment = .leading
-        button.backgroundColor = .systemGray6
-        button.layer.cornerRadius = 8
-        button.layer.borderWidth = 1
-        button.layer.borderColor = UIColor.systemGray4.cgColor
+        // Filled with the page background rather than a gray: the card is already
+        // `secondarySystemBackground`, so a gray-on-gray row had no edge.
+        button.backgroundColor = .systemBackground
+        button.layer.cornerRadius = Metrics.optionRadius
+        button.layer.cornerCurve = .continuous
+        button.layer.borderWidth = Metrics.hairline
+        button.layer.borderColor = SurveyCell.optionBorderColor(isSelected: false)
 
         let action = UIAction { [weak self] _ in
             if isRadio {
@@ -322,26 +448,18 @@ class SurveyCell: OBAListViewCell {
 
     private func selectButton(_ button: UIButton) {
         button.isSelected = true
-        button.backgroundColor = .systemGreen.withAlphaComponent(0.15)
-        button.layer.borderColor = UIColor.systemGreen.cgColor
+        button.backgroundColor = ThemeColors.shared.brand.withAlphaComponent(0.12)
+        button.layer.borderColor = SurveyCell.optionBorderColor(isSelected: true)
     }
 
     private func deselectButton(_ button: UIButton) {
         button.isSelected = false
-        button.backgroundColor = .systemGray6
-        button.layer.borderColor = UIColor.systemGray4.cgColor
+        button.backgroundColor = .systemBackground
+        button.layer.borderColor = SurveyCell.optionBorderColor(isSelected: false)
     }
 
     private func updateNextButtonState() {
-        let hasSelection = currentSelection != nil
-        nextButton.isEnabled = hasSelection
-        nextButton.configurationUpdateHandler = { btn in
-            var config = btn.configuration
-            config?.baseBackgroundColor = .systemGreen
-            config?.baseForegroundColor = .white
-            btn.configuration = config
-            btn.alpha = btn.isEnabled ? 1.0 : 0.5
-        }
+        nextButton.isEnabled = pendingAnswer != nil
     }
 
 }

--- a/OBAKitTests/Surveys/SurveyCellTests.swift
+++ b/OBAKitTests/Surveys/SurveyCellTests.swift
@@ -1,0 +1,87 @@
+//
+//  SurveyCellTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Covers the inline stop-page survey card's Next-button gating.
+///
+/// A `.label` hero question is display-only — there is no option to pick and no
+/// field to fill in — so gating Next on a stored selection left the button
+/// permanently disabled and the card impossible to advance past.
+@Suite(.serialized)
+@MainActor
+struct SurveyCellTests {
+
+    /// Records the card's callbacks. `SurveyStopListItem` is a `nonisolated`
+    /// struct, so the closures it stores are nonisolated too and cannot touch a
+    /// (default-main-actor) test-local box — hence the explicit `nonisolated`.
+    nonisolated private final class Recorder {
+        var nextAnswers: [String] = []
+        var dismissCount = 0
+    }
+
+    private func makeCell(
+        type: QuestionType,
+        options: [String]? = nil,
+        recorder: Recorder
+    ) -> SurveyCell {
+        // `heroQuestion` is the question at position 1.
+        let hero = SurveysTestHelpers.makeSurveyQuestion(
+            id: 1,
+            position: 1,
+            type: type,
+            labelText: "Share your transit story",
+            options: options
+        )
+        let item = SurveyStopListItem(
+            survey: SurveysTestHelpers.makeSurvey(questions: [hero]),
+            stopID: "1_11370",
+            onNext: { recorder.nextAnswers.append($0) },
+            onDismiss: { recorder.dismissCount += 1 },
+            onSelectionChanged: { _ in }
+        )
+
+        let cell = SurveyCell(frame: .zero)
+        cell.apply(SurveyContentConfiguration(item))
+        return cell
+    }
+
+    @Test func `Next is enabled for a label hero question`() {
+        let cell = makeCell(type: .label, recorder: Recorder())
+
+        #expect(cell.nextButton.isEnabled)
+    }
+
+    /// A label collects no answer, so advancing submits an empty one rather than
+    /// dropping the tap.
+    @Test func `Tapping Next on a label hero question submits an empty answer`() {
+        let recorder = Recorder()
+        let cell = makeCell(type: .label, recorder: recorder)
+
+        cell.nextButton.sendActions(for: .touchUpInside)
+
+        #expect(recorder.nextAnswers == [""])
+    }
+
+    /// Regression guard for the answerable case: a radio hero question still has
+    /// to be answered before Next does anything.
+    @Test func `Next stays inert until a radio option is selected`() {
+        let recorder = Recorder()
+        let cell = makeCell(type: .radio, options: ["Yes", "No"], recorder: recorder)
+
+        #expect(!cell.nextButton.isEnabled)
+
+        cell.nextButton.sendActions(for: .touchUpInside)
+        #expect(recorder.nextAnswers.isEmpty)
+    }
+}


### PR DESCRIPTION
The card gated Next on a stored selection, so a `.label` hero question — display-only, with no option to pick and no field to fill in — left Next permanently disabled and the survey impossible to advance past. Add `pendingAnswer`, which yields an empty answer for a hero that collects nothing, and read it from both `isEnabled` and the tap handler. Covered by new SurveyCellTests, including a guard that a `.radio` hero still has to be answered first.

Restyle to match `SurveyLauncherCardView` while we're here:

- The cell drew a border and corner radius on itself while spanning the full row width at zero horizontal inset, so its corners fell off-screen and the chrome rendered as hairlines across the whole display. The cell is now transparent with an inner rounded card, and the survey row takes a 16pt horizontal listRowInset.
- Dismiss is borderless and secondary rather than a bordered half-width box competing with Next; `fillEqually` gives way to a spacer plus two intrinsic-width buttons. Open Survey joins that row instead of sitting full-width above a stranded Dismiss.
- Drop the layer.cornerRadius fighting UIButton.Configuration's own radius, and the alpha = 0.5 disabled hack in favour of UIKit's native treatment.
- systemGreen gives way to ThemeColors.shared.brand throughout.
- Adorn the card with a brand-filled `questionmark.bubble` tile, sized off UIFontMetrics so it doesn't shrink into a bullet beside accessibility-size text, and capped so an AX5 tile doesn't squeeze the question to one word per line.

Add #Previews for the label, radio and external-survey variants so this surface is inspectable without a live survey on the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated survey cards with a clearer card layout, header icon, grouped actions, and improved adaptive sizing.
  * Improved answer controls with branded colors, bordered options, and clearer selected states.
  * Display-only survey questions can now continue without selecting an answer.
* **Bug Fixes**
  * Improved spacing around survey cards for a more consistent appearance.
  * Next actions now correctly remain unavailable until required options are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->