### PR TITLE
Open the map on the selected region, not GPS

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -751,6 +751,14 @@ class MapViewController: UIViewController,
             return
         }
 
+        // Same rule as launch: don't yank a rider in another city onto GPS
+        // just because the app sat in the background for ten minutes (#615).
+        if let region = application.regionsService.currentRegion,
+           let location = application.locationService.currentLocation,
+           !region.contains(location: location) {
+            return
+        }
+
         centerMapOnUserLocation()
     }
 
@@ -1522,13 +1530,36 @@ class MapViewController: UIViewController,
 
     /// Updates the visible area on the map view based on the user's selected `Region` and current location.
     private func updateVisibleMapRect() {
+        applyLaunchCamera(userLocation: application.locationService.currentLocation)
+    }
+
+    /// Frames GPS when it sits in the selected region; otherwise the region's
+    /// service rect (or last in-region viewport). The first location fix used
+    /// to call `programmaticallyUpdateVisibleMapRegion` unconditionally, which
+    /// is why a Taipei GPS with Puget Sound selected opened on Taipei (#615).
+    private func applyLaunchCamera(userLocation: CLLocation?) {
         guard let currentRegion = application.regionsService.currentRegion else { return }
 
-        if let location = application.locationService.currentLocation, promptUserOnRegionMismatch {
-            if currentRegion.contains(location: location) {
-                programmaticallyUpdateVisibleMapRegion(location: location)
+        switch LaunchMapCamera.target(
+            selectedRegion: currentRegion,
+            userLocation: userLocation,
+            lastVisibleMapRect: mapRegionManager.lastVisibleMapRect
+        ) {
+        case .userLocation:
+            if let userLocation {
+                programmaticallyUpdateVisibleMapRegion(location: userLocation)
             }
-            else {
+        case .mapRect(let rect, let showMismatch):
+            if !initialMapChangeMade {
+                mapRegionManager.mapView.visibleMapRect = rect
+                // Latch on mismatch so the next GPS callback cannot yank the
+                // camera to the device. No GPS yet: leave the latch open so a
+                // later in-region fix can still zoom in for stops.
+                if showMismatch {
+                    initialMapChangeMade = true
+                }
+            }
+            if showMismatch && promptUserOnRegionMismatch {
                 promptUserOnRegionMismatch = false
                 if let regionMismatchBulletin = RegionMismatchBulletin(application: application),
                    let uiApp = application.delegate?.uiApplication {
@@ -1536,12 +1567,6 @@ class MapViewController: UIViewController,
                     self.regionMismatchBulletin?.show(in: uiApp)
                 }
             }
-        }
-        else if let lastVisibleRegion = mapRegionManager.lastVisibleMapRect {
-            mapRegionManager.mapView.visibleMapRect = lastVisibleRegion
-        }
-        else {
-            mapRegionManager.mapView.visibleMapRect = currentRegion.serviceRect
         }
     }
 
@@ -1556,7 +1581,7 @@ class MapViewController: UIViewController,
     }
 
     public func locationService(_ service: LocationService, locationChanged location: CLLocation) {
-        programmaticallyUpdateVisibleMapRegion(location: location)
+        applyLaunchCamera(userLocation: location)
     }
 
     // MARK: - Context Menus

--- a/OBAKit/Regions/RegionMismatchBulletin.swift
+++ b/OBAKit/Regions/RegionMismatchBulletin.swift
@@ -18,7 +18,11 @@ class RegionMismatchBulletin: NSObject {
     private let page: ThemedBulletinPage
     private let application: Application
 
-    init?(application: Application) {
+    init?(
+        application: Application,
+        onChangedPhysicalRegion: (() -> Void)? = nil,
+        onShowSelectedRegionOnMap: (() -> Void)? = nil
+    ) {
         guard
             let currentRegion = application.regionsService.currentRegion,
             let physicalRegion = application.regionsService.physicallyLocatedRegion
@@ -42,6 +46,7 @@ class RegionMismatchBulletin: NSObject {
 
             self.application.regionsService.currentRegion = physicalRegion
             self.application.regionsService.automaticallySelectRegion = true
+            onChangedPhysicalRegion?()
             self.bulletinManager.dismissBulletin()
         }
 
@@ -50,7 +55,11 @@ class RegionMismatchBulletin: NSObject {
         page.alternativeHandler = { [weak self] _ in
             guard let self = self else { return }
 
-            self.application.mapRegionManager.mapView.visibleMapRect = currentRegion.serviceRect
+            if let onShowSelectedRegionOnMap {
+                onShowSelectedRegionOnMap()
+            } else {
+                self.application.mapRegionManager.mapView.visibleMapRect = currentRegion.serviceRect
+            }
             self.bulletinManager.dismissBulletin()
         }
     }

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -49,6 +49,7 @@ struct MapPanelRootView: View {
     @State private var needsInitialRecenter = false
     @State private var regionMismatchBulletin: RegionMismatchBulletin?
     @State private var didPromptRegionMismatch = false
+    @StateObject private var mismatchCamera = RegionMismatchCameraActions()
 
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.colorScheme) private var colorScheme
@@ -203,6 +204,18 @@ struct MapPanelRootView: View {
         // from `reloadStopAnnotations`, i.e. on a region change.
         .onChange(of: mapViewModel.mapType) { _, _ in
             recomputeStopLabels()
+        }
+        .onChange(of: mismatchCamera.applyLaunch) { _, flag in
+            guard flag else { return }
+            mismatchCamera.applyLaunch = false
+            applyLaunchCamera()
+        }
+        .onChange(of: mismatchCamera.showSelectedServiceRect) { _, flag in
+            guard flag else { return }
+            mismatchCamera.showSelectedServiceRect = false
+            guard let selected = application.currentRegion else { return }
+            cameraPosition = .rect(selected.serviceRect)
+            viewportRecorder.record(selected.serviceRect)
         }
         .onChange(of: selectedStopID) { _, id in
             guard let id else { return }
@@ -508,7 +521,15 @@ extension MapPanelRootView {
         guard !didPromptRegionMismatch else { return }
         didPromptRegionMismatch = true
         guard
-            let bulletin = RegionMismatchBulletin(application: application),
+            let bulletin = RegionMismatchBulletin(
+                application: application,
+                onChangedPhysicalRegion: { [mismatchCamera] in
+                    mismatchCamera.applyLaunch = true
+                },
+                onShowSelectedRegionOnMap: { [mismatchCamera] in
+                    mismatchCamera.showSelectedServiceRect = true
+                }
+            ),
             let uiApp = application.delegate?.uiApplication
         else { return }
         regionMismatchBulletin = bulletin
@@ -591,3 +612,12 @@ extension MapPanelRootView {
     }
 
 }
+
+/// Holds one-shot camera requests from `RegionMismatchBulletin`. The bulletin
+/// cannot write `MapCameraPosition` itself — that lives in SwiftUI `@State` —
+/// so buttons flip these flags and the view applies them in `.onChange`.
+private final class RegionMismatchCameraActions: ObservableObject {
+    @Published var applyLaunch = false
+    @Published var showSelectedServiceRect = false
+}
+

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -47,6 +47,8 @@ struct MapPanelRootView: View {
     /// first reported (non-zero) size, in which case the recenter must be
     /// retried when the size lands.
     @State private var needsInitialRecenter = false
+    @State private var regionMismatchBulletin: RegionMismatchBulletin?
+    @State private var didPromptRegionMismatch = false
 
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.colorScheme) private var colorScheme
@@ -102,10 +104,26 @@ struct MapPanelRootView: View {
         self.factory = factory
         self.viewportRecorder = MapViewportRecorder(application: application)
 
-        // With no location fix, frame the current transit region rather than
-        // letting `.automatic` frame the bookmark annotations.
+        // Frame the selected region unless GPS is already inside it.
+        // `.userLocation` follows the device, which is what opened Taipei
+        // over Puget Sound (#615).
         let fallback: MapCameraPosition = application.currentRegion.map { .rect($0.serviceRect) } ?? .automatic
-        _cameraPosition = State(initialValue: .userLocation(fallback: fallback))
+        let initialPosition: MapCameraPosition
+        if let selected = application.currentRegion {
+            switch LaunchMapCamera.target(
+                selectedRegion: selected,
+                userLocation: application.locationService.currentLocation,
+                lastVisibleMapRect: application.mapRegionManager.lastVisibleMapRect
+            ) {
+            case .userLocation:
+                initialPosition = .userLocation(fallback: fallback)
+            case .mapRect(let rect, _):
+                initialPosition = .rect(rect)
+            }
+        } else {
+            initialPosition = fallback
+        }
+        _cameraPosition = State(initialValue: initialPosition)
 
         // A returning user already has a fix here, so the `.onChange` below
         // never fires — the flag is already `true` and never transitions. Seed
@@ -456,14 +474,45 @@ extension MapPanelRootView {
 
     // MARK: - Actions
 
-    /// Performs the once-per-launch recenter on the user's first location fix,
-    /// waiting out the `mapSize == .zero` window: called both when the fix
-    /// arrives and when the Map reports a size, and only consumes the flag when
-    /// a recenter can actually happen.
+    /// One-shot launch camera: GPS inside the selected region zooms to the
+    /// user (nearby stops); GPS outside frames the region (#615). The locate
+    /// button still calls `centerOnUser()`.
     private func attemptInitialRecenter() {
         guard needsInitialRecenter, mapSize != .zero else { return }
         needsInitialRecenter = false
-        centerOnUser()
+        applyLaunchCamera()
+    }
+
+    private func applyLaunchCamera() {
+        guard let selected = application.currentRegion else {
+            centerOnUser()
+            return
+        }
+        switch LaunchMapCamera.target(
+            selectedRegion: selected,
+            userLocation: application.locationService.currentLocation,
+            lastVisibleMapRect: application.mapRegionManager.lastVisibleMapRect
+        ) {
+        case .userLocation:
+            centerOnUser()
+        case .mapRect(let rect, let showMismatch):
+            cameraPosition = .rect(rect)
+            viewportRecorder.record(rect)
+            if showMismatch {
+                presentRegionMismatchIfNeeded()
+            }
+        }
+    }
+
+    private func presentRegionMismatchIfNeeded() {
+        guard !didPromptRegionMismatch else { return }
+        didPromptRegionMismatch = true
+        guard
+            let bulletin = RegionMismatchBulletin(application: application),
+            let uiApp = application.delegate?.uiApplication
+        else { return }
+        regionMismatchBulletin = bulletin
+        bulletin.show(in: uiApp)
     }
 
     private func centerOnUser() {

--- a/OBAKitCore/Location/LaunchMapCamera.swift
+++ b/OBAKitCore/Location/LaunchMapCamera.swift
@@ -1,0 +1,51 @@
+//
+//  LaunchMapCamera.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+import MapKit
+
+/// Launch (and first-fix) camera for the map. GPS inside the selected region
+/// still zooms to the user so nearby stops appear. GPS outside must not win
+/// over the region the rider picked (#615). The locate button is a separate
+/// path and always centers on the user.
+public enum LaunchMapCamera {
+
+    public enum Target {
+        /// Device is inside the selected region's service rect.
+        case userLocation
+        /// Last in-region viewport, or the region's service rect.
+        case mapRect(MKMapRect, showRegionMismatch: Bool)
+    }
+
+    public static func target(
+        selectedRegion: Region,
+        userLocation: CLLocation?,
+        lastVisibleMapRect: MKMapRect?
+    ) -> Target {
+        if let userLocation, selectedRegion.contains(location: userLocation) {
+            return .userLocation
+        }
+
+        let showMismatch = userLocation != nil
+        let rect: MKMapRect
+        if let lastVisibleMapRect {
+            if showMismatch {
+                rect = lastVisibleMapRect.intersects(selectedRegion.serviceRect)
+                    ? lastVisibleMapRect
+                    : selectedRegion.serviceRect
+            } else {
+                rect = lastVisibleMapRect
+            }
+        } else {
+            rect = selectedRegion.serviceRect
+        }
+        return .mapRect(rect, showRegionMismatch: showMismatch)
+    }
+}

--- a/OBAKitTests/Application/Mapping/LaunchMapCameraTests.swift
+++ b/OBAKitTests/Application/Mapping/LaunchMapCameraTests.swift
@@ -46,7 +46,10 @@ struct LaunchMapCameraTests {
     }
 
     @Test func `GPS outside prefers a last viewport that still sits in the region`() {
-        let last = pugetSound.serviceRect
+        let last = TestData.seattleMapRect
+        #expect(last.intersects(pugetSound.serviceRect))
+        #expect(!MKMapRectEqualToRect(last, pugetSound.serviceRect))
+
         let target = LaunchMapCamera.target(
             selectedRegion: pugetSound,
             userLocation: TestData.mockTampaLocation,
@@ -57,6 +60,7 @@ struct LaunchMapCameraTests {
             return
         }
         #expect(MKMapRectEqualToRect(rect, last))
+        #expect(!MKMapRectEqualToRect(rect, pugetSound.serviceRect))
         #expect(showMismatch)
     }
 

--- a/OBAKitTests/Application/Mapping/LaunchMapCameraTests.swift
+++ b/OBAKitTests/Application/Mapping/LaunchMapCameraTests.swift
@@ -1,0 +1,106 @@
+//
+//  LaunchMapCameraTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKitCore
+
+/// Launch camera for #615. A rider in Tampa with Puget Sound selected must
+/// open on Puget Sound, not GPS. The locate button is a separate path.
+@Suite(.serialized)
+struct LaunchMapCameraTests {
+
+    private var pugetSound: Region { Fixtures.pugetSoundRegion }
+
+    @Test func `GPS inside the selected region zooms to the user`() {
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: TestData.mockSeattleLocation,
+            lastVisibleMapRect: nil
+        )
+        guard case .userLocation = target else {
+            Issue.record("expected userLocation, got \(target)")
+            return
+        }
+    }
+
+    @Test func `GPS outside the selected region frames the region's service rect`() {
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: TestData.mockTampaLocation,
+            lastVisibleMapRect: nil
+        )
+        guard case .mapRect(let rect, let showMismatch) = target else {
+            Issue.record("expected mapRect, got \(target)")
+            return
+        }
+        #expect(MKMapRectEqualToRect(rect, pugetSound.serviceRect))
+        #expect(showMismatch)
+    }
+
+    @Test func `GPS outside prefers a last viewport that still sits in the region`() {
+        let last = pugetSound.serviceRect
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: TestData.mockTampaLocation,
+            lastVisibleMapRect: last
+        )
+        guard case .mapRect(let rect, let showMismatch) = target else {
+            Issue.record("expected mapRect, got \(target)")
+            return
+        }
+        #expect(MKMapRectEqualToRect(rect, last))
+        #expect(showMismatch)
+    }
+
+    @Test func `GPS outside ignores a last viewport that is also outside the region`() {
+        let tampaViewport = Fixtures.tampaRegion.serviceRect
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: TestData.mockTampaLocation,
+            lastVisibleMapRect: tampaViewport
+        )
+        guard case .mapRect(let rect, let showMismatch) = target else {
+            Issue.record("expected mapRect, got \(target)")
+            return
+        }
+        #expect(MKMapRectEqualToRect(rect, pugetSound.serviceRect))
+        #expect(showMismatch)
+    }
+
+    @Test func `No GPS restores the last viewport`() {
+        let last = TestData.seattleMapRect
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: nil,
+            lastVisibleMapRect: last
+        )
+        guard case .mapRect(let rect, let showMismatch) = target else {
+            Issue.record("expected mapRect, got \(target)")
+            return
+        }
+        #expect(MKMapRectEqualToRect(rect, last))
+        #expect(!showMismatch)
+    }
+
+    @Test func `No GPS and no last viewport frames the region's service rect`() {
+        let target = LaunchMapCamera.target(
+            selectedRegion: pugetSound,
+            userLocation: nil,
+            lastVisibleMapRect: nil
+        )
+        guard case .mapRect(let rect, let showMismatch) = target else {
+            Issue.record("expected mapRect, got \(target)")
+            return
+        }
+        #expect(MKMapRectEqualToRect(rect, pugetSound.serviceRect))
+        #expect(!showMismatch)
+    }
+}

--- a/docs/launch-map-camera.md
+++ b/docs/launch-map-camera.md
@@ -1,0 +1,23 @@
+# Launch map camera
+
+On launch the map used GPS even when the selected region was somewhere else.
+A rider in Taipei with Puget Sound selected opened on Taipei. The mismatch
+bulletin existed on the UIKit map but did not move the camera. #615.
+
+## Policy
+
+`LaunchMapCamera.target(selectedRegion:userLocation:lastVisibleMapRect:)`:
+
+1. GPS inside the selected region's `serviceRect` → zoom to the user (nearby stops).
+2. GPS outside → last viewport *if that viewport still intersects the region*, otherwise the region's `serviceRect`. Show the existing region-mismatch bulletin.
+3. No GPS → last viewport, or the region's `serviceRect`. No bulletin.
+
+The locate button still centers on the user. Backgrounding for ten minutes does not recenter on GPS when the device is still outside the region.
+
+## Surfaces
+
+UIKit `MapViewController` and SwiftUI `MapPanelRootView` both call the same function. Tests do not load either view.
+
+## Tests
+
+`LaunchMapCameraTests`. Puget Sound + Seattle GPS → user. Puget Sound + Tampa GPS → Puget Sound rect.


### PR DESCRIPTION
## Summary
- Launch (and the first location fix) zoomed to GPS even when that fix was outside the selected region. A rider in Taipei with Puget Sound selected opened on Taipei. The mismatch bulletin existed on the UIKit map and did not move the camera.
- `LaunchMapCamera` decides the frame: GPS inside the region → zoom to the user (nearby stops). GPS outside → last viewport if it still intersects the region, otherwise the region's `serviceRect`, plus the existing mismatch bulletin. No GPS → last viewport or `serviceRect`.
- UIKit `MapViewController` and SwiftUI `MapPanelRootView` share that function. The locate button still centers on the user. Returning from background after ten minutes does not yank to GPS when the device is still outside the region.

Closes #615.

## Test plan
- [x] `LaunchMapCameraTests` (6) — Puget Sound + Seattle GPS → user; Puget Sound + Tampa GPS → Puget Sound rect; out-of-region last viewport is ignored
- [ ] Select Puget Sound, simulate a location in Taipei (or any other region): map opens on Puget Sound, mismatch bulletin appears
- [ ] Locate button still jumps to the simulated GPS
- [ ] Device actually in Puget Sound: map still zooms to the user so nearby stops appear
- [ ] Background the app for >10 minutes while GPS is outside the region: map does not jump to GPS on resume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved map startup and recentering based on the selected region, current location, and previous viewport.
  * Added region-mismatch notifications when the device is outside the selected service area.
  * Preserved the current map view when returning from the background in another city.

* **Documentation**
  * Documented launch-camera behavior and region mismatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->