### PR TITLE
Add ProximityAlertManager to fire destination alerts

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -106,6 +106,17 @@ public class Application: CoreApplication, PushServiceDelegate {
     @MainActor
     lazy var walkingSpeedManager = WalkingSpeedManager(userDataStore: userDataStore)
 
+    /// Owns the rider's destination proximity alerts.
+    ///
+    /// `lazy` only because it needs a fully-initialized `self`; `init` forces it
+    /// immediately, and the comment there explains why it must not wait for a
+    /// first use that may never come.
+    @MainActor
+    public private(set) lazy var proximityAlertManager = ProximityAlertManager(
+        locationService: locationService,
+        userDataStore: userDataStore
+    )
+
     @objc lazy var userActivityBuilder = UserActivityBuilder(application: self)
 
     /// Handles all deep-linking into the app.
@@ -169,6 +180,15 @@ public class Application: CoreApplication, PushServiceDelegate {
         bookmarkWidgetRefresher = BookmarkWidgetRefresher()
 
         super.init(config: config)
+
+        // Force the proximity alert manager now instead of leaving it to a first
+        // use that may never come. A geofence crossing relaunches a terminated
+        // app, and Core Location delivers the queued region event to whatever
+        // `LocationService` delegates exist once launch finishes — a launch on
+        // which no screen is ever built and nothing touches this property.
+        // Constructing it here registers the delegate, and re-arms the regions,
+        // before that event lands.
+        _ = proximityAlertManager
 
         configureAppearanceProxies()
     }
@@ -364,6 +384,29 @@ public class Application: CoreApplication, PushServiceDelegate {
         Task { await pushRegistrationManager.registerIfNeeded() }
     }
 
+    public func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID) {
+        // The current region is the right one by construction: the geofence that
+        // produced this notification is only crossed where the rider physically
+        // is. `queueOrOpenStop` still needs one named, because it refuses to open
+        // a stop against a different region's API.
+        guard let regionID = regionsService.currentRegion?.regionIdentifier else {
+            // No region yet — the ordinary case for a tap that relaunched a
+            // terminated app, since the regions list loads asynchronously. Stash
+            // without one, exactly as the fired-alarm handler above does: the
+            // drain navigates as soon as a root controller exists, and
+            // `regionsService(_:updatedRegion:)` drains again once a region lands.
+            // Returning here instead would drop the only thing the rider tapped.
+            Logger.info("Proximity alert tap for stop \(stopID) arrived before a region loaded; deferring navigation.")
+            pendingStopID = stopID
+            // Cleared rather than left alone: a region stashed by an earlier
+            // navigation would make the drain refuse this stop as belonging to
+            // somewhere else.
+            pendingStopRegionID = nil
+            return
+        }
+        queueOrOpenStop(AppLinksRouter.StopDestination(stopID: stopID, regionID: regionID))
+    }
+
     /// Deletes the stored alarm whose deep-link identity matches `pushBody`, so the stop
     /// page reflects the fired state without waiting for the next full refresh.
     @MainActor
@@ -497,6 +540,12 @@ public class Application: CoreApplication, PushServiceDelegate {
         }
 
         configureConnectivity()
+
+        // Re-arm proximity geofences and reap alerts that expired while the app was
+        // away. Same reason the Live Activity cleanup below runs here: alerts age
+        // out on a clock that keeps running with no process to notice, and the
+        // regions standing for them outlive the process that armed them.
+        proximityAlertManager.reconcileMonitoredRegions()
 
         // Clean up Live Activity subscriptions whose activities are gone. This has to run on an
         // app-lifecycle hook rather than in a view controller: an activity the user dismissed

