### PR TITLE
Address trip-sharing follow-ups from #1120

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -243,7 +243,7 @@ extension View {
                     Label(Strings.addBookmark, systemImage: "bookmark")
                 }
                 Button(action: actions.onShareTrip) {
-                    Label(OBALoc("stop_page.row.share_trip", value: "Share Trip", comment: "Context menu action that shares the trip after choosing a destination stop"), systemImage: "square.and.arrow.up")
+                    Label(Strings.shareTrip, systemImage: "square.and.arrow.up")
                 }
             }, preview: {
                 actions.makePreview()

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -928,7 +928,7 @@ public class StopViewController: UIViewController,
                 actions.append(schedule)
             }
 
-            let shareTrip = UIAction(title: OBALoc("stop_controller.share_trip", value: "Share Trip", comment: "Context menu button that allows the user to share their trip status."), image: Icons.share) { [weak self] _ in
+            let shareTrip = UIAction(title: Strings.shareTrip, image: Icons.share) { [weak self] _ in
                 self?.shareTripStatus(viewModel: viewModel)
             }
             actions.append(shareTrip)

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "عرض التقرير";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "تعذّر تحديد نقطة صعودك في هذه الرحلة.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "تعذّر الاتصال بخدمة النقل.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "جارٍ تحميل المحطات";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "لا توجد محطات متبقية في هذه الرحلة.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "لا توجد محطات متاحة";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "إعادة المحاولة";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "أين ستنزل؟";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "مشاركة الرحلة دون تحديد محطة وصول";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "مشاركة دون وجهة";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "اختر الوجهة";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "يُطوَّر هذا التطبيق حاليًا بجهود تطوعية بنسبة 100%، ونحتاج إلى مساعدتك لتمويل التطوير المستقبلي.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "تبدأ باسم %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "حدث خطأ أثناء تجهيز رابط الرحلة. يُرجى المحاولة مرة أخرى.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "تعذّرت المشاركة";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "معرّف المركبة: %@";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "View Report";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Couldn't determine your boarding point on this trip.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Unable to connect to the transit service.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Loading Stops";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "There are no remaining stops on this trip.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "No Stops Available";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Try Again";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Where are you getting off?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Share trip without a destination stop";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Share Without Destination";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Select Destination";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "This app is currently built with 100% volunteer labor, and we need you to help us fund future development.";
 
@@ -1504,6 +1534,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Starts as %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Something went wrong while preparing the trip link. Please try again.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Unable to Share";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "Vehicle ID: %@";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "View Report";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "No se pudo determinar tu punto de subida en este viaje.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "No se puede conectar con el servicio de transporte.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Cargando paradas";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "No quedan paradas en este viaje.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "No hay paradas disponibles";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Reintentar";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "¿Dónde te bajas?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Compartir viaje sin parada de destino";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Compartir sin destino";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Seleccionar destino";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Esta aplicación se desarrolla actualmente con trabajo 100% voluntario, y necesitamos su ayuda para financiar el desarrollo futuro.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Comienza como %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Algo salió mal al preparar el enlace del viaje. Inténtalo de nuevo.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "No se puede compartir";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "ID de vehículo: %@";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Tingnan ang Ulat";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Hindi matukoy ang iyong sakayan sa biyaheng ito.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Hindi makakonekta sa serbisyo ng transit.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Nilo-load ang mga hintuan";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Wala nang natitirang hintuan sa biyaheng ito.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Walang Available na Hintuan";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Subukang Muli";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Saan ka bababa?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Ibahagi ang biyahe nang walang hintuang patutunguhan";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Ibahagi nang Walang Destinasyon";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Pumili ng Destinasyon";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Ang app na ito ay kasalukuyang ginagawa nang 100% boluntaryo, at kailangan namin ang tulong mo para pondohan ang susunod na development.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Magsisimula bilang %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "May naganap na problema sa paghahanda ng link ng biyahe. Pakisubukang muli.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Hindi Maibahagi";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "Vehicle ID: %@";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Afficher le rapport";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Impossible de déterminer votre point de montée sur ce trajet.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Impossible de se connecter au service de transport.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Chargement des arrêts";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Il ne reste aucun arrêt sur ce trajet.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Aucun arrêt disponible";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Réessayer";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Où descendez-vous ?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Partager le trajet sans arrêt de destination";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Partager sans destination";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Choisir la destination";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Cette app est actuellement développée à 100 % par des bénévoles, et nous avons besoin de votre aide pour financer son développement futur.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Commence en tant que %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Une erreur s'est produite lors de la préparation du lien du trajet. Veuillez réessayer.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Partage impossible";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "ID du véhicule : %@";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "View Report";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Impossibile determinare la tua fermata di salita su questo itinerario.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Impossibile connettersi al servizio di trasporto.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Caricamento fermate";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Non ci sono altre fermate su questo itinerario.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Nessuna fermata disponibile";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Riprova";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Dove scendi?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Condividi l'itinerario senza fermata di destinazione";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Condividi senza destinazione";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Seleziona destinazione";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Questa app è attualmente realizzata con il 100% di lavoro volontario e abbiamo bisogno del tuo aiuto per finanziare lo sviluppo futuro.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Parte come: %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Si è verificato un errore durante la preparazione del link dell'itinerario. Riprova.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Impossibile condividere";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "Identificativo veicolo %@";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "보고서 보기";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "이 여정에서 탑승 지점을 확인할 수 없습니다.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "대중교통 서비스에 연결할 수 없습니다.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "정류장 불러오는 중";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "이 여정에 남은 정류장이 없습니다.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "이용 가능한 정류장 없음";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "다시 시도";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "어디에서 내리시나요?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "목적지 정류장 없이 여정 공유";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "목적지 없이 공유";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "목적지 선택";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "이 앱은 현재 100% 자원봉사로 만들어지고 있으며, 향후 개발 자금 마련을 위해 여러분의 도움이 필요합니다.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "%@(으)로 운행 시작";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "여정 링크를 준비하는 중 문제가 발생했습니다. 다시 시도해 주세요.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "공유할 수 없음";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "차량 ID: %@";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Zobacz raport";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Nie udało się ustalić Twojego przystanku początkowego na tym kursie.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Nie można połączyć się z serwisem przewoźnika.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Wczytywanie przystanków";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Na tym kursie nie ma już kolejnych przystanków.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Brak dostępnych przystanków";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Spróbuj ponownie";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Gdzie wysiadasz?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Udostępnij kurs bez przystanku docelowego";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Udostępnij bez celu podróży";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Wybierz cel podróży";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Ta aplikacja jest obecnie tworzona w 100% przez wolontariuszy i potrzebujemy Twojej pomocy w finansowaniu dalszego rozwoju.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Rozpoczyna jako %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Coś poszło nie tak podczas przygotowywania linku do kursu. Spróbuj ponownie.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Nie można udostępnić";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "ID pojazdu: %@";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Ver Relatório";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Não foi possível determinar seu ponto de embarque nesta viagem.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Não foi possível conectar ao serviço de transporte.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Carregando paradas";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Não há mais paradas nesta viagem.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Nenhuma parada disponível";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Tentar Novamente";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Onde você vai descer?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Compartilhar viagem sem parada de destino";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Compartilhar sem destino";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Selecionar destino";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Este app é desenvolvido atualmente com trabalho 100% voluntário, e precisamos da sua ajuda para financiar o desenvolvimento futuro.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Começa como %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Algo deu errado ao preparar o link da viagem. Tente novamente.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Não é possível compartilhar";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "ID do Veículo: %@";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Показать отчёт";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Не удалось определить вашу остановку посадки в этой поездке.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Не удалось подключиться к транспортной службе.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Загрузка остановок";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "В этой поездке больше нет остановок.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Нет доступных остановок";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Повторить";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Где вы выходите?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Поделиться поездкой без остановки назначения";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Поделиться без пункта назначения";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Выберите пункт назначения";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Это приложение создаётся исключительно силами волонтёров, и нам нужна ваша помощь для финансирования дальнейшей разработки.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Начинает движение как %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "При подготовке ссылки на поездку произошла ошибка. Попробуйте ещё раз.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Не удалось поделиться";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "ID транспорта: %@";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "Xem báo cáo";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "Không thể xác định điểm lên xe của bạn trên chuyến đi này.";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "Không thể kết nối với dịch vụ vận tải.";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "Đang tải điểm dừng";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "Không còn điểm dừng nào trên chuyến đi này.";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "Không có điểm dừng nào";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "Thử lại";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "Bạn xuống ở đâu?";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "Chia sẻ chuyến đi mà không có điểm dừng đến";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "Chia sẻ không kèm điểm đến";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "Chọn điểm đến";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "Ứng dụng này hiện được xây dựng hoàn toàn bằng công sức tình nguyện, và chúng tôi cần bạn giúp tài trợ cho việc phát triển trong tương lai.";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Bắt đầu là %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "Đã xảy ra lỗi khi chuẩn bị liên kết chuyến đi. Vui lòng thử lại.";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "Không thể chia sẻ";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "Mã phương tiện: %@";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "View Report";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "无法确定您在本次车程中的上车站点。";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "无法连接到公交服务。";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "正在加载站点";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "本次车程没有剩余站点。";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "没有可用站点";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "重试";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "您在哪里下车？";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "不选择目的地站点，直接分享车程";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "不选目的地直接分享";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "选择目的地";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "本App目前完全由志愿者开发，我们需要您的帮助来资助未来的开发工作。";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "以%@为名启程";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "准备车程链接时出错。请重试。";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "无法分享";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "服务车辆编号：%@";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -217,6 +217,36 @@
 /* Button title to let the user view a data migration report. */
 "data_migration_bulletin.view_report_button" = "檢視報告";
 
+/* Error shown when the boarding stop cannot be found in the trip's stop list. */
+"destination_stop_picker.error_boarding_stop_not_found" = "無法確認您在此行程中的上車站牌。";
+
+/* Error shown when the API service is unavailable in the destination stop picker. */
+"destination_stop_picker.error_no_service" = "無法連線至大眾運輸服務。";
+
+/* Title shown while loading the list of stops for destination selection. */
+"destination_stop_picker.loading_title" = "正在載入站牌";
+
+/* Body text shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_body" = "此行程沒有剩餘的站牌。";
+
+/* Title shown when there are no stops available after the boarding stop. */
+"destination_stop_picker.no_stops_title" = "沒有可用的站牌";
+
+/* Button to retry loading stops after an error. */
+"destination_stop_picker.retry_button" = "再試一次";
+
+/* Section header prompting user to select their destination stop. */
+"destination_stop_picker.select_destination_header" = "您要在哪裡下車？";
+
+/* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
+"destination_stop_picker.share_without_destination_a11y_label" = "不選擇目的地站牌，直接分享行程";
+
+/* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
+"destination_stop_picker.share_without_destination_button" = "不選目的地直接分享";
+
+/* Navigation bar title for the destination stop picker when sharing a trip. */
+"destination_stop_picker.title" = "選擇目的地";
+
 /* Body of the donation widget that appears on the stop view controller */
 "donation_cell.body" = "本 App 目前完全由志工打造，我們需要您的協助來資助未來的開發。";
 
@@ -1502,6 +1532,12 @@
 
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "先前行駛 %@";
+
+/* Alert message when trip sharing fails. */
+"trip_sharing.share_error.message" = "準備行程連結時發生錯誤，請再試一次。";
+
+/* Alert title when trip sharing fails. */
+"trip_sharing.share_error.title" = "無法分享";
 
 /* A formatted string for displaying a vehicle's ID on the trip status map. e.g. 'Vehicle ID: 12345' */
 "trip_status_annotation.title_fmt" = "車輛編號：%@";

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -51,6 +51,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
         didSet {
             guard isViewLoaded else { return }
             listView.applyData(animated: false)
+            updateShareEscapeVisibility()
         }
     }
 
