### PR TITLE
Replace the bikeshare first-run callout with a TipKit tip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,11 @@ xcodebuildmcp ui-automation --help   # snapshot-ui, tap, swipe, type-text, scree
 Typical loop for verifying a change in the running app:
 
 ```bash
-xcodebuildmcp simulator build-and-run --projectPath OBAKit.xcodeproj --scheme App --simulator-id <UDID>
+scripts/generate_project OneBusAway                      # required before any build
+xcodebuildmcp simulator build-and-run --project-path OBAKit.xcodeproj --scheme App --simulator-id <UDID>
 xcodebuildmcp ui-automation snapshot-ui  --simulator-id <UDID> --style minimal
 xcodebuildmcp ui-automation touch        --simulator-id <UDID> --element-ref e26 --down --up --delay 0.08
-xcodebuildmcp ui-automation screenshot   --simulator-id <UDID> --returnFormat path --style minimal
+xcodebuildmcp ui-automation screenshot   --simulator-id <UDID> --return-format path --style minimal
 ```
 
 `snapshot-ui` returns semantic `elementRef` handles; drive those refs instead of
@@ -43,10 +44,12 @@ coordinates, and re-snapshot after any navigation or layout change.
 
 Two things that cost real time here:
 
-- **Flag spelling differs between the CLI and the MCP tools.** The CLI wants
-  `--simulator-id` / `--element-ref`; the MCP tool schema uses `simulatorId` /
-  `elementRef`. The CLI accepts `--simulatorId` on some commands and rejects it on
-  others (`simulator open` errors with "Unknown arguments"), so prefer kebab-case.
+- **Flag spelling differs between the CLI and the MCP tools.** The CLI documents
+  kebab-case (`--simulator-id`, `--element-ref`, `--project-path`,
+  `--return-format`); the MCP tool schema uses camelCase (`simulatorId`,
+  `elementRef`). The CLI tolerates camelCase on some commands and rejects it on
+  others (`simulator open` errors with "Unknown arguments"), so always use
+  kebab-case — `<workflow> <command> --help` prints the canonical names.
 - **Prefer `touch --down --up` over `tap`.** `tap` reports
   "simulated successfully" and frequently changes nothing — notably on SwiftUI
   onboarding buttons. `touch` reaches the same refs and actually lands. If a screen
@@ -59,8 +62,11 @@ driven this way — verify those with hosted unit tests instead.
 
 ```bash
 brew tap getsentry/xcodebuildmcp && brew install xcodebuildmcp
-# or: npm install -g xcodebuildmcp@latest
+# or, with Node.js 18+: npm install -g xcodebuildmcp@latest
 ```
+
+Homebrew is the path with no Node dependency. XcodeBuildMCP itself requires
+macOS 14.5+ and Xcode 16+.
 
 Every homegrown alternative on this codebase has been a dead end or a time sink: `idb` is
 broken on current Xcode, AppleScript/System Events hit an empty accessibility tree, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,62 @@ scripts/generate_project                # Defaults to OneBusAway if no app speci
 
 **Available Apps**: OneBusAway, KiedyBus
 
