### PR TITLE
Open donated stop shortcuts instead of a no-op launch

### DIFF
--- a/OBAKit/DeepLinks/AppLinksRouter.swift
+++ b/OBAKit/DeepLinks/AppLinksRouter.swift
@@ -42,6 +42,9 @@ public class AppLinksRouter: NSObject {
 
     private let deepLinkPathFormat = "/regions/%d/stops/%@/trips"
     private let deepLinkPattern = "/regions/(?<region>.*)/stops/(?<stop>.*)/trips"
+    /// Stop pages are the same path without the `/trips` suffix. Named groups are
+    /// `[^/]+` so a trip URL cannot masquerade as a stop whose ID contains `/trips`.
+    private static let stopPathPattern = "/regions/(?<region>[^/]+)/stops/(?<stop>[^/]+)$"
 
     /// Encodes an `ArrivalDeparture` into an `URL` so that it can be shared as a deep link with others.
     /// - Parameters:
@@ -117,9 +120,64 @@ public class AppLinksRouter: NSObject {
         return deepLink
     }
 
+    // MARK: - Stop user activities
+
+    /// The stop a donated `NSUserActivity` (or a stop webpage URL) should open.
+    struct StopDestination: Equatable {
+        let stopID: StopID
+        let regionID: Int
+    }
+
+    /// Reads the stop out of a Siri/Shortcuts activity.
+    ///
+    /// Shortcuts round-trips `userInfo` through a plist, so `regionID` may arrive
+    /// as `Int`, `NSNumber`, or `String`. When `userInfo` is stripped entirely,
+    /// the donated `webpageURL` (`/regions/{id}/stops/{stopID}`) still names the
+    /// stop. Trip URLs (`.../trips`) are not stops. See #1221.
+    static func stopDestination(userInfo: [AnyHashable: Any]?, webpageURL: URL?) -> StopDestination? {
+        if let userInfo,
+           let stopID = userInfo[UserActivityBuilder.UserInfoKeys.stopID] as? StopID,
+           let regionID = regionIdentifier(from: userInfo[UserActivityBuilder.UserInfoKeys.regionID]) {
+            return StopDestination(stopID: stopID, regionID: regionID)
+        }
+
+        guard let webpageURL else { return nil }
+        return stopDestination(fromWebpageURL: webpageURL)
+    }
+
+    static func stopDestination(fromWebpageURL url: URL) -> StopDestination? {
+        guard
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let matches = components.path.caseInsensitiveMatch(
+                pattern: stopPathPattern,
+                namedGroups: ["stop", "region"]
+            ),
+            let regionIDStr = matches["region"],
+            let regionID = Int(regionIDStr),
+            let stopID = matches["stop"],
+            !stopID.isEmpty
+        else {
+            return nil
+        }
+
+        return StopDestination(stopID: stopID, regionID: regionID)
+    }
+
+    /// Plist round-trips turn `Int` into `NSNumber`; some Shortcuts builds
+    /// stringify it. `as? Int` only covers the first two via bridging.
+    private static func regionIdentifier(from value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let string = value as? String { return Int(string) }
+        return nil
+    }
+
     // MARK: - UI Routing
 
-    public var showStopHandler: ((Stop) -> Void)?
+    /// Opens a stop by ID. The caller is responsible for stashing the ID when
+    /// the UI or current region is not ready yet — this router does not fetch
+    /// a `Stop` and then drop it on a nil `topViewController`.
+    var showStopDestinationHandler: ((StopDestination) -> Void)?
     public var showArrivalDepartureDeepLink: ((ArrivalDepartureDeepLink) -> Void)?
 
     public func route(userActivity: NSUserActivity) -> Bool {
@@ -147,37 +205,28 @@ public class AppLinksRouter: NSObject {
     }
 
     private func route(url: URL) -> Bool {
-        guard let deepLink = decode(url: url) else {
-            return false
+        if let deepLink = decode(url: url) {
+            showArrivalDepartureDeepLink?(deepLink)
+            return true
         }
 
-        showArrivalDepartureDeepLink?(deepLink)
+        if let destination = Self.stopDestination(fromWebpageURL: url) {
+            showStopDestinationHandler?(destination)
+            return true
+        }
 
-        return true
+        return false
     }
 
     private func routeStop(userActivity: NSUserActivity) -> Bool {
-        guard
-            let userInfo = userActivity.userInfo,
-            let stopID = userInfo[UserActivityBuilder.UserInfoKeys.stopID] as? StopID,
-            let regionID = userInfo[UserActivityBuilder.UserInfoKeys.regionID] as? Int,
-            let apiService = application.apiService,
-            application.currentRegion?.regionIdentifier == regionID
-            else {
-                return false
+        guard let destination = Self.stopDestination(
+            userInfo: userActivity.userInfo,
+            webpageURL: userActivity.webpageURL
+        ) else {
+            return false
         }
 
-        Task(priority: .userInitiated) {
-            do {
-                let stop = try await apiService.getStop(id: stopID)
-                await MainActor.run {
-                    self.showStopHandler?(stop.entry)
-                }
-            } catch {
-                await self.application.displayError(error)
-            }
-        }
-
+        showStopDestinationHandler?(destination)
         return true
     }
 

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -114,15 +114,8 @@ public class Application: CoreApplication, PushServiceDelegate {
     private func makeAppLinksRouter() -> AppLinksRouter? {
         let router = AppLinksRouter(application: self)
 
-        router?.showStopHandler = { [weak self] stop in
-            guard
-                let self = self,
-                let topVC = self.topViewController
-            else { return }
-
-            Task { @MainActor in
-                self.viewRouter.navigateTo(stop: stop, from: topVC)
-            }
+        router?.showStopDestinationHandler = { [weak self] destination in
+            self?.queueOrOpenStop(destination)
         }
 
         router?.showArrivalDepartureDeepLink = { [weak self] deepLink in
@@ -376,10 +369,15 @@ public class Application: CoreApplication, PushServiceDelegate {
         }
     }
 
-    /// A stop navigation (fired alarm push or `viewStop` deep link) received before the
-    /// root view controller was installed (cold launch). Drained on activation once a
-    /// root view controller exists.
-    private var pendingStopID: StopID?
+    /// A stop navigation (fired alarm push, `viewStop` deep link, or a donated
+    /// stop `NSUserActivity`) received before the root view controller was
+    /// installed, or before `currentRegion` had loaded. Drained once both exist.
+    /// Internal so tests can assert the shortcut was stashed rather than dropped.
+    var pendingStopID: StopID?
+    /// Region the stashed stop belongs to. Nil for the URL-scheme path, which
+    /// historically did not carry a region. When set, drain refuses to open the
+    /// stop against a different region's API.
+    var pendingStopRegionID: Int?
     private var presentDonationUIOnActive = false
     private var presentAddRegionAlertOnActive = false
     private var donationPromptID: String?
@@ -549,8 +547,19 @@ public class Application: CoreApplication, PushServiceDelegate {
         guard !isOnboardingRoot else { return }
 
         if let stopID = pendingStopID, let topViewController {
+            if let neededRegion = pendingStopRegionID {
+                // Region still loading: wait. Loaded but different: drop — do not
+                // fetch this stop against the wrong region's API.
+                guard let current = currentRegion?.regionIdentifier else { return }
+                if current != neededRegion {
+                    pendingStopID = nil
+                    pendingStopRegionID = nil
+                    return
+                }
+            }
             viewRouter.navigateTo(stopID: stopID, from: topViewController)
             pendingStopID = nil
+            pendingStopRegionID = nil
         }
 
         if presentDonationUIOnActive, let topViewController {
@@ -613,6 +622,22 @@ public class Application: CoreApplication, PushServiceDelegate {
     /// Proxies the delegate method.
     var credits: [String: String] {
         delegate?.credits ?? [:]
+    }
+
+    /// Opens `destination` now, or stashes it until the root UI and matching
+    /// region exist. Does not fetch this stop against a different region's API.
+    func queueOrOpenStop(_ destination: AppLinksRouter.StopDestination) {
+        if let current = currentRegion?.regionIdentifier, current != destination.regionID {
+            return
+        }
+
+        if let topViewController, currentRegion?.regionIdentifier == destination.regionID {
+            viewRouter.navigateTo(stopID: destination.stopID, from: topViewController)
+            return
+        }
+
+        pendingStopID = destination.stopID
+        pendingStopRegionID = destination.regionID
     }
 
     @objc public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
@@ -744,6 +769,10 @@ public class Application: CoreApplication, PushServiceDelegate {
         // By the time updatedRegion fires, willUpdateToRegion has already rebuilt
         // obacoService for the new region, so this registers the token there.
         Task { await pushRegistrationManager.registerIfNeeded() }
+
+        // A donated stop shortcut that arrived before `currentRegion` was set
+        // is sitting in `pendingStopID`. Drain now that we know which region we are in.
+        drainPendingUIPresentations()
     }
 
     public func regionsService(_ service: RegionsService, displayError error: Error) {

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -549,6 +549,100 @@ final class ApplicationTests: OBATestCase {
         #expect(!result)
     }
 
+    /// Donated stop shortcuts launch the app via `continue userActivity`. Before
+    /// the root UI exists, that used to return `false` (no `apiService` / no
+    /// `currentRegion`) and drop the stop. Same stash as the `viewStop` URL-scheme
+    /// cold-launch path.
+    /// See: https://github.com/OneBusAway/onebusaway-ios/issues/1221
+    @Test func `Application continues a stop user activity on cold launch`() async {
+        let app = makeApplicationForUserActivity()
+        guard let builder = app.userActivityBuilder else {
+            Issue.record("Test host is missing NSUserActivityTypes")
+            return
+        }
+
+        let activity = NSUserActivity(activityType: builder.stopActivityType)
+        activity.userInfo = [
+            UserActivityBuilder.UserInfoKeys.stopID: "1_75403",
+            UserActivityBuilder.UserInfoKeys.regionID: 1
+        ]
+
+        let result = await MainActor.run {
+            app.application(UIApplication.shared, continue: activity, restorationHandler: { _ in })
+        }
+        #expect(result)
+        #expect(app.pendingStopID == "1_75403")
+        #expect(app.pendingStopRegionID == 1)
+    }
+
+    /// Shortcuts reconstitutes `userInfo` through a plist, so the donated
+    /// `regionID` may arrive as `NSNumber`. The parser has to accept that
+    /// shape, not only a Swift `Int`.
+    @Test func `Application continues a stop user activity whose region ID is an NSNumber`() async {
+        let app = makeApplicationForUserActivity()
+        guard let builder = app.userActivityBuilder else {
+            Issue.record("Test host is missing NSUserActivityTypes")
+            return
+        }
+
+        let activity = NSUserActivity(activityType: builder.stopActivityType)
+        activity.userInfo = [
+            UserActivityBuilder.UserInfoKeys.stopID: "1_75403",
+            UserActivityBuilder.UserInfoKeys.regionID: NSNumber(value: 1)
+        ]
+
+        let result = await MainActor.run {
+            app.application(UIApplication.shared, continue: activity, restorationHandler: { _ in })
+        }
+        #expect(result)
+        #expect(app.pendingStopID == "1_75403")
+        #expect(app.pendingStopRegionID == 1)
+    }
+
+    /// When Shortcuts strips `userInfo` and leaves only `webpageURL`, the stop
+    /// path (`/regions/{id}/stops/{stopID}`) still has to open that stop. Trip
+    /// URLs keep going through the existing trip decoder.
+    @Test func `Application continues a stop user activity from its webpage URL`() async {
+        let app = makeApplicationForUserActivity()
+        guard let builder = app.userActivityBuilder else {
+            Issue.record("Test host is missing NSUserActivityTypes")
+            return
+        }
+
+        let activity = NSUserActivity(activityType: builder.stopActivityType)
+        activity.webpageURL = URL(string: "https://onebusaway.co/regions/1/stops/1_75403")
+
+        let result = await MainActor.run {
+            app.application(UIApplication.shared, continue: activity, restorationHandler: { _ in })
+        }
+        #expect(result)
+        #expect(app.pendingStopID == "1_75403")
+        #expect(app.pendingStopRegionID == 1)
+    }
+
+    @Test func `Application continues a browsing-web stop URL`() async {
+        let app = makeApplicationForUserActivity()
+
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = URL(string: "https://onebusaway.co/regions/1/stops/1_75403")
+
+        let result = await MainActor.run {
+            app.application(UIApplication.shared, continue: activity, restorationHandler: { _ in })
+        }
+        #expect(result)
+        #expect(app.pendingStopID == "1_75403")
+        #expect(app.pendingStopRegionID == 1)
+    }
+
+    private func makeApplicationForUserActivity() -> Application {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        let locManager = LocationManagerMock()
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        let config = AppConfig(regionsBaseURL: regionsURL, apiKey: apiKey, appVersion: appVersion, userDefaults: userDefaults, analytics: AnalyticsMock(), queue: queue, locationService: locationService, bundledRegionsFilePath: bundledRegionsPath, regionsAPIPath: regionsAPIPath, dataLoader: dataLoader)
+        return Application(config: config)
+    }
+
     // MARK: - Analytics Tests
 
     @Test func `Application has analytics property`() {

--- a/OBAKitTests/Modeling/DeepLinks/StopUserActivityRoutingTests.swift
+++ b/OBAKitTests/Modeling/DeepLinks/StopUserActivityRoutingTests.swift
@@ -1,0 +1,86 @@
+//
+//  StopUserActivityRoutingTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Donated stop shortcuts (`NSUserActivity`) used to launch the app and then
+/// do nothing: `routeStop` required a live `apiService` and matching
+/// `currentRegion` before it would accept the activity, and it ignored the
+/// stop `webpageURL` when Shortcuts stripped `userInfo`.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1221
+@MainActor
+@Suite(.serialized)
+struct StopUserActivityRoutingTests {
+
+    private let stopKey = UserActivityBuilder.UserInfoKeys.stopID
+    private let regionKey = UserActivityBuilder.UserInfoKeys.regionID
+    private let stopURL = URL(string: "https://onebusaway.co/regions/1/stops/1_75403")!
+    private let tripURL = URL(string: "https://onebusaway.co/regions/1/stops/1_75403/trips?trip_id=1_545_trip&service_date=1710273600.0&stop_sequence=12")!
+
+    @Test func `Stop destination reads a Swift Int region ID`() {
+        let destination = AppLinksRouter.stopDestination(
+            userInfo: [stopKey: "1_75403", regionKey: 1],
+            webpageURL: nil
+        )
+
+        #expect(destination?.stopID == "1_75403")
+        #expect(destination?.regionID == 1)
+    }
+
+    @Test func `Stop destination reads an NSNumber region ID restored by Shortcuts`() {
+        let destination = AppLinksRouter.stopDestination(
+            userInfo: [stopKey: "1_75403", regionKey: NSNumber(value: 1)],
+            webpageURL: nil
+        )
+
+        #expect(destination?.stopID == "1_75403")
+        #expect(destination?.regionID == 1)
+    }
+
+    @Test func `Stop destination reads a region ID restored as a string`() {
+        let destination = AppLinksRouter.stopDestination(
+            userInfo: [stopKey: "1_75403", regionKey: "1"],
+            webpageURL: nil
+        )
+
+        #expect(destination?.stopID == "1_75403")
+        #expect(destination?.regionID == 1)
+    }
+
+    @Test func `Stop destination uses the stop webpage URL when userInfo is missing the keys`() {
+        let destination = AppLinksRouter.stopDestination(userInfo: [:], webpageURL: stopURL)
+
+        #expect(destination?.stopID == "1_75403")
+        #expect(destination?.regionID == 1)
+    }
+
+    @Test func `Stop destination prefers userInfo over the webpage URL`() {
+        let destination = AppLinksRouter.stopDestination(
+            userInfo: [stopKey: "1_999", regionKey: 2],
+            webpageURL: stopURL
+        )
+
+        #expect(destination?.stopID == "1_999")
+        #expect(destination?.regionID == 2)
+    }
+
+    @Test func `Stop destination ignores a trip deep link URL`() {
+        let destination = AppLinksRouter.stopDestination(userInfo: nil, webpageURL: tripURL)
+        #expect(destination == nil)
+    }
+
+    @Test func `Stop destination is nil when both userInfo and webpage URL are missing`() {
+        #expect(AppLinksRouter.stopDestination(userInfo: nil, webpageURL: nil) == nil)
+        #expect(AppLinksRouter.stopDestination(userInfo: [:], webpageURL: nil) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Donated stop `NSUserActivity`s (Siri/Shortcuts “Show me my bus”) used to return `false` from `routeStop` unless `apiService` and `currentRegion` were already live, and `showStopHandler` then dropped the `Stop` when `topViewController` was still nil. The app opened; the stop did not.
- Routing now reads the stop from `userInfo` (`Int` / `NSNumber` / `String` region IDs) or from the donated `webpageURL` (`/regions/{id}/stops/{stopID}`). Trip URLs (`.../trips`) stay on the existing trip decoder.
- The stop ID is queued on the same `pendingStopID` stash the alarm-push and `viewStop` URL-scheme paths already use, and drained once the root UI exists **and** `currentRegion` matches. A mismatched region is dropped rather than fetched against the wrong API.

Refs #1221. This opens the **stop** those donated activities already describe (same as Handoff). It is not the Track Bookmark Live Activity path (#1298 / #1222).

## Test plan
- [x] `Stop destination reads a Swift Int region ID`
- [x] `Stop destination reads an NSNumber region ID restored by Shortcuts`
- [x] `Stop destination reads a region ID restored as a string` — fails if production only accepts `as? Int`
- [x] `Stop destination uses the stop webpage URL when userInfo is missing the keys`
- [x] `Stop destination ignores a trip deep link URL`
- [x] `Application continues a stop user activity on cold launch` — asserts `pendingStopID` is stashed, not just `true`
- [x] `Application continues a browsing-web stop URL`
- [ ] Manual: add a Siri Shortcut from a stop (“Show me my bus”), kill the app, run the shortcut — the stop page should open, not just the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep-link support for transit stop URLs and stop-related web links.
  * Stop links now work with multiple region ID formats and user activity metadata.
  * Stop navigation is deferred until the app and requested region are ready, including during cold launch.

* **Bug Fixes**
  * Prevented trip links from being incorrectly treated as stop links.
  * Discarded pending stop navigation requests for mismatched regions.

* **Tests**
  * Added coverage for cold-launch activities, URL formats, region identifiers, and routing fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->