### PR TITLE
Make the whole onboarding region row tappable

### DIFF
--- a/OBAKit/Onboarding/Views/OnboardingRegionView.swift
+++ b/OBAKit/Onboarding/Views/OnboardingRegionView.swift
@@ -57,7 +57,7 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
         ) {
             VStack(spacing: 0) {
                 if let region = resolved {
-                    selectedCard(for: region)
+                    selectedCard(for: region, isDetected: region.id == detected?.id)
                         .padding(.top, 22)
                 }
 
@@ -79,6 +79,12 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.horizontal, 16)
                                     .frame(height: 48)
+                                    // Without this the row's tappable area collapses to the
+                                    // glyphs of the region name: `.buttonStyle(.plain)` derives
+                                    // the hit region from the label's content rather than from
+                                    // the frame drawn around it, so most of the row ignored
+                                    // taps. See https://github.com/OneBusAway/onebusaway-ios/issues/1315
+                                    .contentShape(.rect)
                             }
                             .buttonStyle(.plain)
                             if index != shortList.count - 1 { Divider() }
@@ -108,7 +114,7 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
         .errorAlert(error: $error)
     }
 
-    private func selectedCard(for region: Region) -> some View {
+    private func selectedCard(for region: Region, isDetected: Bool) -> some View {
         VStack(spacing: 0) {
             // Live map preview, preferred over MKMapSnapshotter because snapshots
             // don't adapt to dark mode.
@@ -116,16 +122,21 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
                 .allowsHitTesting(false)
                 .frame(height: 108)
                 .clipped()
-            cardFooter(for: region)
+            cardFooter(for: region, isDetected: isDetected)
         }
         .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 20))
         .clipShape(RoundedRectangle(cornerRadius: 20))
     }
 
-    private func cardFooter(for region: Region) -> some View {
+    private func cardFooter(for region: Region, isDetected: Bool) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(OBALoc("onboarding.region.detected_label", value: "Detected near you", comment: "Label on the detected-region card"))
+                // The same card renders a region the rider picked from the list
+                // below, and calling that one "detected near you" would claim
+                // something untrue about how it got there.
+                Text(isDetected
+                     ? OBALoc("onboarding.region.detected_label", value: "Detected near you", comment: "Label on the detected-region card")
+                     : OBALoc("onboarding.region.selected_label", value: "Your selection", comment: "Label on the region card when the rider chose the region from the list rather than it being detected from their location"))
                     .font(.caption.weight(.bold))
                     .foregroundStyle(Color.accentColor)
                     .textCase(.uppercase)

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "عرض كل المناطق";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "اختيارك";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "منطقتك";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "See all regions";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Your selection";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Your region";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Ver todas las regiones";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Tu selección";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Tu región";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Tingnan ang lahat ng rehiyon";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Iyong pinili";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Ang Iyong Rehiyon";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Voir toutes les régions";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Votre sélection";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Votre région";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Vedi tutte le regioni";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "La tua selezione";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "La tua regione";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "모든 지역 보기";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "내가 선택함";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "내 지역";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Zobacz wszystkie regiony";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Twój wybór";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Twój region";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Ver todas as regiões";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Sua seleção";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Sua região";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Смотреть все регионы";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Ваш выбор";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Ваш регион";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "Xem tất cả khu vực";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "Lựa chọn của bạn";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "Khu vực của bạn";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "查看所有地区";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "你的选择";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "你的地区";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -762,6 +762,9 @@
 /* Link to the full region picker */
 "onboarding.region.see_all_button" = "查看所有地區";
 
+/* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
+"onboarding.region.selected_label" = "你的選擇";
+
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "你的地區";
 


### PR DESCRIPTION
### Summary
The rows in "Or choose another" are plain-styled buttons with no .contentShape, so only the region name text was tappable — anywhere else in the row did nothing. Added .contentShape(.rect), the same thing SearchListRowView does for its rows.
One extra thing: the card always said "Detected near you", even for a region you picked yourself. You only notice once tapping works, so I fixed it here — new onboarding.region.selected_label ("Your selection"), translated in all 13 catalogs. Say the word if you'd rather I split it out.
 Closes #1315.

### Video

https://github.com/user-attachments/assets/7253ce66-9413-4ee2-bf8e-5ed8970a50ca



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region cards now indicate whether a region was automatically detected or manually selected.
  * Alternate-region options respond when tapping anywhere across the full row.

* **Localization**
  * Added translated labels for manually selected regions across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->