@@ -88,6 +89,10 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
             target: self,
             action: #selector(cancelTapped)
         )
+
+        // `state`'s `didSet` keeps this current from here on, but it does not
+        // fire for the initial `.loading` value, so seed it once.
+        updateShareEscapeVisibility()
 
         view.backgroundColor = ThemeColors.shared.systemBackground
 
@@ -203,6 +208,59 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
         delegate?.destinationStopPickerDidCancel(self)
     }
 
+    @objc private func shareWithoutDestinationTapped() {
+        // The same delegate call the empty state's share button makes, so both
+        // escapes converge on one path. The delegate is weak by design: if it
+        // has gone away there is no sharing flow left to drive, which is the
+        // contract `TripSharingCoordinator` documents for its own presenter.
+        delegate?.destinationStopPickerDidSkipDestination(self)
+    }
+
+    // MARK: - Share Escape
+
+    /// One string for two surfaces: the empty state's body button and the error
+    /// state's navigation bar escape. A second key for the same words is the
+    /// defect this change set exists to remove.
+    private static let shareWithoutDestinationTitle = OBALoc(
+        "destination_stop_picker.share_without_destination_button",
+        value: "Share Without Destination",
+        comment: "Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination."
+    )
+
+    /// Built once rather than per state change: the item carries no state, so
+    /// there is nothing to rebuild.
+    private lazy var shareWithoutDestinationButton: UIBarButtonItem = {
+        let item = UIBarButtonItem(
+            title: Self.shareWithoutDestinationTitle,
+            style: .plain,
+            target: self,
+            action: #selector(shareWithoutDestinationTapped)
+        )
+        item.accessibilityLabel = OBALoc(
+            "destination_stop_picker.share_without_destination_a11y_label",
+            value: "Share trip without a destination stop",
+            comment: "VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded."
+        )
+        return item
+    }()
+
+    /// Offers the destination-less share in `.error`, where the only other exits
+    /// are Try Again and Cancel. The destination is optional, so a failed fetch
+    /// need not block sharing.
+    ///
+    /// `.empty` deliberately does not get it: that state already offers the same
+    /// action as its body button, and putting the identical control on screen
+    /// twice reads as a bug. `.loading` and `.data` are not dead ends — the list
+    /// is still coming, or it has arrived and the user should pick a stop.
+    private func updateShareEscapeVisibility() {
+        switch state {
+        case .error:
+            navigationItem.rightBarButtonItem = shareWithoutDestinationButton
+        case .loading, .empty, .data:
+            navigationItem.rightBarButtonItem = nil
+        }
+    }
+
     // MARK: - UI
 
     private let listView = OBAListView()