--- a/OBAKit/ProximityAlerts/ProximityAlertManager.swift
+++ b/OBAKit/ProximityAlerts/ProximityAlertManager.swift
@@ -1,0 +1,393 @@
+//
+//  ProximityAlertManager.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import CoreLocation
+import UserNotifications
+import OBAKitCore
+
+/// The outcome of a rider's request for a proximity alert on a stop.
+///
+/// Everything other than `activated` is a condition the rider has to be told
+/// about. A proximity alert is silent by design right up until it fires, so an
+/// alert that never armed looks exactly like one that simply hasn't fired yet —
+/// the rider finds out at the stop they meant to get off at.
+public enum ProximityAlertActivationResult: Equatable {
+    /// Stored and armed at the requested radius.
+    case activated(ProximityAlert)
+
+    /// Stored and armed, but at a smaller radius than requested, because this
+    /// device will not monitor one that large. The alert will fire closer to the
+    /// stop than the rider asked for.
+    case activatedWithClampedRadius(ProximityAlert, requested: CLLocationDistance, monitored: CLLocationDistance)
+
+    /// Nothing was stored: geofences only deliver in the background under
+    /// `.authorizedAlways`, and the app holds the status carried here.
+    case needsLocationAuthorization(CLAuthorizationStatus)
+
+    /// Nothing was stored: the geofence would arm, but the notification it exists
+    /// to show could never be delivered. `.notDetermined` means nobody has asked
+    /// the rider yet; `.denied` means they have to be sent to Settings.
+    case needsNotificationAuthorization(UNAuthorizationStatus)
+
+    /// Nothing was stored: the app already monitors `limit` regions, which is all
+    /// iOS allows. An existing alert has to go before another can arm.
+    case regionLimitReached(limit: Int)
+}
+
+/// Owns the destination proximity alerts a rider has set: which ones are armed
+/// with Core Location, what happens when one fires, and how the two are kept in
+/// agreement.
+///
+/// Two stores of truth have to be reconciled here, and they drift apart in both
+/// directions. Monitored regions live in Core Location, survive app termination,
+/// and are the only thing that can wake the app in the background. The
+/// `ProximityAlert` values that explain those regions live in `UserDataStore`,
+/// expire 24 hours after they were created, and can be mutated by anything
+/// holding the store. Neither side notices the other changing, so every entry
+/// point funnels into ``reconcileMonitoredRegions()``.
+///
+/// This has to exist before launch finishes. A geofence crossing relaunches a
+/// terminated app, and Core Location delivers the queued event to whatever
+/// `LocationService` delegates exist by then — so `Application` builds this
+/// eagerly in its initializer rather than lazily on first use, which on a
+/// background launch would be never.
+@MainActor
+public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
+
+    /// Injectable for tests; defaults to the real notification-center status.
+    /// Mirrors ``PushRegistrationManager/AuthorizationStatusProvider``.
+    public typealias AuthorizationStatusProvider = @Sendable () async -> UNAuthorizationStatus
+
+    /// Hands a notification request to the system.
+    ///
+    /// Deliberately the completion-handler form rather than the `async` one. The
+    /// fire path runs during a Core Location background launch, where the process
+    /// has seconds to live; this posts the request to the notification daemon on
+    /// the spot instead of parking it in a `Task` the system may suspend the app
+    /// before ever scheduling.
+    public typealias NotificationScheduler = (UNNotificationRequest, @escaping @Sendable (Error?) -> Void) -> Void
+
+    /// Key under which the fired alert's stop ID travels in the notification's
+    /// `userInfo`, and the name `PushService` routes a tap on.
+    static let notificationUserInfoKey = "proximity_alert"
+
+    /// Namespaces the `UNNotificationRequest` identifier so a proximity
+    /// notification can never collide with, or replace, one from another feature.
+    static let notificationIdentifierPrefix = "oba.proximity-alert."
+
+    private let locationService: LocationService
+    private let userDataStore: UserDataStore
+    private let notificationCenter: NotificationCenter
+    private let authorizationStatusProvider: AuthorizationStatusProvider
+    private let scheduleNotification: NotificationScheduler
+
+    /// Guards against re-entering reconciliation through the store notifications
+    /// that reconciliation itself provokes: reaping a single expired alert posts
+    /// `.proximityAlertsDidChange`, which lands back here mid-pass and would run
+    /// the whole comparison a second time against half-updated state.
+    private var isReconciling = false
+
+    /// - Parameters:
+    ///   - locationService: Arms and disarms the geofences, and reports crossings.
+    ///   - userDataStore: Persists the alerts the geofences stand for.
+    ///   - notificationCenter: Carries `.proximityAlertsDidChange`. `UserDataStore`
+    ///     posts to `.default`, so an injected center only sees store changes if
+    ///     it is that same center.
+    ///   - authorizationStatusProvider: Injectable for tests; defaults to the real
+    ///     notification-center authorization status.
+    ///   - scheduleNotification: Injectable for tests; defaults to
+    ///     `UNUserNotificationCenter.current().add(_:withCompletionHandler:)`.
+    public init(
+        locationService: LocationService,
+        userDataStore: UserDataStore,
+        notificationCenter: NotificationCenter = .default,
+        authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        },
+        scheduleNotification: @escaping NotificationScheduler = { request, completion in
+            UNUserNotificationCenter.current().add(request, withCompletionHandler: completion)
+        }
+    ) {
+        self.locationService = locationService
+        self.userDataStore = userDataStore
+        self.notificationCenter = notificationCenter
+        self.authorizationStatusProvider = authorizationStatusProvider
+        self.scheduleNotification = scheduleNotification
+
+        super.init()
+
+        locationService.addDelegate(self)
+
+        // The selector form, not `addObserver(forName:object:queue:using:)`. The
+        // block form hands back a token that has to be removed in `deinit`, and
+        // this object's last release lands wherever `Application`'s does — which
+        // is a background cooperative thread often enough to matter. A `deinit`
+        // that has to touch main-actor state to unregister traps there. Selector
+        // observers are held weakly and dropped by the center on dealloc, so
+        // there is nothing to unregister and no `deinit` to isolate.
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(proximityAlertsDidChange),
+            name: .proximityAlertsDidChange,
+            object: nil
+        )
+
+        reconcileMonitoredRegions()
+    }
+
+    /// Delivered synchronously on whichever thread mutated the store. Every
+    /// mutation the app makes runs on the main actor — the same assumption
+    /// `MapViewController` makes of `.bookmarksDidChange`, from the same store.
+    @objc private func proximityAlertsDidChange() {
+        reconcileMonitoredRegions()
+    }
+
+    // MARK: - Reading Alerts
+
+    /// The alerts the rider has set, expired ones included — reaping is
+    /// ``reconcileMonitoredRegions()``'s job, and it has not necessarily run since
+    /// the last one aged out.
+    public var proximityAlerts: [ProximityAlert] {
+        userDataStore.proximityAlerts
+    }
+
+    /// The unexpired alert set on `stopID`, if there is one.
+    public func activeAlert(for stopID: StopID) -> ProximityAlert? {
+        userDataStore.proximityAlerts.first { $0.stopID == stopID && !$0.isExpired }
+    }
+
+    // MARK: - Creating and Cancelling
+
+    /// Stores and arms an alert on `stop`, or explains why it couldn't.
+    ///
+    /// Nothing is stored unless the geofence actually armed. The reverse order —
+    /// persist, then try to monitor — is what leaves the app holding an alert the
+    /// rider believes in and Core Location knows nothing about.
+    public func createProximityAlert(
+        for stop: Stop,
+        radiusMeters: CLLocationDistance = ProximityAlert.defaultRadiusMeters
+    ) async -> ProximityAlertActivationResult {
+        // Checked ahead of arming rather than after, so a refusal costs no region
+        // slot and leaves no half-created state to unwind.
+        guard locationService.isProximityMonitoringAuthorized else {
+            return .needsLocationAuthorization(locationService.authorizationStatus)
+        }
+
+        // Unlike departure alarms — where `pushID()` downstream triggers the
+        // first-time system prompt, so `.notDetermined` is safe to fall through —
+        // nothing later in this path prompts. `UNUserNotificationCenter.add` on an
+        // undetermined app neither asks nor delivers, so both statuses are dead
+        // ends here and the caller has to resolve them.
+        let notificationStatus = await authorizationStatusProvider()
+        guard Self.allowsNotificationDelivery(notificationStatus) else {
+            return .needsNotificationAuthorization(notificationStatus)
+        }
+
+        let alert = ProximityAlert(stop: stop, radiusMeters: radiusMeters)
+
+        switch locationService.startMonitoringProximity(for: alert) {
+        case .started:
+            userDataStore.add(proximityAlert: alert)
+            return .activated(alert)
+        case .startedWithClampedRadius(let requested, let monitored):
+            userDataStore.add(proximityAlert: alert)
+            return .activatedWithClampedRadius(alert, requested: requested, monitored: monitored)
+        case .insufficientAuthorization(let status):
+            return .needsLocationAuthorization(status)
+        case .regionLimitReached(let limit):
+            return .regionLimitReached(limit: limit)
+        }
+    }
+
+    /// Disarms and forgets a single alert.
+    public func cancelProximityAlert(_ alert: ProximityAlert) {
+        locationService.stopMonitoringProximity(for: alert)
+        userDataStore.delete(proximityAlert: alert)
+    }
+
+    /// Disarms and forgets every alert, leaving regions the app monitors for
+    /// other reasons alone.
+    public func cancelAllProximityAlerts() {
+        locationService.stopMonitoringAllProximityAlerts()
+        userDataStore.deleteAllProximityAlerts()
+    }
+
+    // MARK: - Reconciliation
+
+    /// Brings Core Location's armed regions back in line with the stored alerts.
+    ///
+    /// Called on every occasion the two can disagree — construction (which on a
+    /// background launch is the app's only chance to re-arm), any change to the
+    /// store, a return to the foreground, and the grant of Always authorization.
+    /// They all repair the same disagreement, so they all run the same comparison
+    /// rather than each patching the case it happens to know about.
+    ///
+    /// Idempotent: arming an alert that is already monitored replaces its region
+    /// instead of adding one, so extra calls cost nothing.
+    public func reconcileMonitoredRegions() {
+        guard !isReconciling else { return }
+        isReconciling = true
+        defer { isReconciling = false }
+
+        userDataStore.deleteExpiredProximityAlerts()
+
+        let alerts = userDataStore.proximityAlerts
+        let storedIDs = Set(alerts.map(\.id))
+
+        // Regions whose alert is gone — deleted while this process wasn't running,
+        // or reaped as expired a line ago. Nothing would be able to explain them
+        // if they fired. Disarming them first also returns their slots to the
+        // twenty-region budget before the arming pass below spends it.
+        for orphanedID in locationService.monitoredProximityAlertIDs.subtracting(storedIDs) {
+            Logger.info("Disarming proximity region \(orphanedID), whose alert is no longer stored.")
+            locationService.stopMonitoringProximityAlert(id: orphanedID)
+        }
+
+        for alert in alerts {
+            let result = locationService.startMonitoringProximity(for: alert)
+            guard !result.isMonitoring else { continue }
+            // `startMonitoringProximity` logs the specifics. This says which alert
+            // the rider is going to be let down by, which that call cannot know is
+            // interesting until someone is tracking a set of them.
+            Logger.warn("Proximity alert \(alert.id) for stop \(alert.stopID) is stored but not armed: \(result).")
+        }
+    }
+
+    // MARK: - LocationServiceDelegate
+
+    public func locationService(_ service: LocationService, didEnterMonitoredRegion identifier: String) {
+        guard let alertID = LocationService.proximityAlertID(forRegionIdentifier: identifier) else {
+            Logger.error("Entered proximity region \(identifier), whose identifier carries no alert ID. Ignoring.")
+            return
+        }
+
+        guard let alert = userDataStore.proximityAlerts.first(where: { $0.id == alertID }) else {
+            // Armed with nothing left to explain it: the alert was deleted by a
+            // process that has since been replaced, and no reconciliation has run
+            // in this one yet. Reap it rather than let it fire again tomorrow.
+            Logger.warn("Entered proximity region for alert \(alertID), which is no longer stored. Disarming it.")
+            service.stopMonitoringProximityAlert(id: alertID)
+            return
+        }
+
+        // Set for a trip that ended a day or more ago. Waking the rider now would
+        // be worse than never firing at all, and this is the last line of defense:
+        // the region stays armed until something reconciles, which on a background
+        // launch happens moments before this callback, not after it.
+        guard !alert.isExpired else {
+            Logger.info("Proximity alert \(alertID) crossed its geofence after expiring. Discarding it.")
+            cancelProximityAlert(alert)
+            return
+        }
+
+        deliverArrivalNotification(for: alert)
+
+        // One-shot. The rider set this for one trip; a geofence left armed fires
+        // again on tomorrow's commute past the same stop.
+        cancelProximityAlert(alert)
+    }
+
+    public func locationService(_ service: LocationService, authorizationStatusChanged status: CLAuthorizationStatus) {
+        // Region monitoring has no self-healing re-arm of its own: an alert that
+        // could not arm under When In Use stays dead after the rider grants Always
+        // in Settings, because nothing asks Core Location a second time. This is
+        // the only place that gap closes.
+        guard service.isProximityMonitoringAuthorized else {
+            // Not an error — When In Use is an ordinary state, and during
+            // onboarding there is nothing armed to lose. But when alerts *are*
+            // armed this is the moment they may quietly stop being deliverable,
+            // and nothing else records it: Core Location reports nothing when a
+            // region that is already monitored loses the authorization that let
+            // it deliver in the background.
+            let armedCount = service.monitoredProximityAlertIDs.count
+            if armedCount > 0 {
+                Logger.warn("Location authorization is now \(status) with \(armedCount) proximity alert(s) armed; they may no longer deliver in the background.")
+            }
+            return
+        }
+        reconcileMonitoredRegions()
+    }
+
+    public func locationService(_ service: LocationService, monitoringDidFailFor identifier: String?, error: Error, kind: RegionMonitoringFailureKind) {
+        guard !kind.isTransient else {
+            // The OS deferred the request instead of refusing it, and will get to
+            // it on its own. Re-arming now would race that retry.
+            Logger.info("Proximity monitoring for \(identifier ?? "an unattributed region") was delayed; leaving it armed.")
+            return
+        }
+
+        guard let identifier, let alertID = LocationService.proximityAlertID(forRegionIdentifier: identifier) else {
+            // Core Location reports the region-count cap, and some setup failures,
+            // with no region attached. There is no alert to act on.
+            Logger.error("Proximity monitoring failed (\(kind)) without naming a region: \(error)")
+            return
+        }
+
+        // The region is dead and won't recover on its own, so give its slot back.
+        // The alert itself stays stored: it is the rider's, not ours to delete on
+        // an OS error, and the next reconciliation gets to try once more.
+        Logger.error("Proximity monitoring failed permanently (\(kind)) for alert \(alertID); disarming its region: \(error)")
+        service.stopMonitoringProximityAlert(id: alertID)
+    }
+
+    // MARK: - Notification Delivery
+
+    private func deliverArrivalNotification(for alert: ProximityAlert) {
+        let content = UNMutableNotificationContent()
+        content.title = OBALoc(
+            "proximity_alert.notification.title",
+            value: "Approaching your stop",
+            comment: "Title of the notification shown when the rider nears the stop they set a destination alert on."
+        )
+        content.body = String(
+            format: OBALoc(
+                "proximity_alert.notification.body_fmt",
+                value: "You're getting close to %@.",
+                comment: "Body of the destination alert notification. %@ is the name of the rider's destination stop."
+            ),
+            alert.stopName
+        )
+        content.sound = .default
+        content.userInfo = [Self.notificationUserInfoKey: alert.stopID]
+
+        let request = UNNotificationRequest(
+            identifier: Self.notificationIdentifierPrefix + alert.id.uuidString,
+            content: content,
+            trigger: nil // Deliver now.
+        )
+
+        // Interpolated up front: the completion handler runs on a notification
+        // center queue rather than the main actor, and `alert` is not Sendable.
+        let alertID = alert.id.uuidString
+        scheduleNotification(request) { error in
+            if let error {
+                Logger.error("Failed to deliver the notification for proximity alert \(alertID): \(error)")
+            }
+        }
+    }
+
+    /// Whether a notification posted under `status` would reach the rider at all.
+    ///
+    /// `.provisional` is included even though it delivers quietly, straight to
+    /// Notification Center with no banner or sound — a poor fit for an alert whose
+    /// whole job is to interrupt someone watching the road. Refusing to set the
+    /// alert would still be worse: quiet delivery is delivery, and the rider can
+    /// promote it from the notification itself.
+    private static func allowsNotificationDelivery(_ status: UNAuthorizationStatus) -> Bool {
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined, .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -52,6 +52,17 @@ public protocol PushServiceDelegate: NSObjectProtocol {
     func pushService(_ pushService: PushService, received arrivalDeparture: AlarmPushBody)
     func pushService(_ pushService: PushService, receivedDonationPrompt id: String?)
 
+    /// Called when the rider taps the destination proximity alert notification
+    /// that ``ProximityAlertManager`` posted for `stopID`.
+    ///
+    /// Local, not remote — it arrives here only because `OBACloudPushService` owns
+    /// the app's single `UNUserNotificationCenter` delegate and forwards every
+    /// notification tap through this service. Routing it is not optional: the
+    /// fallback for an unrecognized payload re-presents the notification's own
+    /// text in a modal alert, which for this one would tell the rider they are
+    /// approaching their stop a second time and nothing else.
+    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID)
+
     /// Called whenever APNs issues the device a (possibly rotated) push token.
     func pushService(_ pushService: PushService, receivedDeviceToken token: String)
 }
