### PR TITLE
Document FixedRegionName for white-label region pinning

### DIFF
--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -164,15 +164,15 @@ If you choose to leave out `RegionsServerBaseAddress` and `RegionsServerAPIPath`
 
 ### Default region from OBAKitConfig
 
-These keys are **not a pin**. `RegionsService.init` picks a region in this order, and later steps never run if an earlier one already set `currentRegion`:
+These keys are **not a pin**. `RegionsService.init` resolves a region in this order:
 
-1. Previously stored region (UserDefaults)
-2. Location-based auto-select — if auto-select is on (the default) *or* no region is stored yet, and `LocationService` already has a cached fix inside a known region
-3. `FixedRegionName`, then `FixedRegionOBABaseURL` if the name matches nothing
+1. Previously stored region (UserDefaults), **unless** location auto-select is on (the default) — then a cached fix inside a known region can overwrite it
+2. Location-based auto-select when auto-select is on *or* no region is stored yet (`|| currentRegion == nil`), and `LocationService` already has a cached fix inside a known region
+3. `FixedRegionName`, then `FixedRegionOBABaseURL` if the name matches nothing — only when `currentRegion` is still nil after steps 1–2
 4. The only *active* region in the list, when there is exactly one
 5. The region picker
 
-A rider whose device already has a location fix inside another region's bounds will get **that** region, not the configured one. `OBAKitTests` covers this as `Location based selection takes priority`. An agency that needs every install on one region must ship a list with only that region (or turn location auto-select off themselves); these keys will not override a location match.
+A rider whose device already has a location fix inside another region's bounds will get **that** region, not the configured one. `OBAKitTests` covers this as `Location based selection takes priority`. Because location runs whenever `currentRegion` is nil (including first launch), registering `OBAAutomaticallySelectRegionUserDefaultsKey` as `false` does **not** skip that match on the launch where `FixedRegionName` could apply. An agency that needs every install on one region must ship a list with only that region (or avoid prompting for location so `currentLocation` stays nil); these keys will not override a location match.
 
 * `FixedRegionName` - Optional. The `name` of a region in the bundled (or downloaded) list. Used only when steps 1–2 left `currentRegion` nil. A successful match writes that region and turns auto-select off so a *later* location fix cannot steal it — an *earlier* one already can.
 * `FixedRegionOBABaseURL` - Optional. Used only when `FixedRegionName` is set and does not match any known region. The first region whose OBA base URL equals this value is selected instead. A missing or unparseable URL is ignored.

--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -150,15 +150,28 @@ These are parameters specified in your app's `project.yml` file that customizes 
 
 ### Regions
 
-There are three parameters that are associated with regions:
+There are five parameters that are associated with regions:
 
 * `BundledRegionsFileName` - Required.
 * `RegionsServerBaseAddress` - Optional.
 * `RegionsServerAPIPath` - Optional.
+* `FixedRegionName` - Optional.
+* `FixedRegionOBABaseURL` - Optional.
 
 The regions JSON file that you will specify with the `BundledRegionsFileName` parameter is required so that the app can show the user a list of available regions as soon as the application launches, without having to worry about having an internet connection. However, that list will eventually/inevitably become out of date, and so the app will also regularly download the remote copy of the regions file to make sure that changes (names, features, new regions, deleted regions) are handled.
 
 If you choose to leave out `RegionsServerBaseAddress` and `RegionsServerAPIPath`, then your app will rely solely on the bundled regions file for all regions that your application will know about. It is _highly_ recommended that you provide a regions server URL and path, but it is not strictly required.
+
+### Pinning a region at launch
+
+A white-label app that only serves one agency can skip the region picker:
+
+* `FixedRegionName` - Optional. The `name` of a region in the bundled (or downloaded) list. When the user has no current region, the app selects this one and turns auto-select off so a later location fix cannot steal it.
+* `FixedRegionOBABaseURL` - Optional. Used only when `FixedRegionName` is set and does not match any known region. The first region whose OBA base URL equals this value is selected instead. A missing or unparseable URL is ignored.
+
+Name match wins over URL match. Neither key overrides a region the user (or a previous launch) already chose. If both are omitted, the picker still appears — unless the list contains exactly one *active* region, in which case that region is selected automatically.
+
+Invalid optional URLs degrade to nil; a name that matches nothing and has no URL fallback leaves the current region unset so the picker can still run.
 
 ### Arrival and Departure Display
 

--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -162,16 +162,24 @@ The regions JSON file that you will specify with the `BundledRegionsFileName` pa
 
 If you choose to leave out `RegionsServerBaseAddress` and `RegionsServerAPIPath`, then your app will rely solely on the bundled regions file for all regions that your application will know about. It is _highly_ recommended that you provide a regions server URL and path, but it is not strictly required.
 
-### Pinning a region at launch
+### Default region from OBAKitConfig
 
-A white-label app that only serves one agency can skip the region picker:
+These keys are **not a pin**. `RegionsService.init` picks a region in this order, and later steps never run if an earlier one already set `currentRegion`:
 
