### PR TITLE
De-emphasize the travelled half of the trip polyline

### DIFF
--- a/OBAKit/Mapping/Layers/TripFocus/TripRouteOverlays.swift
+++ b/OBAKit/Mapping/Layers/TripFocus/TripRouteOverlays.swift
@@ -1,0 +1,59 @@
+//
+//  TripRouteOverlays.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import UIKit
+
+/// Builds the two polylines `TripViewController` draws on its map: gray behind
+/// the vehicle, route-colored ahead of it. The SwiftUI trip page already does
+/// this via `TripFocusMapLayer`; this is the same split for the UIKit map
+/// `TripViewController` still owns.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/444
+enum TripRouteOverlays {
+
+    /// - Parameter fraction: `nil` when the trip reports no progress (schedule-
+    ///   only, or a feed that omits total distance). The whole shape is then
+    ///   ahead — the same choice `TripPageViewController` makes — rather than
+    ///   inventing a split point.
+    static func make(coordinates: [CLLocationCoordinate2D], fraction: Double?) -> [TripShapeOverlay] {
+        let split = fraction.map {
+            TripShapeSplit.split(coordinates: coordinates, atFraction: $0)
+        } ?? TripShapeSplit.Result(spent: [], ahead: coordinates)
+
+        var overlays: [TripShapeOverlay] = []
+        if split.spent.count >= 2 {
+            overlays.append(TripShapeOverlay.make(coordinates: split.spent, isSpent: true, isCasing: false))
+        }
+        if split.ahead.count >= 2 {
+            overlays.append(TripShapeOverlay.make(coordinates: split.ahead, isSpent: false, isCasing: false))
+        }
+        return overlays
+    }
+}
+
+/// Stroke for one half of the UIKit trip polyline. Extracted so a test can
+/// assert spent is gray and thinner without loading `TripViewController.view`.
+struct TripRouteOverlayAppearance {
+    let strokeColor: UIColor
+    let lineWidth: CGFloat
+
+    static func make(isSpent: Bool, routeColor: UIColor, needsIncreasedVisibility: Bool) -> TripRouteOverlayAppearance {
+        if isSpent {
+            return TripRouteOverlayAppearance(strokeColor: .systemGray3, lineWidth: 4)
+        }
+
+        var color = routeColor
+        if !needsIncreasedVisibility {
+            color = color.withAlphaComponent(0.75)
+        }
+        return TripRouteOverlayAppearance(strokeColor: color, lineWidth: 6)
+    }
+}

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -378,28 +378,26 @@ class TripViewController: UIViewController,
     public func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         let renderer = MKPolylineRenderer(polyline: overlay as! MKPolyline) // swiftlint:disable:this force_cast
 
-        // Tries to use an agency provided color, if available.
-        var strokeColor = tripConvertible.arrivalDeparture?.route.color ?? ThemeColors.shared.brand
-
-        // If the user has High Contrast or Reduce Transparency turned ON in iOS,
-        // don't apply the transparency to the stroke color.
+        let isSpent = (overlay as? TripShapeOverlay)?.isSpent ?? false
+        let routeColor = tripConvertible.arrivalDeparture?.route.color ?? ThemeColors.shared.brand
         let needsIncreasedVisibility =
             traitCollection.userInterfaceStyle == .dark ||
             traitCollection.accessibilityContrast == .high ||
             UIAccessibility.isReduceTransparencyEnabled
 
-        if !needsIncreasedVisibility {
-            strokeColor = strokeColor.withAlphaComponent(0.75)
-        }
-        renderer.strokeColor = strokeColor
-
-        renderer.lineWidth = 6.0
+        let appearance = TripRouteOverlayAppearance.make(
+            isSpent: isSpent,
+            routeColor: routeColor,
+            needsIncreasedVisibility: needsIncreasedVisibility
+        )
+        renderer.strokeColor = appearance.strokeColor
+        renderer.lineWidth = appearance.lineWidth
         renderer.lineCap = .round
 
         return renderer
     }
 
-    private var routeOverlay: MKPolyline?
+    private var routeOverlays: [MKOverlay] = []
     private var userLocationAnnotationView: PulsingAnnotationView?
 
     private var vehicleAnnotationView: PulsingAnnotationView?
