### PR TITLE
Make the Stop page navigable under VoiceOver

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -761,41 +761,45 @@ class MapViewController: UIViewController,
     ///   - annotation: The annotation the stop was opened from, if any. Deselected when the
     ///     stop sheet closes so the map doesn't keep a pin highlighted for a dismissed sheet.
     func show(stop: Stop, deselecting annotation: MKAnnotation? = nil) {
-        // Under VoiceOver the redesigned Stop page pushes full-screen instead of coming up as a
-        // half-detent sheet. A partial-height FloatingPanel over a live map is a poor modal for
-        // VoiceOver — the map behind it stays in the accessibility tree, and the detents,
-        // swipe-to-dismiss, and collapse-to-`.tip` behaviors are drag gestures VoiceOver can't
-        // perform. The pushed presentation (`showToolbarOnBottom: false`) is a standard, opaque
-        // screen with a nav-bar back button and contained focus. Decided at open time only; a
-        // sheet already onscreen when VoiceOver is switched on is left as-is.
-        if UIAccessibility.isVoiceOverRunning {
-            pushStopForVoiceOver(application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: false), deselecting: annotation)
-        } else {
+        guard prefersPushedStopPage else {
             present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+            return
         }
+        deselectForPushedStopPage(annotation)
+        application.viewRouter.navigateTo(stop: stop, from: self)
     }
 
     /// Displays the specified stop by ID.
     func show(stopID: StopID) {
-        // See `show(stop:)` for why VoiceOver gets the pushed presentation rather than the sheet.
-        if UIAccessibility.isVoiceOverRunning {
-            pushStopForVoiceOver(application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: false))
-        } else {
+        guard prefersPushedStopPage else {
             present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+            return
         }
+        application.viewRouter.navigateTo(stopID: stopID, from: self)
     }
 
-    /// Pushes the Stop page onto the map's navigation stack — the VoiceOver alternative to the
-    /// map sheet. Deselects the source annotation right away: a full-screen push covers the map,
-    /// so leaving a pin selected only strands a highlight for the rider to find on the way back.
-    /// Deliberately skips the sheet path's map-focus wiring (route highlight, recentering,
-    /// tab-bar hiding, `stopSheetStopID`) — all of it is map-visual bookkeeping that means
+    /// `true` while VoiceOver is running, where the Stop page opens as a full-screen push
+    /// instead of the map's half-detent sheet.
+    ///
+    /// A partial-height FloatingPanel over a live map is a poor modal for VoiceOver — the map
+    /// behind it stays in the accessibility tree, and the detents, swipe-to-dismiss, and
+    /// collapse-to-`.tip` behaviors are drag gestures VoiceOver can't perform. The pushed
+    /// presentation the router builds is a standard, opaque screen with a nav-bar back button
+    /// and contained focus, and it skips the sheet path's map-focus wiring (route highlight,
+    /// recentering, tab-bar hiding, `stopSheetStopID`) — map-visual bookkeeping that means
     /// nothing while a pushed screen covers the map, exactly as the legacy push path skips it.
-    private func pushStopForVoiceOver(_ stopController: UIViewController, deselecting annotation: MKAnnotation? = nil) {
-        if let annotation {
-            mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
-        }
-        application.viewRouter.navigate(to: stopController, from: self)
+    ///
+    /// Read at open time only: a sheet already onscreen when VoiceOver is switched on is left
+    /// as-is.
+    private var prefersPushedStopPage: Bool {
+        UIAccessibility.isVoiceOverRunning
+    }
+
+    /// A full-screen push covers the map, so leaving the tapped pin selected only strands a
+    /// highlight for the rider to find on the way back.
+    private func deselectForPushedStopPage(_ annotation: MKAnnotation?) {
+        guard let annotation else { return }
+        mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
     }
 
     /// Routes a stop screen to the presentation that suits it: the redesigned Stop page comes

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -761,12 +761,41 @@ class MapViewController: UIViewController,
     ///   - annotation: The annotation the stop was opened from, if any. Deselected when the
     ///     stop sheet closes so the map doesn't keep a pin highlighted for a dismissed sheet.
     func show(stop: Stop, deselecting annotation: MKAnnotation? = nil) {
-        present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+        // Under VoiceOver the redesigned Stop page pushes full-screen instead of coming up as a
+        // half-detent sheet. A partial-height FloatingPanel over a live map is a poor modal for
+        // VoiceOver — the map behind it stays in the accessibility tree, and the detents,
+        // swipe-to-dismiss, and collapse-to-`.tip` behaviors are drag gestures VoiceOver can't
+        // perform. The pushed presentation (`showToolbarOnBottom: false`) is a standard, opaque
+        // screen with a nav-bar back button and contained focus. Decided at open time only; a
+        // sheet already onscreen when VoiceOver is switched on is left as-is.
+        if UIAccessibility.isVoiceOverRunning {
+            pushStopForVoiceOver(application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: false), deselecting: annotation)
+        } else {
+            present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+        }
     }
 
     /// Displays the specified stop by ID.
     func show(stopID: StopID) {
-        present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+        // See `show(stop:)` for why VoiceOver gets the pushed presentation rather than the sheet.
+        if UIAccessibility.isVoiceOverRunning {
+            pushStopForVoiceOver(application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: false))
+        } else {
+            present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+        }
+    }
+
+    /// Pushes the Stop page onto the map's navigation stack — the VoiceOver alternative to the
+    /// map sheet. Deselects the source annotation right away: a full-screen push covers the map,
+    /// so leaving a pin selected only strands a highlight for the rider to find on the way back.
+    /// Deliberately skips the sheet path's map-focus wiring (route highlight, recentering,
+    /// tab-bar hiding, `stopSheetStopID`) — all of it is map-visual bookkeeping that means
+    /// nothing while a pushed screen covers the map, exactly as the legacy push path skips it.
+    private func pushStopForVoiceOver(_ stopController: UIViewController, deselecting annotation: MKAnnotation? = nil) {
+        if let annotation {
+            mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
+        }
+        application.viewRouter.navigate(to: stopController, from: self)
     }
 
     /// Routes a stop screen to the presentation that suits it: the redesigned Stop page comes

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -92,7 +92,18 @@ struct DepartureRowView: View {
         .onTapGesture(perform: onTap)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityText)
