### PR TITLE
Interpolate vehicle markers between arrival polls

### DIFF
--- a/OBAKit/Mapping/Layers/StopRouteFocus/StopVehicleAnnotation.swift
+++ b/OBAKit/Mapping/Layers/StopRouteFocus/StopVehicleAnnotation.swift
@@ -94,8 +94,14 @@ final class StopVehicleAnnotation: VehicleAnnotation {
         // same as the initializer's `super.init(tripStatus:)` — so the
         // position-preferred coordinate must be assigned AFTER, or it gets
         // clobbered exactly as the initializer's comment describes.
+        //
+        // Restore `from` before `VehicleCoordinateUpdate.apply` so a city-block
+        // hop interpolates instead of that didSet teleporting the pin. A
+        // kilometre-scale jump still snaps; see VehicleCoordinateUpdate.
+        let from = self.coordinate
         self.tripStatus = tripStatus
-        self.coordinate = coordinate
+        self.coordinate = from
         self.routeColor = routeColor
+        VehicleCoordinateUpdate.apply(from: from, to: coordinate, on: self)
     }
 }

--- a/OBAKit/Mapping/Layers/TripFocus/TripFocusMapLayer.swift
+++ b/OBAKit/Mapping/Layers/TripFocus/TripFocusMapLayer.swift
@@ -110,9 +110,15 @@ final class TripFocusMapLayer: NSObject, MapLayer {
     // MARK: - Rendering
 
     private func render(_ content: TripMapFocus.Content?) {
-        removeAllContent()
+        // Shape and stops are cheap to replace. The vehicle marker is not:
+        // removing it dismisses any callout and pops the pin instead of sliding
+        // it. See `drawVehicle`.
+        removeShapeAndStops()
 
-        guard let content else { return }
+        guard let content else {
+            removeVehicle()
+            return
+        }
 
         // Split once: the drawing and the camera have to agree about which half
         // of the shape is still ahead of the bus.
@@ -159,11 +165,41 @@ final class TripFocusMapLayer: NSObject, MapLayer {
     }
 
     private func drawVehicle(_ content: TripMapFocus.Content) {
-        guard let status = content.vehicle, Self.vehicleCoordinate(content) != nil else { return }
+        guard let status = content.vehicle, let coord = Self.vehicleCoordinate(content) else {
+            removeVehicle()
+            return
+        }
 
+        if let existing = vehicleAnnotation, Self.isSameVehicle(existing.tripStatus, status) {
+            // `tripStatus`'s didSet writes lastKnownLocation onto coordinate
+            // immediately. Restore `from` so `VehicleCoordinateUpdate` can
+            // interpolate instead of that assignment teleporting the pin.
+            let from = existing.coordinate
+            existing.tripStatus = status
+            existing.coordinate = from
+            VehicleCoordinateUpdate.apply(from: from, to: coord, on: existing)
+            if let view = mapView.view(for: existing) as? PulsingVehicleAnnotationView {
+                view.realTimeAnnotationColor = content.routeColor
+                view.applyTripStatus(status)
+            }
+            return
+        }
+
+        removeVehicle()
         let annotation = VehicleAnnotation(tripStatus: status)
         vehicleAnnotation = annotation
         mapView.addAnnotation(annotation)
+    }
+
+    /// Same bus, not merely the same trip: a block handoff should replace the
+    /// marker rather than interpolate across the depot. Missing vehicle IDs
+    /// still count as the same marker — this layer only ever draws one.
+    private static func isSameVehicle(_ existing: TripStatus?, _ incoming: TripStatus) -> Bool {
+        guard let existing else { return false }
+        if let existingID = existing.vehicleID, let incomingID = incoming.vehicleID {
+            return existingID == incomingID
+        }
+        return true
     }
 
     /// The part of the map this layer may frame into — everything the host isn't
@@ -220,13 +256,21 @@ final class TripFocusMapLayer: NSObject, MapLayer {
     }
 
     private func removeAllContent() {
+        removeShapeAndStops()
+        removeVehicle()
+    }
+
+    private func removeShapeAndStops() {
         mapView.removeOverlays(shapeOverlays)
         mapView.removeAnnotations(stopAnnotations)
+        shapeOverlays.removeAll()
+        stopAnnotations.removeAll()
+    }
+
+    private func removeVehicle() {
         if let vehicleAnnotation {
             mapView.removeAnnotation(vehicleAnnotation)
         }
-        shapeOverlays.removeAll()
-        stopAnnotations.removeAll()
         vehicleAnnotation = nil
     }
 

--- a/OBAKit/Mapping/VehicleCoordinateUpdate.swift
+++ b/OBAKit/Mapping/VehicleCoordinateUpdate.swift
@@ -1,0 +1,70 @@
+//
+//  VehicleCoordinateUpdate.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import MapKit
+import OBAKitCore
+import UIKit
+
+/// Whether a vehicle marker should interpolate to a new coordinate or jump.
+///
+/// Arrival polls land every 15–30s. Assigning `coordinate` each time teleports
+/// the pin; interpolating every hop looks like motion. Distances larger than
+/// one or two polls at motorway speed are a new fix (or a trip change), not
+/// something to ease across the map.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1109
+enum VehicleCoordinateUpdate {
+    enum Decision: Equatable {
+        case unchanged
+        case snap
+        case animate(duration: TimeInterval)
+    }
+
+    static let animationDuration: TimeInterval = 0.8
+
+    /// A bit over one 30s poll at ~50 km/h. Farther than that, jump.
+    static let snapBeyondMeters: CLLocationDistance = 500
+
+    /// GPS jitter below this is not worth restarting an in-flight animation.
+    static let ignoreBelowMeters: CLLocationDistance = 2
+
+    static func decision(from: CLLocationCoordinate2D, to: CLLocationCoordinate2D) -> Decision {
+        guard CLLocationCoordinate2DIsValid(from), CLLocationCoordinate2DIsValid(to) else {
+            return .snap
+        }
+        if from.isNullIsland || to.isNullIsland {
+            return .snap
+        }
+
+        let meters = from.distance(from: to)
+        if meters < ignoreBelowMeters { return .unchanged }
+        if meters > snapBeyondMeters { return .snap }
+        return .animate(duration: animationDuration)
+    }
+
+    /// Moves `annotation` according to `decision(from:to:)`.
+    ///
+    /// The caller is responsible for restoring `from` after any `tripStatus`
+    /// assignment: `VehicleAnnotation.tripStatus`'s `didSet` writes
+    /// `lastKnownLocation` onto `coordinate` immediately, which would skip
+    /// the animation if left in place.
+    static func apply(from: CLLocationCoordinate2D, to: CLLocationCoordinate2D, on annotation: MKPointAnnotation) {
+        switch decision(from: from, to: to) {
+        case .unchanged:
+            break
+        case .snap:
+            annotation.coordinate = to
+        case .animate(let duration):
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState]) {
+                annotation.coordinate = to
+            }
+        }
+    }
+}

