### PR TITLE
Resolve the simulator by UDID in CLAUDE.md, not a hardcoded device name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,24 +152,15 @@ jobs:
     # the image ever carry a pre-SDK runtime alongside iOS 27, the tests must not
     # land on it — that's the isolated-deinit shim crash described in the download
     # step's note. Booting it here isolates first-boot cost from the test step.
+    #
+    # The selection itself lives in scripts/resolve_simulator_udid, shared with the
+    # commands CLAUDE.md documents so the two cannot drift apart. Note that the
+    # script's UDID reaches later steps only because it is written to $GITHUB_ENV
+    # here; a plain shell variable would not survive the step boundary.
     - name: Prepare iOS Simulator
       run: |
         set -euo pipefail
-        xcrun simctl list devices available -j > /tmp/devices.json
-        UDID=$(python3 <<'PY'
-        import json, re
-        data = json.load(open('/tmp/devices.json'))['devices']
-        def version(key):
-            m = re.search(r'iOS-(\d+)-(\d+)', key)
-            return (int(m.group(1)), int(m.group(2))) if m else (0, 0)
-        for key in sorted(data, key=version, reverse=True):
-            phones = [d for d in data[key] if d['name'].startswith('iPhone')]
-            if phones:
-                print(phones[0]['udid'])
-                break
-        PY
-        )
-        [ -n "$UDID" ] || { echo "::error::No available iPhone simulator found"; exit 1; }
+        UDID=$(scripts/resolve_simulator_udid)
         echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
         echo "Using simulator UDID: $UDID"
         xcrun simctl boot "$UDID" || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,35 @@ scripts/generate_project                # Defaults to OneBusAway if no app speci
 
 **Available Apps**: OneBusAway, KiedyBus
 
+### Picking a Simulator
+
+Both sections below need a simulator UDID. Resolve one first — the newest installed
+iOS runtime's first iPhone, which is the same selection `.github/workflows/tests.yml`
+makes:
+
+```bash
+SIMULATOR_UDID=$(xcrun simctl list devices available -j | python3 -c '
+import json, re, sys
+devices = json.load(sys.stdin)["devices"]
+def ios_version(runtime):
+    match = re.search(r"iOS-(\d+)-(\d+)", runtime)
+    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+for runtime in sorted(devices, key=ios_version, reverse=True):
+    phones = [d for d in devices[runtime] if d["name"].startswith("iPhone")]
+    if phones:
+        print(phones[0]["udid"])
+        break
+')
+: "${SIMULATOR_UDID:?No available iPhone simulator found — install a runtime in Xcode > Settings > Components}"
+```
+
+Address the device by `id=` rather than `name=`. A hardcoded `name=iPhone 17 Pro`
+fails two different ways behind the *same* misleading error — "Unable to find a device
+matching the provided destination specifier" — when the named device is not installed,
+and when it is ambiguous across multiple installed runtimes. `OS=latest` fixes only the
+second. It also goes stale on every Xcode release: this line has already been `iPhone 16`
+and `iPhone 17 Pro`.
+
 ### Building, Testing, and Driving the App: use `xcodebuildmcp`
 
 **Reach for `xcodebuildmcp` first.** It wraps `xcodebuild`/`xcrun simctl` and — critically —
@@ -33,10 +62,10 @@ Typical loop for verifying a change in the running app:
 
 ```bash
 scripts/generate_project OneBusAway                      # required before any build
-xcodebuildmcp simulator build-and-run --project-path OBAKit.xcodeproj --scheme App --simulator-id <UDID>
-xcodebuildmcp ui-automation snapshot-ui  --simulator-id <UDID> --style minimal
-xcodebuildmcp ui-automation touch        --simulator-id <UDID> --element-ref e26 --down --up --delay 0.08
-xcodebuildmcp ui-automation screenshot   --simulator-id <UDID> --return-format path --style minimal
+xcodebuildmcp simulator build-and-run --project-path OBAKit.xcodeproj --scheme App --simulator-id "$SIMULATOR_UDID"
+xcodebuildmcp ui-automation snapshot-ui  --simulator-id "$SIMULATOR_UDID" --style minimal
+xcodebuildmcp ui-automation touch        --simulator-id "$SIMULATOR_UDID" --element-ref e26 --down --up --delay 0.08
+xcodebuildmcp ui-automation screenshot   --simulator-id "$SIMULATOR_UDID" --return-format path --style minimal
 ```
 
 `snapshot-ui` returns semantic `elementRef` handles; drive those refs instead of
@@ -81,13 +110,13 @@ Use these only when `xcodebuildmcp` genuinely cannot do the job.
 
 ```bash
 # Build for testing
-xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild clean build-for-testing -scheme 'App' -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
 
 # Run unit tests
-xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
 
 # Run specific test class
-xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
 ```
 
 ### Code Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,17 @@ the two cannot drift apart.
 **Run it in the same shell invocation as the command that uses it.** It sets an
 ordinary shell variable, and this file's audience is Claude Code, whose Bash tool
 starts a fresh shell per call — the working directory persists, environment does
