### PR TITLE
Stop the map pin reset flash on pan

### DIFF
--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -649,70 +649,46 @@ public class MapRegionManager: NSObject,
 
         let existingAnnotations = mapView.annotations
         let existingStopIDs = Set(existingAnnotations.compactMap { ($0 as? Stop)?.id })
-        var affectedStopIDs: Set<StopID> = []
-
-        // Remove Stop annotations that now have a corresponding Bookmark
-        let stopAnnotationsToRemove = existingAnnotations.compactMap { annotation -> MKAnnotation? in
-            guard
-                let stop = annotation as? Stop,
-                bookmarksHash[stop.id] != nil
-            else {
-                return nil
-            }
-
-            affectedStopIDs.insert(stop.id)
-            return stop
+        let existingBookmarks = existingAnnotations.compactMap { annotation -> StopAnnotationSync.BookmarkRef? in
+            guard let bookmark = annotation as? Bookmark else { return nil }
+            return StopAnnotationSync.BookmarkRef(id: bookmark.id, stopID: bookmark.stopID)
         }
-
-        // Remove Bookmark annotations that are stale:
-        //   - The bookmark's stop no longer has ANY bookmark (deleted), OR
-        //   - The bookmark on the map is a different object than the current one (replaced)
-        let bookmarkAnnotationsToRemove = existingAnnotations.compactMap { annotation -> MKAnnotation? in
-            guard let bookmark = annotation as? Bookmark else {
-                return nil
-            }
-
-            guard let currentBookmark = bookmarksHash[bookmark.stopID] else {
-                // No bookmark exists for this stop anymore, remove the stale annotation
-                affectedStopIDs.insert(bookmark.stopID)
-                return bookmark
-            }
-
-            // If a different bookmark now represents this stop, remove the old one
-            if currentBookmark.id != bookmark.id {
-                affectedStopIDs.insert(bookmark.stopID)
-                return bookmark
-            }
-
+        let selectedStopIDs = Set(existingAnnotations.compactMap { annotation -> StopID? in
+            guard mapView.selectedAnnotations.contains(where: { $0 === annotation }) else { return nil }
+            if let stop = annotation as? Stop { return stop.id }
+            if let bookmark = annotation as? Bookmark { return bookmark.stopID }
             return nil
-        }
+        })
 
-        let allAnnotationsToRemove = stopAnnotationsToRemove + bookmarkAnnotationsToRemove
-        for annotation in allAnnotationsToRemove {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: existingStopIDs,
+            existingBookmarks: existingBookmarks,
+            incomingStopIDs: Set(stops.map(\.id)),
+            bookmarksByStopID: Dictionary(uniqueKeysWithValues: bookmarksHash.map { ($0.key, $0.value.id) }),
+            selectedStopIDs: selectedStopIDs,
+            isStopsLayerEnabled: isStopsLayerEnabled
+        )
+
+        let stopsToRemove = existingAnnotations.compactMap { $0 as? Stop }
+            .filter { changes.stopIDsToRemove.contains($0.id) }
+        let bookmarksToRemove = existingAnnotations.compactMap { $0 as? Bookmark }
+            .filter { changes.bookmarkIDsToRemove.contains($0.id) }
+        let annotationsToRemove: [MKAnnotation] = stopsToRemove + bookmarksToRemove
+
+        for annotation in annotationsToRemove {
             guard mapView.selectedAnnotations.contains(where: { $0 === annotation }) else { continue }
             mapView.deselectAnnotation(annotation, animated: false)
         }
-        mapView.removeAnnotations(allAnnotationsToRemove)
+        mapView.removeAnnotations(annotationsToRemove)
 
-        // Add new Bookmark annotations that aren't already on the map
-        // Check by bookmark ID (not just stopID) to correctly add replacements
-        let existingBookmarkIDs = Set(mapView.annotations.compactMap { ($0 as? Bookmark)?.id })
-        let bookmarksToAdd = bookmarksHash.values.filter {
-            !existingBookmarkIDs.contains($0.id)
-        }
-        mapView.addAnnotations(Array(bookmarksToAdd))
+        mapView.addAnnotations(bookmarksHash.values.filter { changes.bookmarkIDsToAdd.contains($0.id) })
+        mapView.addAnnotations(stops.filter { changes.stopIDsToAdd.contains($0.id) })
 
-        // Re-add Stop annotations for stops that no longer have bookmarks.
-        // With the stops layer toggled off, nothing is added — bookmarks are
-        // user content and stay visible regardless.
-        let stopsToAdd = isStopsLayerEnabled ? stops.filter {
-            !bookmarksHash.keys.contains($0.id) &&
-            !existingStopIDs.contains($0.id)
-        } : []
-        mapView.addAnnotations(stopsToAdd)
-
-        // Removing a sibling Stop for a bookmarked stopID shouldn't refresh a
-        // selected Bookmark — rebinding its view dismisses an open callout.
+        // A bookmark↔stop identity change still needs the surviving view rebound.
+        // Skip selected bookmarks: rebinding dismisses an open callout (#1266).
+        var affectedStopIDs = changes.stopIDsToRemove.union(
+            Set(bookmarksToRemove.map(\.stopID))
+        )
         let selectedBookmarkStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Bookmark)?.stopID })
         affectedStopIDs.subtract(selectedBookmarkStopIDs)
 