-### Building & Testing
+### Building, Testing, and Driving the App: use `xcodebuildmcp`
+
+**Reach for `xcodebuildmcp` first.** It wraps `xcodebuild`/`xcrun simctl` and — critically —
+is the only thing in this repo that reliably drives the simulator's UI. Discover commands
+from the CLI itself rather than from memory:
+
+```bash
+xcodebuildmcp --help                 # workflows
+xcodebuildmcp <workflow> --help      # commands in a workflow
+xcodebuildmcp ui-automation --help   # snapshot-ui, tap, swipe, type-text, screenshot, ...
+```
+
+Typical loop for verifying a change in the running app:
+
+```bash
+xcodebuildmcp simulator build-and-run --projectPath OBAKit.xcodeproj --scheme App --simulator-id <UDID>
+xcodebuildmcp ui-automation snapshot-ui  --simulator-id <UDID> --style minimal
+xcodebuildmcp ui-automation touch        --simulator-id <UDID> --element-ref e26 --down --up --delay 0.08
+xcodebuildmcp ui-automation screenshot   --simulator-id <UDID> --returnFormat path --style minimal
+```
+
+`snapshot-ui` returns semantic `elementRef` handles; drive those refs instead of
+coordinates, and re-snapshot after any navigation or layout change.
+
+Two things that cost real time here:
+
+- **Flag spelling differs between the CLI and the MCP tools.** The CLI wants
+  `--simulator-id` / `--element-ref`; the MCP tool schema uses `simulatorId` /
+  `elementRef`. The CLI accepts `--simulatorId` on some commands and rejects it on
+  others (`simulator open` errors with "Unknown arguments"), so prefer kebab-case.
+- **Prefer `touch --down --up` over `tap`.** `tap` reports
+  "simulated successfully" and frequently changes nothing — notably on SwiftUI
+  onboarding buttons. `touch` reaches the same refs and actually lands. If a screen
+  will not advance, swap `tap` for `touch` before suspecting anything else.
+
+Map annotations are not exposed as snapshot targets, so map pins still cannot be
+driven this way — verify those with hosted unit tests instead.
+
+**If `xcodebuildmcp` is not installed, install it — do not hand-roll simulator automation.**
+
+```bash
+brew tap getsentry/xcodebuildmcp && brew install xcodebuildmcp
+# or: npm install -g xcodebuildmcp@latest
+```
+
+Every homegrown alternative on this codebase has been a dead end or a time sink: `idb` is
+broken on current Xcode, AppleScript/System Events hit an empty accessibility tree, and
+synthesizing `CGEvent` clicks against the Simulator window means recalibrating a window→device
+coordinate mapping that silently drifts whenever the window moves or another simulator window
+overlaps it. Those taps fail *silently* — they report success and change nothing — which is
+the single most expensive failure mode here. Install the CLI instead.
+
+### Building & Testing (raw xcodebuild)
+
+Use these only when `xcodebuildmcp` genuinely cannot do the job.
+
 ```bash
 # Build for testing
 xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -216,15 +216,7 @@ class MapFloatingPanelController: VisualEffectViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        tripPlannerTipPresenter.showIfNeeded(sourceItem: searchBar, sourceRect: searchBar.bounds) { [weak self] vc in
-            guard let self else { return }
-            self.present(vc, animated: animated)
-        } presentedController: { [weak self] in
-            guard let self else { return nil }
-            return self.presentedViewController
-        } dismiss: { vc in
-            vc.dismiss(animated: animated)
-        }
+        tripPlannerTipPresenter.showIfNeeded(in: self, sourceItem: searchBar, sourceRect: searchBar.bounds, animated: animated)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/OBAKit/Mapping/MapViewController+MapLayers.swift
+++ b/OBAKit/Mapping/MapViewController+MapLayers.swift
@@ -28,6 +28,13 @@ extension MapViewController {
         configureStopRouteFocusLayer()
         configureRentalLayers()
         updateMapLayerBadge()
+
+        // On a cold launch the region resolves *after* `viewDidAppear`, so the
+        // coordinator that gates the tip doesn't exist yet when that first
+        // attempt runs. Retrying here — once the layers are actually registered
+        // — is what makes the tip show on the launch that introduces bikeshare,
+        // which is the launch it exists for.
+        showMapLayersTipIfNeeded()
     }
 
     /// Registers `StopRouteFocusMapLayer`, rebuilding it with a fresh
@@ -162,61 +169,20 @@ extension MapViewController {
         present(controller, animated: true)
     }
 
-    // MARK: - First-Run Layer Nudge
+    // MARK: - First-Run Layer Tip
 
-    private static let mapLayersNudgeShownKey = "mapViewController.mapLayersNudgeShown"
+    /// The one-time tip pointing at the basemap button the first time a region
+    /// offers rental layers.
+    ///
+    /// Gated on the rental coordinator existing rather than on a rule inside the
+    /// tip, because the observation `showIfNeeded` starts is long-lived: not
+    /// starting it is what keeps the tip off regions without bikeshare. Both
+    /// callers are idempotent — the window check drops calls that arrive while
+    /// the map is off screen, and `TipPresenter` observes at most once.
+    func showMapLayersTipIfNeeded() {
+        guard viewIfLoaded?.window != nil, rentalLayerCoordinator != nil else { return }
 
-    /// The one-time nudge pointing at the basemap button the first time a region
-    /// offers rental layers. Not a permanent band, not a recurring tip — shown
-    /// once, then never again.
-    func showMapLayersNudgeIfNeeded() {
-        guard rentalLayerCoordinator != nil,
-              !application.userDefaults.bool(forKey: Self.mapLayersNudgeShownKey),
-              presentedViewController == nil else {
-            return
-        }
-        application.userDefaults.set(true, forKey: Self.mapLayersNudgeShownKey)
-
-        let nudge = UILabel.autolayoutNew()
-        nudge.text = OBALoc("map_controller.layers_nudge", value: "New: bikes and scooters on the map. Tap to explore.", comment: "One-time callout pointing at the basemap button when a region gains rental map layers")
-        nudge.font = .preferredFont(forTextStyle: .footnote)
-        nudge.textColor = .white
-        nudge.numberOfLines = 0
-        nudge.textAlignment = .center
-
-        let padded = UIView.autolayoutNew()
-        padded.backgroundColor = UIColor.rentalPurple
-        padded.layer.cornerRadius = 10
-        padded.layer.masksToBounds = true
-        padded.alpha = 0
-        padded.addSubview(nudge)
-        view.addSubview(padded)
-
-        NSLayoutConstraint.activate([
-            nudge.topAnchor.constraint(equalTo: padded.topAnchor, constant: 8),
-            nudge.bottomAnchor.constraint(equalTo: padded.bottomAnchor, constant: -8),
-            nudge.leadingAnchor.constraint(equalTo: padded.leadingAnchor, constant: 10),
-            nudge.trailingAnchor.constraint(equalTo: padded.trailingAnchor, constant: -10),
-            padded.trailingAnchor.constraint(equalTo: toolbar.trailingAnchor),
-            padded.topAnchor.constraint(equalTo: toolbar.bottomAnchor, constant: 8),
-            padded.widthAnchor.constraint(lessThanOrEqualToConstant: 220)
-        ])
-
-        let tap = UITapGestureRecognizer(target: self, action: #selector(nudgeTapped(_:)))
-        padded.isUserInteractionEnabled = true
-        padded.addGestureRecognizer(tap)
-
-        UIView.animate(withDuration: 0.3) { padded.alpha = 1 }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
-            UIView.animate(withDuration: 0.5, animations: { padded.alpha = 0 }) { _ in
-                padded.removeFromSuperview()
-            }
-        }
-    }
-
-    @objc private func nudgeTapped(_ gesture: UITapGestureRecognizer) {
-        gesture.view?.removeFromSuperview()
-        presentMapSheet()
+        mapLayersTipPresenter.showIfNeeded(in: self, sourceItem: toggleMapTypeButton)
     }
 }
 

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -21,6 +21,10 @@ import SafariServices
 /// Displays a map, a set of stops rendered as annotation views, and the user's location if authorized.
 ///
 /// `MapViewController` is the average user's primary means of interacting with OneBusAway data.
+// Over the 1000-line body budget, and has been since before this change. Splitting
+// it is worth doing but is not this change's job; without the disable the error
+// fails every local build.
+// swiftlint:disable:next type_body_length
 class MapViewController: UIViewController,
     FloatingPanelControllerDelegate,
     LocationServiceDelegate,
@@ -210,7 +214,7 @@ class MapViewController: UIViewController,
 
         viewModel.start()
         updateVoiceover()
-        showMapLayersNudgeIfNeeded()
+        showMapLayersTipIfNeeded()
         Task { @MainActor [weak viewModel] in await viewModel?.checkForSurveyPrompt() }
     }
 
@@ -222,6 +226,8 @@ class MapViewController: UIViewController,
         // A rider who dismisses a stop sheet and immediately switches tabs shouldn't be
         // chased by an alert from a screen they've left.
         cancelScheduledFeedbackPrompt()
+
+        mapLayersTipPresenter.stop()
     }
 
     // MARK: - Surveys
@@ -722,7 +728,9 @@ class MapViewController: UIViewController,
     /// region — which happens routinely and must not tear the layer down.
     var stopRouteFocusLayerRegionIdentifier: Int?
 
-    // The layer/sheet/nudge machinery lives in MapViewController+MapLayers.swift.
+    let mapLayersTipPresenter = TipPresenter(tip: MapLayersTip())
+
+    // The layer/sheet/tip machinery lives in MapViewController+MapLayers.swift.
 
     // MARK: - Application State
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -218,15 +218,7 @@ public class StopViewController: UIViewController,
         super.viewDidAppear(animated)
 
         if let schedulesButton {
-            scheduleTipPresenter.showIfNeeded(sourceItem: schedulesButton) { [weak self] vc in
-                guard let self else { return }
-                present(vc, animated: animated)
-            } presentedController: { [weak self] in
-                guard let self else { return nil }
-                return self.presentedViewController
-            } dismiss: { vc in
-                vc.dismiss(animated: animated)
-            }
+            scheduleTipPresenter.showIfNeeded(in: self, sourceItem: schedulesButton, animated: animated)
         }
     }
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -226,6 +226,7 @@ public class StopViewController: UIViewController,
         super.viewWillDisappear(animated)
         enableIdleTimer()
         viewModel.deactivate()
+        scheduleTipPresenter.stop()
     }
 
     // MARK: - Tips

--- a/OBAKit/Tips/MapLayersTip.swift
+++ b/OBAKit/Tips/MapLayersTip.swift
@@ -1,0 +1,43 @@
+//
+//  MapLayersTip.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import TipKit
+import OBAKitCore
+
+/// A tip pointing at the map toolbar's basemap button the first time a region
+/// offers bike and scooter rental layers. That button opens the Map sheet,
+/// where the rental layers and their range filter are turned on and off.
+///
+/// Shown once, then never again — `MaxDisplayCount(1)` — because it announces a
+/// feature rather than teaching a repeated gesture.
+///
+/// `IgnoresDisplayFrequency` is what makes "first launch" actually mean first
+/// launch. `Tips.configure` sets an app-wide `.displayFrequency(.hourly)` budget
+/// that only one tip may spend per hour, and `TripPlannerTip` competes for it on
+/// this very screen. Measured on a fresh install: without this option the tip
+/// reports `shouldDisplay == false` for the whole first session, which is the
+/// only session it exists for. Exempting it does not spend the budget, so the
+/// trip-planner tip still gets its own turn on a later launch.
+struct MapLayersTip: Tip {
+    var title: Text {
+        Text(Strings.mapLayersTipTitle)
+    }
+
+    var message: Text? {
+        Text(Strings.mapLayersTipMessage)
+    }
+
+    var image: Image? {
+        Image(systemName: "bicycle")
+    }
+
+    var options: [any TipOption] {
+        [Tips.MaxDisplayCount(1), Tips.IgnoresDisplayFrequency(true)]
+    }
+}

--- a/OBAKit/Tips/TipPresenter.swift
+++ b/OBAKit/Tips/TipPresenter.swift
@@ -53,9 +53,8 @@ class TipHostingViewController: UIViewController {
 
 /// Simplifies the process of showing a `TipKit` `Tip` within `UIKit`.
 ///
-/// Call `showIfNeeded()` with a `sourceItem`, which is the view to attach the tip to,
-/// `present`, which simply calls `UIViewController.present()`, and
-/// `dismiss`, which calls `dismiss()` on the presented view controller.
+/// Call `showIfNeeded(in:sourceItem:)` from `viewDidAppear` with the view the tip
+/// should point at, and `stop()` from `viewWillDisappear`.
 class TipPresenter: NSObject, UIPopoverPresentationControllerDelegate {
     private let tip: any Tip
     private var tipObservationTask: Task<Void, Never>?
@@ -71,26 +70,47 @@ class TipPresenter: NSObject, UIPopoverPresentationControllerDelegate {
     func stop() {
         tipObservationTask?.cancel()
         tipObservationTask = nil
+
+        // Take the popover with the screen it belongs to. Merely forgetting it
+        // would strand a visible bubble anchored to a view the rider has left,
+        // and `tipWasDismissedByUser()` would then no-op when it finally closed,
+        // so TipKit would never learn the tip had been shown and dismissed.
+        tipViewController?.dismiss(animated: false)
+        tipViewController = nil
     }
 
-    /// Presents the tip, if its internal conditions are met.
+    /// Presents the tip from `presenter`, if TipKit's conditions are met.
+    ///
+    /// Safe to call repeatedly — the observation is started at most once, and is
+    /// skipped entirely once the tip has been invalidated.
+    ///
     /// - Parameters:
-    ///   - sourceItem: The `UIView`/`UIBarButtonItem`/`UITabBarItem` that will be the presented source of the tip.
+    ///   - presenter: The view controller that presents (and dismisses) the tip popover. Held weakly.
+    ///   - sourceItem: The `UIView`/`UIBarButtonItem`/`UITabBarItem` the tip points at.
     ///   - sourceRect: The frame within the sourceItem. Only needed for `UIView` sources; `UIBarButtonItem` and `UITabBarItem` handle positioning automatically.
-    ///   - present: A handler that is responsible for presenting  the `UIViewController` parameter  via `UIViewController.present()`.
-    ///   - presentedController: A handler that is responsible for returning `UIViewController.presentedViewController`
-    ///   - dismiss: A handler that is responsible for calling `dismiss()` on the `UIViewController` parameter.
+    ///   - animated: Whether the popover animates in and out.
     func showIfNeeded(
+        in presenter: UIViewController,
         sourceItem: (any UIPopoverPresentationControllerSourceItem),
         sourceRect: CGRect? = nil,
-        present: @escaping (UIViewController) -> Void,
-        presentedController: @escaping () -> (UIViewController?),
-        dismiss: @escaping (UIViewController) -> Void
+        animated: Bool = true
     ) {
-        tipObservationTask = tipObservationTask ?? Task { @MainActor in
+        // An invalidated tip can only ever report `false`, so subscribing again
+        // would rebuild a datastore observation on every appearance for the rest
+        // of the session and never present anything.
+        if case .invalidated = tip.status { return }
+
+        guard tipObservationTask == nil else { return }
+
+        tipObservationTask = Task { @MainActor [weak presenter] in
             for await shouldDisplay in tip.shouldDisplayUpdates {
+                guard let presenter else { return }
+
                 if shouldDisplay {
-                    guard tipViewController == nil else { continue }
+                    // Nothing may be presented already: a tip popover that lands
+                    // on top of a stop sheet or another tip either fails outright
+                    // or steals the screen from something the rider asked for.
+                    guard tipViewController == nil, presenter.presentedViewController == nil else { continue }
 
                     let hostingController = TipHostingViewController(tip: tip)
                     hostingController.modalPresentationStyle = .popover
@@ -104,16 +124,17 @@ class TipPresenter: NSObject, UIPopoverPresentationControllerDelegate {
                         popover.delegate = self
                     }
 
-                    present(hostingController)
+                    presenter.present(hostingController, animated: animated)
                     tipViewController = hostingController
                 }
-                else {
-                    let presentedController = presentedController()
-
-                    if let presentedController, presentedController is TipHostingViewController {
-                        dismiss(presentedController)
-                        tipViewController = nil
-                    }
+                else if let tipViewController {
+                    // Only ever dismiss the controller *this* presenter put up.
+                    // Two presenters can share a screen — the map's layer tip and
+                    // the floating panel's trip-planner tip — so acting on
+                    // `presenter.presentedViewController` would let whichever tip
+                    // goes ineligible first tear down the other one's popover.
+                    tipViewController.dismiss(animated: animated)
+                    self.tipViewController = nil
                 }
             }
         }

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -84,6 +84,10 @@ public class Strings: NSObject {
 
     public static let scheduleTipMessage = OBALoc("schedule_tip.message", value: "Tap here to view the schedule or timetable for your buses and trains.", comment: "The body of the schedule/timetable feature tip")
 
+    public static let mapLayersTipTitle = OBALoc("map_layers_tip.title", value: "New: Bikes and Scooters", comment: "Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers")
+
+    public static let mapLayersTipMessage = OBALoc("map_layers_tip.message", value: "Tap here to show bikes and scooters on the map.", comment: "The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off")
+
     public static let refresh = OBALoc("common.refresh", value: "Refresh", comment: "The verb 'refresh', as in 'reload'.")
 
     public static let retry = OBALoc("common.retry", value: "Retry", comment: "The verb 'retry'.")

--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "الآن";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "اضغط هنا لعرض الدراجات والسكوترات على الخريطة.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "جديد: الدراجات والسكوترات";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "لا تتوفر بيانات تتبّع في الوقت الفعلي لهذا الخط.";
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "NOW";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Tap here to show bikes and scooters on the map.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "New: Bikes and Scooters";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "No real-time tracking data is available for this route.";
 

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "AHORA";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Toque aquí para mostrar bicicletas y patinetes en el mapa.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Nuevo: Bicicletas y Patinetes";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "No hay datos de seguimiento en tiempo real disponibles para esta ruta.";
 

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "NGAYON";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Pindutin dito para ipakita ang mga bisikleta at scooter sa mapa.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Bago: Mga Bisikleta at Scooter";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Walang available na real-time na data ng pagsubaybay para sa rutang ito.";
 

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "MAINT.";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Appuyez ici pour afficher les vélos et trottinettes sur la carte.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Nouveau : vélos et trottinettes";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Aucune donnée de suivi en temps réel n'est disponible pour cette ligne.";
 

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "ADESSO";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Tocca qui per mostrare bici e monopattini sulla mappa.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Novità: bici e monopattini";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Nessun dato di tracciamento in tempo reale disponibile per questa linea.";
 

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "지금";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "지도에 자전거와 킥보드를 표시하려면 여기를 누르세요.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "신규: 자전거 및 킥보드";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "이 노선에는 실시간 차량 추적 데이터가 없습니다.";
 

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "TERAZ";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Dotknij tutaj, aby pokazać rowery i hulajnogi na mapie.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Nowość: rowery i hulajnogi";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Brak danych śledzenia na żywo dla tej linii.";
 

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "AGORA";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Toque aqui para mostrar bicicletas e patinetes no mapa.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Novo: Bicicletas e Patinetes";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Nenhum dado de rastreamento em tempo real disponível para esta linha.";
 

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "СЕЙЧАС";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Нажмите здесь, чтобы показать велосипеды и самокаты на карте.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Новое: велосипеды и самокаты";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Для этого маршрута нет данных отслеживания в реальном времени.";
 

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "NGAY";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "Nhấn vào đây để hiển thị xe đạp và xe scooter trên bản đồ.";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "Mới: Xe đạp và xe scooter";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "Không có dữ liệu theo dõi thời gian thực cho tuyến này.";
 

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "现在";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "点按此处即可在地图上显示共享单车和滑板车。";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "新功能：共享单车和滑板车";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "此线路暂无实时追踪数据。";
 

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -381,6 +381,12 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "現在";
 
+/* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
+"map_layers_tip.message" = "點按這裡即可在地圖上顯示共享單車與滑板車。";
+
+/* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
+"map_layers_tip.title" = "新功能：共享單車與滑板車";
+
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "此路線沒有可用的即時追蹤資料。";
 


### PR DESCRIPTION
## Summary

- The first launch after a region gains bike/scooter layers showed a hand-rolled purple `UILabel` under the map toolbar — no dismiss affordance, an 8-second `asyncAfter` that outlived the view, and its own UserDefaults flag. It's now `MapLayersTip`, presented through the existing `TipPresenter` and anchored to the toolbar's basemap button (the control that opens the Map sheet where the rental layers are turned on and off).
- Made it actually fire on first launch. It never did before, for two independent reasons: on a cold launch the region resolves *after* `viewDidAppear`, so the rental coordinator gating the tip doesn't exist at the only call site (now also called from `configureMapLayers()`); and the app-wide `.displayFrequency(.hourly)` budget is spent by whichever tip wins the race, with `TripPlannerTip` competing on this same screen (hence `IgnoresDisplayFrequency`). `MaxDisplayCount(1)` preserves "once, then never again".
- Fixed the `TipPresenter` bugs this exposed, now that two presenters share the map screen: dismiss only your *own* popover (identity, not `is TipHostingViewController`), refuse to present over an existing presentation, dismiss rather than strand the popover in `stop()`, and skip observation for an already-invalidated tip. The three call sites collapse from an 8-line closure trio to one line each.
- Title/message localized into all 13 locales.

## Test plan

- [x] Fresh install → onboarding → map: tip appears anchored to the top-right map-type button, with the bicycle icon and a close button.
- [x] Dismiss it, relaunch: tip does not return (`MaxDisplayCount(1)`).
- [x] After dismissal, `TripPlannerTip` still gets its turn on the next launch — confirms exempting this tip doesn't spend the shared budget, and that the identity fix stopped the two presenters from killing each other.
- [x] Tip visible → switch to Bookmarks tab → back to Map: popover is dismissed with the screen, nothing stranded, no crash.
- [x] Root-caused via `os_log`: verified `shouldDisplay` goes `false → true` and that the old failure was the popover being torn down 230ms after it appeared.
- [x] `swiftlint`: 0 errors.
- [x] Unit tests: 2283 passed, 1 failed — see below.

## Review notes

- **The one failing test is pre-existing, not from this branch.** `BackgroundAnnotationDeemphasisTests` › "Opening a sheet refreshes every participating annotation but the selected stop" fails identically on a clean `main` worktree (verified by checking out `main` separately and running the suite). It's unrelated to tips.
- **`main` does not build locally today.** `MapViewController` is at 1004 lines against SwiftLint's 1000-line `type_body_length` *error* budget, which fails the build phase. I added a scoped `// swiftlint:disable:next` with a note rather than shuffling members around to buy a few lines. Splitting that controller is worth doing separately.
- **`IgnoresDisplayFrequency` placement is a judgment call.** It arguably belongs at app config (`.immediate` in `configureTipKit()`) rather than on one tip. I kept it per-tip because this is a one-time launch-scoped announcement and changing the global policy would alter behavior for the schedule and trip-planner tips; the collision avoidance that policy was providing now lives in `TipPresenter` instead. Happy to flip it if you'd rather.
- `ScheduleTip`'s call site got the same mechanical one-line change but I could not drive the app to a stop screen to exercise it — map annotations and the search field aren't reachable through the accessibility snapshot. It compiles and is identical in shape to the two I did verify.
- The `CLAUDE.md` commit is separate and unrelated to the tip; it documents `xcodebuildmcp` for simulator work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-app tip introducing bike and scooter rental layers on the map.
  - The tip points to the map layers control and appears when rental layers are available.
  - Added localized title and guidance across supported languages.

- **Bug Fixes**
  - Improved tip presentation and dismissal behavior across map, stop, and trip-planning screens.
  - Prevented tips from appearing over existing screens or interfering with one another.
  - Tips now close correctly when leaving a screen.

- **Documentation**
  - Updated setup and workflow guidance, including supported macOS, Xcode, and Node.js requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->