-        .accessibilityAddTraits(.isButton)
+        // `.updatesFrequently` so a focused row re-speaks its changing countdown,
+        // matching the legacy `StopArrivalView`'s `[.button, .updatesFrequently]`.
+        // VoiceOver re-reads only the focused element, so this isn't chatty.
+        .accessibilityAddTraits([.isButton, .updatesFrequently])
+        // Wire the row's primary action to VoiceOver's activate (double-tap).
+        // `.isButton` only changes the spoken trait; the row's tap lives on
+        // `.onTapGesture`, which is invisible to assistive tech, so without an
+        // explicit default action VoiceOver announces "button" but activating
+        // does nothing. A default `.accessibilityAction` closure touches only
+        // the accessibility layer, so it avoids the nested-Button gesture
+        // conflict called out on `alarmCircleButton`.
+        .accessibilityAction { onTap() }
         .accessibilityActions {
             if showsAlarmAffordance {
                 Button(hasAlarm ? removeAlarmTitle : Strings.addAlarm) {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -96,13 +96,13 @@ struct DepartureRowView: View {
         // matching the legacy `StopArrivalView`'s `[.button, .updatesFrequently]`.
         // VoiceOver re-reads only the focused element, so this isn't chatty.
         .accessibilityAddTraits([.isButton, .updatesFrequently])
-        // Wire the row's primary action to VoiceOver's activate (double-tap).
-        // `.isButton` only changes the spoken trait; the row's tap lives on
-        // `.onTapGesture`, which is invisible to assistive tech, so without an
-        // explicit default action VoiceOver announces "button" but activating
-        // does nothing. A default `.accessibilityAction` closure touches only
-        // the accessibility layer, so it avoids the nested-Button gesture
-        // conflict called out on `alarmCircleButton`.
+        // THE contract for every tap-driven row on this page, restated nowhere
+        // else: `.isButton` only changes the spoken trait, and the row's tap lives
+        // on `.onTapGesture`, which assistive tech cannot reach — so without an
+        // explicit default action VoiceOver announces "button" and activating does
+        // nothing. A default `.accessibilityAction` touches only the accessibility
+        // layer, so it avoids the nested-Button gesture conflict called out on
+        // `alarmCircleButton`.
         .accessibilityAction { onTap() }
         .accessibilityActions {
             if showsAlarmAffordance {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -93,10 +93,8 @@ struct GroupedListView: View {
         // `.updatesFrequently` so a focused card re-speaks its changing countdown,
         // matching the legacy `StopArrivalView` and the flat departure rows.
         .accessibilityAddTraits([.isButton, .updatesFrequently])
-        // Wire the card's expand/collapse to VoiceOver's activate (double-tap):
-        // the header's tap lives on `.onTapGesture`, which assistive tech can't
-        // reach, so `.isButton` alone would speak "button" while double-tap did
-        // nothing. See the matching note on `DepartureRowView`.
+        // Activation expands the card. See `DepartureRowView` for why a tap-driven
+        // row needs this on top of `.isButton`.
         .accessibilityAction { onToggleRoute(group.routeID) }
         // Disclosure state: the card header's activation toggles the list of
         // departures beneath it, so announce which way it will go.
@@ -311,9 +309,8 @@ struct GroupedListView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
             .accessibilityAddTraits([.isButton, .updatesFrequently])
-            // Wire the row's activate (double-tap) to open the trip: the tap
-            // lives on `.onTapGesture`, invisible to assistive tech, so
-            // `.isButton` alone announces "button" but activating does nothing.
+            // Activation opens the trip. See `DepartureRowView` for why a
+            // tap-driven row needs this on top of `.isButton`.
             .accessibilityAction { onSelectDeparture(departure) }
             .accessibilityActions {
                 if showsAlarmAffordance(for: departure) {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -90,7 +90,14 @@ struct GroupedListView: View {
         .onTapGesture { onToggleRoute(group.routeID) }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(groupAccessibilityLabel(group, status: status))
-        .accessibilityAddTraits(.isButton)
+        // `.updatesFrequently` so a focused card re-speaks its changing countdown,
+        // matching the legacy `StopArrivalView` and the flat departure rows.
+        .accessibilityAddTraits([.isButton, .updatesFrequently])
+        // Wire the card's expand/collapse to VoiceOver's activate (double-tap):
+        // the header's tap lives on `.onTapGesture`, which assistive tech can't
+        // reach, so `.isButton` alone would speak "button" while double-tap did
+        // nothing. See the matching note on `DepartureRowView`.
+        .accessibilityAction { onToggleRoute(group.routeID) }
         // Disclosure state: the card header's activation toggles the list of
         // departures beneath it, so announce which way it will go.
         .accessibilityValue(expandedRouteID == group.routeID
@@ -303,7 +310,11 @@ struct GroupedListView: View {
             // as a custom action just like the header's alarm pill.
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
-            .accessibilityAddTraits(.isButton)
+            .accessibilityAddTraits([.isButton, .updatesFrequently])
+            // Wire the row's activate (double-tap) to open the trip: the tap
+            // lives on `.onTapGesture`, invisible to assistive tech, so
+            // `.isButton` alone announces "button" but activating does nothing.
+            .accessibilityAction { onSelectDeparture(departure) }
             .accessibilityActions {
                 if showsAlarmAffordance(for: departure) {
                     Button(alarmActionName(for: alarmLookup(departure))) {

--- a/OBAKit/Stops/StopPage/ServiceAlertsSection.swift
+++ b/OBAKit/Stops/StopPage/ServiceAlertsSection.swift
@@ -109,6 +109,9 @@ struct ServiceAlertsSection: View {
         .accessibilityValue(showsServiceAlerts
             ? OBALoc("stop_page.service_alerts.a11y_expanded", value: "expanded", comment: "VoiceOver value of the service-alerts card header when the alert list is showing.")
             : OBALoc("stop_page.service_alerts.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of the service-alerts card header when the alert list is hidden."))
+        // Also a heading so it anchors VoiceOver's Headings rotor between the
+        // stop title and the departures.
+        .accessibilityAddTraits(.isHeader)
     }
 
     private var showAllRow: some View {

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -60,6 +60,11 @@ struct StopDeparturesSections: View {
     let onShowAllDepartureTypes: () -> Void
     let onLoadMore: () -> Void
 
+    /// Moves VoiceOver focus to the empty-state message when a filter empties
+    /// the list. Owned here rather than by either presentation: the row it
+    /// targets is this view's, and both presentations want the same behaviour.
+    @AccessibilityFocusState private var emptyStateFocused: Bool
+
     /// Leading/trailing inset shared by the page's full-width card rows,
     /// matching the inset-grouped card margin.
     private static let horizontalRowInset: CGFloat = 0
@@ -87,6 +92,9 @@ struct StopDeparturesSections: View {
                     onDismiss: onSurveyDismiss,
                     onOpenExternalSurvey: onSurveyExternal
                 )
+                // Promotional, not core content: read after the departures in the
+                // default VoiceOver sweep (the rotor jumps past it entirely).
+                .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 8, leading: Self.surveyRowInset, bottom: 8, trailing: Self.surveyRowInset))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
@@ -103,6 +111,9 @@ struct StopDeparturesSections: View {
                     onLearnMore: onDonate,
                     onClose: onDonationClose
                 )
+                // Promotional, not core content: read after the departures in the
+                // default VoiceOver sweep (the rotor jumps past it entirely).
+                .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
@@ -147,6 +158,17 @@ struct StopDeparturesSections: View {
                         onShowAllRoutes: onShowAllRoutes,
                         onShowAllDepartureTypes: onShowAllDepartureTypes
                     )
+                    .accessibilityFocused($emptyStateFocused)
+                    // A filter that empties the list strands VoiceOver focus on a
+                    // row that no longer exists, with nothing spoken to say why.
+                    // Only for the filtered cases: a stop that simply has no
+                    // departures shows this row from the first frame, and moving
+                    // focus there would cut off the header VoiceOver is reading.
+                    .onAppear {
+                        if content.isFilteredEmpty || content.isDepartureFilterEmpty {
+                            emptyStateFocused = true
+                        }
+                    }
                 }
             }
         } else if !content.isGrouped {

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -92,8 +92,12 @@ struct StopDeparturesSections: View {
                     onDismiss: onSurveyDismiss,
                     onOpenExternalSurvey: onSurveyExternal
                 )
-                // Promotional, not core content: read after the departures in the
-                // default VoiceOver sweep (the rotor jumps past it entirely).
+                // Promotional, not core content, so it asks to be swept last.
+                // A hint, not a guarantee: sort priority only reorders siblings
+                // within one accessibility container, and each card here is its
+                // own List row — whether VoiceOver honors it across rows is
+                // unverified. The Departures rotor skips the card either way,
+                // which is what actually gets a rider to the buses.
                 .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 8, leading: Self.surveyRowInset, bottom: 8, trailing: Self.surveyRowInset))
                 .listRowBackground(Color.clear)
@@ -111,8 +115,7 @@ struct StopDeparturesSections: View {
                     onLearnMore: onDonate,
                     onClose: onDonationClose
                 )
-                // Promotional, not core content: read after the departures in the
-                // default VoiceOver sweep (the rotor jumps past it entirely).
+                // Deprioritized for the same reason as the survey card above.
                 .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                 .listRowBackground(Color.clear)
@@ -140,6 +143,10 @@ struct StopDeparturesSections: View {
             }
         }
 
+        // The two states the row itself offers a "show everything" button for —
+        // and the only ones where focus should jump to it.
+        let isFilterCausedEmpty = content.isFilteredEmpty || content.isDepartureFilterEmpty
+
         if content.listIsEmpty {
             if content.showsLoadingState {
                 Section {
@@ -164,11 +171,13 @@ struct StopDeparturesSections: View {
                     // Only for the filtered cases: a stop that simply has no
                     // departures shows this row from the first frame, and moving
                     // focus there would cut off the header VoiceOver is reading.
-                    .onAppear {
-                        if content.isFilteredEmpty || content.isDepartureFilterEmpty {
-                            emptyStateFocused = true
-                        }
-                    }
+                    //
+                    // Set, never cleared. `onAppear` fires again whenever the List
+                    // rebuilds this row, and writing `false` to a focus binding whose
+                    // element is currently focused yanks VoiceOver off it — so an
+                    // unconditional assignment would steal focus from a rider sitting
+                    // on the "no departures" message when the next refresh lands.
+                    .onAppear { if isFilterCausedEmpty { emptyStateFocused = true } }
                 }
             }
         } else if !content.isGrouped {

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -84,6 +84,9 @@ struct StopPageHeaderView: View {
             // button below stays separate so it remains individually
             // focusable and activatable.
             .accessibilityElement(children: .combine)
+            // The screen's title: mark it a heading so it anchors VoiceOver's
+            // Headings rotor for quick top-of-page navigation.
+            .accessibilityAddTraits(.isHeader)
             if let walkTime {
                 Button(action: onWalkingDirections) {
                     Label(walkChipText(walkTime), systemImage: "figure.walk")

--- a/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
+++ b/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
@@ -142,14 +142,21 @@ struct StopPageListHeaderRow: View {
         .padding(.vertical, 4)
         // The visible "Arrivals & Departures" title was dropped to save vertical
         // space, which left VoiceOver's Headings rotor with no anchor for the list
-        // itself. A container heading restores that anchor at zero visual cost —
-        // the Past and mode controls inside stay individually focusable.
+        // itself. `.contain` keeps the Past and mode controls individually
+        // focusable while naming the group they belong to.
+        //
+        // Whether the header trait on a *container* also surfaces in the Headings
+        // rotor is unverified — containers aren't focusable elements, so it may
+        // not. If a device check says it doesn't, the anchor has to be a real
+        // element: a visually hidden `Text` heading above this row.
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Self.departuresHeading)
         .accessibilityAddTraits(.isHeader)
     }
 
-    private static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor; not shown on screen.")
+    /// Shared with `StopPageView`'s Departures rotor: the heading and the rotor
+    /// name the same list, so they must not drift in translation.
+    static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen.")
 
     private var sideBySide: some View {
         HStack(spacing: 12) {
@@ -179,7 +186,7 @@ struct StopPageListHeaderRow: View {
     /// The chevron follows the conventional disclosure direction — down closed, up
     /// open — rather than pointing at the disclosed rows, which are below.
     private var pastButton: some View {
-        Button(action: togglePast) {
+        Button(action: togglePastAndAnnounce) {
             HStack(spacing: 5) {
                 Text(showPast
                      ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips")
@@ -213,7 +220,7 @@ struct StopPageListHeaderRow: View {
     /// which VoiceOver has no reason to re-read — so say what just happened.
     /// Announced here rather than by the callers because this row is where both
     /// the count and the direction are already known.
-    private func togglePast() {
+    private func togglePastAndAnnounce() {
         onTogglePast()
         let message = showPast
             ? OBALoc("stop_page.a11y.past_hidden", value: "Past departures hidden", comment: "VoiceOver announcement when the Past disclosure is closed.")

--- a/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
+++ b/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
@@ -140,7 +140,16 @@ struct StopPageListHeaderRow: View {
             }
         }
         .padding(.vertical, 4)
+        // The visible "Arrivals & Departures" title was dropped to save vertical
+        // space, which left VoiceOver's Headings rotor with no anchor for the list
+        // itself. A container heading restores that anchor at zero visual cost —
+        // the Past and mode controls inside stay individually focusable.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Self.departuresHeading)
+        .accessibilityAddTraits(.isHeader)
     }
+
+    private static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor; not shown on screen.")
 
     private var sideBySide: some View {
         HStack(spacing: 12) {
@@ -170,7 +179,7 @@ struct StopPageListHeaderRow: View {
     /// The chevron follows the conventional disclosure direction — down closed, up
     /// open — rather than pointing at the disclosed rows, which are below.
     private var pastButton: some View {
-        Button(action: onTogglePast) {
+        Button(action: togglePast) {
             HStack(spacing: 5) {
                 Text(showPast
                      ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips")
@@ -198,6 +207,18 @@ struct StopPageListHeaderRow: View {
         .accessibilityLabel(showPast
             ? OBALoc("stop_page.past_toggle_hide_a11y", value: "Hide past departures", comment: "VoiceOver label for the button hiding recently departed trips")
             : String(format: OBALoc("stop_page.past_toggle_show_a11y_fmt", value: "Show %d past departures", comment: "VoiceOver label for the button revealing recently departed trips. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), pastCount))
+    }
+
+    /// Toggling the disclosure inserts or removes rows well below this button,
+    /// which VoiceOver has no reason to re-read — so say what just happened.
+    /// Announced here rather than by the callers because this row is where both
+    /// the count and the direction are already known.
+    private func togglePast() {
+        onTogglePast()
+        let message = showPast
+            ? OBALoc("stop_page.a11y.past_hidden", value: "Past departures hidden", comment: "VoiceOver announcement when the Past disclosure is closed.")
+            : String(format: OBALoc("stop_page.a11y.past_shown_fmt", value: "Showing %d past departures", comment: "VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), pastCount)
+        AccessibilityNotification.Announcement(message).post()
     }
 }
 

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -155,6 +155,10 @@ struct StopPageView: View {
     /// immediately instead of waiting for the next view-model refresh to re-read
     /// `shouldRequestDonations`.
     @State private var donationHidden = false
+    /// Suppresses the "Departures updated" VoiceOver announcement for the very
+    /// first successful load — the page has just appeared and VoiceOver is
+    /// already reading it, so only later refreshes announce.
+    @State private var didInitialA11yLoad = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     var body: some View {
@@ -162,6 +166,8 @@ struct StopPageView: View {
         // chronological partition, and the divider all read one snapshot of it.
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
+
+        let rotorEntries = departuresRotorEntries(content: content, walkMinutes: walkTime?.walkMinutes)
 
         List {
             if let stop = viewModel.stop {
@@ -234,6 +240,32 @@ struct StopPageView: View {
         .onChange(of: content.routeIDs) { _, ids in
             if let rid = expandedRouteID, !ids.contains(rid) { expandedRouteID = nil }
         }
+        // A custom rotor so a VoiceOver user can spin to "Departures" and flick
+        // straight through the buses, skipping the header, status line, survey,
+        // donation, service-alerts card, and the mode/Past controls above them —
+        // the "so much information … hard to get bus schedules" complaint. Entries
+        // bind to the rows by the same id the ForEach uses (departure id in
+        // chronological mode, route id in grouped mode).
+        .accessibilityRotor(Text(Self.departuresRotorTitle)) {
+            ForEach(rotorEntries, id: \.id) { entry in
+                AccessibilityRotorEntry(entry.label, id: entry.id)
+            }
+        }
+        // Announce dynamic changes that otherwise mutate the list silently.
+        .onChange(of: viewModel.isLoading) { wasLoading, isLoading in
+            guard wasLoading, !isLoading, content.hasLoadedArrivals else { return }
+            if didInitialA11yLoad {
+                AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
+            } else {
+                didInitialA11yLoad = true
+            }
+        }
+        .onChange(of: viewModel.arrivalDepartureFilter) { _, _ in
+            AccessibilityNotification.Announcement(Self.filterChangedAnnouncement).post()
+        }
+        .onChange(of: viewModel.isListFiltered) { _, filtered in
+            AccessibilityNotification.Announcement(filtered ? Self.routesFilteredAnnouncement : Self.routesAllAnnouncement).post()
+        }
     }
 
     /// The sheet presentation's bottom chrome. Reads the view model directly — `StopPageView` is
@@ -281,6 +313,33 @@ struct StopPageView: View {
             pastCollapsed: $pastCollapsed
         )
     }
+
+    // MARK: - VoiceOver announcements
+
+    /// The rows the custom "Departures" rotor steps through, in render order.
+    /// Each `id` matches the row's `ForEach` identity — departure id in
+    /// chronological mode, route id in grouped mode, both `String` — so the
+    /// rotor lands on the real rows. Collapsed Past rows are left out; there is
+    /// nothing rendered for the rotor to focus.
+    ///
+    /// The partition is recomputed rather than shared with
+    /// `StopDeparturesSections`: it is a pure function of values this body
+    /// already holds, and threading it through the sections' argument list would
+    /// buy nothing but another parameter.
+    private func departuresRotorEntries(content: StopPageContent, walkMinutes: Int?) -> [(label: String, id: String)] {
+        if content.isGrouped {
+            return content.routeGroups.map { ($0.next.routeAndHeadsign, $0.routeID) }
+        }
+        let partition = StopPageListBuilder.chronologicalPartition(content.departures, walkMinutes: walkMinutes)
+        let rows = (pastCollapsed ? [] : partition.past) + partition.missed + partition.reachable
+        return rows.map { ($0.routeAndHeadsign, $0.id) }
+    }
+
+    private static let departuresRotorTitle = OBALoc("stop_page.rotor.departures", value: "Departures", comment: "Title of the VoiceOver rotor that steps through the departure rows, skipping the header and cards above them.")
+    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a manual refresh finishes and the departure times have been updated.")
+    private static let filterChangedAnnouncement = OBALoc("stop_page.a11y.filter_changed", value: "Departure filter changed", comment: "VoiceOver announcement posted when the Departure Type filter changes which departures are visible.")
+    private static let routesFilteredAnnouncement = OBALoc("stop_page.a11y.routes_filtered", value: "Showing filtered routes", comment: "VoiceOver announcement posted when the route filter is turned on.")
+    private static let routesAllAnnouncement = OBALoc("stop_page.a11y.routes_all", value: "Showing all routes", comment: "VoiceOver announcement posted when the route filter is turned off.")
 }
 
 #Preview("Initial loading") {

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -150,15 +150,21 @@ struct StopPageView: View {
         showToolbarOnBottom && !isCollapsed
     }
 
+    /// Read from the environment rather than the `formatters` property `StopPageRootView`
+    /// publishes: this view is constructed by that wrapper, so its own property wrappers
+    /// resolve against the environment it was handed.
+    @Environment(\.obaFormatters) private var formatters
+    /// Gates the rotor's entry list, the one piece of per-body work here that scales with
+    /// the whole departure list rather than the handful of rows the `List` materializes.
+    /// An environment read, not `UIAccessibility.isVoiceOverRunning`, so switching
+    /// VoiceOver on invalidates the body instead of waiting for an incidental one.
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+
     @State private var expandedRouteID: RouteID?
     /// Set when the user explicitly dismisses the donation card, so it disappears
     /// immediately instead of waiting for the next view-model refresh to re-read
     /// `shouldRequestDonations`.
     @State private var donationHidden = false
-    /// Suppresses the "Departures updated" VoiceOver announcement for the very
-    /// first successful load — the page has just appeared and VoiceOver is
-    /// already reading it, so only later refreshes announce.
-    @State private var didInitialA11yLoad = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     var body: some View {
@@ -167,7 +173,7 @@ struct StopPageView: View {
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
 
-        let rotorEntries = departuresRotorEntries(content: content, walkMinutes: walkTime?.walkMinutes)
+        let rotorEntries = voiceOverEnabled ? departuresRotorEntries(content: content) : []
 
         List {
             if let stop = viewModel.stop {
@@ -229,7 +235,7 @@ struct StopPageView: View {
                 toolbar
             }
         }
-        .refreshable { await viewModel.refresh() }
+        .refreshable { await refreshAndAnnounce() }
         .stopPageLifecycle(
             viewModel: viewModel,
             userDefaults: userDefaults,
@@ -252,14 +258,6 @@ struct StopPageView: View {
             }
         }
         // Announce dynamic changes that otherwise mutate the list silently.
-        .onChange(of: viewModel.isLoading) { wasLoading, isLoading in
-            guard wasLoading, !isLoading, content.hasLoadedArrivals else { return }
-            if didInitialA11yLoad {
-                AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
-            } else {
-                didInitialA11yLoad = true
-            }
-        }
         .onChange(of: viewModel.arrivalDepartureFilter) { _, _ in
             AccessibilityNotification.Announcement(Self.filterChangedAnnouncement).post()
         }
@@ -281,7 +279,7 @@ struct StopPageView: View {
             isListFiltered: viewModel.isListFiltered,
             activeDepartureFilter: viewModel.arrivalDepartureFilter,
             hasServiceAlerts: !(viewModel.stopArrivals?.serviceAlerts ?? []).isEmpty,
-            onRefresh: { Task { await viewModel.refresh() } },
+            onRefresh: { Task { await refreshAndAnnounce() } },
             onSetListFiltered: { filtered in
                 viewModel.isListFiltered = filtered
                 // Picking "Filtered Routes" opens the picker, matching the pushed
@@ -316,27 +314,58 @@ struct StopPageView: View {
 
     // MARK: - VoiceOver announcements
 
-    /// The rows the custom "Departures" rotor steps through, in render order.
-    /// Each `id` matches the row's `ForEach` identity — departure id in
-    /// chronological mode, route id in grouped mode, both `String` — so the
-    /// rotor lands on the real rows. Collapsed Past rows are left out; there is
-    /// nothing rendered for the rotor to focus.
+    /// The rows the custom "Departures" rotor steps through, in the order the
+    /// list renders them. Each `id` matches the row's `ForEach` identity —
+    /// departure id in chronological mode, route id in grouped mode, both
+    /// `String` — so the rotor lands on the real rows. Collapsed Past rows are
+    /// left out; there is nothing rendered for the rotor to focus.
     ///
-    /// The partition is recomputed rather than shared with
-    /// `StopDeparturesSections`: it is a pure function of values this body
-    /// already holds, and threading it through the sections' argument list would
-    /// buy nothing but another parameter.
-    private func departuresRotorEntries(content: StopPageContent, walkMinutes: Int?) -> [(label: String, id: String)] {
+    /// The chronological order is the plain time sort rather than
+    /// `chronologicalPartition`: that partition splits the same sorted list into
+    /// past / missed / reachable so the list can draw a walk divider between the
+    /// last two, and `ChronologicalListView` renders the three back to back — so
+    /// reassembling them here would only sort the same rows a second time to
+    /// arrive at the same sequence.
+    private func departuresRotorEntries(content: StopPageContent) -> [(label: String, id: String)] {
         if content.isGrouped {
-            return content.routeGroups.map { ($0.next.routeAndHeadsign, $0.routeID) }
+            return content.routeGroups.map { (rotorLabel(for: $0.next), $0.routeID) }
         }
-        let partition = StopPageListBuilder.chronologicalPartition(content.departures, walkMinutes: walkMinutes)
-        let rows = (pastCollapsed ? [] : partition.past) + partition.missed + partition.reachable
-        return rows.map { ($0.routeAndHeadsign, $0.id) }
+        return content.departures
+            .sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+            .filter { !pastCollapsed || $0.temporalState != .past }
+            .map { (rotorLabel(for: $0), $0.id) }
     }
 
-    private static let departuresRotorTitle = OBALoc("stop_page.rotor.departures", value: "Departures", comment: "Title of the VoiceOver rotor that steps through the departure rows, skipping the header and cards above them.")
-    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a manual refresh finishes and the departure times have been updated.")
+    /// Spoken form of a departure's route, e.g. "Route 49 - University District".
+    /// The rows speak a whole sentence (route, timing, status); the rotor only has
+    /// to say which bus it just landed on, but it says it the way the rest of the
+    /// app does rather than reading the on-screen string and its em dash aloud.
+    private func rotorLabel(for departure: ArrivalDeparture) -> String {
+        formatters.accessibilityLabel(for: departure)
+    }
+
+    /// Pull-to-refresh and the toolbar's Refresh button — the two places the rider
+    /// asks for fresh times and so has reason to be told they arrived. Deliberately
+    /// not the 15-second auto-refresh, which runs through the same view model call
+    /// and would interrupt whatever VoiceOver is reading four times a minute.
+    ///
+    /// Keyed on `lastUpdated` moving rather than on the call returning, because
+    /// `refresh()` returns without fetching in two cases that must stay silent: a
+    /// refresh already in flight (the auto-refresh timer) makes it a no-op, and a
+    /// failed fetch lands in `operationError` and leaves the old times on screen.
+    /// Announcing either as "Departures updated" tells a rider who can't see the
+    /// stale rows that they're fresh.
+    private func refreshAndAnnounce() async {
+        let updatedBefore = viewModel.lastUpdated
+        await viewModel.refresh()
+        guard viewModel.lastUpdated != updatedBefore else { return }
+        AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
+    }
+
+    /// The rotor's title and the list's heading name the same thing, so they share
+    /// one string — two keys would let 13 locales translate them apart.
+    private static let departuresRotorTitle = StopPageListHeaderRow.departuresHeading
+    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated.")
     private static let filterChangedAnnouncement = OBALoc("stop_page.a11y.filter_changed", value: "Departure filter changed", comment: "VoiceOver announcement posted when the Departure Type filter changes which departures are visible.")
     private static let routesFilteredAnnouncement = OBALoc("stop_page.a11y.routes_filtered", value: "Showing filtered routes", comment: "VoiceOver announcement posted when the route filter is turned on.")
     private static let routesAllAnnouncement = OBALoc("stop_page.a11y.routes_all", value: "Showing all routes", comment: "VoiceOver announcement posted when the route filter is turned off.")

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -66,6 +66,22 @@
 			<string>No departures in the next %d minutes</string>
 		</dict>
 	</dict>
+	<key>stop_page.a11y.past_shown_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Showing 1 past departure</string>
+			<key>other</key>
+			<string>Showing %d past departures</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKitTests/Trip/TripPageCollapseTests.swift
+++ b/OBAKitTests/Trip/TripPageCollapseTests.swift
@@ -1,0 +1,69 @@
+//
+//  TripPageCollapseTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import Testing
+import OBAKitCore
+@testable import OBAKit
+
+/// What the trip page shows at the sheet's `.tip` detent.
+///
+/// The regression: the page's action bar is pinned as a bottom `safeAreaInset` and is taller than
+/// the whole `.tip` detent, so at that detent SwiftUI squeezed out the back row and the stop list
+/// and the peek was a Live Activity button floating over the map, naming no trip at all. The page
+/// has to be told which detent it is at — `StopSheetPresenter` only tells content that conforms to
+/// `StopSheetCollapsibleContent` — and drop the bar there.
+@MainActor
+@Suite(.serialized)
+final class TripPageCollapseTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    private func makeTripPage() throws -> TripPageViewController {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        return TripPageViewController(
+            application: application,
+            tripConvertible: TripConvertible(arrivalDeparture: try Fixtures.arrivalDeparture()),
+            originTitle: "3rd Ave & Pike St"
+        )
+    }
+
+    /// Without this conformance the presenter's detent changes never reach the page, which is
+    /// exactly how it ended up rendering its full chrome inside a sliver.
+    @Test func `The page is collapsible sheet content`() throws {
+        let page = try makeTripPage()
+        #expect(page as? StopSheetCollapsibleContent != nil)
+    }
+
+    /// Expanded is the state the page is built in: every other detent has room for the bar.
+    @Test func `The page starts expanded`() throws {
+        let page = try makeTripPage()
+        #expect(page.rootView.isCollapsed == false)
+    }
+
+    @Test func `Moving to the tip detent collapses the page`() throws {
+        let page = try makeTripPage()
+
+        page.setAtTip(true)
+        #expect(page.rootView.isCollapsed)
+
+        page.setAtTip(false)
+        #expect(page.rootView.isCollapsed == false)
+    }
+}


### PR DESCRIPTION
The Stop page announced itself as navigable under VoiceOver without actually being navigable: rows spoke "button" and then did nothing when activated, the departures sat behind six other elements with no way to skip past them, and every list mutation happened silently.

### Rows are activatable

`DepartureRowView`, `GroupedListView`'s route cards, and its expanded rows all carry their tap on `.onTapGesture`, which assistive tech cannot reach — so `.isButton` was a spoken trait over a dead target. Each now wires its primary action through an explicit default `.accessibilityAction`. That touches the accessibility layer only, which avoids the nested-gesture conflict that rules out a real `Button` here. They also gain `.updatesFrequently`, so a focused row re-speaks its countdown the way the legacy `StopArrivalView` did.

### Getting to the departures

Reaching a bus meant flicking past the header, status line, survey, donation, service alerts, and the mode controls — the "so much information, hard to get bus schedules" complaint. A custom **Departures** rotor now steps straight through the rows, binding to the same ids the `ForEach` uses (departure id chronologically, route id when grouped), and speaking each through `Formatters.accessibilityLabel(for:)` so it says "Route 49 - University District" like every other VoiceOver surface. The entry list is built only when VoiceOver is running — it is the one piece of per-body work here that scales with the whole departure list rather than the rows the `List` materializes.

The Headings rotor gets the anchors it was missing: the stop title, the service-alerts card, and a heading on the list header row — whose visible "Arrivals & Departures" title was dropped for vertical space, taking the rotor's only handle on the list with it.

### Silent changes now announce

A departure-type filter change, the route filter going on or off, the Past disclosure (which reports how many rows it revealed), and a completed refresh. The refresh announcement fires only for the two places a rider asks for fresh times, and only when the data actually changed — hanging it off `isLoading` meant the 15-second auto-refresh interrupted VoiceOver four times a minute, and a failed refresh would have claimed times updated under stale ones. When a filter empties the list, focus moves to the empty-state message rather than being stranded on a row that no longer exists.

### Opening a stop from the map

Under VoiceOver, tapping a stop pushes the Stop page instead of presenting the half-detent sheet. A partial-height FloatingPanel over a live map is a poor modal: the map stays in the accessibility tree behind it, and the detents, swipe-to-dismiss, and collapse-to-tip are drag gestures VoiceOver cannot perform. The push is a standard opaque screen with a back button and contained focus, and it skips the sheet path's map-focus bookkeeping — route highlight, recentering, tab-bar hiding — all of which is meaningless under a screen that covers the map, exactly as the legacy push path skips it. Decided at open time; a sheet already onscreen when VoiceOver comes on is left alone.

### Test plan

Driven on an iPhone 17 Pro simulator (iOS 27), toggling VoiceOver via the accessibility defaults:

- [x] VoiceOver **off** → tapping a stop pin opens the half-detent sheet over the live map, unchanged.
- [x] VoiceOver **on** → the same pin opens a full-screen pushed page with a nav-bar back button and no map behind it. Verified for both the annotation path (`show(stop:)`) and the nearby-stops list (`show(stopID:)`).
- [x] Tapping a departure on the pushed page opens the trip page — so skipping the sheet's `attach(focus:)` / `onTripPagePush` wiring doesn't break onward navigation.
- [x] Time ↔ Route toggle and route-card expand/collapse still hit-test correctly, i.e. the new accessibility container on the list header row and the added actions don't swallow touches.
- [x] The sheet's Refresh button still fires a real `arrivals-and-departures-for-stop` request (confirmed in the device log), through the new announce-wrapping path.
- [x] `xcodebuild build` clean; full `OBAKitTests` suite green (2076 tests / 226 suites).

Not verifiable here: actual VoiceOver *speech* and rotor gestures. The simulator reports `isVoiceOverRunning` but does not intercept touches, and the AX-tree tooling (idb, RocketSim, Xcode MCP) is non-functional on Xcode 27.

### Review notes

Three things a reviewer should weigh in on, none of them fixed here:

1. **Two accessibility claims are unverified without a device**, and the comments now say so rather than asserting the effect. (a) `.accessibilitySortPriority(-1)` on the survey and donation cards may be a no-op: sort priority reorders siblings within one accessibility container, and each card is its own `List` row. (b) The header trait sits on an `.accessibilityElement(children: .contain)` container, and containers aren't focusable elements, so it may never reach the Headings rotor. If a device check says it doesn't, the anchor needs to be a real element — a visually hidden `Text` heading above the row.
2. **The rotor and the refresh/filter announcements live on `StopPageView`, not in the shared `StopDeparturesSections`.** So under the map-panel feature flag, `StopDetailsSheetView` gets the correct row labels and actions but no rotor and no announcements — while the shared builder owns the very state (`onShowAllRoutes`, `onShowAllDepartureTypes`) that only one presentation announces. Moving them into a shared modifier is the coherent fix; it's a behavior change beyond this diff, so I left it.
3. **Two gaps in the map routing.** The context-menu peek commit (`willPerformPreviewActionForMenuWith`) calls `present(stopController:)` directly with a controller built for the sheet, so it bypasses the VoiceOver branch; closing that means rebuilding the preview controller at commit time. And the pushed path never calls `scheduleFeedbackPrompt()`, which the sheet dismissal does — so VoiceOver users are excluded from the feedback prompt. Both argue for the deeper fix: making the sheet itself VoiceOver-workable (`accessibilityViewIsModal`, hiding the map behind it, defaulting to `.full`) in `StopSheetPresenter`, which would fix every entry point at once.

### Separately: a pre-existing bug this change makes more visible

Returning from the trip page leaves the Stop page with **no navigation bar at all** — `TripPageViewController.viewDidLoad` calls `setNavigationBarHidden(true)` unconditionally and only `StopSheetPresenter` ever restores it. I reproduced this on `main`'s Recents → stop → trip → back path, which this branch doesn't touch, so it isn't a regression here. But it matters more now: this change routes VoiceOver users into that same plain-push stack from the map, where losing the back button is a worse trap. Worth a separate fix.

### Localization

The seven new keys are not in the `.strings` catalogs — `LocalizationTests` enforces key parity across all 13 locales, so they need to go through `scripts/extract_strings` and translation as a batch. They fall back to their `value:` in the meantime. The one exception is the Past-disclosure plural, which needed a `stringsdict` entry to stop announcing "Showing 1 past departures".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved VoiceOver navigation throughout stop pages with headings, clearer departure announcements, and better service-alert navigation.
  * Added a custom departures rotor for quicker navigation between departures.
  * Improved focus behavior when filters produce no results and adjusted reading order for supporting cards.
  * VoiceOver now announces refreshes and past-departure visibility changes.
  * Stop pages use streamlined navigation when VoiceOver is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->