@@ -741,9 +717,11 @@ public class MapRegionManager: NSObject,
                 continue
             }
 
-            view.prepareForReuse()
+            // `prepareForReuse` is for views leaving the map. Calling it on a
+            // live pin clears the icon and is what the rider sees as a reset.
             view.annotation = annotation
             view.delegate = self
+            view.applyPresentation()
             mapViewDelegate?.mapRegionManager(self, customize: view)
         }
     }
@@ -1162,6 +1140,7 @@ public class MapRegionManager: NSObject,
 
         if let stopAnnotation = annotationView as? StopAnnotationView {
             stopAnnotation.delegate = self
+            stopAnnotation.applyPresentation()
             mapViewDelegate?.mapRegionManager(self, customize: stopAnnotation)
         }
 

--- a/OBAKit/Mapping/MapRegionManager.swift
+++ b/OBAKit/Mapping/MapRegionManager.swift
@@ -685,10 +685,10 @@ public class MapRegionManager: NSObject,
         mapView.addAnnotations(stops.filter { changes.stopIDsToAdd.contains($0.id) })
 
         // A bookmark↔stop identity change still needs the surviving view rebound.
-        // Skip selected bookmarks: rebinding dismisses an open callout (#1266).
-        var affectedStopIDs = changes.stopIDsToRemove.union(
-            Set(bookmarksToRemove.map(\.stopID))
-        )
+        // Only the identity-diff stop IDs — not viewport removals (those annotations
+        // are already gone, so scanning for them is wasted main-thread work on every
+        // pan). Skip selected bookmarks: rebinding dismisses an open callout (#1266).
+        var affectedStopIDs = Set(bookmarksToRemove.map(\.stopID))
         let selectedBookmarkStopIDs = Set(mapView.selectedAnnotations.compactMap { ($0 as? Bookmark)?.stopID })
         affectedStopIDs.subtract(selectedBookmarkStopIDs)
 
@@ -717,8 +717,9 @@ public class MapRegionManager: NSObject,
                 continue
             }
 
-            // `prepareForReuse` is for views leaving the map. Calling it on a
-            // live pin clears the icon and is what the rider sees as a reset.
+            // Re-apply presentation after identity rebinding. The icon flash this
+            // PR removes came from MapKit recycling views on unnecessary re-adds,
+            // not from `prepareForReuse` (which only clears the label stack).
             view.annotation = annotation
             view.delegate = self
             view.applyPresentation()