--- a/OBAKitTests/Mapping/TripFocus/TripFocusMapLayerTests.swift
+++ b/OBAKitTests/Mapping/TripFocus/TripFocusMapLayerTests.swift
@@ -237,6 +237,22 @@ final class TripFocusMapLayerTests {
         #expect(shapeOverlays.count == firstCount)
     }
 
+    /// Polling used to `removeAnnotation`/`addAnnotation` the bus on every
+    /// tick. MapKit treats that as a new pin, so the marker pops instead of
+    /// sliding, and any open callout is dismissed. Keep the same object.
+    /// See: https://github.com/OneBusAway/onebusaway-ios/issues/1109
+    @Test func `A refresh moves the existing vehicle annotation instead of replacing it`() throws {
+        let status = try vehicle()
+        let focus = focus(content(shape: shape(), progress: 0.5, vehicle: status))
+        let first = try #require(mapView.annotations.compactMap { $0 as? VehicleAnnotation }.first)
+
+        focus.apply(content(shape: shape(), progress: 0.6, vehicle: status))
+
+        let after = mapView.annotations.compactMap { $0 as? VehicleAnnotation }
+        #expect(after.count == 1)
+        #expect(after.first === first)
+    }
+
     @Test func `Clearing the focus clears the map`() {
         let focus = focus(content(shape: shape(), progress: 0.5))
 

--- a/OBAKitTests/Mapping/VehicleCoordinateUpdateTests.swift
+++ b/OBAKitTests/Mapping/VehicleCoordinateUpdateTests.swift
@@ -1,0 +1,52 @@
+//
+//  VehicleCoordinateUpdateTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Testing
+import OBAKitCore
+@testable import OBAKit
+
+/// Policy for interpolating a vehicle marker between polls.
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1109
+@Suite(.serialized)
+struct VehicleCoordinateUpdateTests {
+
+    private let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
+
+    /// ~45 m east of `seattle` — well inside one 15s poll at city speed.
+    private var nearby: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3315)
+    }
+
+    /// GPS jitter: under 2 m, not worth restarting an animation.
+    @Test func `Sub-meter jitter is unchanged`() {
+        let almost = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.33211)
+        #expect(VehicleCoordinateUpdate.decision(from: seattle, to: almost) == .unchanged)
+    }
+
+    @Test func `A city-block hop animates`() {
+        let decision = VehicleCoordinateUpdate.decision(from: seattle, to: nearby)
+        #expect(decision == .animate(duration: VehicleCoordinateUpdate.animationDuration))
+    }
+
+    /// Farther than one or two polls at motorway speed is a new fix, not motion.
+    @Test func `A kilometre jump snaps`() {
+        let far = CLLocationCoordinate2D(latitude: 47.62, longitude: -122.33)
+        #expect(VehicleCoordinateUpdate.decision(from: seattle, to: far) == .snap)
+    }
+
+    @Test func `Null island snaps rather than interpolating across the ocean`() {
+        #expect(VehicleCoordinateUpdate.decision(from: .init(), to: seattle) == .snap)
+        #expect(VehicleCoordinateUpdate.decision(from: seattle, to: .init()) == .snap)
+    }
+
+    @Test func `An invalid coordinate snaps`() {
+        #expect(VehicleCoordinateUpdate.decision(from: kCLLocationCoordinate2DInvalid, to: seattle) == .snap)
+    }
+}