@@ -267,11 +325,7 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
         // Without this button the empty state would be a dead end: the
         // only exit is Cancel, with no way to share the trip at all.
         let shareConfig = ActivityIndicatedButton.Configuration(
-            text: OBALoc(
-                "destination_stop_picker.share_without_destination_button",
-                value: "Share Without Destination",
-                comment: "Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination."
-            ),
+            text: Self.shareWithoutDestinationTitle,
             largeContentImage: nil,
             showsActivityIndicatorOnTap: false,
             action: { [weak self] in

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -443,4 +443,110 @@ final class DestinationStopPickerControllerTests: OBATestCase {
             "Retry should reload and show the forward stops"
         )
     }
+
+    // MARK: - Error State Share Escape
+
+    /// A failed fetch used to leave only Try Again and Cancel. The destination is
+    /// optional, so the error state now offers the same destination-less share the
+    /// empty state does — from the navigation bar, because
+    /// `StandardEmptyDataViewModel` holds exactly one `buttonConfig` and `.error`
+    /// must keep its retry.
+    @Test @MainActor
+    func `Error state offers a share escape without giving up the retry button`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let dataLoader = MockDataLoader(testName: name)
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet,
+                                   userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."])
+        dataLoader.mock(response: MockDataResponse(data: nil, urlResponse: nil, error: networkError) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        })
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        let recorder = PickerDelegateRecorder()
+        controller.delegate = recorder
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { controller.navigationItem.rightBarButtonItem != nil },
+            "picker never offered the error state's share escape"
+        )
+
+        let shareItem = try #require(controller.navigationItem.rightBarButtonItem)
+        #expect(shareItem.title == "Share Without Destination")
+        #expect(shareItem.accessibilityLabel == "Share trip without a destination stop")
+        #expect(
+            standardEmptyData(controller, listView)?.buttonConfig?.text == "Try Again",
+            "The escape must not cost the error state its retry button"
+        )
+
+        let target = try #require(shareItem.target as? NSObject)
+        _ = target.perform(try #require(shareItem.action))
+
+        #expect(recorder.didSkipDestination, "The escape shares without a destination")
+        #expect(recorder.selectedStopTime == nil)
+        #expect(!recorder.didCancel)
+    }
+
+    /// The escape belongs to the dead-end state only: while the list is still
+    /// coming there is nothing to escape from, and once stops are on screen the
+    /// user should be picking one.
+    @Test @MainActor
+    func `Share escape is absent while loading and once stops are on screen`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+        let forwardStopIDs = ["1_10915", "1_10916"]
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: forwardStopIDs))) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+
+        #expect(controller.navigationItem.rightBarButtonItem == nil, "Nothing to escape from while the list is still loading")
+
+        let listView = OBAListView()
+        await poll(
+            until: { !controller.items(for: listView).isEmpty },
+            "picker never entered the data state"
+        )
+
+        #expect(
+            controller.navigationItem.rightBarButtonItem == nil,
+            "With stops on screen the user should be picking one, not escaping"
+        )
+    }
+
+    /// `.empty` already offers the destination-less share as its body button, so
+    /// it deliberately does not also get the navigation bar escape — the identical
+    /// control twice on one screen reads as a bug.
+    @Test @MainActor
+    func `Empty state keeps one share button and gains no duplicate in the navigation bar`() async throws {
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let dataLoader = MockDataLoader(testName: name)
+        dataLoader.mock(data: try makeTripDetailsData(stopIDs: stopIDsWithBoarding(arrivalDeparture.stopID, forward: []))) {
+            $0.url?.path.contains("/api/where/trip-details") ?? false
+        }
+        let app = createApplication(dataLoader: dataLoader)
+
+        let controller = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+        controller.loadViewIfNeeded()
+
+        let listView = OBAListView()
+        await poll(
+            until: { self.standardEmptyData(controller, listView)?.buttonConfig != nil },
+            "picker never entered the empty state"
+        )
+
+        #expect(standardEmptyData(controller, listView)?.buttonConfig?.text == "Share Without Destination")
+        #expect(
+            controller.navigationItem.rightBarButtonItem == nil,
+            "The empty state's body button is the only share escape it needs"
+        )
+    }
 }

