### PR TITLE
Make the Stop page navigable under VoiceOver, and fix the trip sheet's collapsed detent

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -761,41 +761,45 @@ class MapViewController: UIViewController,
     ///   - annotation: The annotation the stop was opened from, if any. Deselected when the
     ///     stop sheet closes so the map doesn't keep a pin highlighted for a dismissed sheet.
     func show(stop: Stop, deselecting annotation: MKAnnotation? = nil) {
-        // Under VoiceOver the redesigned Stop page pushes full-screen instead of coming up as a
-        // half-detent sheet. A partial-height FloatingPanel over a live map is a poor modal for
-        // VoiceOver — the map behind it stays in the accessibility tree, and the detents,
-        // swipe-to-dismiss, and collapse-to-`.tip` behaviors are drag gestures VoiceOver can't
-        // perform. The pushed presentation (`showToolbarOnBottom: false`) is a standard, opaque
-        // screen with a nav-bar back button and contained focus. Decided at open time only; a
-        // sheet already onscreen when VoiceOver is switched on is left as-is.
-        if UIAccessibility.isVoiceOverRunning {
-            pushStopForVoiceOver(application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: false), deselecting: annotation)
-        } else {
+        guard prefersPushedStopPage else {
             present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+            return
         }
+        deselectForPushedStopPage(annotation)
+        application.viewRouter.navigateTo(stop: stop, from: self)
     }
 
     /// Displays the specified stop by ID.
     func show(stopID: StopID) {
-        // See `show(stop:)` for why VoiceOver gets the pushed presentation rather than the sheet.
-        if UIAccessibility.isVoiceOverRunning {
-            pushStopForVoiceOver(application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: false))
-        } else {
+        guard prefersPushedStopPage else {
             present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+            return
         }
+        application.viewRouter.navigateTo(stopID: stopID, from: self)
     }
 
-    /// Pushes the Stop page onto the map's navigation stack — the VoiceOver alternative to the
-    /// map sheet. Deselects the source annotation right away: a full-screen push covers the map,
-    /// so leaving a pin selected only strands a highlight for the rider to find on the way back.
-    /// Deliberately skips the sheet path's map-focus wiring (route highlight, recentering,
-    /// tab-bar hiding, `stopSheetStopID`) — all of it is map-visual bookkeeping that means
+    /// `true` while VoiceOver is running, where the Stop page opens as a full-screen push
+    /// instead of the map's half-detent sheet.
+    ///
+    /// A partial-height FloatingPanel over a live map is a poor modal for VoiceOver — the map
+    /// behind it stays in the accessibility tree, and the detents, swipe-to-dismiss, and
+    /// collapse-to-`.tip` behaviors are drag gestures VoiceOver can't perform. The pushed
+    /// presentation the router builds is a standard, opaque screen with a nav-bar back button
+    /// and contained focus, and it skips the sheet path's map-focus wiring (route highlight,
+    /// recentering, tab-bar hiding, `stopSheetStopID`) — map-visual bookkeeping that means
     /// nothing while a pushed screen covers the map, exactly as the legacy push path skips it.
-    private func pushStopForVoiceOver(_ stopController: UIViewController, deselecting annotation: MKAnnotation? = nil) {
-        if let annotation {
-            mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
-        }
-        application.viewRouter.navigate(to: stopController, from: self)
+    ///
+    /// Read at open time only: a sheet already onscreen when VoiceOver is switched on is left
+    /// as-is.
+    private var prefersPushedStopPage: Bool {
+        UIAccessibility.isVoiceOverRunning
+    }
+
+    /// A full-screen push covers the map, so leaving the tapped pin selected only strands a
+    /// highlight for the rider to find on the way back.
+    private func deselectForPushedStopPage(_ annotation: MKAnnotation?) {
+        guard let annotation else { return }
+        mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
     }
 
     /// Routes a stop screen to the presentation that suits it: the redesigned Stop page comes

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -761,12 +761,41 @@ class MapViewController: UIViewController,
     ///   - annotation: The annotation the stop was opened from, if any. Deselected when the
     ///     stop sheet closes so the map doesn't keep a pin highlighted for a dismissed sheet.
     func show(stop: Stop, deselecting annotation: MKAnnotation? = nil) {
-        present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+        // Under VoiceOver the redesigned Stop page pushes full-screen instead of coming up as a
+        // half-detent sheet. A partial-height FloatingPanel over a live map is a poor modal for
+        // VoiceOver — the map behind it stays in the accessibility tree, and the detents,
+        // swipe-to-dismiss, and collapse-to-`.tip` behaviors are drag gestures VoiceOver can't
+        // perform. The pushed presentation (`showToolbarOnBottom: false`) is a standard, opaque
+        // screen with a nav-bar back button and contained focus. Decided at open time only; a
+        // sheet already onscreen when VoiceOver is switched on is left as-is.
+        if UIAccessibility.isVoiceOverRunning {
+            pushStopForVoiceOver(application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: false), deselecting: annotation)
+        } else {
+            present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
+        }
     }
 
     /// Displays the specified stop by ID.
     func show(stopID: StopID) {
-        present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+        // See `show(stop:)` for why VoiceOver gets the pushed presentation rather than the sheet.
+        if UIAccessibility.isVoiceOverRunning {
+            pushStopForVoiceOver(application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: false))
+        } else {
+            present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
+        }
+    }
+
+    /// Pushes the Stop page onto the map's navigation stack — the VoiceOver alternative to the
+    /// map sheet. Deselects the source annotation right away: a full-screen push covers the map,
+    /// so leaving a pin selected only strands a highlight for the rider to find on the way back.
+    /// Deliberately skips the sheet path's map-focus wiring (route highlight, recentering,
+    /// tab-bar hiding, `stopSheetStopID`) — all of it is map-visual bookkeeping that means
+    /// nothing while a pushed screen covers the map, exactly as the legacy push path skips it.
+    private func pushStopForVoiceOver(_ stopController: UIViewController, deselecting annotation: MKAnnotation? = nil) {
+        if let annotation {
+            mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
+        }
+        application.viewRouter.navigate(to: stopController, from: self)
     }
 
     /// Routes a stop screen to the presentation that suits it: the redesigned Stop page comes

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -765,7 +765,7 @@ class MapViewController: UIViewController,
             present(stopController: application.viewRouter.makeStopController(stop: stop, showToolbarOnBottom: true), deselecting: annotation)
             return
         }
-        deselectForPushedStopPage(annotation)
+        prepareMapForPushedStopPage(deselecting: annotation)
         application.viewRouter.navigateTo(stop: stop, from: self)
     }
 
@@ -775,6 +775,7 @@ class MapViewController: UIViewController,
             present(stopController: application.viewRouter.makeStopController(stopID: stopID, showToolbarOnBottom: true))
             return
         }
+        prepareMapForPushedStopPage(deselecting: nil)
         application.viewRouter.navigateTo(stopID: stopID, from: self)
     }
 
@@ -795,9 +796,21 @@ class MapViewController: UIViewController,
         UIAccessibility.isVoiceOverRunning
     }
 
