### PR TITLE
Give loop-route trip stops unique list identifiers

### DIFF
--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -38,7 +38,14 @@ nonisolated struct TripStopListItemRowConfiguration: OBAContentConfiguration {
 }
 
 nonisolated struct TripStopViewModel: OBAListViewItem {
-    var id: String { stop.id }
+    /// Position-qualified: a loop visits the same stop twice, and
+    /// `NSDiffableDataSource` crashes on duplicate item identifiers (#538).
+    /// Same format as `TripStopListModel.Row.id`.
+    var id: String { "\(stopIndex)-\(stop.id)" }
+
+    /// Index of this visit on the trip. Carried so `id` can stay unique
+    /// without parsing the identity string.
+    let stopIndex: Int
 
     var configuration: OBAListViewItemConfiguration {
         return .custom(TripStopListItemRowConfiguration(viewModel: self))
@@ -101,6 +108,7 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         routeType = stopTime.stop.prioritizedRouteTypeForDisplay
 
         self.onSelectAction = onSelectAction
+        self.stopIndex = stopIndex
     }
 
     func hash(into hasher: inout Hasher) {
@@ -114,7 +122,8 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
     }
 
     static func == (lhs: TripStopViewModel, rhs: TripStopViewModel) -> Bool {
-        return lhs.isCurrentVehicleLocation == rhs.isCurrentVehicleLocation &&
+        return lhs.id == rhs.id &&
+            lhs.isCurrentVehicleLocation == rhs.isCurrentVehicleLocation &&
             lhs.isUserDestination == rhs.isUserDestination &&
             lhs.temporalState == rhs.temporalState &&
             lhs.title == rhs.title &&

--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -72,6 +72,54 @@ final class TripStopTemporalStateTests {
 
 @MainActor
 @Suite(.serialized)
+final class TripStopViewModelIdentityTests {
+
+    /// A loop route visits the same stop twice. `NSDiffableDataSource` crashes
+    /// if two rows share an item identifier (#538). The SwiftUI trip page already
+    /// qualifies ids by index (`TripStopListModel`); the UIKit list did not.
+    @Test func `A stop visited twice gets two distinct list ids`() throws {
+        let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
+        let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
+        let stopTime = try #require(response.entry.stopTimes.first)
+
+        let first = TripStopViewModel(
+            stopTime: stopTime,
+            arrivalDeparture: nil,
+            stopIndex: 0,
+            closestStopIndex: nil,
+            onSelectAction: nil
+        )
+        let second = TripStopViewModel(
+            stopTime: stopTime,
+            arrivalDeparture: nil,
+            stopIndex: 5,
+            closestStopIndex: nil,
+            onSelectAction: nil
+        )
+
+        #expect(first.id != second.id)
+        #expect(first.stop.id == second.stop.id)
+        #expect(first != second)
+    }
+
+    @Test func `List ids stay unique across the whole trip`() throws {
+        let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
+        let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
+        let ids = response.entry.stopTimes.enumerated().map { index, stopTime in
+            TripStopViewModel(
+                stopTime: stopTime,
+                arrivalDeparture: nil,
+                stopIndex: index,
+                closestStopIndex: nil,
+                onSelectAction: nil
+            ).id
+        }
+        #expect(Set(ids).count == ids.count)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
 final class TripProgressViewModelTests {
 
     @Test func `Zero total stops returns nil`() {

--- a/docs/duplicate-trip-stop-ids.md
+++ b/docs/duplicate-trip-stop-ids.md
@@ -1,0 +1,14 @@
+# Duplicate trip-stop list identifiers
+
+A loop route visits the same stop twice. `TripStopViewModel.id` was the
+bare `stop.id`, so `NSDiffableDataSource` saw two rows with the same
+item identifier and crashed. That is the App Store crash in #538.
+
+The SwiftUI trip page already qualifies ids by position
+(`TripStopListModel.Row.id` is `"\(index)-\(stopID)"`). The UIKit trip
+list now uses the same format.
+
+`Equatable` includes `id`, matching the protocol's "all values, including
+the identifier" rule. Two visits to one stop are no longer equal.
+
+Tests do not load `TripViewController.view`.


### PR DESCRIPTION
## Summary
- A loop visits the same stop twice. UIKit `TripStopViewModel.id` was the bare `stop.id`, so `NSDiffableDataSource` crashed. That is the App Store crash in #538.
- Ids are now `"\(stopIndex)-\(stop.id)"`, the same format `TripStopListModel` already uses on the SwiftUI trip page.
- `Equatable` includes `id`, matching the list-item protocol. Two visits to one stop are no longer equal.

Closes #538.

## Test plan
- [x] `TripStopViewModelIdentityTests` (2) — two visits to one stop have distinct ids; a full trip's ids are unique
- [x] `TripStopTemporalStateTests` (7) — existing classification still holds
- [ ] Open a loop trip (same stop twice) on the classic trip list: both visits appear, no crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes and display issues on loop routes where the same stop appears multiple times.
  * Stop entries now remain distinct based on their position in the trip, even when they share the same stop record.

* **Tests**
  * Added coverage ensuring repeated stops receive unique identifiers and remain distinct.

* **Documentation**
  * Documented handling of duplicate trip-stop identifiers across UIKit and SwiftUI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->