### PR TITLE
Show direction chevrons on trip and stop route lines

### DIFF
--- a/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
+++ b/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
@@ -147,6 +147,10 @@ final class PolylineArrowAnnotationView: MKAnnotationView {
         super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
         canShowCallout = false
         isEnabled = false
+        // Decorative only — no title/subtitle. Same opt-out as
+        // BackgroundDotAnnotationView: unlabeled chevrons would flood the
+        // VoiceOver rotor (up to ~144 on a busy stop).
+        isAccessibilityElement = false
         displayPriority = .defaultLow
         collisionMode = .none
         applyAnnotation()

--- a/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
+++ b/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
@@ -1,0 +1,168 @@
+//
+//  PolylineDirectionArrows.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import OBAKitCore
+import UIKit
+
+nonisolated struct PolylineArrowPlacement: Equatable {
+    let coordinate: CLLocationCoordinate2D
+    let headingDegrees: CLLocationDirection
+
+    static func == (lhs: PolylineArrowPlacement, rhs: PolylineArrowPlacement) -> Bool {
+        lhs.coordinate.latitude == rhs.coordinate.latitude
+            && lhs.coordinate.longitude == rhs.coordinate.longitude
+            && lhs.headingDegrees == rhs.headingDegrees
+    }
+}
+
+nonisolated enum PolylineDirectionArrows {
+    private static let maximumPlacementCount = 24
+
+    private struct Segment {
+        let start: MKMapPoint
+        let end: MKMapPoint
+        let startDistance: CLLocationDistance
+        let length: CLLocationDistance
+
+        var endDistance: CLLocationDistance { startDistance + length }
+
+        func mapPoint(at distance: CLLocationDistance) -> MKMapPoint {
+            let fraction = (distance - startDistance) / length
+            return MKMapPoint(
+                x: start.x + (end.x - start.x) * fraction,
+                y: start.y + (end.y - start.y) * fraction
+            )
+        }
+    }
+
+    /// Places arrows along `coordinates` every `spacing` meters, beginning one
+    /// full spacing from the first vertex.
+    static func placements(
+        along coordinates: [CLLocationCoordinate2D],
+        spacing: CLLocationDistance = 500
+    ) -> [PolylineArrowPlacement] {
+        guard coordinates.count >= 2, spacing.isFinite, spacing > 0 else { return [] }
+
+        var segments: [Segment] = []
+        var totalDistance: CLLocationDistance = 0
+        for (startCoordinate, endCoordinate) in zip(coordinates, coordinates.dropFirst()) {
+            let length = startCoordinate.distance(from: endCoordinate)
+            guard length.isFinite, length > 0 else { continue }
+
+            segments.append(Segment(
+                start: MKMapPoint(startCoordinate),
+                end: MKMapPoint(endCoordinate),
+                startDistance: totalDistance,
+                length: length
+            ))
+            totalDistance += length
+        }
+
+        guard !segments.isEmpty else { return [] }
+
+        // Leave half a spacing after the final arrow. This avoids a chevron
+        // crowding the terminal stop or vehicle at the end of a short remainder.
+        let finalPlacementDistance = totalDistance - spacing / 2
+        guard finalPlacementDistance >= spacing else { return [] }
+
+        var placements: [PolylineArrowPlacement] = []
+        var distance = spacing
+        while distance <= finalPlacementDistance, placements.count < maximumPlacementCount {
+            guard let point = mapPoint(at: distance, in: segments) else { break }
+
+            // A short sample on each side follows the local tangent through a
+            // vertex instead of inheriting only the segment before or after it.
+            let previous = mapPoint(at: max(0, distance - 1), in: segments) ?? point
+            let next = mapPoint(at: min(totalDistance, distance + 1), in: segments) ?? point
+            placements.append(PolylineArrowPlacement(
+                coordinate: point.coordinate,
+                headingDegrees: heading(from: previous, to: next)
+            ))
+            distance += spacing
+        }
+
+        return placements
+    }
+
+    /// `chevron.up` points north at identity. Compass heading is clockwise from
+    /// north; `CGAffineTransform` rotates counter-clockwise, so the angle is negated.
+    static func viewTransform(headingDegrees: CLLocationDirection) -> CGAffineTransform {
+        CGAffineTransform(rotationAngle: -CGFloat(headingDegrees.radians))
+    }
+
+    private static func mapPoint(at distance: CLLocationDistance, in segments: [Segment]) -> MKMapPoint? {
+        guard let segment = segments.first(where: { distance <= $0.endDistance }) ?? segments.last else {
+            return nil
+        }
+        return segment.mapPoint(at: min(max(distance, segment.startDistance), segment.endDistance))
+    }
+
+    /// MapKit's x axis points east and y axis points south. Swapping the usual
+    /// atan2 arguments and negating y yields compass degrees: north = 0, east = 90.
+    private static func heading(from start: MKMapPoint, to end: MKMapPoint) -> CLLocationDirection {
+        let degrees = atan2(end.x - start.x, -(end.y - start.y)) * 180 / .pi
+        return degrees >= 0 ? degrees : degrees + 360
+    }
+}
+
+final class PolylineArrowAnnotation: NSObject, MKAnnotation {
+    let coordinate: CLLocationCoordinate2D
+    let headingDegrees: CLLocationDirection
+    let tintColor: UIColor
+    let routeID: RouteID?
+    var alpha: CGFloat
+
+    init(
+        placement: PolylineArrowPlacement,
+        tintColor: UIColor,
+        routeID: RouteID? = nil,
+        alpha: CGFloat = 1
+    ) {
+        coordinate = placement.coordinate
+        headingDegrees = placement.headingDegrees
+        self.tintColor = tintColor
+        self.routeID = routeID
+        self.alpha = alpha
+        super.init()
+    }
+}
+
+final class PolylineArrowAnnotationView: MKAnnotationView {
+    static let reuseIdentifier = "PolylineArrowAnnotationView"
+
+    override var annotation: MKAnnotation? {
+        didSet { applyAnnotation() }
+    }
+
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        canShowCallout = false
+        isEnabled = false
+        displayPriority = .defaultLow
+        collisionMode = .none
+        applyAnnotation()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func applyAnnotation() {
+        guard let arrow = annotation as? PolylineArrowAnnotation else { return }
+
+        let configuration = UIImage.SymbolConfiguration(pointSize: 13, weight: .bold)
+        image = UIImage(systemName: "chevron.up", withConfiguration: configuration)?
+            .withTintColor(arrow.tintColor, renderingMode: .alwaysOriginal)
+        transform = PolylineDirectionArrows.viewTransform(headingDegrees: arrow.headingDegrees)
+        alpha = arrow.alpha
+        centerOffset = .zero
+    }
+}

--- a/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
+++ b/OBAKit/Mapping/Layers/PolylineDirectionArrows.swift
@@ -93,9 +93,10 @@ nonisolated enum PolylineDirectionArrows {
     }
 
     /// `chevron.up` points north at identity. Compass heading is clockwise from
-    /// north; `CGAffineTransform` rotates counter-clockwise, so the angle is negated.
+    /// north; UIKit view space has y down, so a positive `CGAffineTransform`
+    /// rotation is clockwise too. Do not negate — that mirrored east/west.
     static func viewTransform(headingDegrees: CLLocationDirection) -> CGAffineTransform {
-        CGAffineTransform(rotationAngle: -CGFloat(headingDegrees.radians))
+        CGAffineTransform(rotationAngle: CGFloat(headingDegrees.radians))
     }
 
     private static func mapPoint(at distance: CLLocationDistance, in segments: [Segment]) -> MKMapPoint? {

--- a/OBAKit/Mapping/Layers/StopRouteFocus/StopRouteFocusMapLayer.swift
+++ b/OBAKit/Mapping/Layers/StopRouteFocus/StopRouteFocusMapLayer.swift
@@ -66,6 +66,7 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
 
     private var overlays: [RouteShapeOverlay] = []
     private var annotations: [StopVehicleAnnotation] = []
+    private var directionArrowAnnotations: [PolylineArrowAnnotation] = []
     private var model: StopRouteFocusModel = .empty
 
     /// Which vehicle the focused route is currently standing on — the one whose
@@ -93,6 +94,10 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
         self.shapeCache = shapeCache
         self.formatters = formatters
         super.init()
+        mapView.register(
+            PolylineArrowAnnotationView.self,
+            forAnnotationViewWithReuseIdentifier: PolylineArrowAnnotationView.reuseIdentifier
+        )
     }
 
     /// Cancels and drops every cached shape. Called by `MapViewController` when
@@ -121,10 +126,13 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
         self.focus = focus
         presentationToken = UUID()
 
+        // `@Published` emits in `willSet`, so a sink that reads
+        // `focus.focusedRouteID` still sees the previous value. The emission
+        // itself is the new focus — pass it through rather than reading back.
         focus.$focusedRouteID
             .removeDuplicates()
             .sink { [weak self] routeID in
-                self?.restyleOverlays()
+                self?.restyleOverlays(focusedRouteID: routeID)
                 self?.selectFocusedVehicleAnnotation(routeID: routeID)
             }
             .store(in: &cancellables)
@@ -355,6 +363,17 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
             mapView.removeOverlays(stale)
             overlays.removeAll { !wantedRouteIDs.contains($0.routeID) }
         }
