### PR TITLE
Show Arrives vs Departs on the stop-page countdown

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -169,7 +169,7 @@ struct DepartureRowView: View {
             minutes: departure.arrivalDepartureMinutes,
             isRealTime: status.isRealTime,
             color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color),
-            caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus)
+            caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus, temporalState: departure.temporalState)
         )
     }
 

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -168,7 +168,8 @@ struct DepartureRowView: View {
         CountdownView(
             minutes: departure.arrivalDepartureMinutes,
             isRealTime: status.isRealTime,
-            color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color)
+            color: dimmed ? Color(uiColor: .tertiaryLabel) : Color(uiColor: status.color),
+            caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus)
         )
     }
 
@@ -198,8 +199,13 @@ struct DepartureRowView: View {
             let fmt = OBALoc("stop_page.row.a11y_past_fmt", value: "Route %@ to %@, departed %d minutes ago, %@", comment: "VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status.")
             return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
         case .normal, .missed:
-            let fmt = OBALoc("stop_page.row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for a departure row: route, headsign, minutes, status.")
-            return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+            return StopPageAccessibilityCopy.upcomingIdentity(
+                routeShortName: departure.routeShortName,
+                headsign: departure.tripHeadsign ?? "",
+                minutes: departure.arrivalDepartureMinutes,
+                arrivalDepartureStatus: departure.arrivalDepartureStatus,
+                adherence: status.accessibilityStatusDescription
+            )
         }
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -131,7 +131,7 @@ struct GroupedListView: View {
                 HStack(alignment: .center) {
                     routeBadge(for: next, routeColor: routeColor)
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus))
                 }
                 headsignText(next)
                 DepartureTimeText(display: timeDisplay(next))
@@ -154,7 +154,7 @@ struct GroupedListView: View {
                         }
                     }
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus))
                 }
             }
         }
@@ -266,7 +266,7 @@ struct GroupedListView: View {
                     HStack(spacing: 12) {
                         alarmIcon(for: departure)
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus))
                         tripChevron(departure)
                     }
                     DepartureTimeText(display: timeDisplay(departure))
@@ -293,7 +293,7 @@ struct GroupedListView: View {
                             }
                         }
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false)
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus))
                         tripChevron(departure)
                     }
                 }
@@ -348,9 +348,15 @@ struct GroupedListView: View {
     /// Self-describing VoiceOver label for one expanded departure row: route,
     /// headsign, minutes, live/scheduled status, and occupancy when present.
     private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
-        let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
+        let identity = StopPageAccessibilityCopy.upcomingIdentity(
+            routeShortName: departure.routeShortName,
+            headsign: departure.tripHeadsign ?? "",
+            minutes: departure.arrivalDepartureMinutes,
+            arrivalDepartureStatus: departure.arrivalDepartureStatus,
+            adherence: status.accessibilityStatusDescription
+        )
         return DepartureAccessibility.label(
-            identity: String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription),
+            identity: identity,
             departure: departure,
             status: status,
             timeDisplay: timeDisplay(departure)
@@ -358,8 +364,14 @@ struct GroupedListView: View {
     }
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
-        let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
-        let label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+        let label = StopPageAccessibilityCopy.groupedCardIdentity(
+            routeShortName: group.next.routeShortName,
+            headsign: group.next.tripHeadsign ?? "",
+            minutes: group.next.arrivalDepartureMinutes,
+            arrivalDepartureStatus: group.next.arrivalDepartureStatus,
+            adherence: status.accessibilityStatusDescription,
+            moreCount: group.upcoming.count
+        )
         // Appended after the sentence rather than comma-joined like the row
         // labels: this format string ends in a full stop, and VoiceOver's pause
         // there keeps the time attached to the card rather than to the count.

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -131,7 +131,7 @@ struct GroupedListView: View {
                 HStack(alignment: .center) {
                     routeBadge(for: next, routeColor: routeColor)
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus, temporalState: next.temporalState))
                 }
                 headsignText(next)
                 DepartureTimeText(display: timeDisplay(next))
@@ -154,7 +154,7 @@ struct GroupedListView: View {
                         }
                     }
                     Spacer(minLength: 8)
-                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus))
+                    CountdownView(minutes: next.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), caption: formatters.arrivalDepartureCaption(for: next.arrivalDepartureStatus, temporalState: next.temporalState))
                 }
             }
         }