--- a/OBAKitTests/Trip/TripSharingCoordinatorTests.swift
+++ b/OBAKitTests/Trip/TripSharingCoordinatorTests.swift
@@ -1,0 +1,388 @@
+//
+//  TripSharingCoordinatorTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+import UIKit
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Records what the coordinator presented, and when.
+///
+/// Extends `MockPresentingViewController` rather than replacing it: that helper
+/// tracks `present` but not `dismiss`, and `TripSharingCoordinator` does all of
+/// its work inside `dismiss`'s completion block — the ordering these tests exist
+/// to pin.
+///
+/// With `autoRunsDismissCompletion` false, `dismiss(animated:completion:)` parks
+/// the completion instead of running it, so a test can observe the window
+/// between "picker dismissed" and "share sheet presented".
+private final class RecordingPresenter: MockPresentingViewController {
+    enum Call: Equatable {
+        case dismiss
+        case present
+    }
+
+    private(set) var calls: [Call] = []
+    private(set) var presentedControllers: [UIViewController] = []
+    private var parkedDismissCompletion: (() -> Void)?
+
+    var autoRunsDismissCompletion = true
+
+    /// The share sheet the coordinator presented, if it got that far.
+    var sharedActivityController: UIActivityViewController? {
+        presentedControllers.compactMap { $0 as? UIActivityViewController }.last
+    }
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        calls.append(.present)
+        presentedControllers.append(viewControllerToPresent)
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        calls.append(.dismiss)
+
+        guard autoRunsDismissCompletion else {
+            parkedDismissCompletion = completion
+            return
+        }
+        completion?()
+    }
+
+    /// Runs the completion block parked by the most recent `dismiss`.
+    func finishDismissal() {
+        let completion = parkedDismissCompletion
+        parkedDismissCompletion = nil
+        completion?()
+    }
+}
+
+/// Covers `TripSharingCoordinator` — the piece both the legacy
+/// `StopViewController` and the redesigned stop page depend on for trip sharing.
+///
+/// `AppLinksRouterDeepLinkFormatTests` builds its `URLComponents` by hand and
+/// never calls `AppLinksRouter.encode`, so the `destination_stop_id` encoding is
+/// exercised here through the production API instead.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/449
+@Suite(.serialized)
+final class TripSharingCoordinatorTests: OBATestCase {
+    var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    // MARK: - Helpers
+
+    /// The fixture's first arrival: tripID `1_40984902`, stopID `1_10914`,
+    /// stopSequence `3`, serviceDate `1541055600000`ms. Every expected URL below
+    /// is spelled out from those values rather than recomputed from the model,
+    /// so an encoding change has to be acknowledged rather than tracked.
+    private func makeArrivalDeparture() throws -> ArrivalDeparture {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
+    }
+
+    /// A `TripStopTime` carrying just the one field the coordinator reads.
+    private func makeStopTime(stopID: StopID) throws -> TripStopTime {
+        try Fixtures.dictionaryToModel(
+            type: TripStopTime.self,
+            dictionary: ["stopId": stopID, "arrivalTime": 0, "departureTime": 0]
+        )
+    }
+
+    private func registerBaseStubs(on dataLoader: MockDataLoader) {
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+        let emptySurveys = Data(#"{"surveys":[]}"#.utf8)
+        dataLoader.mock(data: emptySurveys) { $0.url?.path.contains("/surveys.json") ?? false }
+    }
+
+    /// Builds an `Application` pinned to Puget Sound, whose `sidecarBaseURL`
+    /// (`https://onebusaway.co`) is what `AppLinksRouter` builds share URLs from.
+    ///
+    /// - Parameters:
+    ///   - bundledRegionsFixture: pass `regions-puget-sound-no-sidecar.json` for a
+    ///     region that exists but has no sidecar URL — the only input that makes
+    ///     `AppLinksRouter.encode` return nil.
+    ///   - location: pass Null Island with `pinsRegion: false` to leave
+    ///     `currentRegion` nil.
+    private func createApplication(
+        dataLoader: MockDataLoader,
+        bundledRegionsFixture: String? = nil,
+        location: CLLocation = TestData.mockSeattleLocation,
+        pinsRegion: Bool = true
+    ) -> Application {
+        registerBaseStubs(on: dataLoader)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: location,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locationService.startUpdates()
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsFixture.map { Fixtures.path(to: $0) } ?? bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: pinsRegion ? Fixtures.pugetSoundRegion.name : nil
+        )
+
+        return Application(config: config)
+    }
+
+    /// `RegionsService` prefers the on-disk regions file over the bundled one, and
+    /// a prior run in the same simulator can leave a copy that *does* have a
+    /// sidecar URL. Wipe it so a no-sidecar bundled fixture actually reaches
+    /// `currentRegion`.
+    private func removeStoredRegionsFile() {
+        guard let appSupport = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else { return }
+
+        try? FileManager.default.removeItem(
+            at: appSupport.appendingPathComponent("Regions/default-regions.json")
+        )
+    }
+
+    // MARK: - destination_stop_id encoding
+
+    /// The gap the hand-built deep-link tests leave open: this goes through
+    /// `AppLinksRouter.encode`, the call the coordinator actually makes.
+    @Test @MainActor
+    func `Encoded share URL carries the destination stop alongside the trip identifiers`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let region = try #require(app.currentRegion)
+        let router = try #require(app.appLinksRouter)
+
+        let url = try #require(router.encode(
+            arrivalDeparture: arrivalDeparture,
+            region: region,
+            destinationStopID: "1_431"
+        ))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        #expect(components.host == "onebusaway.co")
+        #expect(components.path == "/regions/1/stops/1_10914/trips")
+        #expect(components.queryItem(named: "destination_stop_id")?.value == "1_431")
+        #expect(components.queryItem(named: "trip_id")?.value == "1_40984902")
+        #expect(components.queryItem(named: "service_date")?.value == "1541055600.0")
+        #expect(components.queryItem(named: "stop_sequence")?.value == "3")
+    }
+
+    /// A nil destination must omit the query item outright. An empty
+    /// `destination_stop_id=` would reach the sidecar as a stop ID matching
+    /// nothing, which is worse than saying nothing at all.
+    @Test @MainActor
+    func `Encoded share URL omits the destination query item when there is no destination`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let region = try #require(app.currentRegion)
+        let router = try #require(app.appLinksRouter)
+
+        let url = try #require(router.encode(
+            arrivalDeparture: arrivalDeparture,
+            region: region,
+            destinationStopID: nil
+        ))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        #expect(components.queryItem(named: "destination_stop_id") == nil)
+        #expect(components.queryItems?.count == 3)
+        #expect(components.path == "/regions/1/stops/1_10914/trips")
+        #expect(components.queryItem(named: "trip_id")?.value == "1_40984902")
+    }
+
+    // MARK: - Delegate paths
+    //
+    // `UIActivityViewController` does not expose its `activityItems`, so the URL
+    // a presented share sheet carries cannot be read back here. Which destination
+    // each delegate method forwards to `encode` is pinned by the encoding tests
+    // above; these pin that each method reaches the share sheet at all — and that
+    // cancel does not.
+
+    @Test @MainActor
+    func `Selecting a destination stop dismisses the picker and shares`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let presenter = RecordingPresenter()
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPicker(picker, didSelectStop: try makeStopTime(stopID: "1_431"))
+
+        #expect(presenter.calls == [.dismiss, .present])
+        #expect(presenter.sharedActivityController != nil, "Selecting a stop must reach the share sheet")
+        #expect(presenter.presentedAlert == nil, "The happy path must not surface the failure alert")
+    }
+
+    @Test @MainActor
+    func `Skipping the destination dismisses the picker and shares`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let presenter = RecordingPresenter()
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPickerDidSkipDestination(picker)
+
+        #expect(presenter.calls == [.dismiss, .present])
+        #expect(
+            presenter.sharedActivityController != nil,
+            "The destination is optional — skipping it must still reach the share sheet"
+        )
+        #expect(presenter.presentedAlert == nil)
+    }
+
+    @Test @MainActor
+    func `Cancelling dismisses the picker without sharing`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let presenter = RecordingPresenter()
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPickerDidCancel(picker)
+
+        #expect(presenter.calls == [.dismiss], "Cancel dismisses and stops there")
+        #expect(presenter.sharedActivityController == nil)
+        #expect(presenter.presentedAlert == nil)
+    }
+
+    // MARK: - Dismiss-then-present ordering
+
+    /// The share sheet must be presented from `dismiss`'s completion block, once
+    /// the picker is actually gone — presenting on top of a still-dismissing
+    /// controller is the bug this ordering avoids.
+    ///
+    /// Parking the completion instead of running it inline is what makes this
+    /// discriminating: a coordinator that presented alongside `dismiss` rather
+    /// than inside its completion would present here, with the completion never
+    /// run at all.
+    @Test @MainActor
+    func `Share sheet is presented from the dismiss completion, not alongside it`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader)
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let presenter = RecordingPresenter()
+        presenter.autoRunsDismissCompletion = false
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPicker(picker, didSelectStop: try makeStopTime(stopID: "1_431"))
+
+        #expect(presenter.calls == [.dismiss], "Nothing may be presented while the picker is still dismissing")
+        #expect(presenter.sharedActivityController == nil)
+
+        presenter.finishDismissal()
+
+        #expect(presenter.calls == [.dismiss, .present])
+        #expect(presenter.sharedActivityController != nil, "The share sheet belongs in the dismiss completion")
+    }
+
+    // MARK: - Unable to Share
+
+    /// First `presentShareError()` guard: no current region.
+    @Test @MainActor
+    func `Sharing without a current region surfaces the failure alert`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        // Null Island (0, 0), in the Gulf of Guinea, is covered by no transit
+        // region — and with no `fixedRegionName` pinning one, `currentRegion`
+        // stays nil.
+        let app = createApplication(
+            dataLoader: dataLoader,
+            location: CLLocation(latitude: 0, longitude: 0),
+            pinsRegion: false
+        )
+        #expect(app.currentRegion == nil, "Precondition: the guard under test needs a nil region")
+
+        let arrivalDeparture = try makeArrivalDeparture()
+        let presenter = RecordingPresenter()
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPickerDidSkipDestination(picker)
+
+        let alert = try #require(presenter.presentedAlert, "A missing region must not fail silently")
+        #expect(alert.title == "Unable to Share")
+        #expect(alert.actions.first?.title == "Dismiss", "The alert needs a way out")
+        #expect(presenter.sharedActivityController == nil, "No share sheet when the link cannot be built")
+    }
+
+    /// Second `presentShareError()` guard: `encode` returns nil. The region is
+    /// present, so the first guard passes, but it carries no `sidecarBaseURL` —
+    /// the only input that makes `AppLinksRouter.encode` fail.
+    @Test @MainActor
+    func `Sharing from a region with no sidecar URL surfaces the failure alert`() throws {
+        removeStoredRegionsFile()
+
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            bundledRegionsFixture: "regions-puget-sound-no-sidecar.json"
+        )
+        let arrivalDeparture = try makeArrivalDeparture()
+
+        let region = try #require(app.currentRegion, "Precondition: this guard needs a region that does exist")
+        #expect(region.sidecarBaseURL == nil)
+
+        let router = try #require(app.appLinksRouter)
+        #expect(
+            router.encode(arrivalDeparture: arrivalDeparture, region: region, destinationStopID: "1_431") == nil,
+            "Precondition: encode must fail here, or the coordinator never reaches the guard under test"
+        )
+
+        let presenter = RecordingPresenter()
+        let coordinator = TripSharingCoordinator(application: app, presenter: presenter)
+        let picker = DestinationStopPickerController(application: app, arrivalDeparture: arrivalDeparture)
+
+        coordinator.destinationStopPicker(picker, didSelectStop: try makeStopTime(stopID: "1_431"))
+
+        let alert = try #require(presenter.presentedAlert, "A failed encode must not fail silently")
+        #expect(alert.title == "Unable to Share")
+        #expect(presenter.sharedActivityController == nil)
+    }
+}