+        let staleArrows = directionArrowAnnotations.filter {
+            guard let routeID = $0.routeID else { return true }
+            return !wantedRouteIDs.contains(routeID)
+        }
+        if !staleArrows.isEmpty {
+            mapView.removeAnnotations(staleArrows)
+            directionArrowAnnotations.removeAll {
+                guard let routeID = $0.routeID else { return true }
+                return !wantedRouteIDs.contains(routeID)
+            }
+        }
         drawnShapeIDsByRoute = drawnShapeIDsByRoute.filter { wantedRouteIDs.contains($0.key) }
 
         for route in model.routes {
@@ -405,11 +424,19 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
         let core = RouteShapeOverlay.make(coordinates: coordinates, routeID: routeID, isCasing: false)
         overlays.append(contentsOf: [casing, core])
         mapView.addOverlays([casing, core], level: .aboveRoads)
+
+        let color = model.routes.first { $0.routeID == routeID }?.color ?? tintColor
+        let arrows = PolylineDirectionArrows.placements(along: coordinates).map {
+            PolylineArrowAnnotation(placement: $0, tintColor: color, routeID: routeID)
+        }
+        directionArrowAnnotations.append(contentsOf: arrows)
+        mapView.addAnnotations(arrows)
+        restyleDirectionArrows(focusedRouteID: focus?.focusedRouteID)
     }
 
     // MARK: - Focus restyling
 
