### PR TITLE
Use … for overflowing map stop route labels

### DIFF
--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -59,6 +59,13 @@ nonisolated extension Stop: @retroactive MKAnnotation {
     public var mapTitle: String? {
         Formatters.formattedMapRoutes(routes)
     }
+
+    /// Callout text for a stop pin. Same overflowing route list as `mapTitle`
+    /// (`"10, 12, 49…"`), plus the rider-visible stop code. Distinct from
+    /// `subtitle`, which Home/Recent/Nearby use and which lists every route.
+    public var mapCalloutText: String {
+        ["#\(code)", mapTitle].compactMap { $0 }.joined(separator: "\n")
+    }
 }
 
 // MARK: - TripStatus/MKAnnotation

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -146,7 +146,7 @@ class StopAnnotationView: MKAnnotationView {
         labelStack.isHidden = delegate.shouldHideExtraStopAnnotationData
         image = delegate.iconFactory.buildIcon(for: bookmark.stop, isBookmarked: true, traits: traitCollection)
         titleLabel.attributedText = strokedText(bookmark.name)
-        detailCalloutAccessoryView = buildDetailLabel(text: bookmark.stop.subtitle)
+        detailCalloutAccessoryView = buildDetailLabel(text: bookmark.stop.mapCalloutText)
     }
 
     private func prepareForDisplay(stop: Stop, delegate: StopAnnotationDelegate) {
@@ -159,7 +159,7 @@ class StopAnnotationView: MKAnnotationView {
             titleLabel.text = ""
         }
 
-        detailCalloutAccessoryView = buildDetailLabel(text: stop.subtitle)
+        detailCalloutAccessoryView = buildDetailLabel(text: stop.mapCalloutText)
     }
 
     private func buildDetailLabel(text: String?) -> UILabel {

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -608,11 +608,13 @@ public class Formatters: NSObject {
 
     /// Compact route list for map pin labels under stop icons.
     ///
-    /// For example: "10, 12, 49..." — no "Routes:" prefix, and an explicit "..." when the
-    /// list overflows so UIKit truncation doesn't silently drop the overflow hint (#132).
+    /// For example: "10, 12, 49…" — no "Routes:" prefix, and an explicit U+2026
+    /// ellipsis when the list overflows so UIKit truncation doesn't silently drop
+    /// the overflow hint (#132, #514). The glyph lives in `OBALoc` so translators
+    /// can substitute locale-conventional marks (zh-Hans `……`).
     ///
     /// - Parameter routes: An array of `Route`s from which the string will be generated.
-    /// - Parameter limit: The number of route names shown before appending "...".
+    /// - Parameter limit: The number of route names shown before appending "…".
     /// - Returns: A comma-separated list of route short names, or `nil` when none are available.
     public class func formattedMapRoutes(_ routes: [Route], limit: Int = 3) -> String? {
         let routeNames = sortedRouteDisplayNames(from: routes)
@@ -621,7 +623,12 @@ public class Formatters: NSObject {
         }
 
         if routeNames.count > limit {
-            return routeNames.prefix(limit).joined(separator: ", ") + "..."
+            let fmt = OBALoc(
+                "formatters.map_routes_overflow_fmt",
+                value: "%@…",
+                comment: "Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…'"
+            )
+            return String(format: fmt, routeNames.prefix(limit).joined(separator: ", "))
         }
         else {
             return routeNames.joined(separator: ", ")

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -172,12 +172,38 @@ final class FormattersTests: OBATestCase {
         #expect(!label.hasPrefix("Routes:"))
     }
 
+    /// U+2026, not three ASCII periods: `StopAnnotationView.titleLabel` truncates
+    /// with UIKit's own `…`, and mixing the two glyphs is the inconsistency #514
+    /// is about. The marker lives in `OBALoc` so translators can substitute
+    /// locale-conventional overflow marks (zh-Hans `……`).
     @Test func `Formatted map routes over the limit appends ellipsis`() throws {
         let routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
         let label = try #require(Formatters.formattedMapRoutes(routes, limit: 3))
-        #expect(label == "10, 20, 30...")
+        #expect(label == "10, 20, 30…")
+        #expect(label.contains("\u{2026}"))
+        #expect(!label.contains("..."))
         #expect(!label.contains("more"))
         #expect(!label.hasPrefix("Routes:"))
+    }
+
+    /// The pin label and the callout must agree. Home/Recent still use
+    /// `Stop.subtitle` (`"Routes: …"` with every route) — that is not a map
+    /// surface, so it is left alone.
+    @Test func `Map callout uses the overflowing map route list, not plus-more`() throws {
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        stop.routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
+
+        let callout = try #require(stop.mapCalloutText)
+        #expect(callout == "#\(stop.code)\n10, 20, 30…")
+        #expect(!callout.contains("more"))
+        #expect(!callout.contains("Routes:"))
+
+        let subtitle = try #require(stop.subtitle)
+        #expect(subtitle.hasPrefix("#\(stop.code)"))
+        #expect(subtitle.contains("Routes:"))
+        #expect(subtitle.contains("62"))
+        #expect(!subtitle.contains("\u{2026}"))
+        #expect(!subtitle.contains("more"))
     }
 
     private func makeRoutes(shortNames: [String]) throws -> [Route] {

--- a/docs/map-route-labels.md
+++ b/docs/map-route-labels.md
@@ -1,0 +1,18 @@
+# Map stop route labels
+
+Stop pins on the map show a compact route list under the icon (`Stop.mapTitle`)
+and the same list in the callout (`Stop.mapCalloutText`):
+
+- Up to three short names, comma-separated, no `"Routes:"` prefix.
+- Overflow is marked with a single ellipsis glyph (`…`, U+2026), e.g. `"10, 12, 49…"`.
+- The marker is inside `OBALoc("formatters.map_routes_overflow_fmt")` so a
+  translator can substitute a locale-conventional overflow mark.
+
+UIKit's own tail truncation also renders `…`. Using three ASCII periods (`...`)
+for the overflow hint made a pin that fit look different from one that UIKit
+truncated — the inconsistency #514 reported.
+
+`Stop.subtitle` is unchanged. Home, Recent, and Nearby list rows still show
+`"Routes: 10, 12, 49"` with every route. That is not a map surface.
+
+See also #132 (pin-label overflow hint) and #1267 (`formattedMapRoutes`).


### PR DESCRIPTION
## Summary
- Map pin labels already used `formattedMapRoutes` (`"10, 12, 49..."`). The callout still used `Stop.subtitle` (`"Routes: 10, 12, 49"` with every route), so the two map surfaces disagreed — the leftover of #514 after #1267.
- Overflow now uses a single ellipsis glyph (`…`, U+2026) inside `OBALoc`, matching UIKit's own truncation mark. Three ASCII periods next to UIKit's `…` was a new flavor of the same inconsistency.
- `Stop.mapCalloutText` is the pin callout. `Stop.subtitle` is unchanged: Home / Recent / Nearby still list every route.

Closes #514.

## Test plan
- [x] `Formatted map routes over the limit appends ellipsis` — `"10, 20, 30…"`, no `"..."`, no `"more"`
- [x] `Map callout uses the overflowing map route list, not plus-more` — callout is `"#code\n10, 20, 30…"`; `subtitle` still has `"Routes:"` and `"62"`
- [x] `FormattersTests` (15)
- [ ] On device: stop with 4+ routes — pin label and callout both end in `…`; Home row still lists every route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Map stop callouts now show the stop code alongside a concise list of route names.
  - Route lists display up to three routes, with additional routes indicated by a localized ellipsis.

- **Improvements**
  - Map route labels now use the proper Unicode ellipsis character and support localized overflow text.
  - Stop subtitles and non-map route lists continue to display complete route information.

- **Documentation**
  - Added guidance describing route-label behavior across map pins, callouts, subtitles, and list views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->