### PR TITLE
Add Directions to/from Here on the stop page

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -579,45 +579,36 @@ class MapViewController: UIViewController,
 
     /// Presents the trip planner.
     /// - Parameters:
+    ///   - origin: Optional prefilled origin. When set, current location is not
+    ///     used as origin — stop-page "Directions from Here" relies on that.
     ///   - destination: Optional prefilled destination.
     ///   - viaPoint: Optional coordinate every planned trip must pass through — used by
     ///     "Plan a trip using this bike" with the vehicle's location.
     ///   - preselectedMode: Optional transport mode to preselect, e.g. `.transitBikeRental`.
-    func showTripPlanner(destination: MKMapItem? = nil, viaPoint: CLLocationCoordinate2D? = nil, preselectedMode: TransportMode? = nil) {
+    func showTripPlanner(
+        origin: MKMapItem? = nil,
+        destination: MKMapItem? = nil,
+        viaPoint: CLLocationCoordinate2D? = nil,
+        preselectedMode: TransportMode? = nil
+    ) {
         guard let currentRegion = application.regionsService.currentRegion,
               currentRegion.supportsOTP,
               application.userDataStore.isTripPlanningEnabled(for: currentRegion) else {
             return
         }
 
-        // Get current location for origin
-        var origin: Location?
-        if let currentLocation = application.locationService.currentLocation {
-            origin = Location(
-                title: "Current Location",
-                subTitle: "Your current location",
-                latitude: currentLocation.coordinate.latitude,
-                longitude: currentLocation.coordinate.longitude
-            )
-        }
-
-        // Convert MKMapItem destination to Location if provided
-        var destinationLocation: Location?
-        if let destination {
-            destinationLocation = Location(
-                title: destination.name ?? "Destination",
-                subTitle: destination.placemark.title ?? "",
-                latitude: destination.placemark.coordinate.latitude,
-                longitude: destination.placemark.coordinate.longitude
-            )
-        }
+        let originLocation = TripPlannerEndpoints.origin(
+            explicit: origin,
+            currentLocation: application.locationService.currentLocation
+        )
+        let destinationLocation = TripPlannerEndpoints.destination(from: destination)
 
         guard let tripPlanner = buildTripPlanner(region: currentRegion) else { return }
 
         subscribeToTripPlannerNotifications()
 
         let tripPlannerView = tripPlanner.createTripPlannerView(
-            origin: origin,
+            origin: originLocation,
             destination: destinationLocation,
             viaPoint: viaPoint,
             transportMode: preselectedMode

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -989,7 +989,8 @@ class MapViewController: UIViewController,
     private var stopFocusCancellables = Set<AnyCancellable>()
 
     /// Owns the half-detent panel that shows the redesigned Stop page over the map.
-    private lazy var stopSheet = StopSheetPresenter()
+    /// Internal so trip-planner tests can put a sheet up the same way a map pin does.
+    lazy var stopSheet = StopSheetPresenter()
 
     /// The stop whose sheet is up, or nil between presentations — the single
     /// switch behind both of the things the map does differently while a sheet

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -64,9 +64,10 @@ struct MapItemSheetView: View {
                     dismiss: { dismiss() }
                 ),
                 removePinHandler: nil,
-                // No trip-planner route on this surface yet. `nil` hides the button
-                // rather than rendering one that does nothing; wire it up when the
-                // trip planner lands here.
+                // Map-panel mode has no classic `MapViewController` to present the
+                // OTP trip planner on. Leave `nil` so the Plan Trip button stays
+                // hidden rather than shipping a no-op; wire when the panel can
+                // host the planner (see #883 / StopPageActionPresenter).
                 planTripHandler: nil
             )
         }

--- a/OBAKit/Sheet/Content/Stop/Details/StopDetailsSheetView.swift
+++ b/OBAKit/Sheet/Content/Stop/Details/StopDetailsSheetView.swift
@@ -430,6 +430,8 @@ struct StopDetailsSheetView: View {
             onServiceAlerts: navigation.showServiceAlerts,
             onNearbyStops: navigation.showNearbyStops,
             onWalkingDirections: navigation.showWalkingDirections,
+            onDirectionsToHere: navigation.showDirectionsToHere,
+            onDirectionsFromHere: navigation.showDirectionsFromHere,
             onReportProblem: navigation.showReportProblem
         )
     }

--- a/OBAKit/Sheet/Content/Stop/Details/StopPageActionRow.swift
+++ b/OBAKit/Sheet/Content/Stop/Details/StopPageActionRow.swift
@@ -74,6 +74,9 @@ struct StopPageActionRow: View {
     let onServiceAlerts: () -> Void
     let onNearbyStops: () -> Void
     let onWalkingDirections: () -> Void
+    /// Non-nil when OTP trip planning is available for the current region.
+    let onDirectionsToHere: (() -> Void)?
+    let onDirectionsFromHere: (() -> Void)?
     let onReportProblem: () -> Void
 
     /// No horizontal scrolling accommodation, unlike `StopPageToolbar`: that
@@ -258,6 +261,20 @@ struct StopPageActionRow: View {
                 )
             }
             .disabled(!state.canActOnStop)