-not. Resolve it in one call and build in the next and you get
-`-destination "platform=iOS Simulator,id="`, which fails with exactly the error
-below. Each block that follows repeats the line for that reason; keep it when
+not. Resolve it in one call and build in the next and `$SIMULATOR_UDID` is empty,
+so `-destination "platform=iOS Simulator,id="` is rejected while parsing
+arguments, before any device lookup happens:
+
+```
+xcodebuild: error: missing value for key 'id' of option 'Destination'
+```
+
+That is neither of the errors in the table below, and it is the friendlier of the
+three — it names the problem rather than implying the device is missing. Each
+block that follows repeats the resolve line so this cannot arise; keep it when
 copying one.
 
 Address the device by `id=` rather than `name=`. A hardcoded name breaks two ways,
@@ -45,6 +53,10 @@ name fixes both:
 |---|---|
 | not installed | "Unable to find a device matching the provided destination specifier" |
 | ambiguous across runtimes | "The requested device could not be found because multiple devices matched the request" |
+
+The first is verified on the current toolchain. The second is the historical
+wording and has shifted between Xcode releases — treat the text as indicative and
+the cause as the reliable part. `id=` avoids both.
 
 A name also goes stale on every Xcode release: this file has already carried
 `iPhone 16` and `iPhone 17 Pro`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,32 +19,35 @@ scripts/generate_project                # Defaults to OneBusAway if no app speci
 
 ### Picking a Simulator
 
-Both sections below need a simulator UDID. Resolve one first — the newest installed
-iOS runtime's first iPhone, which is the same selection `.github/workflows/tests.yml`
-makes:
+Every command below needs a simulator UDID. Resolve one with:
 
 ```bash
-SIMULATOR_UDID=$(xcrun simctl list devices available -j | python3 -c '
-import json, re, sys
-devices = json.load(sys.stdin)["devices"]
-def ios_version(runtime):
-    match = re.search(r"iOS-(\d+)-(\d+)", runtime)
-    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
-for runtime in sorted(devices, key=ios_version, reverse=True):
-    phones = [d for d in devices[runtime] if d["name"].startswith("iPhone")]
-    if phones:
-        print(phones[0]["udid"])
-        break
-')
-: "${SIMULATOR_UDID:?No available iPhone simulator found — install a runtime in Xcode > Settings > Components}"
+SIMULATOR_UDID=$(scripts/resolve_simulator_udid)
 ```
 
-Address the device by `id=` rather than `name=`. A hardcoded `name=iPhone 17 Pro`
-fails two different ways behind the *same* misleading error — "Unable to find a device
-matching the provided destination specifier" — when the named device is not installed,
-and when it is ambiguous across multiple installed runtimes. `OS=latest` fixes only the
-second. It also goes stale on every Xcode release: this line has already been `iPhone 16`
-and `iPhone 17 Pro`.
+That prints the first iPhone on the newest installed iOS runtime — the same
+selection `.github/workflows/tests.yml` makes, from the same implementation, so
+the two cannot drift apart.
+
+**Run it in the same shell invocation as the command that uses it.** It sets an
+ordinary shell variable, and this file's audience is Claude Code, whose Bash tool
+starts a fresh shell per call — the working directory persists, environment does
+not. Resolve it in one call and build in the next and you get
+`-destination "platform=iOS Simulator,id="`, which fails with exactly the error
+below. Each block that follows repeats the line for that reason; keep it when
+copying one.
+
+Address the device by `id=` rather than `name=`. A hardcoded name breaks two ways,
+and they report differently — which is why neither `OS=latest` nor a fresh device
+name fixes both:
+
+| | Error |
+|---|---|
+| not installed | "Unable to find a device matching the provided destination specifier" |
+| ambiguous across runtimes | "The requested device could not be found because multiple devices matched the request" |
+
+A name also goes stale on every Xcode release: this file has already carried
+`iPhone 16` and `iPhone 17 Pro`.
 
 ### Building, Testing, and Driving the App: use `xcodebuildmcp`
 
@@ -62,6 +65,7 @@ Typical loop for verifying a change in the running app:
 
 ```bash
 scripts/generate_project OneBusAway                      # required before any build
+SIMULATOR_UDID=$(scripts/resolve_simulator_udid)         # same shell invocation as the commands below
 xcodebuildmcp simulator build-and-run --project-path OBAKit.xcodeproj --scheme App --simulator-id "$SIMULATOR_UDID"
 xcodebuildmcp ui-automation snapshot-ui  --simulator-id "$SIMULATOR_UDID" --style minimal
 xcodebuildmcp ui-automation touch        --simulator-id "$SIMULATOR_UDID" --element-ref e26 --down --up --delay 0.08
@@ -109,6 +113,8 @@ the single most expensive failure mode here. Install the CLI instead.
 Use these only when `xcodebuildmcp` genuinely cannot do the job.
 
 ```bash