--- a/OBAKit/Mapping/StopAnnotationSync.swift
+++ b/OBAKit/Mapping/StopAnnotationSync.swift
@@ -1,0 +1,66 @@
+//
+//  StopAnnotationSync.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// The add/remove set `displayUniqueStopAnnotations` should apply. Extracted so
+/// a pan that returns the same stop IDs cannot re-add pins (MapKit then
+/// recycles views and the icons flash to the default image).
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/563
+enum StopAnnotationSync {
+
+    struct BookmarkRef: Equatable {
+        var id: UUID
+        var stopID: StopID
+    }
+
+    struct Changes: Equatable {
+        var stopIDsToRemove: Set<StopID>
+        var bookmarkIDsToRemove: Set<UUID>
+        var stopIDsToAdd: Set<StopID>
+        var bookmarkIDsToAdd: Set<UUID>
+    }
+
+    static func changes(
+        existingStopIDs: Set<StopID>,
+        existingBookmarks: [BookmarkRef],
+        incomingStopIDs: Set<StopID>,
+        bookmarksByStopID: [StopID: UUID],
+        selectedStopIDs: Set<StopID>,
+        isStopsLayerEnabled: Bool
+    ) -> Changes {
+        let wantedBookmarkIDs = Set(bookmarksByStopID.values)
+        let existingBookmarkIDs = Set(existingBookmarks.map(\.id))
+        let selectedBookmarkIDs = Set(
+            existingBookmarks
+                .filter { selectedStopIDs.contains($0.stopID) }
+                .map(\.id)
+        )
+
+        var bookmarkIDsToRemove = existingBookmarkIDs.subtracting(wantedBookmarkIDs)
+        bookmarkIDsToRemove.subtract(selectedBookmarkIDs)
+        let bookmarkIDsToAdd = wantedBookmarkIDs.subtracting(existingBookmarkIDs)
+
+        let bookmarkedStopIDs = Set(bookmarksByStopID.keys)
+        var wantedStopIDs: Set<StopID> = []
+        if isStopsLayerEnabled {
+            wantedStopIDs = incomingStopIDs.subtracting(bookmarkedStopIDs)
+        }
+        wantedStopIDs.formUnion(selectedStopIDs.subtracting(bookmarkedStopIDs))
+
+        return Changes(
+            stopIDsToRemove: existingStopIDs.subtracting(wantedStopIDs),
+            bookmarkIDsToRemove: bookmarkIDsToRemove,
+            stopIDsToAdd: wantedStopIDs.subtracting(existingStopIDs),
+            bookmarkIDsToAdd: bookmarkIDsToAdd
+        )
+    }
+}