+
+            if let onDirectionsToHere {
+                Button(action: onDirectionsToHere) {
+                    Label(StopTripPlannerAction.directionsToHereTitle, systemImage: "arrow.triangle.turn.up.right.diamond")
+                }
+                .disabled(!state.canActOnStop)
+            }
+
+            if let onDirectionsFromHere {
+                Button(action: onDirectionsFromHere) {
+                    Label(StopTripPlannerAction.directionsFromHereTitle, systemImage: "arrow.triangle.turn.up.right.diamond.fill")
+                }
+                .disabled(!state.canActOnStop)
+            }
         }
 
         Section {
@@ -330,7 +347,9 @@ struct StopPageActionRow: View {
     StopPageActionRow(
         state: StopPageActionRowState(hasStop: true, routeCount: 4, hasHiddenRoutes: true, isListFiltered: true, departureFilter: .all, hasServiceAlerts: true),
         onSchedule: {}, onSetListFiltered: { _ in }, onSetDepartureFilter: { _ in }, onBookmark: {},
-        onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {}, onReportProblem: {}
+        onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {},
+        onDirectionsToHere: nil, onDirectionsFromHere: nil,
+        onReportProblem: {}
     )
 }
 
@@ -340,6 +359,8 @@ struct StopPageActionRow: View {
     StopPageActionRow(
         state: StopPageActionRowState(hasStop: false, routeCount: 0, hasHiddenRoutes: false, isListFiltered: false, departureFilter: .all, hasServiceAlerts: false),
         onSchedule: {}, onSetListFiltered: { _ in }, onSetDepartureFilter: { _ in }, onBookmark: {},
-        onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {}, onReportProblem: {}
+        onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {},
+        onDirectionsToHere: nil, onDirectionsFromHere: nil,
+        onReportProblem: {}
     )
 }

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -195,7 +195,7 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
     }
 
     private func makeStopClosures(viewModel: StopViewModel) -> StopClosures {
-        let tripPlannerAvailable = StopTripPlannerAction.isAvailable(application: application)
+        let tripPlannerAvailable = StopTripPlannerAction.canPresent(application: application)
         return StopClosures(
             showWalkingDirections: { [weak self] in
                 guard let coordinate = viewModel.stop?.coordinate else { return }
@@ -428,32 +428,8 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
 
     /// Switches to the map tab and opens the classic trip planner with this stop
     /// as origin or destination. Shared by the pushed Stop page and the map sheet.
-    ///
-    /// When `viewRouter.rootController` is nil (experimental map-panel mode),
-    /// logs and returns — there is no `MapViewController` to present on.
     func showTripPlanner(action: StopTripPlannerAction, stop: Stop) {
-        guard StopTripPlannerAction.isAvailable(application: application) else { return }
-
-        guard let rootController = application.viewRouter.rootController else {
-            // Same posture as `ViewRouter.rootNavigateTo`: map-panel mode bypasses
-            // the classic tab root, so Directions to/from Here cannot open the
-            // UIKit trip planner. Prefer an honest no-op over a dead button.
-            Logger.error("StopPageActionPresenter: showTripPlanner dropped — no classic root controller (map-panel mode is active)")
-            return
-        }
-
-        application.viewRouter.rootNavigateTo(page: .map)
-
-        let mapController = rootController.mapController
-        mapController.navigationController?.popToRootViewController(animated: false)
-
-        let stopMapItem = TripPlannerEndpoints.mapItem(from: stop)
-        switch action {
-        case .directionsToStop:
-            mapController.showTripPlanner(destination: stopMapItem)
-        case .directionsFromStop:
-            mapController.showTripPlanner(origin: stopMapItem, destination: nil)
-        }
+        StopTripPlannerAction.present(action, stop: stop, application: application)
     }
 
     /// An unanchored action sheet is a hard crash on a regular-width device.

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -109,6 +109,8 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             showScheduleForRoute: trip.showScheduleForRoute,
             canScheduleForRoute: application.currentRegion?.supportsScheduleForRoute ?? true,
             showWalkingDirections: stop.showWalkingDirections,
+            showDirectionsToHere: stop.showDirectionsToHere,
+            showDirectionsFromHere: stop.showDirectionsFromHere,
             showAlertDetail: stop.showAlertDetail,
             showBookmarkEditor: stop.showBookmarkEditor,
             shareTrip: trip.shareTrip,
@@ -182,6 +184,8 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
     /// Everything scoped to the stop as a whole.
     private struct StopClosures {
         let showWalkingDirections: () -> Void
+        let showDirectionsToHere: (() -> Void)?
+        let showDirectionsFromHere: (() -> Void)?
         let showAlertDetail: (ServiceAlert) -> Void
         let showBookmarkEditor: (ArrivalDeparture?) -> Void
         let showRouteFilter: () -> Void
@@ -191,11 +195,20 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
     }
 
     private func makeStopClosures(viewModel: StopViewModel) -> StopClosures {
-        StopClosures(
+        let tripPlannerAvailable = StopTripPlannerAction.isAvailable(application: application)
+        return StopClosures(
             showWalkingDirections: { [weak self] in
                 guard let coordinate = viewModel.stop?.coordinate else { return }
                 self?.showWalkingDirections(coordinate: coordinate)
             },
+            showDirectionsToHere: tripPlannerAvailable ? { [weak self] in
+                guard let stop = viewModel.stop else { return }
+                self?.showTripPlanner(action: .directionsToStop, stop: stop)
+            } : nil,
+            showDirectionsFromHere: tripPlannerAvailable ? { [weak self] in
+                guard let stop = viewModel.stop else { return }
+                self?.showTripPlanner(action: .directionsFromStop, stop: stop)
+            } : nil,
             showAlertDetail: { [weak self] alert in
                 guard let self, let host = self.presentationHost(for: "alert detail") else { return }
                 self.application.viewRouter.navigateTo(alert: alert, from: host)
@@ -411,6 +424,36 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
         }
         sheet.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
         present(actionSheet: sheet)
+    }
+
+    /// Switches to the map tab and opens the classic trip planner with this stop
+    /// as origin or destination. Shared by the pushed Stop page and the map sheet.
+    ///
+    /// When `viewRouter.rootController` is nil (experimental map-panel mode),
+    /// logs and returns — there is no `MapViewController` to present on.
+    func showTripPlanner(action: StopTripPlannerAction, stop: Stop) {
+        guard StopTripPlannerAction.isAvailable(application: application) else { return }
+
+        guard let rootController = application.viewRouter.rootController else {
+            // Same posture as `ViewRouter.rootNavigateTo`: map-panel mode bypasses
+            // the classic tab root, so Directions to/from Here cannot open the
+            // UIKit trip planner. Prefer an honest no-op over a dead button.
+            Logger.error("StopPageActionPresenter: showTripPlanner dropped — no classic root controller (map-panel mode is active)")
+            return
+        }
+
+        application.viewRouter.rootNavigateTo(page: .map)
+
+        let mapController = rootController.mapController
+        mapController.navigationController?.popToRootViewController(animated: false)
+
+        let stopMapItem = TripPlannerEndpoints.mapItem(from: stop)
+        switch action {
+        case .directionsToStop:
+            mapController.showTripPlanner(destination: stopMapItem)
+        case .directionsFromStop:
+            mapController.showTripPlanner(origin: stopMapItem, destination: nil)
+        }
     }
 
     /// An unanchored action sheet is a hard crash on a regular-width device.

--- a/OBAKit/Stops/StopPage/StopPageToolbar.swift
+++ b/OBAKit/Stops/StopPage/StopPageToolbar.swift
@@ -47,6 +47,9 @@ struct StopPageToolbar: View {
     let onServiceAlerts: () -> Void
     let onNearbyStops: () -> Void
     let onWalkingDirections: () -> Void
+    /// Non-nil when OTP trip planning is available for the current region.
+    let onDirectionsToHere: (() -> Void)?
+    let onDirectionsFromHere: (() -> Void)?
     let onReportProblem: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -178,6 +181,16 @@ struct StopPageToolbar: View {
                 Button(action: onWalkingDirections) {
                     Label(OBALoc("stops_controller.walking_directions", value: "Walking Directions", comment: "Button that launches a maps app with walking directions to this stop"), systemImage: "figure.walk")
                 }
+                if let onDirectionsToHere {
+                    Button(action: onDirectionsToHere) {
+                        Label(StopTripPlannerAction.directionsToHereTitle, systemImage: "arrow.triangle.turn.up.right.diamond")
+                    }
+                }
+                if let onDirectionsFromHere {
+                    Button(action: onDirectionsFromHere) {
+                        Label(StopTripPlannerAction.directionsFromHereTitle, systemImage: "arrow.triangle.turn.up.right.diamond.fill")
+                    }
+                }
             }
 
             Section {
@@ -260,7 +273,9 @@ struct StopPageToolbar: View {
             hasServiceAlerts: true,
             onRefresh: {}, onSetListFiltered: { _ in }, onSetDepartureFilter: { _ in },
             onBookmark: {}, onSchedule: {},
-            onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {}, onReportProblem: {}
+            onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {},
+            onDirectionsToHere: nil, onDirectionsFromHere: nil,
+            onReportProblem: {}
         )
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -29,6 +29,12 @@ struct StopPageNavigationHandler {
     /// Opens walking directions to the stop in an external maps app (header
     /// walk pill). Presents a choice sheet when more than one app is available.
     let showWalkingDirections: () -> Void
+    /// Opens the in-app OTP trip planner with this stop as the destination
+    /// (origin = current location). `nil` when trip planning is unavailable.
+    let showDirectionsToHere: (() -> Void)?
+    /// Opens the in-app OTP trip planner with this stop as the origin.
+    /// `nil` when trip planning is unavailable.
+    let showDirectionsFromHere: (() -> Void)?
     /// Pushes the alert-detail screen for a tapped service alert.
     let showAlertDetail: (ServiceAlert) -> Void
     /// Opens the bookmark editor: `nil` for a stop-level bookmark, an
@@ -295,6 +301,8 @@ struct StopPageView: View {
             onServiceAlerts: navigation.showServiceAlerts,
             onNearbyStops: navigation.showNearbyStops,
             onWalkingDirections: navigation.showWalkingDirections,
+            onDirectionsToHere: navigation.showDirectionsToHere,
+            onDirectionsFromHere: navigation.showDirectionsFromHere,
             onReportProblem: navigation.showReportProblem
         )
     }
@@ -442,7 +450,9 @@ struct StopPageView: View {
             hasServiceAlerts: false,
             onRefresh: {}, onSetListFiltered: { _ in }, onSetDepartureFilter: { _ in },
             onBookmark: {}, onSchedule: {},
-            onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {}, onReportProblem: {}
+            onServiceAlerts: {}, onNearbyStops: {}, onWalkingDirections: {},
+            onDirectionsToHere: nil, onDirectionsFromHere: nil,
+            onReportProblem: {}
         )
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -216,6 +216,8 @@ class StopPageViewController: UIHostingController<StopPageRootView>,
         showScheduleForRoute: { _ in },
         canScheduleForRoute: false,
         showWalkingDirections: {},
+        showDirectionsToHere: nil,
+        showDirectionsFromHere: nil,
         showAlertDetail: { _ in },
         showBookmarkEditor: { _ in },
         shareTrip: { _ in },
@@ -560,7 +562,25 @@ private extension StopPageViewController {
             walkingDirectionsElement = UIMenu(title: walkingDirectionsTitle, image: walkingDirectionsImage, children: walkingDirectionActions)
         }
 
-        return UIMenu(title: "Location", options: .displayInline, children: [nearbyAction, walkingDirectionsElement])
+        var locationChildren: [UIMenuElement] = [nearbyAction, walkingDirectionsElement]
+
+        if StopTripPlannerAction.isAvailable(application: application), let stop = viewModel.stop {
+            let directionsToHere = UIAction(
+                title: StopTripPlannerAction.directionsToHereTitle,
+                image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond")
+            ) { [unowned self] _ in
+                self.actionPresenter.showTripPlanner(action: .directionsToStop, stop: stop)
+            }
+            let directionsFromHere = UIAction(
+                title: StopTripPlannerAction.directionsFromHereTitle,
+                image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond.fill")
+            ) { [unowned self] _ in
+                self.actionPresenter.showTripPlanner(action: .directionsFromStop, stop: stop)
+            }
+            locationChildren.append(contentsOf: [directionsToHere, directionsFromHere])
+        }
+
+        return UIMenu(title: "Location", options: .displayInline, children: locationChildren)
     }
 
     func helpMenu() -> UIMenu {

--- a/OBAKit/Stops/StopPage/StopPageViewController.swift
+++ b/OBAKit/Stops/StopPage/StopPageViewController.swift
@@ -564,7 +564,7 @@ private extension StopPageViewController {
 
         var locationChildren: [UIMenuElement] = [nearbyAction, walkingDirectionsElement]
 
-        if StopTripPlannerAction.isAvailable(application: application), let stop = viewModel.stop {
+        if StopTripPlannerAction.canPresent(application: application), let stop = viewModel.stop {
             let directionsToHere = UIAction(
                 title: StopTripPlannerAction.directionsToHereTitle,
                 image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond")

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -417,20 +417,18 @@ public class StopViewController: UIViewController,
 
         var locationChildren: [UIMenuElement] = [nearbyAction, walkingDirectionsElement]
 
-        if StopTripPlannerAction.isAvailable(application: application), let stop {
+        if StopTripPlannerAction.canPresent(application: application), let stop {
             let directionsToHere = UIAction(
                 title: StopTripPlannerAction.directionsToHereTitle,
                 image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond")
             ) { [unowned self] _ in
-                StopPageActionPresenter(application: self.application, presentingController: { [weak self] in self })
-                    .showTripPlanner(action: .directionsToStop, stop: stop)
+                StopTripPlannerAction.present(.directionsToStop, stop: stop, application: self.application)
             }
             let directionsFromHere = UIAction(
                 title: StopTripPlannerAction.directionsFromHereTitle,
                 image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond.fill")
             ) { [unowned self] _ in
-                StopPageActionPresenter(application: self.application, presentingController: { [weak self] in self })
-                    .showTripPlanner(action: .directionsFromStop, stop: stop)
+                StopTripPlannerAction.present(.directionsFromStop, stop: stop, application: self.application)
             }
             locationChildren.append(contentsOf: [directionsToHere, directionsFromHere])
         }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -415,7 +415,27 @@ public class StopViewController: UIViewController,
             walkingDirectionsElement = UIMenu(title: walkingDirectionsTitle, image: walkingDirectionsImage, children: walkingDirectionActions)
         }
 
-        return UIMenu(title: "Location", options: .displayInline, children: [nearbyAction, walkingDirectionsElement])
+        var locationChildren: [UIMenuElement] = [nearbyAction, walkingDirectionsElement]
+
+        if StopTripPlannerAction.isAvailable(application: application), let stop {
+            let directionsToHere = UIAction(
+                title: StopTripPlannerAction.directionsToHereTitle,
+                image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond")
+            ) { [unowned self] _ in
+                StopPageActionPresenter(application: self.application, presentingController: { [weak self] in self })
+                    .showTripPlanner(action: .directionsToStop, stop: stop)
+            }
+            let directionsFromHere = UIAction(
+                title: StopTripPlannerAction.directionsFromHereTitle,
+                image: UIImage(systemName: "arrow.triangle.turn.up.right.diamond.fill")
+            ) { [unowned self] _ in
+                StopPageActionPresenter(application: self.application, presentingController: { [weak self] in self })
+                    .showTripPlanner(action: .directionsFromStop, stop: stop)
+            }
+            locationChildren.append(contentsOf: [directionsToHere, directionsFromHere])
+        }
+
+        return UIMenu(title: "Location", options: .displayInline, children: locationChildren)
     }
 
     fileprivate func sortMenu() -> UIMenu {

--- a/OBAKit/TripPlanning/StopTripPlannerAction.swift
+++ b/OBAKit/TripPlanning/StopTripPlannerAction.swift
@@ -53,6 +53,9 @@ enum StopTripPlannerAction {
 
         let mapController = rootController.mapController
         mapController.navigationController?.popToRootViewController(animated: false)
+        // Map-pin stops live in `stopSheet`, not the nav stack. Same teardown
+        // as opening a map item or another panel (#883).
+        mapController.dismissStopSheetForReplacement()
 
         let stopMapItem = TripPlannerEndpoints.mapItem(from: stop)
         switch action {

--- a/OBAKit/TripPlanning/StopTripPlannerAction.swift
+++ b/OBAKit/TripPlanning/StopTripPlannerAction.swift
@@ -1,0 +1,47 @@
+//
+//  StopTripPlannerAction.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import OBAKitCore
+
+/// Stop-page trip-planner menu actions. Menus and toolbars can gate on
+/// `isAvailable` without instantiating a view controller.
+enum StopTripPlannerAction {
+    /// Prefill destination as the stop; origin stays current location.
+    case directionsToStop
+    /// Prefill origin as the stop; destination left empty for the rider to pick.
+    case directionsFromStop
+
+    /// `true` when OTP trip planning is running for the current region and the
+    /// rider has not disabled it for that region.
+    static func isAvailable(application: Application) -> Bool {
+        guard application.features.tripPlanning == .running,
+              let region = application.regionsService.currentRegion
+                ?? application.currentRegion,
+              application.userDataStore.isTripPlanningEnabled(for: region) else {
+            return false
+        }
+        return true
+    }
+
+    static var directionsToHereTitle: String {
+        OBALoc(
+            "stops_controller.directions_to_here",
+            value: "Directions to Here",
+            comment: "Stop Location menu action that opens the trip planner with this stop as the destination."
+        )
+    }
+
+    static var directionsFromHereTitle: String {
+        OBALoc(
+            "stops_controller.directions_from_here",
+            value: "Directions from Here",
+            comment: "Stop Location menu action that opens the trip planner with this stop as the origin."
+        )
+    }
+}

--- a/OBAKit/TripPlanning/StopTripPlannerAction.swift
+++ b/OBAKit/TripPlanning/StopTripPlannerAction.swift
@@ -10,7 +10,7 @@
 import OBAKitCore
 
 /// Stop-page trip-planner menu actions. Menus and toolbars can gate on
-/// `isAvailable` without instantiating a view controller.
+/// `canPresent` without instantiating a view controller.
 enum StopTripPlannerAction {
     /// Prefill destination as the stop; origin stays current location.
     case directionsToStop
@@ -18,7 +18,8 @@ enum StopTripPlannerAction {
     case directionsFromStop
 
     /// `true` when OTP trip planning is running for the current region and the
-    /// rider has not disabled it for that region.
+    /// rider has not disabled it for that region. Does not imply the classic
+    /// map tab can present the planner — see `canPresent`.
     static func isAvailable(application: Application) -> Bool {
         guard application.features.tripPlanning == .running,
               let region = application.regionsService.currentRegion
@@ -27,6 +28,39 @@ enum StopTripPlannerAction {
             return false
         }
         return true
+    }
+
+    /// Hide the stop-page actions unless the classic tab root can host
+    /// `MapViewController.showTripPlanner`. Map-panel mode leaves
+    /// `viewRouter.rootController` nil; showing the rows there would be a
+    /// dead button.
+    static func canPresent(application: Application) -> Bool {
+        isAvailable(application: application) && application.viewRouter.rootController != nil
+    }
+
+    /// Pops to the map tab and opens the existing trip planner. No-ops (with
+    /// a log) when `canPresent` is false.
+    static func present(_ action: StopTripPlannerAction, stop: Stop, application: Application) {
+        guard canPresent(application: application),
+              let rootController = application.viewRouter.rootController else {
+            if isAvailable(application: application) {
+                Logger.error("StopTripPlannerAction: present dropped — no classic root controller (map-panel mode is active)")
+            }
+            return
+        }
+
+        application.viewRouter.rootNavigateTo(page: .map)
+
+        let mapController = rootController.mapController
+        mapController.navigationController?.popToRootViewController(animated: false)
+
+        let stopMapItem = TripPlannerEndpoints.mapItem(from: stop)
+        switch action {
+        case .directionsToStop:
+            mapController.showTripPlanner(destination: stopMapItem)
+        case .directionsFromStop:
+            mapController.showTripPlanner(origin: stopMapItem, destination: nil)
+        }
     }
 
     static var directionsToHereTitle: String {

--- a/OBAKit/TripPlanning/TripPlannerEndpoints.swift
+++ b/OBAKit/TripPlanning/TripPlannerEndpoints.swift
@@ -1,0 +1,63 @@
+//
+//  TripPlannerEndpoints.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import OTPKit
+import OBAKitCore
+
+/// Converts stop / map / GPS inputs into the shapes `showTripPlanner` already
+/// understands, so stop-page menus can prefill origin or destination without
+/// touching `MapViewController.view`.
+enum TripPlannerEndpoints {
+
+    /// Stop title + coordinate as an `MKMapItem` suitable for the trip planner.
+    static func mapItem(from stop: Stop) -> MKMapItem {
+        let mapItem = MKMapItem(placemark: MKPlacemark(coordinate: stop.coordinate))
+        mapItem.name = stop.title
+        return mapItem
+    }
+
+    /// Maps a place pin into OTPKit's `Location`. Untitled items fall back to
+    /// `"Destination"`, matching `MapViewController.showTripPlanner`.
+    static func location(from mapItem: MKMapItem) -> Location {
+        Location(
+            title: mapItem.name ?? "Destination",
+            subTitle: mapItem.placemark.title ?? "",
+            latitude: mapItem.placemark.coordinate.latitude,
+            longitude: mapItem.placemark.coordinate.longitude
+        )
+    }
+
+    /// Hardcoded English titles match the existing `MapViewController` origin
+    /// construction; do not expand localization here without need.
+    static func location(fromCurrentLocation location: CLLocation) -> Location {
+        Location(
+            title: "Current Location",
+            subTitle: "Your current location",
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+        )
+    }
+
+    /// Explicit origin wins; otherwise current location is used when available.
+    static func origin(explicit: MKMapItem?, currentLocation: CLLocation?) -> Location? {
+        if let explicit {
+            return location(from: explicit)
+        }
+        if let currentLocation {
+            return location(fromCurrentLocation: currentLocation)
+        }
+        return nil
+    }
+
+    static func destination(from mapItem: MKMapItem?) -> Location? {
+        mapItem.map { location(from: $0) }
+    }
+}

--- a/OBAKitTests/Stops/StopPage/StopPageActionPresenterTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageActionPresenterTests.swift
@@ -247,9 +247,8 @@ final class StopPageActionPresenterTests: OBATestCase {
         #expect(host.presentedViewController === modal)
     }
 
-    /// Map-panel mode leaves `viewRouter.rootController` nil. Directions
-    /// to/from Here must log and return rather than crash — classic
-    /// `MapViewController.showTripPlanner` is unreachable there.
+    /// Map-panel mode leaves `viewRouter.rootController` nil. `canPresent` is
+    /// false so the rows stay hidden; calling `present` anyway must not crash.
     @Test func `Trip planner from stop returns when rootController is nil`() async throws {
         let host = makeHost()
         let (presenter, application) = makePresenter(host: host)

--- a/OBAKitTests/Stops/StopPage/StopPageActionPresenterTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageActionPresenterTests.swift
@@ -246,4 +246,17 @@ final class StopPageActionPresenterTests: OBATestCase {
         #expect(presented is ScheduleForStopViewController)
         #expect(host.presentedViewController === modal)
     }
+
+    /// Map-panel mode leaves `viewRouter.rootController` nil. Directions
+    /// to/from Here must log and return rather than crash — classic
+    /// `MapViewController.showTripPlanner` is unreachable there.
+    @Test func `Trip planner from stop returns when rootController is nil`() async throws {
+        let host = makeHost()
+        let (presenter, application) = makePresenter(host: host)
+        #expect(application.viewRouter.rootController == nil)
+
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        presenter.showTripPlanner(action: .directionsToStop, stop: stop)
+        presenter.showTripPlanner(action: .directionsFromStop, stop: stop)
+    }
 }

--- a/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
+++ b/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
@@ -1,0 +1,100 @@
+//
+//  StopTripPlannerActionTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Gates the stop-page "Directions to/from Here" affordances on OTP availability
+/// and the per-region trip-planning preference.
+@MainActor
+@Suite(.serialized)
+final class StopTripPlannerActionTests: OBATestCase {
+
+    private var queue: OperationQueue!
+
+    override init() async throws {
+        try await super.init()
+        queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+    }
+
+    isolated deinit {
+        queue.cancelAllOperations()
+    }
+
+    @Test func `isAvailable is true when OTP is running and trip planning is enabled`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let maybeRegion = await waitForRegion(application)
+        let region = try #require(maybeRegion)
+
+        #expect(region.supportsOTP)
+        #expect(application.features.tripPlanning == .running)
+        #expect(application.userDataStore.isTripPlanningEnabled(for: region))
+        #expect(StopTripPlannerAction.isAvailable(application: application))
+    }
+
+    @Test func `isAvailable is false when trip planning is disabled for the region`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let maybeRegion = await waitForRegion(application)
+        let region = try #require(maybeRegion)
+
+        application.userDataStore.setTripPlanningEnabled(false, for: region)
+
+        #expect(application.features.tripPlanning == .running)
+        #expect(!StopTripPlannerAction.isAvailable(application: application))
+    }
+
+    @Test func `isAvailable is false when the region has no OTP`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        // Seed a non-OTP region before Application init so RegionsService loads it.
+        userDefaults.set(2, forKey: "OBACurrentRegionIdentifierUserDefaultsKey") // MTA New York — no OTP
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: URL(string: "https://bustime.mta.info/")!)
+
+        let locManager = MockAuthorizedLocationManager(
+            updateLocation: TestData.mockSeattleLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader
+        )
+        let application = Application(config: config)
+        let maybeRegion = await waitForRegion(application)
+        let region = try #require(maybeRegion)
+
+        #expect(!region.supportsOTP)
+        #expect(application.features.tripPlanning == .off)
+        #expect(!StopTripPlannerAction.isAvailable(application: application))
+    }
+
+    /// `fixedRegionName` selects the region during Application init; poll briefly
+    /// in case regions load finishes after construction.
+    private func waitForRegion(_ application: Application) async -> Region? {
+        for _ in 0..<40 {
+            if let region = application.currentRegion ?? application.regionsService.currentRegion {
+                return region
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return application.currentRegion ?? application.regionsService.currentRegion
+    }
+}

--- a/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
+++ b/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
@@ -39,6 +39,9 @@ final class StopTripPlannerActionTests: OBATestCase {
         #expect(application.features.tripPlanning == .running)
         #expect(application.userDataStore.isTripPlanningEnabled(for: region))
         #expect(StopTripPlannerAction.isAvailable(application: application))
+        // Tests construct `Application` without a classic tab root, so the
+        // stop-page rows stay hidden — same as experimental map-panel mode.
+        #expect(!StopTripPlannerAction.canPresent(application: application))
     }
 
     @Test func `isAvailable is false when trip planning is disabled for the region`() async throws {
@@ -51,6 +54,7 @@ final class StopTripPlannerActionTests: OBATestCase {
 
         #expect(application.features.tripPlanning == .running)
         #expect(!StopTripPlannerAction.isAvailable(application: application))
+        #expect(!StopTripPlannerAction.canPresent(application: application))
     }
 
     @Test func `isAvailable is false when the region has no OTP`() async throws {
@@ -84,6 +88,7 @@ final class StopTripPlannerActionTests: OBATestCase {
         #expect(!region.supportsOTP)
         #expect(application.features.tripPlanning == .off)
         #expect(!StopTripPlannerAction.isAvailable(application: application))
+        #expect(!StopTripPlannerAction.canPresent(application: application))
     }
 
     /// `fixedRegionName` selects the region during Application init; poll briefly

--- a/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
+++ b/OBAKitTests/TripPlanning/StopTripPlannerActionTests.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import UIKit
 import Testing
 @testable import OBAKit
 @testable import OBAKitCore
@@ -89,6 +90,48 @@ final class StopTripPlannerActionTests: OBATestCase {
         #expect(application.features.tripPlanning == .off)
         #expect(!StopTripPlannerAction.isAvailable(application: application))
         #expect(!StopTripPlannerAction.canPresent(application: application))
+    }
+
+    /// A map-pin stop is a FloatingPanel on the map, not a nav push. `popToRoot`
+    /// leaves that sheet up and keeps the tab bar hidden (#883).
+    @Test func `present dismisses the map-pin stop sheet before the trip planner`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        stubStopsForLocation(dataLoader: dataLoader)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let region = try #require(await waitForRegion(application))
+        #expect(region.supportsOTP)
+
+        let root = ClassicApplicationRootController(application: application)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+        root.view.layoutIfNeeded()
+
+        let map = root.mapController
+        #expect(StopTripPlannerAction.canPresent(application: application))
+
+        map.stopSheet.present(UIViewController(), from: map, onDismiss: {})
+        #expect(map.stopSheet.isPresenting)
+        for _ in 0..<20 {
+            if root.isTabBarHidden { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(root.isTabBarHidden)
+
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        StopTripPlannerAction.present(.directionsToStop, stop: stop, application: application)
+
+        #expect(!map.stopSheet.isPresenting)
+        #expect(!root.isTabBarHidden)
+
+        window.isHidden = true
+    }
+
+    private func stubStopsForLocation(dataLoader: MockDataLoader) {
+        dataLoader.mock(
+            url: URL(string: "https://api.pugetsound.onebusaway.org/api/where/stops-for-location.json")!,
+            with: Fixtures.loadData(file: "stops_for_location_seattle.json")
+        )
     }
 
     /// `fixedRegionName` selects the region during Application init; poll briefly

--- a/OBAKitTests/TripPlanning/TripPlannerEndpointsTests.swift
+++ b/OBAKitTests/TripPlanning/TripPlannerEndpointsTests.swift
@@ -1,0 +1,87 @@
+//
+//  TripPlannerEndpointsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import Testing
+import OTPKit
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Pins the stop ↔ map-item ↔ OTPKit `Location` mapping used to prefill the
+/// trip planner from a stop page — without loading `MapViewController.view`.
+@MainActor
+@Suite(.serialized)
+final class TripPlannerEndpointsTests: OBATestCase {
+
+    @Test func `Stop maps to MKMapItem with stop title and coordinate`() throws {
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        let mapItem = TripPlannerEndpoints.mapItem(from: stop)
+
+        #expect(mapItem.name == stop.title)
+        #expect(mapItem.placemark.coordinate.latitude == stop.coordinate.latitude)
+        #expect(mapItem.placemark.coordinate.longitude == stop.coordinate.longitude)
+    }
+
+    @Test func `MKMapItem maps to OTPKit Location with name and coordinates`() {
+        let coordinate = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
+        let mapItem = MKMapItem(placemark: MKPlacemark(coordinate: coordinate))
+        mapItem.name = "Pike Place Market"
+
+        let location = TripPlannerEndpoints.location(from: mapItem)
+
+        #expect(location.title == "Pike Place Market")
+        #expect(location.latitude == coordinate.latitude)
+        #expect(location.longitude == coordinate.longitude)
+    }
+
+    @Test func `Current CLLocation maps to Current Location titled OTP Location`() {
+        let current = CLLocation(latitude: 47.61, longitude: -122.33)
+        let location = TripPlannerEndpoints.location(fromCurrentLocation: current)
+
+        #expect(location.title == "Current Location")
+        #expect(location.subTitle == "Your current location")
+        #expect(location.latitude == 47.61)
+        #expect(location.longitude == -122.33)
+    }
+
+    @Test func `Explicit origin wins over current location`() {
+        let stopItem = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        stopItem.name = "Stop Origin"
+        let current = CLLocation(latitude: 47.61, longitude: -122.33)
+
+        let origin = TripPlannerEndpoints.origin(explicit: stopItem, currentLocation: current)
+
+        #expect(origin?.title == "Stop Origin")
+        #expect(origin?.latitude == 47.6)
+        #expect(origin?.longitude == -122.3)
+    }
+
+    @Test func `Nil explicit origin falls back to current location`() {
+        let current = CLLocation(latitude: 47.61, longitude: -122.33)
+
+        let origin = TripPlannerEndpoints.origin(explicit: nil, currentLocation: current)
+
+        #expect(origin?.title == "Current Location")
+        #expect(origin?.latitude == 47.61)
+        #expect(origin?.longitude == -122.33)
+    }
+
+    @Test func `Destination maps from map item when present`() {
+        let destinationItem = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.62, longitude: -122.35)))
+        destinationItem.name = "Stop Destination"
+
+        let destination = TripPlannerEndpoints.destination(from: destinationItem)
+
+        #expect(destination?.title == "Stop Destination")
+        #expect(destination?.latitude == 47.62)
+        #expect(destination?.longitude == -122.35)
+        #expect(TripPlannerEndpoints.destination(from: nil) == nil)
+    }
+}

--- a/docs/trip-planner-from-stop.md
+++ b/docs/trip-planner-from-stop.md
@@ -1,0 +1,8 @@
+# Trip planner from a stop
+
+When OTP trip planning is on for the current region, the stop Location menu
+offers **Directions to Here** and **Directions from Here**. Those switch to the
+map tab and open the existing trip planner with the stop prefilled as
+destination or origin.
+
+Walking directions (Apple / Google Maps) are unchanged.

--- a/docs/trip-planner-from-stop.md
+++ b/docs/trip-planner-from-stop.md
@@ -5,4 +5,6 @@ offers **Directions to Here** and **Directions from Here**. Those switch to the
 map tab and open the existing trip planner with the stop prefilled as
 destination or origin.
 
-Walking directions (Apple / Google Maps) are unchanged.
+The rows are hidden in the experimental map-panel experience: that shell has
+no `MapViewController` to present the planner on. Walking directions
+(Apple / Google Maps) are unchanged.


### PR DESCRIPTION
## Summary
- The trip planner was only reachable from search or a long-press pin. The stop Location menu (legacy, Stop page, and toolbar) now offers **Directions to Here** / **Directions from Here** when OTP is on and the rider has not disabled trip planning for the region.
- Those actions pop to the map tab and open the existing planner with the stop prefilled as destination or origin. Walking directions (Apple / Google Maps) are unchanged.
- Rows stay hidden in the experimental map-panel shell: that UI has no `MapViewController` to present on. `showTripPlanner` takes an optional `origin` so current location is not overwritten on “from here.”

Closes #883.

## Test plan
- [x] `TripPlannerEndpointsTests` (6) — stop → `MKMapItem`; explicit origin wins over GPS; nil destination stays nil
- [x] `StopTripPlannerActionTests` (3) — available when OTP is on; hidden when disabled / no OTP / no classic root
- [x] `StopPageActionPresenterTests` — presenting with `rootController == nil` does not crash
- [ ] Puget Sound, classic map: open a stop → Location menu → Directions to Here; planner opens with the stop as destination
- [ ] Same stop: Directions from Here; origin is the stop, destination empty
- [ ] Region with trip planning off (or no OTP): those rows are absent; walking directions still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Directions to Here” and “Directions from Here” actions to stop menus when trip planning is available.
  - Open trip planning with a selected stop as either the origin or destination.
  - Preserve current-location fallback when no origin is specified.
  - Added safeguards for unsupported regions and unavailable map presentation contexts.

- **Documentation**
  - Documented trip planning from stops, including map-tab behavior and map-panel limitations.

- **Bug Fixes**
  - Prevented crashes when trip planning cannot be presented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->