@@ -509,16 +507,27 @@ private extension TripViewController {
 
     func bindRouteOverlay() {
         viewModel.$routePolylineCoordinates
-            .compactMap { $0 }
-            .sink { [weak self] coordinates in
-                guard let self else { return }
-                if let existing = routeOverlay { mapView.removeOverlay(existing) }
-                let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
-                routeOverlay = polyline
-                mapView.addOverlay(polyline)
+            .combineLatest(viewModel.$tripDetails)
+            .sink { [weak self] coordinates, details in
+                guard let self, let coordinates, coordinates.count >= 2 else { return }
+
+                let fraction = details?.status.flatMap {
+                    TripShapeSplit.fraction(
+                        distanceAlongTrip: $0.distanceAlongTrip,
+                        totalDistanceAlongTrip: $0.totalDistanceAlongTrip
+                    )
+                }
+
+                mapView.removeOverlays(routeOverlays)
+                let overlays = TripRouteOverlays.make(coordinates: coordinates, fraction: fraction)
+                routeOverlays = overlays
+                mapView.addOverlays(overlays)
+
                 if !mapView.hasBeenTouched {
+                    let fit = overlays.reduce(MKMapRect.null) { $0.union($1.boundingMapRect) }
+                    guard !fit.isNull else { return }
                     mapView.visibleMapRect = mapView.mapRectThatFits(
-                        polyline.boundingMapRect,
+                        fit,
                         edgePadding: UIEdgeInsets(top: 60, left: 20, bottom: 128, right: 20)
                     )
                 }

--- a/OBAKitTests/Mapping/TripFocus/TripRouteOverlayTests.swift
+++ b/OBAKitTests/Mapping/TripFocus/TripRouteOverlayTests.swift
@@ -1,0 +1,84 @@
+//
+//  TripRouteOverlayTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Testing
+@testable import OBAKit
+
+/// The classic `TripViewController` map used to draw one route-colored polyline
+/// for the whole trip. These tests lock the split the UIKit map must apply so
+/// the travelled half is a separate overlay from the half still ahead.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/444
+@MainActor
+@Suite(.serialized)
+struct TripRouteOverlayTests {
+
+    private func parallel(from startLon: Double, to endLon: Double, points: Int) -> [CLLocationCoordinate2D] {
+        precondition(points >= 2)
+        return (0..<points).map { index in
+            let t = Double(index) / Double(points - 1)
+            return CLLocationCoordinate2D(latitude: 47, longitude: startLon + (endLon - startLon) * t)
+        }
+    }
+
+    @Test func `No reported progress draws the whole shape as ahead`() {
+        let line = parallel(from: -122, to: -121.99, points: 4)
+        let overlays = TripRouteOverlays.make(coordinates: line, fraction: nil)
+
+        #expect(overlays.count == 1)
+        #expect(overlays[0].isSpent == false)
+        #expect(overlays[0].pointCount == 4)
+    }
+
+    @Test func `Mid-trip progress yields a spent overlay and an ahead overlay`() {
+        let line = parallel(from: -122, to: -121.99, points: 2)
+        let overlays = TripRouteOverlays.make(coordinates: line, fraction: 0.5)
+
+        #expect(overlays.count == 2)
+        #expect(overlays[0].isSpent == true)
+        #expect(overlays[1].isSpent == false)
+        #expect(overlays[0].pointCount == 2)
+        #expect(overlays[1].pointCount == 2)
+    }
+
+    @Test func `A trip that has not started has no spent overlay`() {
+        let line = parallel(from: -122, to: -121.99, points: 4)
+        let overlays = TripRouteOverlays.make(coordinates: line, fraction: 0)
+
+        #expect(overlays.count == 1)
+        #expect(overlays[0].isSpent == false)
+        #expect(overlays[0].pointCount == 4)
+    }
+
+    @Test func `A finished trip has no ahead overlay`() {
+        let line = parallel(from: -122, to: -121.99, points: 4)
+        let overlays = TripRouteOverlays.make(coordinates: line, fraction: 1)
+
+        #expect(overlays.count == 1)
+        #expect(overlays[0].isSpent == true)
+        #expect(overlays[0].pointCount == 4)
+    }
+
+    @Test func `Spent stroke is gray and thinner than the live half`() {
+        let spent = TripRouteOverlayAppearance.make(
+            isSpent: true,
+            routeColor: .red,
+            needsIncreasedVisibility: false
+        )
+        let ahead = TripRouteOverlayAppearance.make(
+            isSpent: false,
+            routeColor: .red,
+            needsIncreasedVisibility: false
+        )
+
+        #expect(spent.lineWidth < ahead.lineWidth)
+        #expect(spent.strokeColor != ahead.strokeColor)
+    }
+}


### PR DESCRIPTION
## Summary
- `TripViewController`'s map drew one route-colored `MKPolyline` for the entire shape. The SwiftUI trip page already splits that shape (`TripShapeSplit` + `TripFocusMapLayer`); the classic UIKit trip did not.
- The UIKit map now draws two `TripShapeOverlay`s from the same fraction: gray/thinner behind the vehicle, route color ahead. No progress (schedule-only / missing total distance) keeps the whole shape ahead — the same choice `TripPageViewController` already documents. There is no invented split point.
- Stroke is `TripRouteOverlayAppearance`, so tests do not load `TripViewController.view` (that path reads an unresolved `ArrivalDeparture.route`).

Refs #444.

## Test plan
- [x] `No reported progress draws the whole shape as ahead`
- [x] `Mid-trip progress yields a spent overlay and an ahead overlay`
- [x] `A trip that has not started has no spent overlay`
- [x] `A finished trip has no ahead overlay`
- [x] `Spent stroke is gray and thinner than the live half`
- [x] Existing `TripShapeSplitTests` still pass
- [ ] Manual (feature flag off / transfer path that still pushes `TripViewController`): open a live trip — behind the vehicle is gray, ahead is the route color. Schedule-only trip stays one color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip routes now visually distinguish completed portions from upcoming portions.
  * Route styling adapts to accessibility visibility settings and trip progress.
  * Map framing updates to include the full combined trip route and details.

* **Bug Fixes**
  * Improved route overlay updates when trip progress or route details change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->