--- a/OBAKit/Mapping/StopAnnotationSync.swift
+++ b/OBAKit/Mapping/StopAnnotationSync.swift
@@ -39,14 +39,12 @@ enum StopAnnotationSync {
     ) -> Changes {
         let wantedBookmarkIDs = Set(bookmarksByStopID.values)
         let existingBookmarkIDs = Set(existingBookmarks.map(\.id))
-        let selectedBookmarkIDs = Set(
-            existingBookmarks
-                .filter { selectedStopIDs.contains($0.stopID) }
-                .map(\.id)
-        )
 
-        var bookmarkIDsToRemove = existingBookmarkIDs.subtracting(wantedBookmarkIDs)
-        bookmarkIDsToRemove.subtract(selectedBookmarkIDs)
+        // Identity diff only — deleted bookmark, or a different bookmark now
+        // representing this stop. Do not exempt selection here; open-callout
+        // protection lives in `MapRegionManager` via
+        // `affectedStopIDs.subtract(selectedBookmarkStopIDs)`.
+        let bookmarkIDsToRemove = existingBookmarkIDs.subtracting(wantedBookmarkIDs)
         let bookmarkIDsToAdd = wantedBookmarkIDs.subtracting(existingBookmarkIDs)
 
         let bookmarkedStopIDs = Set(bookmarksByStopID.keys)

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -111,19 +111,19 @@ class StopAnnotationView: MKAnnotationView {
 
     public override func prepareForDisplay() {
         super.prepareForDisplay()
+        applyPresentation()
+    }
 
-        // The delegate's answer can change between displays — it reads a feature flag the user
-        // can flip mid-session — and a recycled view still carries the previous one.
+    /// Sets the icon before MapKit shows the view. `prepareForDisplay` can run
+    /// a frame later; leaving `image` nil for that frame is the default-pin flash.
+    func applyPresentation() {
         updateCalloutVisibility()
 
-        guard let delegate = delegate else {
-            return
-        }
+        guard let delegate else { return }
 
         if let bookmark = annotation as? Bookmark {
             prepareForDisplay(bookmark: bookmark, delegate: delegate)
-        }
-        else if let stop = annotation as? Stop {
+        } else if let stop = annotation as? Stop {
             prepareForDisplay(stop: stop, delegate: delegate)
         }
     }

--- a/OBAKitTests/Mapping/StopAnnotationSyncTests.swift
+++ b/OBAKitTests/Mapping/StopAnnotationSyncTests.swift
@@ -1,0 +1,101 @@
+//
+//  StopAnnotationSyncTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Pan used to add every newly fetched stop without removing ones that left
+/// the viewport. MapKit then recycled annotation views and every pin flashed
+/// to the default image. These tests fail if that extra-add returns.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/563
+@Suite(.serialized)
+struct StopAnnotationSyncTests {
+
+    private let bookmarkA = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
+    private let bookmarkB = UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!
+
+    @Test func `A pan that returns the same stop IDs adds and removes nothing`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: ["1", "2", "3"],
+            existingBookmarks: [],
+            incomingStopIDs: ["1", "2", "3"],
+            bookmarksByStopID: [:],
+            selectedStopIDs: [],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(changes.stopIDsToAdd.isEmpty)
+        #expect(changes.stopIDsToRemove.isEmpty)
+        #expect(changes.bookmarkIDsToAdd.isEmpty)
+        #expect(changes.bookmarkIDsToRemove.isEmpty)
+    }
+
+    @Test func `A pan removes stops that left the viewport and adds only new IDs`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: ["1", "2"],
+            existingBookmarks: [],
+            incomingStopIDs: ["2", "3"],
+            bookmarksByStopID: [:],
+            selectedStopIDs: [],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(changes.stopIDsToRemove == ["1"])
+        #expect(changes.stopIDsToAdd == ["3"])
+    }
+
+    @Test func `A selected stop that left the viewport is not removed`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: ["1", "2"],
+            existingBookmarks: [],
+            incomingStopIDs: ["3"],
+            bookmarksByStopID: [:],
+            selectedStopIDs: ["1"],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(!changes.stopIDsToRemove.contains("1"))
+        #expect(changes.stopIDsToRemove == ["2"])
+        #expect(changes.stopIDsToAdd == ["3"])
+    }
+
+    @Test func `A bookmark replaces the Stop annotation for that stop ID`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: ["1"],
+            existingBookmarks: [],
+            incomingStopIDs: ["1"],
+            bookmarksByStopID: ["1": bookmarkA],
+            selectedStopIDs: [],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(changes.stopIDsToRemove == ["1"])
+        #expect(changes.bookmarkIDsToAdd == [bookmarkA])
+        #expect(changes.stopIDsToAdd.isEmpty)
+    }
+
+    @Test func `Stops layer off adds no Stop annotations and keeps bookmarks`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: ["1"],
+            existingBookmarks: [.init(id: bookmarkA, stopID: "2")],
+            incomingStopIDs: ["1", "3"],
+            bookmarksByStopID: ["2": bookmarkA],
+            selectedStopIDs: [],
+            isStopsLayerEnabled: false
+        )
+
+        #expect(changes.stopIDsToRemove == ["1"])
+        #expect(changes.stopIDsToAdd.isEmpty)
+        #expect(changes.bookmarkIDsToAdd.isEmpty)
+        #expect(changes.bookmarkIDsToRemove.isEmpty)
+    }
+}