### PR DESCRIPTION
Three of the four follow-ups named at the #1120 merge. The fourth (route-grouped mode has no context menu) is its own issue — it costs Show Trip, Alarm, Schedule and Bookmark too, not just Share Trip.

**One `Strings.shareTrip`.** `stop_controller.share_trip` and `stop_page.row.share_trip` are gone. Both call sites now use the existing `Strings.shareTrip` (`common.share_trip`), which was already in OBAKitCore, already translated in all 13 catalogs, and referenced by nothing. Two keys deleted, none added.

**`.error` gets a share escape.** The destination is optional, so a failed fetch shouldn't block sharing. It's a right bar button item reusing the empty state's string and the same `destinationStopPickerDidSkipDestination` call.

Two calls worth your eye:

- `StandardEmptyDataViewModel` holds one `buttonConfig` and `.error` has to keep Try Again, so the escape went in the nav bar rather than the body. Adding a secondary-button slot would change an app-wide control. Happy to move it if you'd rather have it there.
- It shows in `.error` only, not `.empty`. `.empty` already offers that same action as its body button, and the identical control twice on one screen reads like a bug.

**`TripSharingCoordinator` tests.** The `destination_stop_id` encoding through `AppLinksRouter.encode` — the existing deep-link tests build `URLComponents` by hand and never touch it — plus both `presentShareError()` guards and the dismiss-then-present ordering.

While consolidating the keys I found none of #1120's strings had reached the catalogs, so every locale was falling back to English. All 12 now land in all 13 with real translations.

## Testing

Full suite: 2318 tests, one pre-existing unrelated failure (`RentalFormatTests.rangeFallbackUsesAbbreviatedUnits`). SwiftLint clean in the changed files.

Refs #1120, #449.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to share a trip without selecting a destination when destination lookup fails.
  * Added loading, empty-state, retry, accessibility, and trip-sharing error messages across supported languages.
  * Improved trip-sharing error alerts when trip-link preparation fails.

* **Bug Fixes**
  * Standardized “Share Trip” labels across stop and departure menus.

* **Tests**
  * Added coverage for destination selection states, sharing behavior, URL handling, cancellation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->