+SIMULATOR_UDID=$(scripts/resolve_simulator_udid)         # same shell invocation as the commands below
+
 # Build for testing
 xcodebuild clean build-for-testing -scheme 'App' -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
 

--- a/scripts/resolve_simulator_udid
+++ b/scripts/resolve_simulator_udid
@@ -40,7 +40,14 @@ fi
 udid=$(printf '%s' "$devices_json" | python3 -c '
 import json, re, sys
 
-devices = json.load(sys.stdin)["devices"]
+# simctl can exit 0 and still emit something that is not the device list, so
+# report that as itself rather than letting a traceback reach the caller and be
+# mistaken for "no simulator installed".
+try:
+    devices = json.load(sys.stdin)["devices"]
+except (json.JSONDecodeError, KeyError, TypeError) as error:
+    sys.exit("error: could not parse the device list from "
+             "xcrun simctl list devices available -j: " + str(error))
 
 def ios_version(runtime):
     match = re.search(r"iOS-(\d+)-(\d+)", runtime)

--- a/scripts/resolve_simulator_udid
+++ b/scripts/resolve_simulator_udid
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Prints the UDID of the first available iPhone simulator on the newest
+# installed iOS runtime, for use in an xcodebuild `-destination`.
+#
+# Usage:
+#   SIMULATOR_UDID=$(scripts/resolve_simulator_udid)
+#   xcodebuild ... -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
+#
+# Address the device by `id=` rather than `name=`. A hardcoded name breaks two
+# ways, and the two report differently, which is why neither `OS=latest` nor a
+# fresh device name fixes both:
+#
+#   - not installed  -> "Unable to find a device matching the provided
+#                        destination specifier"
+#   - ambiguous across runtimes
+#                    -> "The requested device could not be found because
+#                        multiple devices matched the request"
+#
+# A name also goes stale on every Xcode release. CLAUDE.md has already carried
+# `iPhone 16` and `iPhone 17 Pro`; resolving at run time ends that cycle.
+#
+# Newest-runtime matters: if a pre-SDK runtime is installed alongside the
+# current one, tests must not land on it. See the isolated-deinit shim note in
+# .github/workflows/tests.yml.
+#
+# This is the single implementation shared by that workflow and by CLAUDE.md's
+# documented commands, so the two cannot drift apart.
+
+set -euo pipefail
+
+if ! devices_json=$(xcrun simctl list devices available -j 2>&1); then
+    echo "error: \`xcrun simctl\` failed:" >&2
+    echo "$devices_json" >&2
+    echo "If it reports a missing developer directory, point xcode-select at a full" >&2
+    echo "Xcode install: sudo xcode-select -s /Applications/Xcode.app" >&2
+    exit 1
+fi
+
+udid=$(printf '%s' "$devices_json" | python3 -c '
+import json, re, sys
+
+devices = json.load(sys.stdin)["devices"]
+
+def ios_version(runtime):
+    match = re.search(r"iOS-(\d+)-(\d+)", runtime)
+    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+
+for runtime in sorted(devices, key=ios_version, reverse=True):
+    if not re.search(r"iOS-\d+-\d+", runtime):
+        continue
+    phones = [d for d in devices[runtime] if d["name"].startswith("iPhone")]
+    if phones:
+        print(phones[0]["udid"])
+        break
+')
+
+if [ -z "$udid" ]; then
+    echo "error: no available iPhone simulator on any installed iOS runtime." >&2
+    echo "Install one in Xcode > Settings > Components, or run: xcodebuild -downloadPlatform iOS" >&2
+    exit 1
+fi
+
+printf '%s\n' "$udid"


### PR DESCRIPTION
Part 2 of #1303 — docs only.

The three `xcodebuild` examples hardcoded `name=iPhone 17 Pro`, which only works if you happen to have that exact simulator installed. It's also the second device name these lines have carried (`iPhone 16` before it), so renaming it again would just push the problem to the next Xcode release.

Switched them to select by UDID instead — the first iPhone on the newest installed runtime, which is what `tests.yml` already does. Added a short "Picking a Simulator" section so there's one place that resolves `$SIMULATOR_UDID`, and pointed the xcodebuildmcp examples at it too, since they asked for a `--simulator-id <UDID>` that nothing in the file explained how to get.

Easy to miss in review: `-destination` went from single to double quotes so the variable actually expands.

Tested by running the snippet straight out of the committed file — resolves in both zsh and bash, and `xcodebuild` accepts the destination.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting an iOS simulator and using its unique identifier with build commands.
  * Updated simulator examples to resolve the appropriate device automatically instead of relying on fixed device details.

* **CI Improvements**
  * Standardized simulator selection across test workflows and local guidance.
  * Automatically selects the first available iPhone simulator on the newest installed iOS runtime.
  * Runs linting independently from builds.
  * Provides clearer errors when simulator discovery fails or no compatible device is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->