-    /// A full-screen push covers the map, so leaving the tapped pin selected only strands a
-    /// highlight for the rider to find on the way back.
-    private func deselectForPushedStopPage(_ annotation: MKAnnotation?) {
+    /// Clears the map of what the sheet path would have replaced, because a full-screen push
+    /// covers it just as thoroughly.
+    ///
+    /// A sheet left open behind the push is not merely stale scenery: `stopSheetStopID` stays
+    /// set, so every other marker is held down as a gray dot and the zoom pill stays hidden for
+    /// the rest of the session, and its route-focus layer and refresh timer keep running behind
+    /// a screen nobody can see. Reachable whenever VoiceOver is switched on with a sheet already
+    /// up — the one case `prefersPushedStopPage` leaves as-is — and the next stop the rider
+    /// opens then pushes over it.
+    ///
+    /// Deselecting for the same reason: leaving the tapped pin selected only strands a highlight
+    /// for the rider to find on the way back.
+    private func prepareMapForPushedStopPage(deselecting annotation: MKAnnotation?) {
+        dismissStopSheetForReplacement()
+
         guard let annotation else { return }
         mapRegionManager.mapView.deselectAnnotation(annotation, animated: false)
     }

--- a/OBAKit/Mapping/StopSheetPresenter.swift
+++ b/OBAKit/Mapping/StopSheetPresenter.swift
@@ -372,11 +372,17 @@ extension StopSheetPresenter: UINavigationControllerDelegate {
 
     /// Raises a sheet sitting at `.tip` when something is pushed over the stop page.
     ///
-    /// `.tip` shows a sliver — the collapsed stop header and nothing else. That is a
-    /// deliberate peek-at-the-map detent for the *stop page*, which has a collapsed form
-    /// built for it; a pushed screen has none, so it arrives entirely below the fold and the
-    /// tap that pushed it reads as having done nothing. `.half` is where the sheet opens,
-    /// so it's the detent the rider already associates with "this is on screen now."
+    /// `.tip` shows a sliver — one row's worth of content. That is a deliberate
+    /// peek-at-the-map detent for whatever is *already* onscreen, not a detent to arrive at:
+    /// a screen pushed into it lands below the fold and the tap that pushed it reads as
+    /// having done nothing. `.half` is where the sheet opens, so it's the detent the rider
+    /// already associates with "this is on screen now."
+    ///
+    /// Raises regardless of whether the pushed page has a collapsed form. The trip page now
+    /// does (`StopSheetCollapsibleContent`), so this could instead let a conformer stay at
+    /// `.tip` — but its collapsed form names the stop the trip was opened *from*, which is
+    /// the sliver the rider was already looking at. Landing there would still read as
+    /// nothing having happened.
     ///
     /// Only from `.tip`: at `.half` or `.full` the pushed screen is already visible, and
     /// moving the sheet under the rider would be its own surprise. Popping back doesn't

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -92,7 +92,18 @@ struct DepartureRowView: View {
         .onTapGesture(perform: onTap)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityText)
-        .accessibilityAddTraits(.isButton)
+        // `.updatesFrequently` so a focused row re-speaks its changing countdown,
+        // matching the legacy `StopArrivalView`'s `[.button, .updatesFrequently]`.
+        // VoiceOver re-reads only the focused element, so this isn't chatty.
+        .accessibilityAddTraits([.isButton, .updatesFrequently])
+        // Wire the row's primary action to VoiceOver's activate (double-tap).
+        // `.isButton` only changes the spoken trait; the row's tap lives on
+        // `.onTapGesture`, which is invisible to assistive tech, so without an
+        // explicit default action VoiceOver announces "button" but activating
+        // does nothing. A default `.accessibilityAction` closure touches only
+        // the accessibility layer, so it avoids the nested-Button gesture
+        // conflict called out on `alarmCircleButton`.
+        .accessibilityAction { onTap() }
         .accessibilityActions {
             if showsAlarmAffordance {
                 Button(hasAlarm ? removeAlarmTitle : Strings.addAlarm) {

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -96,13 +96,13 @@ struct DepartureRowView: View {
         // matching the legacy `StopArrivalView`'s `[.button, .updatesFrequently]`.
         // VoiceOver re-reads only the focused element, so this isn't chatty.
         .accessibilityAddTraits([.isButton, .updatesFrequently])
-        // Wire the row's primary action to VoiceOver's activate (double-tap).
-        // `.isButton` only changes the spoken trait; the row's tap lives on
-        // `.onTapGesture`, which is invisible to assistive tech, so without an
-        // explicit default action VoiceOver announces "button" but activating
-        // does nothing. A default `.accessibilityAction` closure touches only
-        // the accessibility layer, so it avoids the nested-Button gesture
-        // conflict called out on `alarmCircleButton`.
+        // THE contract for every tap-driven row on this page, restated nowhere
+        // else: `.isButton` only changes the spoken trait, and the row's tap lives
+        // on `.onTapGesture`, which assistive tech cannot reach — so without an
+        // explicit default action VoiceOver announces "button" and activating does
+        // nothing. A default `.accessibilityAction` touches only the accessibility
+        // layer, so it avoids the nested-Button gesture conflict called out on
+        // `alarmCircleButton`.
         .accessibilityAction { onTap() }
         .accessibilityActions {
             if showsAlarmAffordance {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -93,10 +93,8 @@ struct GroupedListView: View {
         // `.updatesFrequently` so a focused card re-speaks its changing countdown,
         // matching the legacy `StopArrivalView` and the flat departure rows.
         .accessibilityAddTraits([.isButton, .updatesFrequently])
-        // Wire the card's expand/collapse to VoiceOver's activate (double-tap):
-        // the header's tap lives on `.onTapGesture`, which assistive tech can't
-        // reach, so `.isButton` alone would speak "button" while double-tap did
-        // nothing. See the matching note on `DepartureRowView`.
+        // Activation expands the card. See `DepartureRowView` for why a tap-driven
+        // row needs this on top of `.isButton`.
         .accessibilityAction { onToggleRoute(group.routeID) }
         // Disclosure state: the card header's activation toggles the list of
         // departures beneath it, so announce which way it will go.
@@ -311,9 +309,8 @@ struct GroupedListView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
             .accessibilityAddTraits([.isButton, .updatesFrequently])
-            // Wire the row's activate (double-tap) to open the trip: the tap
-            // lives on `.onTapGesture`, invisible to assistive tech, so
-            // `.isButton` alone announces "button" but activating does nothing.
+            // Activation opens the trip. See `DepartureRowView` for why a
+            // tap-driven row needs this on top of `.isButton`.
             .accessibilityAction { onSelectDeparture(departure) }
             .accessibilityActions {
                 if showsAlarmAffordance(for: departure) {

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -90,7 +90,14 @@ struct GroupedListView: View {
         .onTapGesture { onToggleRoute(group.routeID) }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(groupAccessibilityLabel(group, status: status))
-        .accessibilityAddTraits(.isButton)
+        // `.updatesFrequently` so a focused card re-speaks its changing countdown,
+        // matching the legacy `StopArrivalView` and the flat departure rows.
+        .accessibilityAddTraits([.isButton, .updatesFrequently])
+        // Wire the card's expand/collapse to VoiceOver's activate (double-tap):
+        // the header's tap lives on `.onTapGesture`, which assistive tech can't
+        // reach, so `.isButton` alone would speak "button" while double-tap did
+        // nothing. See the matching note on `DepartureRowView`.
+        .accessibilityAction { onToggleRoute(group.routeID) }
         // Disclosure state: the card header's activation toggles the list of
         // departures beneath it, so announce which way it will go.
         .accessibilityValue(expandedRouteID == group.routeID
@@ -303,7 +310,11 @@ struct GroupedListView: View {
             // as a custom action just like the header's alarm pill.
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(expandedRowAccessibilityLabel(departure, status: status))
-            .accessibilityAddTraits(.isButton)
+            .accessibilityAddTraits([.isButton, .updatesFrequently])
+            // Wire the row's activate (double-tap) to open the trip: the tap
+            // lives on `.onTapGesture`, invisible to assistive tech, so
+            // `.isButton` alone announces "button" but activating does nothing.
+            .accessibilityAction { onSelectDeparture(departure) }
             .accessibilityActions {
                 if showsAlarmAffordance(for: departure) {
                     Button(alarmActionName(for: alarmLookup(departure))) {

--- a/OBAKit/Stops/StopPage/ServiceAlertsSection.swift
+++ b/OBAKit/Stops/StopPage/ServiceAlertsSection.swift
@@ -109,6 +109,9 @@ struct ServiceAlertsSection: View {
         .accessibilityValue(showsServiceAlerts
             ? OBALoc("stop_page.service_alerts.a11y_expanded", value: "expanded", comment: "VoiceOver value of the service-alerts card header when the alert list is showing.")
             : OBALoc("stop_page.service_alerts.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of the service-alerts card header when the alert list is hidden."))
+        // Also a heading so it anchors VoiceOver's Headings rotor between the
+        // stop title and the departures.
+        .accessibilityAddTraits(.isHeader)
     }
 
     private var showAllRow: some View {

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -60,6 +60,11 @@ struct StopDeparturesSections: View {
     let onShowAllDepartureTypes: () -> Void
     let onLoadMore: () -> Void
 
+    /// Moves VoiceOver focus to the empty-state message when a filter empties
+    /// the list. Owned here rather than by either presentation: the row it
+    /// targets is this view's, and both presentations want the same behaviour.
+    @AccessibilityFocusState private var emptyStateFocused: Bool
+
     /// Leading/trailing inset shared by the page's full-width card rows,
     /// matching the inset-grouped card margin.
     private static let horizontalRowInset: CGFloat = 0
@@ -87,6 +92,9 @@ struct StopDeparturesSections: View {
                     onDismiss: onSurveyDismiss,
                     onOpenExternalSurvey: onSurveyExternal
                 )
+                // Promotional, not core content: read after the departures in the
+                // default VoiceOver sweep (the rotor jumps past it entirely).
+                .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 8, leading: Self.surveyRowInset, bottom: 8, trailing: Self.surveyRowInset))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
@@ -103,6 +111,9 @@ struct StopDeparturesSections: View {
                     onLearnMore: onDonate,
                     onClose: onDonationClose
                 )
+                // Promotional, not core content: read after the departures in the
+                // default VoiceOver sweep (the rotor jumps past it entirely).
+                .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
@@ -147,6 +158,17 @@ struct StopDeparturesSections: View {
                         onShowAllRoutes: onShowAllRoutes,
                         onShowAllDepartureTypes: onShowAllDepartureTypes
                     )
+                    .accessibilityFocused($emptyStateFocused)
+                    // A filter that empties the list strands VoiceOver focus on a
+                    // row that no longer exists, with nothing spoken to say why.
+                    // Only for the filtered cases: a stop that simply has no
+                    // departures shows this row from the first frame, and moving
+                    // focus there would cut off the header VoiceOver is reading.
+                    .onAppear {
+                        if content.isFilteredEmpty || content.isDepartureFilterEmpty {
+                            emptyStateFocused = true
+                        }
+                    }
                 }
             }
         } else if !content.isGrouped {

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -65,6 +65,13 @@ struct StopDeparturesSections: View {
     /// targets is this view's, and both presentations want the same behaviour.
     @AccessibilityFocusState private var emptyStateFocused: Bool
 
+    /// Armed when the list *becomes* filter-empty under the rider, and consumed by the
+    /// empty-state row's `onAppear` — see the header row's `onChange` for why the transition,
+    /// rather than the state, is what may move focus. Set from both sides because SwiftUI
+    /// makes no promise about whether the change lands before or after the row is inserted:
+    /// the direct write covers a row that already exists, the flag covers one still arriving.
+    @State private var pendingEmptyStateFocus = false
+
     /// Leading/trailing inset shared by the page's full-width card rows,
     /// matching the inset-grouped card margin.
     private static let horizontalRowInset: CGFloat = 0
@@ -127,6 +134,10 @@ struct StopDeparturesSections: View {
             ServiceAlertsSection(alerts: serviceAlerts, onSelect: onSelectAlert)
         }
 
+        // The two states the row itself offers a "show everything" button for —
+        // and the only ones where focus should jump to it.
+        let isFilterCausedEmpty = content.isFilteredEmpty || content.isDepartureFilterEmpty
+
         if content.hasLoadedArrivals {
             Section {
                 StopPageListHeaderRow(
@@ -137,15 +148,21 @@ struct StopDeparturesSections: View {
                     onTogglePast: onTogglePast,
                     onChangeMode: onChangeMode
                 )
+                // Watched from here, not from the empty-state row: a filter the rider already
+                // had on — the app-wide departure-type filter, or routes hidden at this stop —
+                // makes the list filter-empty from the first frame it renders, and focusing the
+                // row then cuts off the stop name VoiceOver is reading. This row outlives the
+                // list going empty and coming back, so it can tell "just went empty" from
+                // "arrived empty"; `onChange` deliberately doesn't fire for its initial value.
+                .onChange(of: isFilterCausedEmpty) { _, nowEmpty in
+                    pendingEmptyStateFocus = nowEmpty
+                    if nowEmpty { emptyStateFocused = true }
+                }
                 .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
             }
         }
-
-        // The two states the row itself offers a "show everything" button for —
-        // and the only ones where focus should jump to it.
-        let isFilterCausedEmpty = content.isFilteredEmpty || content.isDepartureFilterEmpty
 
         if content.listIsEmpty {
             if content.showsLoadingState {
@@ -168,16 +185,23 @@ struct StopDeparturesSections: View {
                     .accessibilityFocused($emptyStateFocused)
                     // A filter that empties the list strands VoiceOver focus on a
                     // row that no longer exists, with nothing spoken to say why.
-                    // Only for the filtered cases: a stop that simply has no
-                    // departures shows this row from the first frame, and moving
-                    // focus there would cut off the header VoiceOver is reading.
+                    // Only when a filter emptied it *just now*, which the header
+                    // row's `onChange` decides: a stop that has no departures — or
+                    // one whose pre-existing filter hides them all — shows this row
+                    // from the frame the first fetch lands on, and moving focus
+                    // there would cut off the header VoiceOver is reading.
                     //
-                    // Set, never cleared. `onAppear` fires again whenever the List
-                    // rebuilds this row, and writing `false` to a focus binding whose
-                    // element is currently focused yanks VoiceOver off it — so an
-                    // unconditional assignment would steal focus from a rider sitting
-                    // on the "no departures" message when the next refresh lands.
-                    .onAppear { if isFilterCausedEmpty { emptyStateFocused = true } }
+                    // Only ever set to `true`. `onAppear` fires again whenever the
+                    // List rebuilds this row, and writing `false` to a focus binding
+                    // whose element is currently focused yanks VoiceOver off it — so
+                    // an unconditional assignment would steal focus from a rider
+                    // sitting on the "no departures" message when the next refresh
+                    // lands.
+                    .onAppear {
+                        guard pendingEmptyStateFocus else { return }
+                        pendingEmptyStateFocus = false
+                        emptyStateFocused = true
+                    }
                 }
             }
         } else if !content.isGrouped {

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -92,8 +92,12 @@ struct StopDeparturesSections: View {
                     onDismiss: onSurveyDismiss,
                     onOpenExternalSurvey: onSurveyExternal
                 )
-                // Promotional, not core content: read after the departures in the
-                // default VoiceOver sweep (the rotor jumps past it entirely).
+                // Promotional, not core content, so it asks to be swept last.
+                // A hint, not a guarantee: sort priority only reorders siblings
+                // within one accessibility container, and each card here is its
+                // own List row — whether VoiceOver honors it across rows is
+                // unverified. The Departures rotor skips the card either way,
+                // which is what actually gets a rider to the buses.
                 .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 8, leading: Self.surveyRowInset, bottom: 8, trailing: Self.surveyRowInset))
                 .listRowBackground(Color.clear)
@@ -111,8 +115,7 @@ struct StopDeparturesSections: View {
                     onLearnMore: onDonate,
                     onClose: onDonationClose
                 )
-                // Promotional, not core content: read after the departures in the
-                // default VoiceOver sweep (the rotor jumps past it entirely).
+                // Deprioritized for the same reason as the survey card above.
                 .accessibilitySortPriority(-1)
                 .listRowInsets(EdgeInsets(top: 4, leading: Self.horizontalRowInset, bottom: 4, trailing: Self.horizontalRowInset))
                 .listRowBackground(Color.clear)
@@ -140,6 +143,10 @@ struct StopDeparturesSections: View {
             }
         }
 
+        // The two states the row itself offers a "show everything" button for —
+        // and the only ones where focus should jump to it.
+        let isFilterCausedEmpty = content.isFilteredEmpty || content.isDepartureFilterEmpty
+
         if content.listIsEmpty {
             if content.showsLoadingState {
                 Section {
@@ -164,11 +171,13 @@ struct StopDeparturesSections: View {
                     // Only for the filtered cases: a stop that simply has no
                     // departures shows this row from the first frame, and moving
                     // focus there would cut off the header VoiceOver is reading.
-                    .onAppear {
-                        if content.isFilteredEmpty || content.isDepartureFilterEmpty {
-                            emptyStateFocused = true
-                        }
-                    }
+                    //
+                    // Set, never cleared. `onAppear` fires again whenever the List
+                    // rebuilds this row, and writing `false` to a focus binding whose
+                    // element is currently focused yanks VoiceOver off it — so an
+                    // unconditional assignment would steal focus from a rider sitting
+                    // on the "no departures" message when the next refresh lands.
+                    .onAppear { if isFilterCausedEmpty { emptyStateFocused = true } }
                 }
             }
         } else if !content.isGrouped {

--- a/OBAKit/Stops/StopPage/StopPageHeaderView.swift
+++ b/OBAKit/Stops/StopPage/StopPageHeaderView.swift
@@ -84,6 +84,9 @@ struct StopPageHeaderView: View {
             // button below stays separate so it remains individually
             // focusable and activatable.
             .accessibilityElement(children: .combine)
+            // The screen's title: mark it a heading so it anchors VoiceOver's
+            // Headings rotor for quick top-of-page navigation.
+            .accessibilityAddTraits(.isHeader)
             if let walkTime {
                 Button(action: onWalkingDirections) {
                     Label(walkChipText(walkTime), systemImage: "figure.walk")

--- a/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
+++ b/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
@@ -142,14 +142,21 @@ struct StopPageListHeaderRow: View {
         .padding(.vertical, 4)
         // The visible "Arrivals & Departures" title was dropped to save vertical
         // space, which left VoiceOver's Headings rotor with no anchor for the list
-        // itself. A container heading restores that anchor at zero visual cost —
-        // the Past and mode controls inside stay individually focusable.
+        // itself. `.contain` keeps the Past and mode controls individually
+        // focusable while naming the group they belong to.
+        //
+        // Whether the header trait on a *container* also surfaces in the Headings
+        // rotor is unverified — containers aren't focusable elements, so it may
+        // not. If a device check says it doesn't, the anchor has to be a real
+        // element: a visually hidden `Text` heading above this row.
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Self.departuresHeading)
         .accessibilityAddTraits(.isHeader)
     }
 
-    private static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor; not shown on screen.")
+    /// Shared with `StopPageView`'s Departures rotor: the heading and the rotor
+    /// name the same list, so they must not drift in translation.
+    static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen.")
 
     private var sideBySide: some View {
         HStack(spacing: 12) {
@@ -179,7 +186,7 @@ struct StopPageListHeaderRow: View {
     /// The chevron follows the conventional disclosure direction — down closed, up
     /// open — rather than pointing at the disclosed rows, which are below.
     private var pastButton: some View {
-        Button(action: togglePast) {
+        Button(action: togglePastAndAnnounce) {
             HStack(spacing: 5) {
                 Text(showPast
                      ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips")
@@ -213,7 +220,7 @@ struct StopPageListHeaderRow: View {
     /// which VoiceOver has no reason to re-read — so say what just happened.
     /// Announced here rather than by the callers because this row is where both
     /// the count and the direction are already known.
-    private func togglePast() {
+    private func togglePastAndAnnounce() {
         onTogglePast()
         let message = showPast
             ? OBALoc("stop_page.a11y.past_hidden", value: "Past departures hidden", comment: "VoiceOver announcement when the Past disclosure is closed.")

--- a/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
+++ b/OBAKit/Stops/StopPage/StopPageListHeaderRow.swift
@@ -140,7 +140,16 @@ struct StopPageListHeaderRow: View {
             }
         }
         .padding(.vertical, 4)
+        // The visible "Arrivals & Departures" title was dropped to save vertical
+        // space, which left VoiceOver's Headings rotor with no anchor for the list
+        // itself. A container heading restores that anchor at zero visual cost —
+        // the Past and mode controls inside stay individually focusable.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Self.departuresHeading)
+        .accessibilityAddTraits(.isHeader)
     }
+
+    private static let departuresHeading = OBALoc("stop_page.departures_heading", value: "Departures", comment: "VoiceOver-only heading that anchors the departures list in the Headings rotor; not shown on screen.")
 
     private var sideBySide: some View {
         HStack(spacing: 12) {
@@ -170,7 +179,7 @@ struct StopPageListHeaderRow: View {
     /// The chevron follows the conventional disclosure direction — down closed, up
     /// open — rather than pointing at the disclosed rows, which are below.
     private var pastButton: some View {
-        Button(action: onTogglePast) {
+        Button(action: togglePast) {
             HStack(spacing: 5) {
                 Text(showPast
                      ? OBALoc("stop_page.past_toggle_hide", value: "Hide past", comment: "Button hiding recently departed trips")
@@ -198,6 +207,18 @@ struct StopPageListHeaderRow: View {
         .accessibilityLabel(showPast
             ? OBALoc("stop_page.past_toggle_hide_a11y", value: "Hide past departures", comment: "VoiceOver label for the button hiding recently departed trips")
             : String(format: OBALoc("stop_page.past_toggle_show_a11y_fmt", value: "Show %d past departures", comment: "VoiceOver label for the button revealing recently departed trips. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), pastCount))
+    }
+
+    /// Toggling the disclosure inserts or removes rows well below this button,
+    /// which VoiceOver has no reason to re-read — so say what just happened.
+    /// Announced here rather than by the callers because this row is where both
+    /// the count and the direction are already known.
+    private func togglePast() {
+        onTogglePast()
+        let message = showPast
+            ? OBALoc("stop_page.a11y.past_hidden", value: "Past departures hidden", comment: "VoiceOver announcement when the Past disclosure is closed.")
+            : String(format: OBALoc("stop_page.a11y.past_shown_fmt", value: "Showing %d past departures", comment: "VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), pastCount)
+        AccessibilityNotification.Announcement(message).post()
     }
 }
 

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -155,6 +155,10 @@ struct StopPageView: View {
     /// immediately instead of waiting for the next view-model refresh to re-read
     /// `shouldRequestDonations`.
     @State private var donationHidden = false
+    /// Suppresses the "Departures updated" VoiceOver announcement for the very
+    /// first successful load — the page has just appeared and VoiceOver is
+    /// already reading it, so only later refreshes announce.
+    @State private var didInitialA11yLoad = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     var body: some View {
@@ -162,6 +166,8 @@ struct StopPageView: View {
         // chronological partition, and the divider all read one snapshot of it.
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
+
+        let rotorEntries = departuresRotorEntries(content: content, walkMinutes: walkTime?.walkMinutes)
 
         List {
             if let stop = viewModel.stop {
@@ -234,6 +240,32 @@ struct StopPageView: View {
         .onChange(of: content.routeIDs) { _, ids in
             if let rid = expandedRouteID, !ids.contains(rid) { expandedRouteID = nil }
         }
+        // A custom rotor so a VoiceOver user can spin to "Departures" and flick
+        // straight through the buses, skipping the header, status line, survey,
+        // donation, service-alerts card, and the mode/Past controls above them —
+        // the "so much information … hard to get bus schedules" complaint. Entries
+        // bind to the rows by the same id the ForEach uses (departure id in
+        // chronological mode, route id in grouped mode).
+        .accessibilityRotor(Text(Self.departuresRotorTitle)) {
+            ForEach(rotorEntries, id: \.id) { entry in
+                AccessibilityRotorEntry(entry.label, id: entry.id)
+            }
+        }
+        // Announce dynamic changes that otherwise mutate the list silently.
+        .onChange(of: viewModel.isLoading) { wasLoading, isLoading in
+            guard wasLoading, !isLoading, content.hasLoadedArrivals else { return }
+            if didInitialA11yLoad {
+                AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
+            } else {
+                didInitialA11yLoad = true
+            }
+        }
+        .onChange(of: viewModel.arrivalDepartureFilter) { _, _ in
+            AccessibilityNotification.Announcement(Self.filterChangedAnnouncement).post()
+        }
+        .onChange(of: viewModel.isListFiltered) { _, filtered in
+            AccessibilityNotification.Announcement(filtered ? Self.routesFilteredAnnouncement : Self.routesAllAnnouncement).post()
+        }
     }
 
     /// The sheet presentation's bottom chrome. Reads the view model directly — `StopPageView` is
@@ -281,6 +313,33 @@ struct StopPageView: View {
             pastCollapsed: $pastCollapsed
         )
     }
+
+    // MARK: - VoiceOver announcements
+
+    /// The rows the custom "Departures" rotor steps through, in render order.
+    /// Each `id` matches the row's `ForEach` identity — departure id in
+    /// chronological mode, route id in grouped mode, both `String` — so the
+    /// rotor lands on the real rows. Collapsed Past rows are left out; there is
+    /// nothing rendered for the rotor to focus.
+    ///
+    /// The partition is recomputed rather than shared with
+    /// `StopDeparturesSections`: it is a pure function of values this body
+    /// already holds, and threading it through the sections' argument list would
+    /// buy nothing but another parameter.
+    private func departuresRotorEntries(content: StopPageContent, walkMinutes: Int?) -> [(label: String, id: String)] {
+        if content.isGrouped {
+            return content.routeGroups.map { ($0.next.routeAndHeadsign, $0.routeID) }
+        }
+        let partition = StopPageListBuilder.chronologicalPartition(content.departures, walkMinutes: walkMinutes)
+        let rows = (pastCollapsed ? [] : partition.past) + partition.missed + partition.reachable
+        return rows.map { ($0.routeAndHeadsign, $0.id) }
+    }
+
+    private static let departuresRotorTitle = OBALoc("stop_page.rotor.departures", value: "Departures", comment: "Title of the VoiceOver rotor that steps through the departure rows, skipping the header and cards above them.")
+    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a manual refresh finishes and the departure times have been updated.")
+    private static let filterChangedAnnouncement = OBALoc("stop_page.a11y.filter_changed", value: "Departure filter changed", comment: "VoiceOver announcement posted when the Departure Type filter changes which departures are visible.")
+    private static let routesFilteredAnnouncement = OBALoc("stop_page.a11y.routes_filtered", value: "Showing filtered routes", comment: "VoiceOver announcement posted when the route filter is turned on.")
+    private static let routesAllAnnouncement = OBALoc("stop_page.a11y.routes_all", value: "Showing all routes", comment: "VoiceOver announcement posted when the route filter is turned off.")
 }
 
 #Preview("Initial loading") {

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -150,15 +150,21 @@ struct StopPageView: View {
         showToolbarOnBottom && !isCollapsed
     }
 
+    /// Read from the environment rather than the `formatters` property `StopPageRootView`
+    /// publishes: this view is constructed by that wrapper, so its own property wrappers
+    /// resolve against the environment it was handed.
+    @Environment(\.obaFormatters) private var formatters
+    /// Gates the rotor's entry list, the one piece of per-body work here that scales with
+    /// the whole departure list rather than the handful of rows the `List` materializes.
+    /// An environment read, not `UIAccessibility.isVoiceOverRunning`, so switching
+    /// VoiceOver on invalidates the body instead of waiting for an incidental one.
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+
     @State private var expandedRouteID: RouteID?
     /// Set when the user explicitly dismisses the donation card, so it disappears
     /// immediately instead of waiting for the next view-model refresh to re-read
     /// `shouldRequestDonations`.
     @State private var donationHidden = false
-    /// Suppresses the "Departures updated" VoiceOver announcement for the very
-    /// first successful load — the page has just appeared and VoiceOver is
-    /// already reading it, so only later refreshes announce.
-    @State private var didInitialA11yLoad = false
     @AppStorage("StopViewController.pastDeparturesCollapsed") private var pastCollapsed = true
 
     var body: some View {
@@ -167,7 +173,7 @@ struct StopPageView: View {
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
 
-        let rotorEntries = departuresRotorEntries(content: content, walkMinutes: walkTime?.walkMinutes)
+        let rotorEntries = voiceOverEnabled ? departuresRotorEntries(content: content) : []
 
         List {
             if let stop = viewModel.stop {
@@ -229,7 +235,7 @@ struct StopPageView: View {
                 toolbar
             }
         }
-        .refreshable { await viewModel.refresh() }
+        .refreshable { await refreshAndAnnounce() }
         .stopPageLifecycle(
             viewModel: viewModel,
             userDefaults: userDefaults,
@@ -252,14 +258,6 @@ struct StopPageView: View {
             }
         }
         // Announce dynamic changes that otherwise mutate the list silently.
-        .onChange(of: viewModel.isLoading) { wasLoading, isLoading in
-            guard wasLoading, !isLoading, content.hasLoadedArrivals else { return }
-            if didInitialA11yLoad {
-                AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
-            } else {
-                didInitialA11yLoad = true
-            }
-        }
         .onChange(of: viewModel.arrivalDepartureFilter) { _, _ in
             AccessibilityNotification.Announcement(Self.filterChangedAnnouncement).post()
         }
@@ -281,7 +279,7 @@ struct StopPageView: View {
             isListFiltered: viewModel.isListFiltered,
             activeDepartureFilter: viewModel.arrivalDepartureFilter,
             hasServiceAlerts: !(viewModel.stopArrivals?.serviceAlerts ?? []).isEmpty,
-            onRefresh: { Task { await viewModel.refresh() } },
+            onRefresh: { Task { await refreshAndAnnounce() } },
             onSetListFiltered: { filtered in
                 viewModel.isListFiltered = filtered
                 // Picking "Filtered Routes" opens the picker, matching the pushed
@@ -316,27 +314,58 @@ struct StopPageView: View {
 
     // MARK: - VoiceOver announcements
 
-    /// The rows the custom "Departures" rotor steps through, in render order.
-    /// Each `id` matches the row's `ForEach` identity — departure id in
-    /// chronological mode, route id in grouped mode, both `String` — so the
-    /// rotor lands on the real rows. Collapsed Past rows are left out; there is
-    /// nothing rendered for the rotor to focus.
+    /// The rows the custom "Departures" rotor steps through, in the order the
+    /// list renders them. Each `id` matches the row's `ForEach` identity —
+    /// departure id in chronological mode, route id in grouped mode, both
+    /// `String` — so the rotor lands on the real rows. Collapsed Past rows are
+    /// left out; there is nothing rendered for the rotor to focus.
     ///
-    /// The partition is recomputed rather than shared with
-    /// `StopDeparturesSections`: it is a pure function of values this body
-    /// already holds, and threading it through the sections' argument list would
-    /// buy nothing but another parameter.
-    private func departuresRotorEntries(content: StopPageContent, walkMinutes: Int?) -> [(label: String, id: String)] {
+    /// The chronological order is the plain time sort rather than
+    /// `chronologicalPartition`: that partition splits the same sorted list into
+    /// past / missed / reachable so the list can draw a walk divider between the
+    /// last two, and `ChronologicalListView` renders the three back to back — so
+    /// reassembling them here would only sort the same rows a second time to
+    /// arrive at the same sequence.
+    private func departuresRotorEntries(content: StopPageContent) -> [(label: String, id: String)] {
         if content.isGrouped {
-            return content.routeGroups.map { ($0.next.routeAndHeadsign, $0.routeID) }
+            return content.routeGroups.map { (rotorLabel(for: $0.next), $0.routeID) }
         }
-        let partition = StopPageListBuilder.chronologicalPartition(content.departures, walkMinutes: walkMinutes)
-        let rows = (pastCollapsed ? [] : partition.past) + partition.missed + partition.reachable
-        return rows.map { ($0.routeAndHeadsign, $0.id) }
+        return content.departures
+            .sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
+            .filter { !pastCollapsed || $0.temporalState != .past }
+            .map { (rotorLabel(for: $0), $0.id) }
     }
 
-    private static let departuresRotorTitle = OBALoc("stop_page.rotor.departures", value: "Departures", comment: "Title of the VoiceOver rotor that steps through the departure rows, skipping the header and cards above them.")
-    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a manual refresh finishes and the departure times have been updated.")
+    /// Spoken form of a departure's route, e.g. "Route 49 - University District".
+    /// The rows speak a whole sentence (route, timing, status); the rotor only has
+    /// to say which bus it just landed on, but it says it the way the rest of the
+    /// app does rather than reading the on-screen string and its em dash aloud.
+    private func rotorLabel(for departure: ArrivalDeparture) -> String {
+        formatters.accessibilityLabel(for: departure)
+    }
+
+    /// Pull-to-refresh and the toolbar's Refresh button — the two places the rider
+    /// asks for fresh times and so has reason to be told they arrived. Deliberately
+    /// not the 15-second auto-refresh, which runs through the same view model call
+    /// and would interrupt whatever VoiceOver is reading four times a minute.
+    ///
+    /// Keyed on `lastUpdated` moving rather than on the call returning, because
+    /// `refresh()` returns without fetching in two cases that must stay silent: a
+    /// refresh already in flight (the auto-refresh timer) makes it a no-op, and a
+    /// failed fetch lands in `operationError` and leaves the old times on screen.
+    /// Announcing either as "Departures updated" tells a rider who can't see the
+    /// stale rows that they're fresh.
+    private func refreshAndAnnounce() async {
+        let updatedBefore = viewModel.lastUpdated
+        await viewModel.refresh()
+        guard viewModel.lastUpdated != updatedBefore else { return }
+        AccessibilityNotification.Announcement(Self.refreshedAnnouncement).post()
+    }
+
+    /// The rotor's title and the list's heading name the same thing, so they share
+    /// one string — two keys would let 13 locales translate them apart.
+    private static let departuresRotorTitle = StopPageListHeaderRow.departuresHeading
+    private static let refreshedAnnouncement = OBALoc("stop_page.a11y.refreshed", value: "Departures updated", comment: "VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated.")
     private static let filterChangedAnnouncement = OBALoc("stop_page.a11y.filter_changed", value: "Departure filter changed", comment: "VoiceOver announcement posted when the Departure Type filter changes which departures are visible.")
     private static let routesFilteredAnnouncement = OBALoc("stop_page.a11y.routes_filtered", value: "Showing filtered routes", comment: "VoiceOver announcement posted when the route filter is turned on.")
     private static let routesAllAnnouncement = OBALoc("stop_page.a11y.routes_all", value: "Showing all routes", comment: "VoiceOver announcement posted when the route filter is turned off.")

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -173,7 +173,9 @@ struct StopPageView: View {
         let walkTime = viewModel.walkTime
         let content = StopPageContent(viewModel: viewModel)
 
-        let rotorEntries = voiceOverEnabled ? departuresRotorEntries(content: content) : []
+        let rotorEntries = voiceOverEnabled
+            ? departuresRotorEntries(content: content, walkMinutes: walkTime?.walkMinutes)
+            : []
 
         List {
             if let stop = viewModel.stop {
@@ -320,20 +322,21 @@ struct StopPageView: View {
     /// `String` — so the rotor lands on the real rows. Collapsed Past rows are
     /// left out; there is nothing rendered for the rotor to focus.
     ///
-    /// The chronological order is the plain time sort rather than
-    /// `chronologicalPartition`: that partition splits the same sorted list into
-    /// past / missed / reachable so the list can draw a walk divider between the
-    /// last two, and `ChronologicalListView` renders the three back to back — so
-    /// reassembling them here would only sort the same rows a second time to
-    /// arrive at the same sequence.
-    private func departuresRotorEntries(content: StopPageContent) -> [(label: String, id: String)] {
+    /// The chronological order is read from `chronologicalPartition` rather than
+    /// re-derived here. A plain time sort happens to produce the same sequence
+    /// today, and costs the same one sort — but it is a second copy of "what
+    /// order do departures come in, and what counts as past" with no test tying
+    /// the two together, so a change to the builder would silently land the
+    /// rotor on rows in an order the screen doesn't show. `ChronologicalListView`
+    /// renders past (when expanded) → missed → reachable, which is what this
+    /// concatenation reproduces.
+    private func departuresRotorEntries(content: StopPageContent, walkMinutes: Int?) -> [(label: String, id: String)] {
         if content.isGrouped {
             return content.routeGroups.map { (rotorLabel(for: $0.next), $0.routeID) }
         }
-        return content.departures
-            .sorted { $0.arrivalDepartureMinutes < $1.arrivalDepartureMinutes }
-            .filter { !pastCollapsed || $0.temporalState != .past }
-            .map { (rotorLabel(for: $0), $0.id) }
+        let partition = StopPageListBuilder.chronologicalPartition(content.departures, walkMinutes: walkMinutes)
+        let rendered = (pastCollapsed ? [] : partition.past) + partition.missed + partition.reachable
+        return rendered.map { (rotorLabel(for: $0), $0.id) }
     }
 
     /// Spoken form of a departure's route, e.g. "Route 49 - University District".

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -66,6 +66,22 @@
 			<string>No departures in the next %d minutes</string>
 		</dict>
 	</dict>
+	<key>stop_page.a11y.past_shown_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Showing 1 past departure</string>
+			<key>other</key>
+			<string>Showing %d past departures</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Trip/TripPage/TripPageView.swift
+++ b/OBAKit/Trip/TripPage/TripPageView.swift
@@ -49,6 +49,16 @@ struct TripPageView: View {
     var hasAlarm = false
     var isTrackingLiveActivity = false
 
+    /// `true` while the sheet showing this page sits at its `.tip` detent, where the only thing
+    /// that fits is the back row.
+    ///
+    /// The action bar is pinned as a bottom `safeAreaInset`, and at `.tip` it is taller than the
+    /// whole detent — so SwiftUI squeezes the back row and the list to nothing and the sheet peeks
+    /// as a Live Activity button floating over the map, with no indication of which trip it
+    /// belongs to. Dropping the bar at this detent leaves the row that names the trip's origin,
+    /// which is what a peek is for. Mirrors `StopPageView.isCollapsed`.
+    var isCollapsed = false
+
     /// The page's laid-out height, which is the sheet detent's — not the screen's. Feeds the
     /// action bar's ceiling at accessibility sizes; see `TripActionBar.maxHeight`.
     @State private var pageHeight: CGFloat = 0
@@ -128,18 +138,20 @@ struct TripPageView: View {
         // discards the reservation. Until someone can explain the difference,
         // this stays where it is empirically correct.
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            TripActionBar(
-                canStartLiveActivity: actions.canStartLiveActivity,
-                isTrackingLiveActivity: isTrackingLiveActivity,
-                canSchedule: actions.canSchedule,
-                canAlarm: actions.canAlarm,
-                hasAlarm: hasAlarm,
-                maxHeight: pageHeight > 0 ? pageHeight * Self.actionBarHeightShare : nil,
-                onLiveActivity: actions.onLiveActivity,
-                onBookmark: actions.onBookmark,
-                onSchedule: actions.onSchedule,
-                onAlarm: actions.onAlarm
-            )
+            if !isCollapsed {
+                TripActionBar(
+                    canStartLiveActivity: actions.canStartLiveActivity,
+                    isTrackingLiveActivity: isTrackingLiveActivity,
+                    canSchedule: actions.canSchedule,
+                    canAlarm: actions.canAlarm,
+                    hasAlarm: hasAlarm,
+                    maxHeight: pageHeight > 0 ? pageHeight * Self.actionBarHeightShare : nil,
+                    onLiveActivity: actions.onLiveActivity,
+                    onBookmark: actions.onBookmark,
+                    onSchedule: actions.onSchedule,
+                    onAlarm: actions.onAlarm
+                )
+            }
         }
         // The page's height is imposed by the host (the sheet detent), not derived from this
         // content, so feeding it back in to bound the bar converges instead of looping.

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -10,7 +10,6 @@
 import ActivityKit
 import CoreLocation
 import Combine
-import CoreLocation
 import SwiftUI
 import OBAKitCore
 
@@ -27,6 +26,7 @@ final class TripPageViewController: UIHostingController<TripPageView>,
     AlarmBuilderDelegate,
     BookmarkEditorDelegate,
     Idleable,
+    StopSheetCollapsibleContent,
     StopSheetSelfChromedContent {
 
     public let application: Application
@@ -39,6 +39,11 @@ final class TripPageViewController: UIHostingController<TripPageView>,
     private var alarmBuilder: AlarmBuilder?
     private var alarmBuilderDeparture: ArrivalDeparture?
     private var isTrackingLiveActivity = false
+
+    /// `true` while the sheet showing this page sits at its `.tip` detent. Stored rather than
+    /// derived so every `render()` — the 30s refresh drives one — rebuilds the page with the
+    /// detent the sheet is actually at instead of resetting it to expanded.
+    private var isAtTip = false
 
     let providesOwnSheetChrome = true
 
@@ -189,8 +194,20 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             actions: makeActions(),
             backBehavior: backBehavior,
             hasAlarm: false,
-            isTrackingLiveActivity: isTrackingLiveActivity
+            isTrackingLiveActivity: isTrackingLiveActivity,
+            isCollapsed: isAtTip
         )
+    }
+
+    // MARK: - StopSheetCollapsibleContent
+
+    /// Called by `StopSheetPresenter` whenever the sheet's detent changes. At `.tip` the page
+    /// drops its pinned action bar, which is taller than that detent, so the peek shows the back
+    /// row naming where the trip was opened from instead of a stranded Live Activity button.
+    func setAtTip(_ isAtTip: Bool) {
+        guard self.isAtTip != isAtTip else { return }
+        self.isAtTip = isAtTip
+        rootView.isCollapsed = isAtTip
     }
 
     // MARK: - Back

--- a/OBAKitTests/Trip/TripPageBackBehaviorTests.swift
+++ b/OBAKitTests/Trip/TripPageBackBehaviorTests.swift
@@ -65,11 +65,8 @@ final class TripPageBackWiringTests: OBATestCase {
     }
 
     private func makeTripPage() throws -> TripPageViewController {
-        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        return TripPageViewController(
-            application: application,
-            tripConvertible: TripConvertible(arrivalDeparture: try Fixtures.arrivalDeparture()),
-            originTitle: "3rd Ave & Pike St"
+        try TripPageFixture.makePage(
+            application: buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
         )
     }
 

--- a/OBAKitTests/Trip/TripPageCollapseTests.swift
+++ b/OBAKitTests/Trip/TripPageCollapseTests.swift
@@ -1,0 +1,69 @@
+//
+//  TripPageCollapseTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import Testing
+import OBAKitCore
+@testable import OBAKit
+
+/// What the trip page shows at the sheet's `.tip` detent.
+///
+/// The regression: the page's action bar is pinned as a bottom `safeAreaInset` and is taller than
+/// the whole `.tip` detent, so at that detent SwiftUI squeezed out the back row and the stop list
+/// and the peek was a Live Activity button floating over the map, naming no trip at all. The page
+/// has to be told which detent it is at — `StopSheetPresenter` only tells content that conforms to
+/// `StopSheetCollapsibleContent` — and drop the bar there.
+@MainActor
+@Suite(.serialized)
+final class TripPageCollapseTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    private func makeTripPage() throws -> TripPageViewController {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        return TripPageViewController(
+            application: application,
+            tripConvertible: TripConvertible(arrivalDeparture: try Fixtures.arrivalDeparture()),
+            originTitle: "3rd Ave & Pike St"
+        )
+    }
+
+    /// Without this conformance the presenter's detent changes never reach the page, which is
+    /// exactly how it ended up rendering its full chrome inside a sliver.
+    @Test func `The page is collapsible sheet content`() throws {
+        let page = try makeTripPage()
+        #expect(page as? StopSheetCollapsibleContent != nil)
+    }
+
+    /// Expanded is the state the page is built in: every other detent has room for the bar.
+    @Test func `The page starts expanded`() throws {
+        let page = try makeTripPage()
+        #expect(page.rootView.isCollapsed == false)
+    }
+
+    @Test func `Moving to the tip detent collapses the page`() throws {
+        let page = try makeTripPage()
+
+        page.setAtTip(true)
+        #expect(page.rootView.isCollapsed)
+
+        page.setAtTip(false)
+        #expect(page.rootView.isCollapsed == false)
+    }
+}

--- a/OBAKitTests/Trip/TripPageCollapseTests.swift
+++ b/OBAKitTests/Trip/TripPageCollapseTests.swift
@@ -44,26 +44,23 @@ final class TripPageCollapseTests: OBATestCase {
         )
     }
 
-    /// Without this conformance the presenter's detent changes never reach the page, which is
-    /// exactly how it ended up rendering its full chrome inside a sliver.
-    @Test func `The page is collapsible sheet content`() throws {
-        let page = try makeTripPage()
-        #expect(page as? StopSheetCollapsibleContent != nil)
-    }
-
-    /// Expanded is the state the page is built in: every other detent has room for the bar.
+    /// Expanded is the state the page is built in: every detent but `.tip` has room for the bar.
     @Test func `The page starts expanded`() throws {
         let page = try makeTripPage()
         #expect(page.rootView.isCollapsed == false)
     }
 
-    @Test func `Moving to the tip detent collapses the page`() throws {
+    /// Driven through the protocol deliberately: the presenter reaches the page as a
+    /// `StopSheetCollapsibleContent` and nothing else, so this asserts the conformance the
+    /// presenter needs as much as the toggle itself.
+    @Test func `Moving to the tip detent collapses the page and back again expands it`() throws {
         let page = try makeTripPage()
+        let collapsible: StopSheetCollapsibleContent = page
 
-        page.setAtTip(true)
+        collapsible.setAtTip(true)
         #expect(page.rootView.isCollapsed)
 
-        page.setAtTip(false)
+        collapsible.setAtTip(false)
         #expect(page.rootView.isCollapsed == false)
     }
 }

--- a/OBAKitTests/Trip/TripPageCollapseTests.swift
+++ b/OBAKitTests/Trip/TripPageCollapseTests.swift
@@ -36,11 +36,8 @@ final class TripPageCollapseTests: OBATestCase {
     }
 
     private func makeTripPage() throws -> TripPageViewController {
-        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
-        return TripPageViewController(
-            application: application,
-            tripConvertible: TripConvertible(arrivalDeparture: try Fixtures.arrivalDeparture()),
-            originTitle: "3rd Ave & Pike St"
+        try TripPageFixture.makePage(
+            application: buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
         )
     }
 

--- a/OBAKitTests/Trip/TripPageFixture.swift
+++ b/OBAKitTests/Trip/TripPageFixture.swift
@@ -1,0 +1,36 @@
+//
+//  TripPageFixture.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import UIKit
+import OBAKitCore
+@testable import OBAKit
+
+/// The recipe for a real `TripPageViewController`, shared by the suites that
+/// exercise one.
+///
+/// `TripPageBackWiringTests` and `TripPageCollapseTests` both need a page built
+/// against a real `Application` — one to resolve its Back row against a stack,
+/// the other to drive its detent. They had the same three-argument construction
+/// written out twice, so the next change to the initializer or to the arrival
+/// fixture had to be made in both.
+enum TripPageFixture {
+
+    /// The screen the page was opened from. Any non-nil title does; it exists so
+    /// the back row has something to render beside its button.
+    static let originTitle = "3rd Ave & Pike St"
+
+    @MainActor
+    static func makePage(application: Application) throws -> TripPageViewController {
+        TripPageViewController(
+            application: application,
+            tripConvertible: TripConvertible(arrivalDeparture: try Fixtures.arrivalDeparture()),
+            originTitle: originTitle
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Stop page under VoiceOver.** Departure rows announced themselves as buttons and then did nothing when activated — their taps live on `.onTapGesture`, which assistive tech can't reach. Each now wires its primary action through an explicit `.accessibilityAction`. A custom "Departures" rotor steps straight through the rows so getting to the buses no longer means flicking past the header, survey, donation, alerts, and mode controls; the Headings rotor gets the anchors it was missing; and list-mutating changes (refresh, filters, the Past disclosure) announce themselves. Opening a stop from the map under VoiceOver pushes the page instead of presenting the half-detent sheet, which is a poor modal for a screen reader.
- **Trip sheet at `.tip`.** `TripActionBar` is pinned as a bottom `safeAreaInset` and is taller than the whole `.tip` detent, so SwiftUI squeezed out the back row and the stop list and the peek became a Live Activity button floating over the map, naming no trip at all. `TripPageViewController` now conforms to `StopSheetCollapsibleContent` and drops the bar at that detent, leaving the row that names where the trip was opened from.
- **Wrap-up passes.** `/simplify` deduped the trip-page test fixture and made the rotor read its row order from `StopPageListBuilder.chronologicalPartition` instead of re-deriving it. `/code-review` fixed two real bugs — see below.

## Test plan

- [x] Full unit suite: **2077 passed, 0 failed** (`OBAKitTests`, iOS 27 simulator)
- [x] Trip sheet driven end-to-end in the simulator: map → stop sheet → departure → trip page
- [x] At `.tip`, the sheet shows the back row and its title; the accessibility tree at that detent contains only `Back` — no Live Activity, Add Bookmark, View schedule, or Add Alarm
- [x] `.half` → `.tip` → `.half` round trip restores all four action-bar buttons
- [x] Re-verified the above after both the `/simplify` and `/code-review` passes
- [x] Stop sheet still renders departures correctly after the rotor change
- [x] `LocalizationTests` green (key parity holds)

## Review notes

**Not verified — needs a real device.** The simulator can toggle `UIAccessibility.isVoiceOverRunning`, but it gives you no VoiceOver touch layer and no readable AX tree, so nothing here confirms speech, focus order, rotor contents, or activation through `.accessibilityAction`. Everything VoiceOver-specific in this PR is reasoned-and-compiled, not observed. Two claims are called out in the code as unverified: whether sort priority reorders cards across `List` rows, and whether a header trait on an accessibility *container* reaches the Headings rotor.

**Findings deliberately left unfixed:**

1. **The new VoiceOver strings are English-only.** `stop_page.departures_heading`, `stop_page.a11y.refreshed`, `.filter_changed`, `.routes_filtered`, `.routes_all`, `.past_hidden` aren't in any `Localizable.strings`, and `stop_page.a11y.past_shown_fmt` is in `en.lproj/Localizable.stringsdict` only. Key parity tests pass (the keys are absent from `en` too, so nothing drifts), but non-English users hear these in English. Wants `scripts/extract_strings` + a translation pass before release.
2. **Spurious "Showing all routes" on load.** `disableFilterIfAllRoutesHidden()` flips `isListFiltered` right after the first fetch, so a rider who has hidden every route at a stop hears the announcement with no action of theirs behind it. Distinguishing rider intent from the model's self-correction needs a signal `StopViewModel` doesn't expose today.
3. **`StopDetailsSheetView` gets none of this.** The rotor and the refresh/filter announcements were added to `StopPageView` only; the map panel's sheet presentation has the same filters and its own `refresh()` and stays un-navigable. Arguably these belong on `StopDeparturesSections`/`StopDeparturesBuilder`, which both presentations already route through — worth deciding before this pattern sets.
4. **The tap-row accessibility contract is copy-pasted three times.** `.accessibilityElement(.ignore)` + label + `[.isButton, .updatesFrequently]` + `.accessibilityAction` appears in `DepartureRowView` and twice in `GroupedListView`, with a comment calling it "THE contract for every tap-driven row on this page". A `View` extension would carry it once. Left alone here because refactoring accessibility modifier chains I can't observe under VoiceOver is not something to do blind.

**Cosmetic, not fixed:** the trip sheet's `.tip` peek clips the trip card mid-text at the screen edge. The stop page's peek bleeds its Time/Route control exactly the same way, so this matches the established pattern; cleaning up both is a separate pass over `StopSheetLayout`'s tip anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved VoiceOver navigation throughout stop and departure pages.
  - Added accessible headings, buttons, actions, announcements, and a departures rotor.
  - VoiceOver users now receive focus when filters produce no results.
  - Stop details open as a full-screen page when VoiceOver is enabled.

- **User Experience**
  - Past-departure expansion now announces its state and count.
  - Refresh and filter changes provide clearer spoken feedback.
  - Trip action controls are hidden when the trip page is collapsed.

- **Bug Fixes**
  - Improved sheet and trip-page collapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->