-* `FixedRegionName` - Optional. The `name` of a region in the bundled (or downloaded) list. When the user has no current region, the app selects this one and turns auto-select off so a later location fix cannot steal it.
+1. Previously stored region (UserDefaults)
+2. Location-based auto-select — if auto-select is on (the default) *or* no region is stored yet, and `LocationService` already has a cached fix inside a known region
+3. `FixedRegionName`, then `FixedRegionOBABaseURL` if the name matches nothing
+4. The only *active* region in the list, when there is exactly one
+5. The region picker
+
+A rider whose device already has a location fix inside another region's bounds will get **that** region, not the configured one. `OBAKitTests` covers this as `Location based selection takes priority`. An agency that needs every install on one region must ship a list with only that region (or turn location auto-select off themselves); these keys will not override a location match.
+
+* `FixedRegionName` - Optional. The `name` of a region in the bundled (or downloaded) list. Used only when steps 1–2 left `currentRegion` nil. A successful match writes that region and turns auto-select off so a *later* location fix cannot steal it — an *earlier* one already can.
 * `FixedRegionOBABaseURL` - Optional. Used only when `FixedRegionName` is set and does not match any known region. The first region whose OBA base URL equals this value is selected instead. A missing or unparseable URL is ignored.
 
-Name match wins over URL match. Neither key overrides a region the user (or a previous launch) already chose. If both are omitted, the picker still appears — unless the list contains exactly one *active* region, in which case that region is selected automatically.
+Name match wins over URL match. Neither key overrides a stored region or a location match.
 
-Invalid optional URLs degrade to nil; a name that matches nothing and has no URL fallback leaves the current region unset so the picker can still run.
+If the name matches nothing and the URL fallback misses too, step 4 still runs: a list with exactly one active region selects that region and the picker does not appear. The picker runs only when every step above leaves `currentRegion` unset.
 
 ### Arrival and Departure Display
 

--- a/OBAKitTests/Extensions/FoundationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/FoundationExtensionsTests.swift
@@ -216,6 +216,35 @@ final class BundleFeedbackConfigTests {
         #expect(!bundle.feedbackPromptEnabled)
     }
 
+    // MARK: - Fixed region (issue #608)
+
+    /// White-label apps pin a region in `OBAKitConfig` so the picker never
+    /// appears. These keys are how `RegionsService` is configured at launch.
+    @Test func `Fixed region name reads from OBA kit config`() throws {
+        let bundle = try FeedbackConfigBundle.create(config: ["FixedRegionName": "Puget Sound"])
+        #expect(bundle.fixedRegionName == "Puget Sound")
+    }
+
+    @Test func `Fixed region name is nil when absent`() throws {
+        let bundle = try FeedbackConfigBundle.create(config: [:])
+        #expect(bundle.fixedRegionName == nil)
+    }
+
+    @Test func `Fixed region OBA base URL reads from OBA kit config`() throws {
+        let bundle = try FeedbackConfigBundle.create(config: [
+            "FixedRegionOBABaseURL": "https://api.tampa.onebusawaycloud.com/"
+        ])
+        #expect(bundle.fixedRegionOBABaseURL == URL(string: "https://api.tampa.onebusawaycloud.com/"))
+    }
+
+    @Test func `Fixed region OBA base URL is nil when absent or unparseable`() throws {
+        let missing = try FeedbackConfigBundle.create(config: [:])
+        #expect(missing.fixedRegionOBABaseURL == nil)
+
+        let garbage = try FeedbackConfigBundle.create(config: ["FixedRegionOBABaseURL": ""])
+        #expect(garbage.fixedRegionOBABaseURL == nil)
+    }
+
     // MARK: - String.normalizedSearchQuery
 
     /// Nil means "match everything". `.searchable` hands a view the empty string


### PR DESCRIPTION
## Summary
- `FixedRegionName` / `FixedRegionOBABaseURL` already drive `RegionsService` (name match, then OBA base URL fallback; never overrides a region the user already chose). White-label agencies had no docs for the keys #608 asked for.
- WhiteLabel.md now documents those keys, plus the existing single-active-region auto-select when both are omitted.
- Bundle tests cover the plist read: present, absent, and an unparseable URL degrading to nil. Behavior tests already live in `RegionsServiceAutoSelectTests`.

Closes #608.

## Test plan
- [x] `Fixed region name reads from OBA kit config` / `is nil when absent`
- [x] `Fixed region OBA base URL reads from OBA kit config` / `is nil when absent or unparseable`
- [x] `RegionsServiceAutoSelectTests` (10)
- [ ] White-label: set `FixedRegionName` to a bundled region with no current region in defaults — picker skipped. OneBusAway itself should leave both keys unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded white-label region configuration guidance to include fixed region name and base URL settings.
  - Documented the order used to resolve a default region, including location-based selection, name and URL matching, and fallback behavior.

- **Tests**
  - Added coverage for reading fixed region settings from configuration.
  - Added validation for missing or invalid fixed region values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->