### PR TITLE
Show weather condition alongside temperature on the map

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -470,16 +470,14 @@ class MapViewController: UIViewController,
     private var weatherDisplay: WeatherDisplay? {
         didSet {
             if let display = weatherDisplay {
-                let image = UIImage(systemName: WeatherFormatter.systemImageName(for: display.header.iconName))?
+                // Configuration-based buttons ignore `setTitle`/`setImage`. Update
+                // the configuration only so the stacked icon + temp actually show.
+                var config = weatherButton.configuration ?? .plain()
+                config.imagePlacement = .top
+                config.image = UIImage(systemName: WeatherFormatter.systemImageName(for: display.header.iconName))?
                     .withRenderingMode(.alwaysTemplate)
-                weatherButton.setImage(image, for: .normal)
-                weatherButton.setTitle(display.buttonTitle, for: .normal)
-                if var config = weatherButton.configuration {
-                    config.imagePlacement = .top
-                    config.image = image
-                    config.title = display.buttonTitle
-                    weatherButton.configuration = config
-                }
+                config.title = display.buttonTitle
+                weatherButton.configuration = config
                 weatherButton.accessibilityValue = display.buttonAccessibilityValue
                 weatherButton.isHidden = false
             } else {

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -144,7 +144,6 @@ class MapViewController: UIViewController,
             toolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: ThemeMetrics.controllerMargin),
             toolbar.widthAnchor.constraint(equalToConstant: 42.0),
             locationButton.heightAnchor.constraint(equalTo: locationButton.widthAnchor),
-            weatherButton.heightAnchor.constraint(equalTo: weatherButton.widthAnchor),
             toggleMapTypeButton.heightAnchor.constraint(equalTo: toggleMapTypeButton.widthAnchor),
             myTripButton.heightAnchor.constraint(equalTo: myTripButton.widthAnchor)
         ])
@@ -441,11 +440,17 @@ class MapViewController: UIViewController,
     // MARK: - Weather
 
     private lazy var weatherButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("—", for: .normal)
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        var config = UIButton.Configuration.plain()
+        config.imagePlacement = .top
+        config.title = "—"
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = UIFont.preferredFont(forTextStyle: .body).bold
+            return outgoing
+        }
+
+        let button = UIButton(configuration: config)
         button.addTarget(self, action: #selector(showWeather), for: .touchUpInside)
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body).bold
         button.accessibilityLabel = OBALoc("map_controller.show_weather_button", value: "Show Weather Forecast", comment: "Accessibility label for a button that provides the current forecast")
         return button
     }()
@@ -465,7 +470,17 @@ class MapViewController: UIViewController,
     private var weatherDisplay: WeatherDisplay? {
         didSet {
             if let display = weatherDisplay {
+                let image = UIImage(systemName: WeatherFormatter.systemImageName(for: display.header.iconName))?
+                    .withRenderingMode(.alwaysTemplate)
+                weatherButton.setImage(image, for: .normal)
                 weatherButton.setTitle(display.buttonTitle, for: .normal)
+                if var config = weatherButton.configuration {
+                    config.imagePlacement = .top
+                    config.image = image
+                    config.title = display.buttonTitle
+                    weatherButton.configuration = config
+                }
+                weatherButton.accessibilityValue = display.buttonAccessibilityValue
                 weatherButton.isHidden = false
             } else {
                 weatherButton.isHidden = true

--- a/OBAKit/Sheet/Root/WeatherButton.swift
+++ b/OBAKit/Sheet/Root/WeatherButton.swift
@@ -10,8 +10,9 @@
 import SwiftUI
 import OBAKitCore
 
-/// Floating temperature pill rendered over `MapPanelRootView`'s map. Hidden when
-/// the forecast is unavailable so the overlay reserves no space.
+/// Floating weather control rendered over `MapPanelRootView`'s map: condition
+/// SF Symbol plus temperature. Hidden when the forecast is unavailable so the
+/// overlay reserves no space.
 struct WeatherButton: View {
     let display: WeatherDisplay?
     let onTap: (WeatherDisplay) -> Void
@@ -21,11 +22,15 @@ struct WeatherButton: View {
             Button {
                 onTap(display)
             } label: {
-                Text(display.buttonTitle)
-                    .font(.body.bold())
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .contentShape(Capsule())
+                HStack {
+                    Image(systemName: WeatherFormatter.systemImageName(for: display.header.iconName))
+                        .accessibilityHidden(true)
+                    Text(display.buttonTitle)
+                }
+                .font(.body.bold())
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .contentShape(Capsule())
             }
             .regularGlassEffectIfAvailable()
             .buttonStyle(.plain)
@@ -36,7 +41,7 @@ struct WeatherButton: View {
                     comment: "Accessibility label for a button that provides the current forecast"
                 ))
             )
-            .accessibilityValue(Text(display.buttonTitle))
+            .accessibilityValue(Text(display.buttonAccessibilityValue))
         }
     }
 }

