### PR TITLE
 Offer Try Again when Current Trip has no location

### DIFF
--- a/OBAKit/Trip/CurrentTripViewController.swift
+++ b/OBAKit/Trip/CurrentTripViewController.swift
@@ -134,10 +134,15 @@ class CurrentTripViewController: UIViewController,
             ))
 
         case .noLocation:
+            // Recoverable like `.noResults` and `.error`: the rider can grant
+            // location access in Settings and come back, and `findVehicle()`
+            // re-reads `currentLocation` on the way in. Without the button the
+            // only way to re-run it is to leave the screen and return.
             return .standard(.init(
                 alignment: .center,
                 title: noLocationTitle,
-                body: nil
+                body: nil,
+                buttonConfig: retryButtonConfig
             ))
 
         case .noResults:


### PR DESCRIPTION
### Summary

` .noResults `and .error both offer retryButtonConfig; `.noLocation` didn't, so the only way to re-run the search after granting location access was to leave the screen and come back. Added the same button — `findVehicle()` re-reads currentLocation, so it recovers properly.
Left `.noRealtime` alone since retrying can't fix a route with no real-time data
Follow-up from your review on #1066.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retry button to the no-location state, allowing riders to try again after enabling location access in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->