--- a/OBAKitTests/Mapping/StopAnnotationSyncTests.swift
+++ b/OBAKitTests/Mapping/StopAnnotationSyncTests.swift
@@ -98,4 +98,39 @@ struct StopAnnotationSyncTests {
         #expect(changes.bookmarkIDsToAdd.isEmpty)
         #expect(changes.bookmarkIDsToRemove.isEmpty)
     }
+
+    /// Deleting a bookmark whose pin is selected must still remove it. Exempting
+    /// selection from the identity-diff removal set left a stale bookmark pin and
+    /// let a Stop reappear underneath (#1306 review).
+    @Test func `A selected bookmark that was deleted is still removed`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: [],
+            existingBookmarks: [.init(id: bookmarkA, stopID: "1")],
+            incomingStopIDs: ["1"],
+            bookmarksByStopID: [:],
+            selectedStopIDs: ["1"],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(changes.bookmarkIDsToRemove == [bookmarkA])
+        #expect(changes.stopIDsToAdd == ["1"])
+        #expect(changes.bookmarkIDsToAdd.isEmpty)
+    }
+
+    /// Replacing the bookmark that represents a stop must remove the old ID even
+    /// while that pin is selected — otherwise two bookmark pins share one stop.
+    @Test func `A selected bookmark that was replaced is still removed`() {
+        let changes = StopAnnotationSync.changes(
+            existingStopIDs: [],
+            existingBookmarks: [.init(id: bookmarkA, stopID: "1")],
+            incomingStopIDs: ["1"],
+            bookmarksByStopID: ["1": bookmarkB],
+            selectedStopIDs: ["1"],
+            isStopsLayerEnabled: true
+        )
+
+        #expect(changes.bookmarkIDsToRemove == [bookmarkA])
+        #expect(changes.bookmarkIDsToAdd == [bookmarkB])
+        #expect(changes.stopIDsToAdd.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- Introduced in #519 (always-on bookmarks). Every camera settle added newly fetched stops and **never removed** ones that left the viewport. MapKit then recycled annotation views; pins flashed to the default image before the stop icon came back. Alan's note on #563: the AXVectorKit logs are unrelated.
- `StopAnnotationSync` is the add/remove set. A pan that returns the same stop IDs adds and removes nothing. Stops that leave the viewport are removed unless they are selected (same exemption #1266 already gives bookmarks). Bookmarks still replace the sibling `Stop` for that stop ID.
- `viewFor` sets the icon via `applyPresentation()` before the view is returned, so MapKit never displays a nil-image placeholder. `refreshAnnotationViews` no longer calls `prepareForReuse` on a live pin — that method is for views leaving the map.

Refs #563.

## Test plan
- [x] `A pan that returns the same stop IDs adds and removes nothing` — fails if production re-adds the current set
- [x] `A pan removes stops that left the viewport and adds only new IDs`
- [x] `A selected stop that left the viewport is not removed`
- [x] `A bookmark replaces the Stop annotation for that stop ID`
- [x] `Stops layer off adds no Stop annotations and keeps bookmarks`
- [x] `Display unique stop annotations preserves selected bookmark` (#1266) still passes — `prepareForReuseCount == 0`
- [x] `BackgroundAnnotationDeemphasisTests` still pass
- [ ] Manual: pan the map at stop-visible zoom — existing pins should not flash to a default marker. Bookmark a stop, tap it, pan — callout stays open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map annotation updates when panning or changing the visible area.
  * Preserved selected bookmark callouts while map views refresh.
  * Prevented bookmarked stops from appearing as duplicate stop annotations.
  * Ensured annotation views retain the correct presentation during updates and reuse.
* **Enhancements**
  * Stop annotations now update more efficiently by adding and removing only items affected by map changes.
  * Improved behavior when the stops layer is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->