@@ -106,6 +117,9 @@ public class PushService: NSObject {
         else if key == "donation" {
             let testID = additionalData["donation"] as? String
             delegate?.pushService(self, receivedDonationPrompt: testID)
+        }
+        else if key == ProximityAlertManager.notificationUserInfoKey, let stopID = additionalData[key] as? StopID {
+            delegate?.pushService(self, receivedProximityAlertForStopID: stopID)
         }
         else {
             displayMessage(message)

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "مرحبًا بك في %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "أنت تقترب من %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "تقترب من محطتك";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "لا يُسمح لـ %1$@ حاليًا بالوصول إلى البيانات الخلوية. لإصلاح ذلك، انتقل إلى الإعدادات > خلوي وفعّل البيانات الخلوية لـ %2$@، أو اتصل بشبكة WiFi.";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Welcome to %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "You're getting close to %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Approaching your stop";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "%1$@ is not currently allowed to access cellular data. To fix this, go to Settings > Cellular and enable cellular data for %2$@, or connect to a WiFi network.";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Bienvenido a %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Te estás acercando a %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Te acercas a tu parada";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "%1$@ no tiene permiso para usar datos móviles en este momento. Para solucionarlo, vaya a Configuración > Datos móviles y active los datos móviles para %2$@, o conéctese a una red WiFi.";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Maligayang Pagdating sa %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Papalapit ka na sa %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Papalapit ka na sa iyong hintuan";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "Kasalukuyang hindi pinapayagan ang %1$@ app na ma-access ang cellular data. Para ayusin ito, pumunta sa Settings > Cellular at i-enable ang cellular data para sa %2$@ app, o kumonekta sa isang WiFi network.";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Bienvenue dans %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Vous approchez de %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Vous approchez de votre arrêt";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "L'app %1$@ n'est actuellement pas autorisée à accéder aux données cellulaires. Pour corriger cela, allez dans Réglages > Données cellulaires et activez les données cellulaires pour %2$@, ou connectez-vous à un réseau Wi-Fi.";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Benvenuto in %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Ti stai avvicinando a %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Ti stai avvicinando alla fermata";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "L'app %1$@ non è attualmente autorizzata ad accedere ai dati cellulari. Per risolvere il problema, vai su Impostazioni > Cellulare e attiva i dati cellulari per %2$@, oppure connettiti a una rete WiFi.";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "%@에 오신 것을 환영합니다";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "%@에 가까워지고 있습니다.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "정류장에 접근 중";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "현재 %1$@의 셀룰러 데이터 사용이 허용되어 있지 않습니다. 설정 > 셀룰러로 이동하여 %2$@의 셀룰러 데이터를 켜거나 WiFi 네트워크에 연결해 주세요.";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Witaj w %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Zbliżasz się do %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Zbliżasz się do przystanku";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "Aplikacja %1$@ nie ma obecnie dostępu do danych komórkowych. Aby to naprawić, przejdź do Ustawienia > Sieć komórkowa i włącz dane komórkowe dla aplikacji %2$@ lub połącz się z siecią Wi-Fi.";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Bem-vindo ao %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Você está chegando perto de %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Aproximando-se do seu ponto";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "O app %1$@ não tem permissão para acessar os dados móveis no momento. Para corrigir, vá em Ajustes > Celular e ative os dados móveis para o app %2$@, ou conecte-se a uma rede Wi-Fi.";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Добро пожаловать в %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Вы приближаетесь к %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Приближаетесь к остановке";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "Приложению %1$@ сейчас запрещён доступ к сотовым данным. Чтобы исправить это, откройте «Настройки» > «Сотовая связь» и включите сотовые данные для приложения %2$@ или подключитесь к сети Wi-Fi.";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "Chào mừng đến với %@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "Bạn đang đến gần %@.";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "Sắp đến điểm dừng của bạn";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "%1$@ hiện không được phép truy cập dữ liệu di động. Để khắc phục, hãy vào Cài đặt > Di động và bật dữ liệu di động cho %2$@, hoặc kết nối với mạng WiFi.";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "欢迎使用%@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "您即将到达%@。";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "即将到达您的站点";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "%1$@当前无法访问蜂窝移动数据。请前往“设置”>“蜂窝网络”，为%2$@开启蜂窝移动数据，或连接到Wi-Fi网络。";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -777,6 +777,12 @@
 /* Title of the first onboarding screen; the argument is the app name */
 "onboarding.welcome.title_fmt" = "歡迎使用%@";
 
+/* Body of the destination alert notification. %@ is the name of the rider's destination stop. */
+"proximity_alert.notification.body_fmt" = "您即將抵達%@。";
+
+/* Title of the notification shown when the rider nears the stop they set a destination alert on. */
+"proximity_alert.notification.title" = "即將抵達您的站點";
+
 /* Reachability bulletin shown when the user has disabled cellular data for this app in iOS Settings. Both substituted values are the app name. */
 "reachability_bulletin.description.cellular_data_restricted_fmt" = "%1$@ 目前無法取用行動數據。若要修正此問題，請前往「設定」>「行動服務」，為 %2$@ 開啟行動數據，或連接 Wi-Fi 網路。";
 

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -530,13 +530,44 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     public static let maximumMonitoredRegions = 20
 
     static func proximityRegionIdentifier(for alert: ProximityAlert) -> String {
-        proximityRegionPrefix + alert.id.uuidString
+        proximityRegionIdentifier(forAlertID: alert.id)
+    }
+
+    /// Builds the same identifier from an alert's ID alone.
+    ///
+    /// An alert deleted while the app wasn't running leaves its region armed with
+    /// no `ProximityAlert` left to name it, so the ID has to be enough.
+    static func proximityRegionIdentifier(forAlertID id: UUID) -> String {
+        proximityRegionPrefix + id.uuidString
+    }
+
+    /// Recovers the proximity alert a monitored region belongs to, or nil for a
+    /// region this service did not create.
+    ///
+    /// `didEnterMonitoredRegion` and `monitoringDidFailFor` hand their delegates a
+    /// bare identifier string, and the prefix-plus-UUID encoding behind it is
+    /// built a few lines above. Decoding it here as well keeps consumers from
+    /// reconstructing a format they don't own — the two drifting apart would
+    /// strand every alert with nothing to attribute a geofence event to.
+    public static func proximityAlertID(forRegionIdentifier identifier: String) -> UUID? {
+        guard identifier.hasPrefix(proximityRegionPrefix) else { return nil }
+        return UUID(uuidString: String(identifier.dropFirst(proximityRegionPrefix.count)))
     }
 
     /// The regions currently monitored on behalf of proximity alerts, excluding
     /// any the app monitors for other reasons.
     public var monitoredProximityRegions: Set<CLRegion> {
         locationManager.monitoredRegions.filter { $0.identifier.hasPrefix(Self.proximityRegionPrefix) }
+    }
+
+    /// The IDs of the proximity alerts currently armed.
+    ///
+    /// Monitored regions outlive the process that armed them, while the alerts
+    /// explaining those regions live in `UserDataStore` and expire on a clock.
+    /// Comparing the two sets is what tells a consumer which alerts still need
+    /// arming and which regions were left behind by alerts that are gone.
+    public var monitoredProximityAlertIDs: Set<UUID> {
+        Set(monitoredProximityRegions.compactMap { Self.proximityAlertID(forRegionIdentifier: $0.identifier) })
     }
 
     /// Starts monitoring a geofence region for the given proximity alert.
@@ -585,11 +616,22 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     /// Stops monitoring the geofence region for the given proximity alert.
     public func stopMonitoringProximity(for alert: ProximityAlert) {
-        let identifier = Self.proximityRegionIdentifier(for: alert)
+        stopMonitoringProximityAlert(id: alert.id)
+    }
+
+    /// Stops monitoring the geofence region armed for `id`, whether or not an
+    /// alert with that ID still exists.
+    ///
+    /// The counterpart to `stopMonitoringProximity(for:)` for the case that has no
+    /// alert to pass: a region whose alert was deleted or expired in an earlier
+    /// run of the app still holds one of the twenty slots, and only its ID
+    /// survives to identify it.
+    public func stopMonitoringProximityAlert(id: UUID) {
+        let identifier = Self.proximityRegionIdentifier(forAlertID: id)
         guard let matchingRegion = locationManager.monitoredRegions.first(where: {
             $0.identifier == identifier
         }) else {
-            Logger.warn("No monitored region found for proximity alert \(alert.id)")
+            Logger.warn("No monitored region found for proximity alert \(id)")
             return
         }
         locationManager.stopMonitoring(for: matchingRegion)

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -696,6 +696,29 @@ final class ApplicationTests: OBATestCase {
 
     // MARK: - Push Service Tests
 
+    @Test func `Push service proximity alert tap is never dropped`() {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        let locManager = LocationManagerMock()
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        let config = AppConfig(regionsBaseURL: regionsURL, apiKey: apiKey, appVersion: appVersion, userDefaults: userDefaults, analytics: AnalyticsMock(), queue: queue, locationService: locationService, bundledRegionsFilePath: bundledRegionsPath, regionsAPIPath: regionsAPIPath, dataLoader: dataLoader)
+        let app = Application(config: config)
+        let pushService = PushService(serviceProvider: MockPushServiceProvider(), delegate: app)
+
+        app.pushService(pushService, receivedProximityAlertForStopID: "1_75403")
+
+        // The tap that matters is the one into a terminated app, where neither a
+        // root controller nor a region exists yet. Both branches must stash: with
+        // no region the handler stashes region-less, and with one `queueOrOpenStop`
+        // stashes it alongside the region. Dropping it would strand the rider on
+        // whatever screen the app happened to open to.
+        #expect(app.pendingStopID == "1_75403")
+        // Whatever region was stashed must be the one actually current, or the
+        // drain will refuse the stop as belonging somewhere else.
+        #expect(app.pendingStopRegionID == app.regionsService.currentRegion?.regionIdentifier)
+    }
+
+
     @Test func `Push service received donation prompt with no top view controller`() {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)

--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -1,0 +1,580 @@
+//
+//  ProximityAlertManagerTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+import UserNotifications
+@testable import OBAKit
+@testable import OBAKitCore
+
+// swiftlint:disable force_try
+
+@Suite(.serialized)
+final class ProximityAlertManagerTests: OBATestCase {
+
+    var locationManagerMock: CountingLocationManagerMock!
+    var locationService: LocationService!
+    var store: UserDefaultsStore!
+    var stops: [Stop]!
+
+    /// Every request the manager handed to the notification system, in order.
+    /// Boxed rather than held as a plain property because the scheduler closure
+    /// stands in for one the real `UNUserNotificationCenter` may call anywhere.
+    var delivered: SendableBox<[UNNotificationRequest]>!
+
+    var stop: Stop { stops[0] }
+
+    override init() async throws {
+        try await super.init()
+
+        let location = CLLocation(latitude: 47.0, longitude: -122.0)
+        locationManagerMock = CountingLocationManagerMock(
+            updateLocation: location,
+            updateHeading: OBAMockHeading(heading: 0.0)
+        )
+        // Always, not When In Use: a geofence armed under When In Use never
+        // delivers in the background, and `startMonitoringProximity` refuses it.
+        locationManagerMock._authorizationStatus = .authorizedAlways
+        locationService = LocationService(userDefaults: userDefaults, locationManager: locationManagerMock)
+        store = UserDefaultsStore(userDefaults: userDefaults)
+        stops = try! Fixtures.loadSomeStops()
+        delivered = SendableBox([])
+    }
+
+    // MARK: - Helpers
+
+    /// - Parameter notificationStatus: what the manager sees when it checks
+    ///   whether a notification it posted could actually reach the rider.
+    private func makeManager(notificationStatus: UNAuthorizationStatus = .authorized) -> ProximityAlertManager {
+        let delivered = self.delivered!
+        return ProximityAlertManager(
+            locationService: locationService,
+            userDataStore: store,
+            authorizationStatusProvider: { notificationStatus },
+            scheduleNotification: { request, completion in
+                delivered.value.append(request)
+                completion(nil)
+            }
+        )
+    }
+
+    /// Stands in for Core Location reporting a crossing into `alert`'s geofence.
+    private func enterRegion(for alert: ProximityAlert) {
+        enterRegion(identifier: LocationService.proximityRegionIdentifier(for: alert))
+    }
+
+    private func enterRegion(identifier: String) {
+        let region = CLCircularRegion(
+            center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
+            radius: 200,
+            identifier: identifier
+        )
+        locationService.locationManager(CLLocationManager(), didEnterRegion: region)
+    }
+
+    private func failMonitoring(for alert: ProximityAlert, error: CLError.Code) {
+        let region = CLCircularRegion(
+            center: alert.coordinate,
+            radius: alert.radiusMeters,
+            identifier: LocationService.proximityRegionIdentifier(for: alert)
+        )
+        locationService.locationManager(CLLocationManager(), monitoringDidFailFor: region, withError: CLError(error))
+    }
+
+    /// Fills the manager with regions this feature did not create. The OS cap on
+    /// monitored regions is per-app, not per-feature.
+    private func fillMonitoredRegions(count: Int) {
+        for index in 0..<count {
+            locationManagerMock.startMonitoring(for: CLCircularRegion(
+                center: CLLocationCoordinate2D(latitude: 47.0, longitude: -122.0),
+                radius: 100,
+                identifier: "filler-region-\(index)"
+            ))
+        }
+    }
+
+    // MARK: - Creating Alerts
+
+    @Test func `Create stores the alert and arms its geofence`() async {
+        let manager = makeManager()
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        guard case .activated(let alert) = result else {
+            Issue.record("Expected .activated, got \(result)")
+            return
+        }
+        #expect(alert.stopID == self.stop.id)
+        #expect(alert.radiusMeters == ProximityAlert.defaultRadiusMeters)
+        #expect(self.store.proximityAlerts.map(\.id) == [alert.id])
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+    }
+
+    @Test func `Create honors a custom radius`() async {
+        let manager = makeManager()
+
+        let result = await manager.createProximityAlert(for: stop, radiusMeters: 500)
+
+        guard case .activated(let alert) = result else {
+            Issue.record("Expected .activated, got \(result)")
+            return
+        }
+        #expect(alert.radiusMeters == 500)
+    }
+
+    @Test func `Create reports a radius the device shrank`() async {
+        locationManagerMock.maximumRegionMonitoringDistance = 150
+        let manager = makeManager()
+
+        let result = await manager.createProximityAlert(for: stop, radiusMeters: 400)
+
+        // Core Location would have clamped this silently, firing the alert 250m
+        // closer than the rider asked for. The alert is still worth keeping — it
+        // works, just not where they expected — so it is stored and armed.
+        guard case .activatedWithClampedRadius(let alert, let requested, let monitored) = result else {
+            Issue.record("Expected .activatedWithClampedRadius, got \(result)")
+            return
+        }
+        #expect(requested == 400)
+        #expect(monitored == 150)
+        #expect(self.store.proximityAlerts.map(\.id) == [alert.id])
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+    }
+
+    @Test func `Create without Always authorization stores nothing`() async {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let manager = makeManager()
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        #expect(result == .needsLocationAuthorization(.authorizedWhenInUse))
+        // Nothing persisted: an alert the rider believes in with no geofence
+        // behind it is worse than a refusal they can act on.
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Create with notifications denied stores nothing`() async {
+        let manager = makeManager(notificationStatus: .denied)
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        #expect(result == .needsNotificationAuthorization(.denied))
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Create with notification authorization undetermined stores nothing`() async {
+        let manager = makeManager(notificationStatus: .notDetermined)
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        // Departure alarms let `.notDetermined` through, because `pushID()`
+        // further down that path triggers the first-time system prompt. Nothing
+        // here does: `UNUserNotificationCenter.add` on an undetermined app neither
+        // asks nor delivers, so this is as dead an end as `.denied`.
+        #expect(result == .needsNotificationAuthorization(.notDetermined))
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Create with provisional notifications is allowed`() async {
+        let manager = makeManager(notificationStatus: .provisional)
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        // Quiet delivery is a poor fit for an alert meant to interrupt someone
+        // watching the road, but it is still delivery.
+        guard case .activated = result else {
+            Issue.record("Expected .activated, got \(result)")
+            return
+        }
+        #expect(self.store.proximityAlerts.count == 1)
+        #expect(self.locationService.monitoredProximityAlertIDs.count == 1)
+    }
+
+    @Test func `Create at the region limit stores nothing`() async {
+        fillMonitoredRegions(count: LocationService.maximumMonitoredRegions)
+        let manager = makeManager()
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        #expect(result == .regionLimitReached(limit: LocationService.maximumMonitoredRegions))
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    // MARK: - Cancelling Alerts
+
+    @Test func `Cancel disarms the geofence and forgets the alert`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        manager.cancelProximityAlert(alert)
+
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Cancel all clears every alert`() async {
+        let manager = makeManager()
+        _ = await manager.createProximityAlert(for: stops[0])
+        _ = await manager.createProximityAlert(for: stops[1])
+        #expect(self.store.proximityAlerts.count == 2)
+
+        manager.cancelAllProximityAlerts()
+
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Cancel all leaves regions the app monitors elsewhere alone`() async {
+        let manager = makeManager()
+        _ = await manager.createProximityAlert(for: stop)
+        fillMonitoredRegions(count: 3)
+
+        manager.cancelAllProximityAlerts()
+
+        #expect(self.locationManagerMock.monitoredRegions.count == 3)
+    }
+
+    // MARK: - Reading Alerts
+
+    @Test func `Active alert finds the alert set on a stop`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        #expect(manager.activeAlert(for: self.stop.id)?.id == alert.id)
+        #expect(manager.activeAlert(for: self.stops[1].id) == nil)
+    }
+
+    @Test func `Active alert ignores an expired alert`() {
+        let expired = ProximityAlert(
+            stop: stop,
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )
+        store.add(proximityAlert: expired)
+        let manager = makeManager()
+
+        #expect(manager.activeAlert(for: self.stop.id) == nil)
+    }
+
+    // MARK: - Reconciliation
+
+    @Test func `Construction re arms alerts stored before launch`() {
+        // The launch that matters: Core Location relaunches a terminated app for
+        // a geofence crossing, and only the stored alerts survive to say which
+        // regions belong to this feature.
+        let alert = ProximityAlert(stop: stop)
+        store.add(proximityAlert: alert)
+
+        _ = makeManager()
+
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+    }
+
+    @Test func `Reconcile disarms a region whose alert is gone`() {
+        let alert = ProximityAlert(stop: stop)
+        #expect(locationService.startMonitoringProximity(for: alert) == .started)
+        // Never stored — stands in for an alert deleted by a process that has
+        // since been replaced, leaving its region armed with nothing to explain it.
+
+        _ = makeManager()
+
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Reconcile reaps expired alerts and disarms them`() {
+        let expired = ProximityAlert(
+            stop: stop,
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )
+        store.add(proximityAlert: expired)
+        #expect(locationService.startMonitoringProximity(for: expired) == .started)
+
+        _ = makeManager()
+
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Reconcile keeps unexpired alerts armed`() {
+        let fresh = ProximityAlert(stop: stops[0])
+        let expired = ProximityAlert(
+            stop: stops[1],
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )
+        store.add(proximityAlert: fresh)
+        store.add(proximityAlert: expired)
+
+        _ = makeManager()
+
+        #expect(self.store.proximityAlerts.map(\.id) == [fresh.id])
+        #expect(self.locationService.monitoredProximityAlertIDs == [fresh.id])
+    }
+
+    @Test func `Reconcile is idempotent`() async {
+        let manager = makeManager()
+        _ = await manager.createProximityAlert(for: stop)
+
+        manager.reconcileMonitoredRegions()
+        manager.reconcileMonitoredRegions()
+        manager.reconcileMonitoredRegions()
+
+        // Re-arming replaces a region rather than adding one, so repeated passes
+        // must not accumulate regions or duplicate the stored alert.
+        #expect(self.locationManagerMock.monitoredRegions.count == 1)
+        #expect(self.store.proximityAlerts.count == 1)
+    }
+
+    @Test func `Reconcile does not re enter itself while reaping`() {
+        // Reaping an expired alert makes the store post `.proximityAlertsDidChange`,
+        // which this manager observes synchronously — landing back inside the pass
+        // that provoked it. Without the `isReconciling` guard the surviving alert
+        // is armed twice: once by the re-entrant pass, then again when the outer
+        // pass resumes. Counted rather than read off `monitoredRegions`, which is
+        // a Set and collapses the second call into the first.
+        let fresh = ProximityAlert(stop: stops[0])
+        let expired = ProximityAlert(
+            stop: stops[1],
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )
+        store.add(proximityAlert: fresh)
+        store.add(proximityAlert: expired)
+        locationManagerMock.resetStartMonitoringCallCount()
+
+        _ = makeManager()
+
+        #expect(self.locationManagerMock.startMonitoringCallCount == 1)
+        #expect(self.locationService.monitoredProximityAlertIDs == [fresh.id])
+    }
+
+    @Test func `Reconcile leaves regions the app monitors elsewhere alone`() {
+        fillMonitoredRegions(count: 3)
+
+        _ = makeManager()
+
+        #expect(self.locationManagerMock.monitoredRegions.count == 3)
+    }
+
+    // MARK: - Store Observation
+
+    @Test func `An alert added straight to the store gets armed`() {
+        let manager = makeManager()
+        let alert = ProximityAlert(stop: stop)
+
+        store.add(proximityAlert: alert)
+
+        // Asserted directly rather than polled. The store posts
+        // `.proximityAlertsDidChange` on the calling thread and the manager
+        // observes it with the selector form, which `NotificationCenter` invokes
+        // inline — so this is already true here, and a regression to an
+        // asynchronous delivery form is exactly what this would catch.
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+        #expect(manager.proximityAlerts.count == 1)
+    }
+
+    @Test func `An alert deleted straight from the store gets disarmed`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        store.delete(proximityAlert: alert)
+
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+        #expect(manager.proximityAlerts.isEmpty)
+    }
+
+    // MARK: - Firing
+
+    @Test func `Entering the geofence delivers a notification naming the stop`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        enterRegion(for: alert)
+
+        #expect(self.delivered.value.count == 1)
+        let request = delivered.value.first
+        #expect(request?.content.title.isEmpty == false)
+        #expect(request?.content.body.contains(self.stop.name) == true)
+        #expect(request?.content.sound == .default)
+        // Namespaced so a proximity notification can never replace another
+        // feature's request that happens to share an identifier.
+        #expect(request?.identifier == ProximityAlertManager.notificationIdentifierPrefix + alert.id.uuidString)
+        // The payload `PushService` routes a tap on, back to the stop page.
+        #expect(request?.content.userInfo[ProximityAlertManager.notificationUserInfoKey] as? String == self.stop.id)
+    }
+
+    @Test func `Entering the geofence clears the alert`() async {
+        let manager = makeManager()
+        guard case .activated = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        enterRegion(for: store.proximityAlerts[0])
+
+        // One-shot. A geofence left armed would fire again on tomorrow's commute
+        // past the same stop.
+        #expect(self.store.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Entering a region with no alert ID delivers nothing`() {
+        _ = makeManager()
+
+        enterRegion(identifier: LocationService.proximityRegionPrefix + "not-a-uuid")
+
+        #expect(self.delivered.value.isEmpty)
+    }
+
+    @Test func `Entering a region whose alert is gone disarms it silently`() {
+        let manager = makeManager()
+        let alert = ProximityAlert(stop: stop)
+        #expect(locationService.startMonitoringProximity(for: alert) == .started)
+
+        enterRegion(for: alert)
+
+        #expect(self.delivered.value.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+        #expect(manager.proximityAlerts.isEmpty)
+    }
+
+    @Test func `Entering the geofence of an expired alert delivers nothing`() {
+        let expired = ProximityAlert(
+            stop: stop,
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )
+        store.add(proximityAlert: expired)
+        let manager = makeManager()
+        // Reconciliation reaped it on construction, so put it back to reach the
+        // guard under test: the crossing arriving before anything reconciles.
+        store.add(proximityAlert: expired)
+        #expect(locationService.startMonitoringProximity(for: expired) == .started)
+
+        enterRegion(for: expired)
+
+        // Waking a rider for a trip that ended a day ago is worse than not firing.
+        #expect(self.delivered.value.isEmpty)
+        #expect(manager.proximityAlerts.isEmpty)
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    // MARK: - Authorization Changes
+
+    @Test func `Granting Always arms alerts that could not arm before`() {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let alert = ProximityAlert(stop: stop)
+        store.add(proximityAlert: alert)
+        let manager = makeManager()
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+
+        locationManagerMock.requestAlwaysAuthorization()
+
+        // Region monitoring has no self-healing re-arm of its own: without this,
+        // an alert stored under When In Use stays dead after the rider grants
+        // Always in Settings.
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+        #expect(manager.proximityAlerts.count == 1)
+    }
+
+    @Test func `A change to less than Always arms nothing`() {
+        locationManagerMock._authorizationStatus = .notDetermined
+        let alert = ProximityAlert(stop: stop)
+        store.add(proximityAlert: alert)
+        _ = makeManager()
+
+        locationManagerMock.requestWhenInUseAuthorization()
+
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    // MARK: - Monitoring Failures
+
+    @Test func `A delayed region stays armed`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        failMonitoring(for: alert, error: .regionMonitoringSetupDelayed)
+
+        // The OS deferred the request rather than refusing it, and will retry on
+        // its own. Disarming now would throw away an alert about to start working.
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+        #expect(self.store.proximityAlerts.count == 1)
+    }
+
+    @Test func `A permanently rejected region is disarmed but its alert kept`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        failMonitoring(for: alert, error: .regionMonitoringFailure)
+
+        // The slot goes back to the twenty-region budget, but the alert is the
+        // rider's — not ours to delete on an OS error, and the next reconciliation
+        // gets to try once more.
+        #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+        #expect(self.store.proximityAlerts.map(\.id) == [alert.id])
+    }
+
+    @Test func `A failure naming no region disarms nothing`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        locationService.locationManager(
+            CLLocationManager(),
+            monitoringDidFailFor: nil,
+            withError: CLError(.regionMonitoringFailure)
+        )
+
+        // Core Location reports the region cap, and some setup failures, with no
+        // region attached. There is no alert to act on, and guessing at one would
+        // disarm whichever alert happened to be looked at first.
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+        #expect(self.store.proximityAlerts.count == 1)
+    }
+}
+
+/// Counts arm calls, which `LocationManagerMock` otherwise collapses into a
+/// `Set` of regions — re-arming the same alert is indistinguishable from arming
+/// it once unless the calls themselves are counted.
+final class CountingLocationManagerMock: AuthorizableLocationManagerMock {
+    private(set) var startMonitoringCallCount = 0
+
+    override func startMonitoring(for region: CLRegion) {
+        startMonitoringCallCount += 1
+        super.startMonitoring(for: region)
+    }
+
+    /// Discards calls made while a test was arranging its fixtures, so the count
+    /// covers only the pass under test.
+    func resetStartMonitoringCallCount() {
+        startMonitoringCallCount = 0
+    }
+}

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -40,6 +40,7 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
     var receivedAlarms: [AlarmPushBody] = []
     var receivedDonationPromptIDs: [String?] = []
     var receivedDeviceTokens: [String] = []
+    var receivedProximityAlertStopIDs: [StopID] = []
 
     func pushServicePresentingController(_ pushService: PushService) -> UIViewController? {
         nil
@@ -55,6 +56,10 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
 
     func pushService(_ pushService: PushService, receivedDeviceToken token: String) {
         receivedDeviceTokens.append(token)
+    }
+
+    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID) {
+        receivedProximityAlertStopIDs.append(stopID)
     }
 }
 
@@ -208,6 +213,36 @@ final class PushServiceTests: OBATestCase {
 
         #expect(delegate.receivedDonationPromptIDs.count == 1)
         #expect(delegate.receivedDonationPromptIDs[0] == "experiment-42")
+    }
+
+    // MARK: - Proximity Alert Payloads
+
+    @Test func `Proximity alert payload forwards stop ID to delegate`() {
+        provider.notificationReceivedHandler("You're getting close to 3rd & Pike", [
+            ProximityAlertManager.notificationUserInfoKey: "1_75403"
+        ])
+
+        #expect(delegate.receivedProximityAlertStopIDs == ["1_75403"])
+    }
+
+    /// Routing this at all is what keeps the fallback below from re-presenting
+    /// the notification's own text in a modal — which for a proximity alert
+    /// would tell the rider they are approaching their stop a second time.
+    @Test func `Proximity alert payload does not route to alarm or donation`() {
+        provider.notificationReceivedHandler("You're getting close to 3rd & Pike", [
+            ProximityAlertManager.notificationUserInfoKey: "1_75403"
+        ])
+
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
+    }
+
+    @Test func `Proximity alert payload with non string stop ID is not routed`() {
+        provider.notificationReceivedHandler("You're getting close", [
+            ProximityAlertManager.notificationUserInfoKey: 123
+        ])
+
+        #expect(delegate.receivedProximityAlertStopIDs.isEmpty)
     }
 
     // MARK: - Fallback Paths


### PR DESCRIPTION
## Add ProximityAlertManager to fire destination alerts

Adds the manager that arms a geofence for a saved destination alert, posts a local notification when the rider crosses it, and keeps Core Location's monitored regions in agreement with the alerts in `UserDataStore`.

Refs [#1150](https://github.com/OneBusAway/onebusaway-ios/issues/1150). PR 3 of 4 for [#455](https://github.com/OneBusAway/onebusaway-ios/issues/455).

PR 2 shipped the geofencing API with no consumer — `ProximityMonitoringResult`, `RegionMonitoringFailureKind`, and the 20-region guard have had nothing reading them. This is that consumer.

### What changed

**New file — `ProximityAlertManager.swift` (`OBAKit`)**

`@MainActor` manager owning the alert lifecycle. `createProximityAlert(for:radiusMeters:)` returns a `ProximityAlertActivationResult` rather than half-succeeding — nothing is persisted unless the geofence actually armed, and notification authorization is checked first, since an armed geofence whose notification can't be shown does nothing. On a crossing it posts the notification and deletes the alert (one-shot). A single `reconcileMonitoredRegions()` is the only repair path, called from construction, `.proximityAlertsDidChange`, `applicationDidBecomeActive`, and the grant of Always authorization — that last one closes the "no self-healing re-arm" gap PR 2 documented but couldn't fix alone.

**Modified — `Application.swift`**

Builds the manager in `init`, not lazily: a geofence crossing relaunches a terminated app, and nothing on that launch would ever touch a lazy property. Adds `pushService(_:receivedProximityAlertForStopID:)`, which stashes into `pendingStopID` when no region has loaded yet rather than dropping the tap.

**Modified — `PushService.swift`**

Routes the notification tap. `OBACloudPushService` owns the app's only `UNUserNotificationCenter` delegate, and its fallback for an unrecognized payload re-presents the notification's own text in a modal — for this one, telling the rider they're approaching their stop a second time.

**Modified — `LocationService.swift` (`OBAKitCore`)**

Three accessors the manager needs: `proximityAlertID(forRegionIdentifier:)`, `monitoredProximityAlertIDs`, and `stopMonitoringProximityAlert(id:)` — the last for a region whose alert no longer exists to name it.

### How to test

No UI in this PR — the stop-page entry point is PR 4, so there's nothing to record on screen.

- `OBAKitTests/ProximityAlertManagerTests` — 32 tests: creation refusals, all four reconciliation triggers, the fire path, authorization changes, both failure classifications
- `OBAKitTests/PushServiceTests` — 3 tests for the new routing branch
-  `OBAKitTests/ApplicationTests` — the tap is stashed, never dropped
-  Full `OBAKitTests` target passes (2343 tests)
-  Strings added to all 13 locales

---

> **PR Roadmap for [#455](https://github.com/OneBusAway/onebusaway-ios/issues/455)**
>
> | # | PR | Status |
> |---|-----|--------|
> | 1 | `ProximityAlert` model + `UserDataStore` persistence | `Merged` |
> | 2 | `LocationService` geofencing + hardening | `Merged` |
> | 3 | **`ProximityAlertManager` + local notifications** | `Current` |
> | 4 | Stop page UI to create and cancel alerts | `Next` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added destination proximity alerts that notify riders as they approach a selected stop.
  * Alerts support custom distances, cancellation, authorization checks, and automatic monitoring cleanup.
  * Tapping a proximity alert opens the associated destination when possible, or completes navigation when the app is ready.
* **Localization**
  * Added proximity-alert notification titles and messages in multiple supported languages.
* **Bug Fixes**
  * Improved handling of expired, missing, or invalid monitored alerts and notification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->