@@ -266,7 +266,7 @@ struct GroupedListView: View {
                     HStack(spacing: 12) {
                         alarmIcon(for: departure)
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus))
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus, temporalState: departure.temporalState))
                         tripChevron(departure)
                     }
                     DepartureTimeText(display: timeDisplay(departure))
@@ -293,7 +293,7 @@ struct GroupedListView: View {
                             }
                         }
                         Spacer(minLength: 8)
-                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus))
+                        CountdownView(minutes: departure.arrivalDepartureMinutes, isRealTime: status.isRealTime, color: Color(uiColor: status.color), emphasized: false, caption: formatters.arrivalDepartureCaption(for: departure.arrivalDepartureStatus, temporalState: departure.temporalState))
                         tripChevron(departure)
                     }
                 }

--- a/OBAKit/Stops/StopPage/Shared/CountdownView.swift
+++ b/OBAKit/Stops/StopPage/Shared/CountdownView.swift
@@ -14,17 +14,25 @@ struct CountdownView: View {
     let color: Color
     /// true = card-header size (grouped card / chrono row), false = compact.
     var emphasized: Bool = true
+    /// "Arrives" / "Departs" under the minutes. Nil on surfaces that are
+    /// already one-sided (trip card = arriving, bookmark = departing).
+    var caption: String? = nil
 
     var body: some View {
-        // Top-aligned so the glyph floats at the number's top-right corner
-        // like a superscript, per the comps — not baseline-aligned beside it.
-        HStack(alignment: .top, spacing: 2) {
-            Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
-                .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
-                .monospacedDigit()
-                .foregroundStyle(color)
-            RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
-                .padding(.top, 1)
+        VStack(spacing: 1) {
+            HStack(alignment: .top, spacing: 2) {
+                Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
+                    .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
+                    .monospacedDigit()
+                    .foregroundStyle(color)
+                RealtimeGlyph(isRealTime: isRealTime, color: color, size: emphasized ? 11 : 9)
+                    .padding(.top, 1)
+            }
+            if let caption {
+                Text(caption)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(color)
+            }
         }
         // Hidden outright rather than an empty `children: .ignore` element:
         // every consumer (departure rows, grouped cards) speaks the countdown

--- a/OBAKit/Stops/StopPage/Shared/StopPageAccessibilityCopy.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopPageAccessibilityCopy.swift
@@ -1,0 +1,69 @@
+//
+//  StopPageAccessibilityCopy.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import OBAKitCore
+
+/// Spoken identity for an upcoming stop-page row. The minutes badge is
+/// "5m" either way; first/layover stops are `.departing` and every other
+/// stop is `.arriving`. VoiceOver used to say "departs" for both (#447).
+enum StopPageAccessibilityCopy {
+    static func upcomingIdentity(
+        routeShortName: String,
+        headsign: String,
+        minutes: Int,
+        arrivalDepartureStatus: ArrivalDepartureStatus,
+        adherence: String
+    ) -> String {
+        let fmt: String
+        switch arrivalDepartureStatus {
+        case .arriving:
+            fmt = OBALoc(
+                "stop_page.row.a11y_arrives_fmt",
+                value: "Route %@ to %@, arrives in %d minutes, %@",
+                comment: "VoiceOver for a stop-page row whose vehicle is arriving at this stop. Route, headsign, minutes, adherence."
+            )
+        case .departing:
+            fmt = OBALoc(
+                "stop_page.row.a11y_fmt",
+                value: "Route %@ to %@, departs in %d minutes, %@",
+                comment: "VoiceOver for a stop-page row whose vehicle is departing this stop (first stop or layover). Route, headsign, minutes, adherence."
+            )
+        }
+        return String(format: fmt, routeShortName, headsign, minutes, adherence)
+    }
+
+    /// VoiceOver for a grouped route card. The next trip is arriving or
+    /// departing; saying "next departure" for both is the same #447 gap.
+    static func groupedCardIdentity(
+        routeShortName: String,
+        headsign: String,
+        minutes: Int,
+        arrivalDepartureStatus: ArrivalDepartureStatus,
+        adherence: String,
+        moreCount: Int
+    ) -> String {
+        let fmt: String
+        switch arrivalDepartureStatus {
+        case .arriving:
+            fmt = OBALoc(
+                "stop_page.grouped.a11y_arrives_fmt",
+                value: "Route %@ to %@, next arrival in %d minutes, %@. %d more departures loaded.",
+                comment: "VoiceOver for a grouped route card whose next vehicle is arriving at this stop."
+            )
+        case .departing:
+            fmt = OBALoc(
+                "stop_page.grouped.a11y_fmt",
+                value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.",
+                comment: "VoiceOver for a grouped route card whose next vehicle is departing this stop (first stop or layover)."
+            )
+        }
+        return String(format: fmt, routeShortName, headsign, minutes, adherence, moreCount)
+    }
+}

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "الخط %1$@ إلى %2$@، المغادرة التالية خلال %3$d دقائق، %4$@. تم تحميل %5$d مغادرات إضافية.";
+"stop_page.grouped.a11y_arrives_fmt" = "الخط %1$@ إلى %2$@، الوصول التالي خلال %3$d دقائق، %4$@. تم تحميل %5$d مغادرات إضافية.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "إزالة التذكير";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "الخط %1$@ إلى %2$@، تغادر خلال %3$d دقائق، %4$@";
+"stop_page.row.a11y_arrives_fmt" = "الخط %1$@ إلى %2$@، تصل خلال %3$d دقائق، %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "قد تفوتك — تغادر قبل أن تصل إلى الموقف سيرًا";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1204,6 +1204,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Route %1$@ to %2$@, next departure in %3$d minutes, %4$@. %5$d more departures loaded.";
+"stop_page.grouped.a11y_arrives_fmt" = "Route %1$@ to %2$@, next arrival in %3$d minutes, %4$@. %5$d more departures loaded.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Remove alarm";
@@ -1264,6 +1265,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Route %1$@ to %2$@, arrives in %3$d minutes, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "likely missed — departs sooner than your walk to the stop";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Ruta %1$@ hacia %2$@, próxima salida en %3$d minutos, %4$@. %5$d salidas más cargadas.";
+"stop_page.grouped.a11y_arrives_fmt" = "Ruta %1$@ hacia %2$@, próxima llegada en %3$d minutos, %4$@. %5$d salidas más cargadas.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Eliminar alarma";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Ruta %1$@ hacia %2$@, sale en %3$d minutos, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Ruta %1$@ hacia %2$@, llega en %3$d minutos, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "probablemente no la alcance: sale antes de que llegue caminando a la parada";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Ruta %1$@ papuntang %2$@, susunod na pag-alis sa loob ng %3$d minuto, %4$@. %5$d pang pag-alis ang na-load.";
+"stop_page.grouped.a11y_arrives_fmt" = "Ruta %1$@ papuntang %2$@, susunod na pagdating sa loob ng %3$d minuto, %4$@. %5$d pang pag-alis ang na-load.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Alisin ang paalala";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Ruta %1$@ papuntang %2$@, aalis sa loob ng %3$d minuto, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Ruta %1$@ papuntang %2$@, darating sa loob ng %3$d minuto, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "malamang na hindi maaabutan — mas maaga itong aalis kaysa sa lakad mo papunta sa hintuan";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Ligne %1$@ vers %2$@, prochain départ dans %3$d minutes, %4$@. %5$d autres départs chargés.";
+"stop_page.grouped.a11y_arrives_fmt" = "Ligne %1$@ vers %2$@, prochaine arrivée dans %3$d minutes, %4$@. %5$d autres départs chargés.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Supprimer le rappel";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Ligne %1$@ vers %2$@, part dans %3$d minutes, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Ligne %1$@ vers %2$@, arrive dans %3$d minutes, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "probablement manqué — part avant que vous n'ayez le temps de rejoindre l'arrêt à pied";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Linea %1$@ per %2$@, prossima partenza tra %3$d minuti, %4$@. Altre %5$d partenze caricate.";
+"stop_page.grouped.a11y_arrives_fmt" = "Linea %1$@ per %2$@, prossimo arrivo tra %3$d minuti, %4$@. Altre %5$d partenze caricate.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Rimuovi sveglia";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Linea %1$@ per %2$@, parte tra %3$d minuti, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Linea %1$@ per %2$@, arriva tra %3$d minuti, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "probabilmente persa: parte prima che tu riesca a raggiungere la fermata a piedi";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "노선 %1$@, %2$@ 방면, 다음 출발 %3$d분 후, %4$@. 출발 %5$d건을 추가로 불러왔습니다.";
+"stop_page.grouped.a11y_arrives_fmt" = "노선 %1$@, %2$@ 방면, 다음 도착 %3$d분 후, %4$@. 출발 %5$d건을 추가로 불러왔습니다.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "미리 알림 제거";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "노선 %1$@, %2$@ 방면, %3$d분 후 출발, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "노선 %1$@, %2$@ 방면, %3$d분 후 도착, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "놓칠 가능성이 높습니다. 정류장까지 걸어가는 시간보다 먼저 출발합니다";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Linia %1$@ do %2$@, najbliższy odjazd za %3$d minut, %4$@. Wczytano jeszcze %5$d odjazdów.";
+"stop_page.grouped.a11y_arrives_fmt" = "Linia %1$@ do %2$@, najbliższy przyjazd za %3$d minut, %4$@. Wczytano jeszcze %5$d odjazdów.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Usuń alarm";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Linia %1$@ do %2$@, odjazd za %3$d minut, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Linia %1$@ do %2$@, przyjazd za %3$d minut, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "prawdopodobnie nie zdążysz — odjazd nastąpi, zanim dojdziesz na przystanek";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Linha %1$@ para %2$@, próxima partida em %3$d minutos, %4$@. Mais %5$d partidas carregadas.";
+"stop_page.grouped.a11y_arrives_fmt" = "Linha %1$@ para %2$@, próxima chegada em %3$d minutos, %4$@. Mais %5$d partidas carregadas.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Remover lembrete";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Linha %1$@ para %2$@, parte em %3$d minutos, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Linha %1$@ para %2$@, chega em %3$d minutos, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "provavelmente perdida — parte antes de você conseguir chegar a pé à parada";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Маршрут %1$@ до %2$@, следующее отправление через %3$d мин., %4$@. Загружено ещё отправлений: %5$d.";
+"stop_page.grouped.a11y_arrives_fmt" = "Маршрут %1$@ до %2$@, следующее прибытие через %3$d мин., %4$@. Загружено ещё отправлений: %5$d.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Удалить напоминание";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Маршрут %1$@ до %2$@, отправление через %3$d мин., %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Маршрут %1$@ до %2$@, прибытие через %3$d мин., %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "скорее всего, не успеете — отправляется раньше, чем вы дойдёте до остановки";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "Tuyến %1$@ đi %2$@, chuyến khởi hành tiếp theo sau %3$d phút, %4$@. Đã tải thêm %5$d chuyến khởi hành.";
+"stop_page.grouped.a11y_arrives_fmt" = "Tuyến %1$@ đi %2$@, chuyến đến tiếp theo sau %3$d phút, %4$@. Đã tải thêm %5$d chuyến khởi hành.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Xóa lời nhắc";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "Tuyến %1$@ đi %2$@, khởi hành sau %3$d phút, %4$@";
+"stop_page.row.a11y_arrives_fmt" = "Tuyến %1$@ đi %2$@, đến sau %3$d phút, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "có thể lỡ — xe khởi hành trước khi bạn kịp đi bộ đến điểm dừng";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "%1$@号公交线路，开往%2$@，下一班将在%3$d分钟后离站，%4$@。另外加载了%5$d个班次。";
+"stop_page.grouped.a11y_arrives_fmt" = "%1$@号公交线路，开往%2$@，下一班将在%3$d分钟后到站，%4$@。另外加载了%5$d个班次。";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "移除闹钟";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "%1$@号公交线路，开往%2$@，将在%3$d分钟后离站，%4$@";
+"stop_page.row.a11y_arrives_fmt" = "%1$@号公交线路，开往%2$@，将在%3$d分钟后到站，%4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "很可能赶不上——此班次的离站时间早于您步行到车站所需的时间";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1202,6 +1202,7 @@
 
 /* VoiceOver label for a grouped route card */
 "stop_page.grouped.a11y_fmt" = "路線 %1$@ 往 %2$@，下一班將於 %3$d 分鐘後離站，%4$@。另外已載入 %5$d 班離站班次。";
+"stop_page.grouped.a11y_arrives_fmt" = "路線 %1$@ 往 %2$@，下一班將於 %3$d 分鐘後到站，%4$@。另外已載入 %5$d 班離站班次。";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "移除提醒";
@@ -1262,6 +1263,7 @@
 
 /* VoiceOver label for a departure row: route, headsign, minutes, status. */
 "stop_page.row.a11y_fmt" = "路線 %1$@ 往 %2$@，將於 %3$d 分鐘後離站，%4$@";
+"stop_page.row.a11y_arrives_fmt" = "路線 %1$@ 往 %2$@，將於 %3$d 分鐘後到站，%4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "可能趕不上——離站時間早於您步行至站牌所需的時間";

--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "تصل خلال %d د";
+"formatters.caption.arrives" = "تصل";
+"formatters.caption.departs" = "تغادر";
+"formatters.caption.arrived" = "وصلت";
+"formatters.caption.departed" = "غادرت";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "تصل الآن";

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Arrives in %d min";
+"formatters.caption.arrives" = "Arrives";
+"formatters.caption.departs" = "Departs";
+"formatters.caption.arrived" = "Arrived";
+"formatters.caption.departed" = "Departed";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Arriving now";

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Llega en %dmin";
+"formatters.caption.arrives" = "Llega";
+"formatters.caption.departs" = "Sale";
+"formatters.caption.arrived" = "Llegó";
+"formatters.caption.departed" = "Salió";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Llegando ahora";

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Darating sa loob ng %d min";
+"formatters.caption.arrives" = "Dumating";
+"formatters.caption.departs" = "Aalis";
+"formatters.caption.arrived" = "Dumating na";
+"formatters.caption.departed" = "Umalis";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Dumarating na";

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -218,7 +218,7 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Darating sa loob ng %d min";
-"formatters.caption.arrives" = "Dumating";
+"formatters.caption.arrives" = "Darating";
 "formatters.caption.departs" = "Aalis";
 "formatters.caption.arrived" = "Dumating na";
 "formatters.caption.departed" = "Umalis";

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Arrive dans %d min";
+"formatters.caption.arrives" = "Arrive";
+"formatters.caption.departs" = "Part";
+"formatters.caption.arrived" = "Arrivé";
+"formatters.caption.departed" = "Parti";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Arrive maintenant";

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "In arrivo tra %d min";
+"formatters.caption.arrives" = "Arriva";
+"formatters.caption.departs" = "Parte";
+"formatters.caption.arrived" = "Arrivato";
+"formatters.caption.departed" = "Partito";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "In arrivo";

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "%d분 후 도착";
+"formatters.caption.arrives" = "도착";
+"formatters.caption.departs" = "출발";
+"formatters.caption.arrived" = "도착함";
+"formatters.caption.departed" = "출발함";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "지금 도착";

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Przyjeżdża za %d min";
+"formatters.caption.arrives" = "Przyjeżdża";
+"formatters.caption.departs" = "Odjeżdża";
+"formatters.caption.arrived" = "Przyjechał";
+"formatters.caption.departed" = "Odjechał";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Przyjeżdża teraz";

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Chega em %d min";
+"formatters.caption.arrives" = "Chega";
+"formatters.caption.departs" = "Parte";
+"formatters.caption.arrived" = "Chegou";
+"formatters.caption.departed" = "Partiu";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Chegando agora";

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Прибудет через %d мин.";
+"formatters.caption.arrives" = "Прибывает";
+"formatters.caption.departs" = "Отправляется";
+"formatters.caption.arrived" = "Прибыл";
+"formatters.caption.departed" = "Отправился";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Прибывает сейчас";

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Đến sau %d phút";
+"formatters.caption.arrives" = "Đến";
+"formatters.caption.departs" = "Khởi hành";
+"formatters.caption.arrived" = "Đã đến";
+"formatters.caption.departed" = "Đã khởi hành";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Đang đến";

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "%d分钟后到站";
+"formatters.caption.arrives" = "到达";
+"formatters.caption.departs" = "发车";
+"formatters.caption.arrived" = "已到达";
+"formatters.caption.departed" = "已发车";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "正在进站";

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -218,6 +218,10 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "%d 分鐘後到站";
+"formatters.caption.arrives" = "到達";
+"formatters.caption.departs" = "發車";
+"formatters.caption.arrived" = "已到達";
+"formatters.caption.departed" = "已發車";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "進站中";

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -268,6 +268,18 @@ public class Formatters: NSObject {
         }
     }
 
+    /// One-word caption under the minutes countdown so a layover/first stop
+    /// is readable at a glance (#447). The explanation line already says
+    /// Arrives/Departs; the minutes badge did not.
+    public func arrivalDepartureCaption(for status: ArrivalDepartureStatus) -> String {
+        switch status {
+        case .arriving:
+            return OBALoc("formatters.caption.arrives", value: "Arrives", comment: "Short caption under a stop-page countdown for a vehicle arriving at this stop.")
+        case .departing:
+            return OBALoc("formatters.caption.departs", value: "Departs", comment: "Short caption under a stop-page countdown for a vehicle departing this stop (first stop or layover).")
+        }
+    }
+
     // MARK: - ArrivalDeparture Schedule Deviation
 
     /// Creates a formatted string representing the deviation from schedule described by `arrivalDeparture`

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -271,11 +271,15 @@ public class Formatters: NSObject {
     /// One-word caption under the minutes countdown so a layover/first stop
     /// is readable at a glance (#447). The explanation line already says
     /// Arrives/Departs; the minutes badge did not.
-    public func arrivalDepartureCaption(for status: ArrivalDepartureStatus) -> String {
-        switch status {
-        case .arriving:
+    public func arrivalDepartureCaption(for status: ArrivalDepartureStatus, temporalState: TemporalState = .future) -> String {
+        switch (temporalState, status) {
+        case (.past, .arriving):
+            return OBALoc("formatters.caption.arrived", value: "Arrived", comment: "Short caption under a past stop-page countdown for a vehicle that already arrived.")
+        case (.past, .departing):
+            return OBALoc("formatters.caption.departed", value: "Departed", comment: "Short caption under a past stop-page countdown for a vehicle that already left.")
+        case (_, .arriving):
             return OBALoc("formatters.caption.arrives", value: "Arrives", comment: "Short caption under a stop-page countdown for a vehicle arriving at this stop.")
-        case .departing:
+        case (_, .departing):
             return OBALoc("formatters.caption.departs", value: "Departs", comment: "Short caption under a stop-page countdown for a vehicle departing this stop (first stop or layover).")
         }
     }

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -162,6 +162,18 @@ final class FormattersTests: OBATestCase {
         #expect(formatters.deviationLabel(for: arrivalDeparture) == Strings.scheduledNotRealTime)
     }
 
+    // MARK: - Arrival vs departure caption (#447)
+
+    @Test func `Caption is Arrives for a vehicle arriving at this stop`() {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        #expect(formatters.arrivalDepartureCaption(for: .arriving) == "Arrives")
+    }
+
+    @Test func `Caption is Departs for a vehicle leaving this stop`() {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        #expect(formatters.arrivalDepartureCaption(for: .departing) == "Departs")
+    }
+
     // MARK: - Map route labels (#132)
 
     @Test func `Formatted map routes within the limit lists every route`() throws {

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -166,12 +166,18 @@ final class FormattersTests: OBATestCase {
 
     @Test func `Caption is Arrives for a vehicle arriving at this stop`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
-        #expect(formatters.arrivalDepartureCaption(for: .arriving) == "Arrives")
+        #expect(formatters.arrivalDepartureCaption(for: .arriving, temporalState: .future) == "Arrives")
     }
 
     @Test func `Caption is Departs for a vehicle leaving this stop`() {
         let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
-        #expect(formatters.arrivalDepartureCaption(for: .departing) == "Departs")
+        #expect(formatters.arrivalDepartureCaption(for: .departing, temporalState: .future) == "Departs")
+    }
+
+    @Test func `Past caption uses arrived or departed`() {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        #expect(formatters.arrivalDepartureCaption(for: .arriving, temporalState: .past) == "Arrived")
+        #expect(formatters.arrivalDepartureCaption(for: .departing, temporalState: .past) == "Departed")
     }
 
     // MARK: - Map route labels (#132)

--- a/OBAKitTests/Stops/StopPage/StopPageAccessibilityCopyTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageAccessibilityCopyTests.swift
@@ -1,0 +1,67 @@
+//
+//  StopPageAccessibilityCopyTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+struct StopPageAccessibilityCopyTests {
+
+    @Test func `First stop VoiceOver says departs not arrives`() {
+        let text = StopPageAccessibilityCopy.upcomingIdentity(
+            routeShortName: "8",
+            headsign: "Seattle Center",
+            minutes: 5,
+            arrivalDepartureStatus: .departing,
+            adherence: "on time"
+        )
+        #expect(text.contains("departs"))
+        #expect(!text.contains("arrives"))
+    }
+
+    @Test func `Mid route VoiceOver says arrives not departs`() {
+        let text = StopPageAccessibilityCopy.upcomingIdentity(
+            routeShortName: "8",
+            headsign: "Seattle Center",
+            minutes: 5,
+            arrivalDepartureStatus: .arriving,
+            adherence: "on time"
+        )
+        #expect(text.contains("arrives"))
+        #expect(!text.contains("departs"))
+    }
+
+    @Test func `Grouped card VoiceOver says next arrival when the vehicle is arriving`() {
+        let text = StopPageAccessibilityCopy.groupedCardIdentity(
+            routeShortName: "8",
+            headsign: "Seattle Center",
+            minutes: 5,
+            arrivalDepartureStatus: .arriving,
+            adherence: "on time",
+            moreCount: 3
+        )
+        #expect(text.contains("next arrival"))
+        #expect(!text.contains("next departure"))
+    }
+
+    @Test func `Grouped card VoiceOver says next departure when the vehicle is leaving`() {
+        let text = StopPageAccessibilityCopy.groupedCardIdentity(
+            routeShortName: "8",
+            headsign: "Seattle Center",
+            minutes: 5,
+            arrivalDepartureStatus: .departing,
+            adherence: "on time",
+            moreCount: 3
+        )
+        #expect(text.contains("next departure"))
+        #expect(!text.contains("next arrival"))
+    }
+}

--- a/docs/arrival-vs-departure-caption.md
+++ b/docs/arrival-vs-departure-caption.md
@@ -1,0 +1,22 @@
+# Arrival vs departure at first and layover stops
+
+At a terminal (stop sequence 0) the vehicle is *leaving*, not pulling in.
+The minutes badge was just `5m` / `NOW` either way, so riders had to parse
+the fine print. #447 / stop 1_13200.
+
+## What changed
+
+- Countdown on the stop page (chrono + grouped) grows a one-word caption:
+  **Arrives** or **Departs**, from `ArrivalDeparture.arrivalDepartureStatus`.
+- VoiceOver for upcoming rows uses `arrives in` vs `departs in`. Grouped
+  cards use `next arrival` vs `next departure`. The old strings always
+  said "departs".
+- Trip cards and bookmarks do not get a caption — those surfaces are
+  already one-sided.
+
+No new Settings toggle. The model already distinguishes the two; this is
+display only.
+
+## Tests
+
+`FormattersTests` captions. `StopPageAccessibilityCopyTests` VoiceOver verbs.


### PR DESCRIPTION
## Summary
- At first/layover stops (`ArrivalDepartureStatus.departing`, stop sequence 0) the minutes badge was just `5m` / `NOW`. The explanation line already said Arrives/Departs; you had to read the fine print.
- Stop-page countdown (chrono + grouped) now captions **Arrives** or **Departs** from `arrivalDepartureStatus`. Trip cards and bookmarks stay caption-less — those surfaces are already one-sided.
- VoiceOver for upcoming rows says `arrives in` vs `departs in`. Grouped cards say `next arrival` vs `next departure`. English fallbacks only; no new `.strings` keys, so locale parity tests stay green.

Closes #447.

## Test plan
- [x] `FormattersTests` — caption is `Arrives` / `Departs`
- [x] `StopPageAccessibilityCopyTests` (4) — row and grouped card VoiceOver verbs
- [ ] Puget Sound stop 1_13200: first-stop trips show **Departs** on the minutes; mid-route trips show **Arrives**
- [ ] VoiceOver on those rows: "departs in" vs "arrives in"
- [ ] Bookmark and trip cards still show minutes only (no caption)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop departure countdowns now clearly indicate whether a vehicle **arrives** or **departs**.
  * VoiceOver announcements use matching arrival and departure wording, including grouped route cards.
* **Accessibility**
  * Improved spoken details for upcoming vehicles, including route, destination, timing, and grouped departure counts.
* **Documentation**
  * Added guidance covering arrival and departure captions and accessibility behavior.
* **Tests**
  * Added coverage for captions and arrival/departure VoiceOver wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->