-    private func restyleOverlays() {
+    private func restyleOverlays(focusedRouteID: RouteID?) {
         // `mapView.renderer(for:)` returns nil for any overlay MapKit has not asked
         // the delegate to render yet — offscreen ones, and everything if the map is
         // not in a window. Re-adding forces a fresh `rendererFor` round trip, which
@@ -418,7 +445,7 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
         var routesNeedingReadd = Set<RouteID>()
         for overlay in overlays {
             if let renderer = mapView.renderer(for: overlay) as? MKPolylineRenderer {
-                apply(style: overlay, to: renderer)
+                apply(style: overlay, to: renderer, focusedRouteID: focusedRouteID)
                 renderer.setNeedsDisplay()
             } else {
                 routesNeedingReadd.insert(overlay.routeID)
@@ -434,11 +461,21 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
             mapView.removeOverlays(needsReadd)
             mapView.addOverlays(needsReadd, level: .aboveRoads)
         }
+        restyleDirectionArrows(focusedRouteID: focusedRouteID)
         applyVehicleZPriority()
     }
 
-    private func apply(style overlay: RouteShapeOverlay, to renderer: MKPolylineRenderer) {
-        let focusedRouteID = focus?.focusedRouteID
+    private func restyleDirectionArrows(focusedRouteID: RouteID?) {
+        for annotation in directionArrowAnnotations {
+            annotation.alpha = (focusedRouteID == nil || annotation.routeID == focusedRouteID)
+                ? Style.normalAlpha
+                : Style.dimmedAlpha
+            mapView.view(for: annotation)?.alpha = annotation.alpha
+        }
+    }
+
+    private func apply(style overlay: RouteShapeOverlay, to renderer: MKPolylineRenderer, focusedRouteID: RouteID? = nil) {
+        let focusedRouteID = focusedRouteID ?? focus?.focusedRouteID
         let isFocused = overlay.routeID == focusedRouteID
         let color = model.routes.first { $0.routeID == overlay.routeID }?.color ?? tintColor
 
@@ -454,8 +491,10 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
     private func removeAllContent() {
         mapView.removeOverlays(overlays)
         mapView.removeAnnotations(annotations)
+        mapView.removeAnnotations(directionArrowAnnotations)
         overlays.removeAll()
         annotations.removeAll()
+        directionArrowAnnotations.removeAll()
     }
 
     // MARK: - MapLayer conformance
@@ -468,6 +507,13 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
     }
 
     func annotationView(for annotation: MKAnnotation, in mapView: MKMapView) -> MKAnnotationView? {
+        if annotation is PolylineArrowAnnotation {
+            return mapView.dequeueReusableAnnotationView(
+                withIdentifier: PolylineArrowAnnotationView.reuseIdentifier,
+                for: annotation
+            )
+        }
+
         guard let annotation = annotation as? StopVehicleAnnotation else { return nil }
         let view = mapView.dequeueReusableAnnotationView(
             withIdentifier: MKMapView.reuseIdentifier(for: PulsingVehicleAnnotationView.self),
@@ -551,7 +597,7 @@ final class StopRouteFocusMapLayer: NSObject, MapLayer {
 
     func mapAnnotationsWereCleared() {
         guard focus != nil else { return }
-        mapView.addAnnotations(annotations)
+        mapView.addAnnotations(annotations + directionArrowAnnotations)
     }
 
     func mapOverlaysWereCleared() {

--- a/OBAKit/Mapping/Layers/TripFocus/TripFocusMapLayer.swift
+++ b/OBAKit/Mapping/Layers/TripFocus/TripFocusMapLayer.swift
@@ -63,6 +63,7 @@ final class TripFocusMapLayer: NSObject, MapLayer {
 
     private var shapeOverlays: [TripShapeOverlay] = []
     private var stopAnnotations: [TripStopAnnotation] = []
+    private var directionArrowAnnotations: [PolylineArrowAnnotation] = []
     private var vehicleAnnotation: VehicleAnnotation?
 
     /// The trip the camera has already been framed for. Framing happens once per
@@ -80,6 +81,10 @@ final class TripFocusMapLayer: NSObject, MapLayer {
         mapView.register(
             TripStopAnnotationView.self,
             forAnnotationViewWithReuseIdentifier: TripStopAnnotationView.reuseIdentifier
+        )
+        mapView.register(
+            PolylineArrowAnnotationView.self,
+            forAnnotationViewWithReuseIdentifier: PolylineArrowAnnotationView.reuseIdentifier
         )
     }
 
@@ -119,6 +124,7 @@ final class TripFocusMapLayer: NSObject, MapLayer {
         let split = Self.split(content)
 
         drawShape(split)
+        drawDirectionArrows(along: split.ahead, color: content.routeColor)
         drawStops(content)
         drawVehicle(content)
         frameCameraIfNeeded(content, split: split)
@@ -146,6 +152,13 @@ final class TripFocusMapLayer: NSObject, MapLayer {
         let core = TripShapeOverlay.make(coordinates: coordinates, isSpent: isSpent, isCasing: false)
         shapeOverlays.append(contentsOf: [casing, core])
         mapView.addOverlays([casing, core], level: .aboveRoads)
+    }
+
+    private func drawDirectionArrows(along coordinates: [CLLocationCoordinate2D], color: UIColor) {
+        directionArrowAnnotations = PolylineDirectionArrows.placements(along: coordinates).map {
+            PolylineArrowAnnotation(placement: $0, tintColor: color)
+        }
+        mapView.addAnnotations(directionArrowAnnotations)
     }
 
     private func drawStops(_ content: TripMapFocus.Content) {
@@ -222,11 +235,13 @@ final class TripFocusMapLayer: NSObject, MapLayer {
     private func removeAllContent() {
         mapView.removeOverlays(shapeOverlays)
         mapView.removeAnnotations(stopAnnotations)
+        mapView.removeAnnotations(directionArrowAnnotations)
         if let vehicleAnnotation {
             mapView.removeAnnotation(vehicleAnnotation)
         }
         shapeOverlays.removeAll()
         stopAnnotations.removeAll()
+        directionArrowAnnotations.removeAll()
         vehicleAnnotation = nil
     }
 
@@ -252,6 +267,13 @@ final class TripFocusMapLayer: NSObject, MapLayer {
         if annotation is TripStopAnnotation {
             return mapView.dequeueReusableAnnotationView(
                 withIdentifier: TripStopAnnotationView.reuseIdentifier,
+                for: annotation
+            )
+        }
+
+        if annotation is PolylineArrowAnnotation {
+            return mapView.dequeueReusableAnnotationView(
+                withIdentifier: PolylineArrowAnnotationView.reuseIdentifier,
                 for: annotation
             )
         }
@@ -283,6 +305,7 @@ final class TripFocusMapLayer: NSObject, MapLayer {
     /// no-op and leak the following trip's markers on top.
     func mapAnnotationsWereCleared() {
         stopAnnotations.removeAll()
+        directionArrowAnnotations.removeAll()
         vehicleAnnotation = nil
     }
 

--- a/OBAKitTests/Mapping/PolylineDirectionArrowsTests.swift
+++ b/OBAKitTests/Mapping/PolylineDirectionArrowsTests.swift
@@ -1,0 +1,86 @@
+//
+//  PolylineDirectionArrowsTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Testing
+@testable import OBAKit
+
+@Suite(.serialized)
+struct PolylineDirectionArrowsTests {
+
+    @Test func `Empty and single-point shapes have no arrow placements`() {
+        let point = CLLocationCoordinate2D(latitude: 47, longitude: -122)
+
+        #expect(PolylineDirectionArrows.placements(along: []).isEmpty)
+        #expect(PolylineDirectionArrows.placements(along: [point]).isEmpty)
+    }
+
+    @Test func `A zero-length shape has no arrow placements`() {
+        let point = CLLocationCoordinate2D(latitude: 47, longitude: -122)
+
+        #expect(PolylineDirectionArrows.placements(along: [point, point]).isEmpty)
+    }
+
+    @Test func `A northbound line places regularly spaced northbound arrows`() {
+        let line = [
+            CLLocationCoordinate2D(latitude: 47, longitude: -122),
+            CLLocationCoordinate2D(latitude: 47.018, longitude: -122)
+        ]
+
+        let placements = PolylineDirectionArrows.placements(along: line, spacing: 500)
+
+        #expect((3...4).contains(placements.count))
+        #expect(placements.allSatisfy { abs($0.headingDegrees) < 3 })
+    }
+
+    @Test func `An eastbound line points arrows east`() {
+        let line = [
+            CLLocationCoordinate2D(latitude: 47, longitude: -122),
+            CLLocationCoordinate2D(latitude: 47, longitude: -121.973)
+        ]
+
+        let placements = PolylineDirectionArrows.placements(along: line, spacing: 500)
+
+        #expect(!placements.isEmpty)
+        #expect(placements.allSatisfy { abs($0.headingDegrees - 90) < 3 })
+    }
+
+    @Test func `Spacing longer than the line produces no arrows`() {
+        let line = [
+            CLLocationCoordinate2D(latitude: 47, longitude: -122),
+            CLLocationCoordinate2D(latitude: 47.001, longitude: -122)
+        ]
+
+        #expect(PolylineDirectionArrows.placements(along: line, spacing: 500).isEmpty)
+    }
+
+    @Test func `Very long lines cap their arrow count`() {
+        let line = [
+            CLLocationCoordinate2D(latitude: 47, longitude: -122),
+            CLLocationCoordinate2D(latitude: 48, longitude: -122)
+        ]
+
+        let placements = PolylineDirectionArrows.placements(along: line, spacing: 100)
+
+        #expect(!placements.isEmpty)
+        #expect(placements.count <= 24)
+    }
+
+    /// `chevron.up` points north at identity. UIKit rotates counter-clockwise,
+    /// compass heading is clockwise, so east (90°) must be `-π/2`.
+    @Test func `View transform maps compass heading onto UIKit rotation`() {
+        let north = PolylineDirectionArrows.viewTransform(headingDegrees: 0)
+        #expect(abs(north.a - 1) < 0.001)
+        #expect(abs(north.b) < 0.001)
+
+        let east = PolylineDirectionArrows.viewTransform(headingDegrees: 90)
+        #expect(abs(east.a) < 0.001)
+        #expect(abs(east.b - (-1)) < 0.001)
+    }
+}

--- a/OBAKitTests/Mapping/PolylineDirectionArrowsTests.swift
+++ b/OBAKitTests/Mapping/PolylineDirectionArrowsTests.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import CoreGraphics
 import CoreLocation
 import Testing
 @testable import OBAKit
@@ -72,15 +73,18 @@ struct PolylineDirectionArrowsTests {
         #expect(placements.count <= 24)
     }
 
-    /// `chevron.up` points north at identity. UIKit rotates counter-clockwise,
-    /// compass heading is clockwise, so east (90°) must be `-π/2`.
+    /// `chevron.up` points north at identity. UIKit view space has y down, so a
+    /// positive `CGAffineTransform` rotation is clockwise — the same sense as a
+    /// compass heading. East must send the up-vector to the right, not the left.
     @Test func `View transform maps compass heading onto UIKit rotation`() {
-        let north = PolylineDirectionArrows.viewTransform(headingDegrees: 0)
-        #expect(abs(north.a - 1) < 0.001)
-        #expect(abs(north.b) < 0.001)
+        let up = CGPoint(x: 0, y: -1)
 
-        let east = PolylineDirectionArrows.viewTransform(headingDegrees: 90)
-        #expect(abs(east.a) < 0.001)
-        #expect(abs(east.b - (-1)) < 0.001)
+        let north = up.applying(PolylineDirectionArrows.viewTransform(headingDegrees: 0))
+        #expect(abs(north.x) < 0.001)
+        #expect(north.y < -0.99)
+
+        let east = up.applying(PolylineDirectionArrows.viewTransform(headingDegrees: 90))
+        #expect(east.x > 0.99)
+        #expect(abs(east.y) < 0.001)
     }
 }

--- a/OBAKitTests/Mapping/StopRouteFocus/StopRouteFocusMapLayerTests.swift
+++ b/OBAKitTests/Mapping/StopRouteFocus/StopRouteFocusMapLayerTests.swift
@@ -446,6 +446,34 @@ final class StopRouteFocusMapLayerTests {
         }
     }
 
+    @Test func `Update adds direction arrows once per route shape`() async {
+        let mapView = MKMapView()
+        let layer = makeLayer(mapView: mapView)
+        layer.begin(focus: StopMapFocus())
+
+        layer.update(model: model(routeIDs: ["H"], vehicleRouteIDs: []))
+        await layer.awaitPendingShapeWork()
+
+        let arrows = mapView.annotations.compactMap { $0 as? PolylineArrowAnnotation }
+        #expect(!arrows.isEmpty)
+        #expect(arrows.allSatisfy { $0.routeID == "H" })
+    }
+
+    @Test func `Direction arrows dim with their unfocused route`() async {
+        let mapView = MKMapView()
+        let layer = makeLayer(mapView: mapView)
+        let focus = StopMapFocus()
+        layer.begin(focus: focus)
+        layer.update(model: model(routeIDs: ["H", "62"], vehicleRouteIDs: ["H", "62"]))
+        await layer.awaitPendingShapeWork()
+
+        focus.toggleFocus(routeID: "H")
+
+        let arrows = mapView.annotations.compactMap { $0 as? PolylineArrowAnnotation }
+        #expect(arrows.filter { $0.routeID == "H" }.allSatisfy { $0.alpha == 1 })
+        #expect(arrows.filter { $0.routeID == "62" }.allSatisfy { $0.alpha < 1 })
+    }
+
     @Test func `end removes everything the layer added`() async {
         let mapView = MKMapView()
         let layer = makeLayer(mapView: mapView)

--- a/OBAKitTests/Mapping/TripFocus/TripFocusMapLayerTests.swift
+++ b/OBAKitTests/Mapping/TripFocus/TripFocusMapLayerTests.swift
@@ -97,6 +97,10 @@ final class TripFocusMapLayerTests {
         mapView.annotations.compactMap { $0 as? TripStopAnnotation }
     }
 
+    private var directionArrowAnnotations: [PolylineArrowAnnotation] {
+        mapView.annotations.compactMap { $0 as? PolylineArrowAnnotation }
+    }
+
     // MARK: - The shape
 
     /// Each half draws twice — a white casing under a colored core — so a split
@@ -121,6 +125,14 @@ final class TripFocusMapLayerTests {
         focus(content(shape: shape(), progress: 0))
 
         #expect(shapeOverlays.allSatisfy { !$0.isSpent })
+    }
+
+    @Test func `Direction arrows are placed only on the part of the trip still ahead`() {
+        let line = shape()
+        focus(content(shape: line, progress: 0.5))
+
+        #expect(!directionArrowAnnotations.isEmpty)
+        #expect(directionArrowAnnotations.allSatisfy { $0.coordinate.longitude > line[2].longitude })
     }
 
     /// An agency that publishes no shape still gets a usable map: the stops carry
@@ -224,6 +236,7 @@ final class TripFocusMapLayerTests {
 
         #expect(shapeOverlays.isEmpty)
         #expect(stopAnnotations.isEmpty)
+        #expect(directionArrowAnnotations.isEmpty)
     }
 
     /// A refresh replaces what's drawn rather than adding to it — otherwise every

--- a/docs/polyline-direction-arrows.md
+++ b/docs/polyline-direction-arrows.md
@@ -1,0 +1,21 @@
+# Polyline Direction Arrows
+
+Route direction is shown with small heading-aware chevrons:
+
+- On the remaining, untraveled shape in trip focus.
+- On each colored route line in stop focus.
+- Every 500 meters, beginning 500 meters from the start of the applicable shape.
+- Capped at 24 chevrons per shape, with short end remainders omitted.
+- Tinted and dimmed with the route line they annotate.
+
+The chevrons indicate the direction encoded by the route geometry. They are
+annotations over the existing colored core line, not additions to its white
+casing.
+
+`chevron.up` points north at identity. Compass heading is clockwise from north;
+UIKit rotation is counter-clockwise, so the view transform is
+`-heading.radians`. Using `CLLocationDirection.affineTransform` as-is would
+point eastbound chevrons west.
+
+This intentionally does not reproduce Transit App's vehicle-dots design. It
+uses lightweight directional marks on OneBusAway's existing route polylines.

--- a/docs/polyline-direction-arrows.md
+++ b/docs/polyline-direction-arrows.md
@@ -12,10 +12,10 @@ The chevrons indicate the direction encoded by the route geometry. They are
 annotations over the existing colored core line, not additions to its white
 casing.
 
-`chevron.up` points north at identity. Compass heading is clockwise from north;
-UIKit rotation is counter-clockwise, so the view transform is
-`-heading.radians`. Using `CLLocationDirection.affineTransform` as-is would
-point eastbound chevrons west.
+`chevron.up` points north at identity. Compass heading is clockwise from
+north; UIKit view space has y down, so a positive `CGAffineTransform`
+rotation is clockwise too. The view transform is `heading.radians` — do
+**not** negate, or eastbound chevrons mirror west.
 
 This intentionally does not reproduce Transit App's vehicle-dots design. It
 uses lightweight directional marks on OneBusAway's existing route polylines.


### PR DESCRIPTION
## Summary
- Same-street inbound/outbound loops are hard to tell apart from the colored polyline alone (#445). Small `chevron.up` annotations now sit on the remaining trip shape and on each stop-focus route line, every 500m, capped at 24, short remainders omitted.
- Heading is compass degrees; UIKit rotates counter-clockwise, so the view transform is `-heading.radians`. `CLLocationDirection.affineTransform` as-is would point eastbound chevrons west.
- Chevrons tint and dim with the line they annotate. Focus restyle uses the `$focusedRouteID` emission, not a read-back of `focus.focusedRouteID` — `@Published` fires in `willSet`. This is not Transit App's vehicle-dots design.

Closes #445.

## Test plan
- [x] `PolylineDirectionArrowsTests` — spacing, east heading, 24-cap, compass→UIKit transform
- [x] `Direction arrows are placed only on the part of the trip still ahead`
- [x] `Direction arrows dim with their unfocused route`
- [x] `PolylineDirectionArrowsTests` + `TripFocusMapLayerTests` + `StopRouteFocusMapLayerTests` (52)
- [ ] On device: open a trip — chevrons only on the untraveled half, pointing along the line
- [ ] Stop with two routes: chip-tap dims the other route's chevrons with the line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directional chevrons along route and trip lines to indicate travel direction.
  * Arrows appear at regular intervals, follow the route’s geometry, and use route-specific styling.
  * Trip views show arrows only on the remaining portion of the journey.
  * Focused routes remain prominent while other route arrows are dimmed.

* **Documentation**
  * Added guidance on arrow spacing, styling, placement, and rotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->