--- a/OBAKit/ViewModels/MapViewModel/WeatherDisplay.swift
+++ b/OBAKit/ViewModels/MapViewModel/WeatherDisplay.swift
@@ -19,7 +19,9 @@ import OBAKitCore
 /// `HeaderRow` / `StatsRow` / hourly strip take exactly the slice they need,
 /// not the whole bag.
 struct WeatherDisplay: Equatable {
-    /// Compact pill string shown on the floating weather button.
+    /// Compact temperature string shown on the map weather control.
+    /// Condition is conveyed by the SF Symbol and VoiceOver, not this title —
+    /// a full phrase like "Partly Cloudy" will not fit the 42pt hover bar.
     let buttonTitle: String
 
     /// Top section of the card: icon, region, condition, chance of rain,
@@ -48,6 +50,13 @@ struct WeatherDisplay: Equatable {
         self.header = Header(forecast: forecast, upcoming: upcoming, locale: locale)
         self.stats = Stats(forecast: forecast.currentForecast, locale: locale)
         self.hourly = HourlyEntry.list(from: upcoming, locale: locale)
+    }
+
+    /// Spoken value for the map weather control: temperature plus condition.
+    /// Unknown-icon placeholder "—" is still included so VoiceOver always
+    /// has the temperature.
+    var buttonAccessibilityValue: String {
+        "\(buttonTitle), \(header.conditionSummary)"
     }
 }
 

--- a/OBAKitTests/Weather/WeatherDisplayTests.swift
+++ b/OBAKitTests/Weather/WeatherDisplayTests.swift
@@ -231,7 +231,9 @@ final class WeatherDisplayTests {
         #expect(display.stats.precipText == "0%")
         #expect(display.stats.windText.contains("mph"))
 
-        // Button pill mirrors the current temperature.
+        // Button pill mirrors the current temperature. Condition lives in
+        // VoiceOver (`buttonAccessibilityValue`) and the SF Symbol, not here —
+        // "Partly Cloudy" will not fit the 42pt map control.
         #expect(display.buttonTitle == "71°")
 
         // Hourly strip — non-empty, first cell labelled "Now" and flagged as
@@ -244,6 +246,19 @@ final class WeatherDisplayTests {
             #expect(display.hourly[1].isNow == false)
             #expect(display.hourly[1].timeLabel != "Now")
         }
+    }
+
+    /// The map control stays compact (temperature-only title) while VoiceOver
+    /// speaks temperature plus the condition. The SF Symbol is derived from
+    /// the same header icon key both surfaces already share.
+    @Test func `Map button accessibility value includes temp and condition`() throws {
+        let forecast = try loadPugetSoundForecast()
+        let display = WeatherDisplay(forecast: forecast, locale: usLocale, now: pugetSoundNow, calendar: utcCalendar)
+
+        #expect(display.buttonTitle == "71°")
+        #expect(display.buttonAccessibilityValue.contains("71°"))
+        #expect(display.buttonAccessibilityValue.contains("Clear"))
+        #expect(WeatherFormatter.systemImageName(for: display.header.iconName) == "sun.max.fill")
     }
 
     // MARK: - Stats / Header derived strings

--- a/docs/weather-map-button.md
+++ b/docs/weather-map-button.md
@@ -1,0 +1,13 @@
+# Weather map button
+
+The map weather control shows a condition SF Symbol plus the temperature
+(for example a sun icon above `71°`). The full condition word is not used as
+the visible title because it will not fit the 42pt hover bar.
+
+VoiceOver still gets both pieces: the button's accessibility label stays
+"Show Weather Forecast", and the value is temperature plus condition
+(`71°, Clear`). An unknown icon still speaks the temperature, with `—` for
+the condition.
+
+Hour-by-hour forecast is the existing weather popup (`WeatherDetailPopup`),
+not this control.


### PR DESCRIPTION
## Summary
- The map weather control was temperature-only (`71°`). It now shows the condition SF Symbol plus that temperature on both the UIKit hover bar and the SwiftUI map-panel pill.
- VoiceOver value is temperature + condition (`71°, Clear`). The visible title stays compact — a phrase like "Partly Cloudy" will not fit the 42pt hover bar.
- Hour-by-hour forecast is unchanged (`WeatherDetailPopup`). The UIKit button is updated through `UIButton.Configuration` only; `setTitle`/`setImage` are ignored once a configuration exists.

Closes #71.

## Test plan
- [x] `WeatherDisplayTests` (15) — `buttonTitle` stays `71°`; `buttonAccessibilityValue` contains `71°` and `Clear`; fixture icon maps to `sun.max.fill`
- [x] `WeatherFormatterTests` (14)
- [ ] On device, map hover bar: condition icon stacked above the temperature; tap still opens the hourly popup
- [ ] VoiceOver: "Show Weather Forecast", value includes both temperature and condition
- [ ] Map-panel experience: same icon + temp on the floating pill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the map weather button with a weather icon, bold temperature display, and improved layout.
  * Weather conditions are now available through VoiceOver while the button visibly shows the temperature.
  * Added a fallback for unknown weather conditions.

* **Documentation**
  * Documented the weather button’s icon, temperature presentation, accessibility behavior, and distinction from hourly weather details.

* **Tests**
  * Added coverage confirming temperature, weather condition, and weather icon accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->