### PR DESCRIPTION
## Summary
- Arrival polls used to `removeAnnotation`/`addAnnotation` the trip-page bus. MapKit treats that as a new pin, so the marker pops and any open callout is dismissed.
- The trip layer now keeps the same `VehicleAnnotation` when the vehicle ID matches, and `StopVehicleAnnotation.update` does the same for stop-focus markers.
- `VehicleCoordinateUpdate` eases hops under 500 m (~one 30s poll at city speed) over 0.8 s, snaps farther than that (or to/from null island), and ignores sub-2 m GPS jitter. No new settings.

Addresses item 1 of #1109. Item 2 has an open PR (#1115). Item 3 landed in #1305.

## Test plan
- [x] `A refresh moves the existing vehicle annotation instead of replacing it`
- [x] `VehicleCoordinateUpdateTests` (5) — jitter / city-block / kilometre / null island / invalid
- [x] `TripFocusMapLayerTests` (13) and `StopVehicleAnnotationTests` (6)
- [ ] Device: open a trip page, wait for an arrivals poll — the bus should slide, not jump. A region change or a different vehicle ID should still snap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Vehicle markers now move smoothly between nearby location updates instead of teleporting.
  * Large or invalid location changes snap directly to the correct position.
  * Vehicle markers remain stable when trip information refreshes.
  * Marker status and route colors update without unnecessary replacement.
  * Missing vehicle information now removes the marker appropriately.

* **Bug Fixes**
  * Prevented incorrect animations caused by GPS jitter, invalid coordinates, or Null Island locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->