### PR TITLE
Move trip planner off MapViewController and lint errors in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,23 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+    # Fail on SwiftLint *errors* (the error-tier rules in .swiftlint.yml), so a
+    # type_body_length breach cannot land on main while staying green on GitHub.
+    # Warnings annotate via the GitHub reporter but do not fail the job —
+    # `--strict` would collapse that split. The Xcode build phase still skips
+    # in CI (scripts/swiftlint.sh); this step is the review-visible gate.
+    # See https://github.com/OneBusAway/onebusaway-ios/issues/1303
+    - name: SwiftLint (errors only)
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        if ! command -v swiftlint >/dev/null; then
+          brew install swiftlint
+        fi
+        swiftlint lint --reporter github-actions-logging
+
+
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .build

--- a/OBAKit/Mapping/MapViewController+TripPlanner.swift
+++ b/OBAKit/Mapping/MapViewController+TripPlanner.swift
@@ -1,0 +1,187 @@
+//
+//  MapViewController+TripPlanner.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import FloatingPanel
+import MapKit
+import OBAKitCore
+import OTPKit
+import SwiftUI
+import UIKit
+
+/// Trip planner presentation. An extension rather than more of `MapViewController`:
+/// the class it hangs off is already at SwiftLint's body-length ceiling.
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1303
+extension MapViewController {
+
+    func showTripPlannerMapView() {
+        tripPlannerMapView.mapType = mapRegionManager.mapView.mapType
+
+        tripPlannerMapView.isHidden = false
+
+        UIView.animate(withDuration: 0.3) {
+            self.mapRegionManager.mapView.alpha = 0
+            self.tripPlannerMapView.alpha = 1
+        } completion: { _ in
+            self.mapRegionManager.mapView.isHidden = true
+        }
+    }
+
+    func hideTripPlannerMapView() {
+        mapRegionManager.mapView.mapType = tripPlannerMapView.mapType
+        mapRegionManager.mapView.region = tripPlannerMapView.region
+
+        mapRegionManager.mapView.isHidden = false
+
+        UIView.animate(withDuration: 0.3) {
+            self.mapRegionManager.mapView.alpha = 1
+            self.tripPlannerMapView.alpha = 0
+        } completion: { _ in
+            self.tripPlannerMapView.isHidden = true
+        }
+    }
+
+    func buildTripPlanner(region: Region) -> TripPlanner? {
+        // GraphQL (OTP 2.x) is the preferred trip-planning API whenever the region
+        // provides it; OTP 1.x REST is the fallback. Only the GraphQL service can
+        // support vehicle rental features.
+        let serverURL: URL
+        let apiService: OTPKit.APIService
+        if let graphQLURL = region.openTripPlannerGraphQLURL {
+            serverURL = graphQLURL
+            apiService = GraphQLAPIService(baseURL: graphQLURL)
+        } else if let restURL = region.openTripPlannerURL {
+            serverURL = restURL
+            apiService = RestAPIService(baseURL: restURL)
+        } else {
+            return nil
+        }
+
+        var enabledModes: [TransportMode] = [.transit, .walk, .bike, .car]
+        if region.isBikeshareEnabled {
+            // The capability filter in OTPKit hides these again if the service
+            // can't actually plan rental trips (e.g. the REST fallback).
+            enabledModes.append(contentsOf: [.transitBikeRental, .bikeRental])
+        }
+
+        let searchRect = application.currentRegion?.serviceRect ?? mapRegionManager.mapView.visibleMapRect
+
+        let config = OTPConfiguration(
+            otpServerURL: serverURL,
+            enabledTransportModes: enabledModes,
+            themeConfiguration: .init(
+                primaryColor: Color(uiColor: ThemeColors().brand)
+            ),
+            searchRegion: MKCoordinateRegion(searchRect)
+        )
+
+        let mapViewProvider = MKMapViewAdapter(mapView: tripPlannerMapView)
+
+        let tripPlanner = TripPlanner(
+            otpConfig: config,
+            apiService: apiService,
+            mapProvider: mapViewProvider,
+            notificationCenter: application.notificationCenter
+        )
+
+        return tripPlanner
+    }
+
+    /// Presents the trip planner.
+    /// - Parameters:
+    ///   - destination: Optional prefilled destination.
+    ///   - viaPoint: Optional coordinate every planned trip must pass through — used by
+    ///     "Plan a trip using this bike" with the vehicle's location.
+    ///   - preselectedMode: Optional transport mode to preselect, e.g. `.transitBikeRental`.
+    func showTripPlanner(destination: MKMapItem? = nil, viaPoint: CLLocationCoordinate2D? = nil, preselectedMode: TransportMode? = nil) {
+        guard let currentRegion = application.regionsService.currentRegion,
+              currentRegion.supportsOTP,
+              application.userDataStore.isTripPlanningEnabled(for: currentRegion) else {
+            return
+        }
+
+        // Get current location for origin
+        var origin: Location?
+        if let currentLocation = application.locationService.currentLocation {
+            origin = Location(
+                title: "Current Location",
+                subTitle: "Your current location",
+                latitude: currentLocation.coordinate.latitude,
+                longitude: currentLocation.coordinate.longitude
+            )
+        }
+
+        // Convert MKMapItem destination to Location if provided
+        var destinationLocation: Location?
+        if let destination {
+            destinationLocation = Location(
+                title: destination.name ?? "Destination",
+                subTitle: destination.placemark.title ?? "",
+                latitude: destination.placemark.coordinate.latitude,
+                longitude: destination.placemark.coordinate.longitude
+            )
+        }
+
+        guard let tripPlanner = buildTripPlanner(region: currentRegion) else { return }
+
+        subscribeToTripPlannerNotifications()
+
+        let tripPlannerView = tripPlanner.createTripPlannerView(
+            origin: origin,
+            destination: destinationLocation,
+            viaPoint: viaPoint,
+            transportMode: preselectedMode
+        ) { [weak self] in
+            guard let self else { return }
+            self.dismissTripPlannerController()
+        }
+
+        self.floatingPanel.move(to: .tip, animated: true)
+
+        let hostingController = UIHostingController(rootView: tripPlannerView)
+        hostingController.view.backgroundColor = .clear
+
+        let semiModal = createSemiModalPanel(childController: hostingController)
+        semiModal.addPanel(toParent: self)
+        self.semiModalTripPlannerController = semiModal
+        self.tripPlanner = tripPlanner
+        self.tripPlannerHostingController = hostingController
+    }
+
+    func dismissTripPlannerController() {
+        guard let tripPlannerHostingController else { return }
+        dismissModalController(tripPlannerHostingController)
+
+        self.semiModalTripPlannerController = nil
+        self.tripPlannerHostingController = nil
+        self.tripPlanner = nil
+        hideTripPlannerMapView()
+
+        unsubscribeFromTripPlannerNotifications()
+    }
+
+    func subscribeToTripPlannerNotifications() {
+        application.notificationCenter.addObserver(self, selector: #selector(itinerariesUpdated), name: Notifications.itinerariesUpdated, object: nil)
+        application.notificationCenter.addObserver(self, selector: #selector(tripStarted), name: Notifications.tripStarted, object: nil)
+    }
+
+    func unsubscribeFromTripPlannerNotifications() {
+        application.notificationCenter.removeObserver(self, name: Notifications.itinerariesUpdated, object: nil)
+        application.notificationCenter.removeObserver(self, name: Notifications.tripStarted, object: nil)
+    }
+
+    @objc func itinerariesUpdated(_ note: NSNotification) {
+        semiModalTripPlannerController?.move(to: .full, animated: true)
+    }
+
+    @objc func tripStarted(_ note: NSNotification) {
+        showTripPlannerMapView()
+
+        semiModalTripPlannerController?.move(to: .tip, animated: true)
+    }
+}

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -21,10 +21,6 @@ import SafariServices
 /// Displays a map, a set of stops rendered as annotation views, and the user's location if authorized.
 ///
 /// `MapViewController` is the average user's primary means of interacting with OneBusAway data.
-// Over the 1000-line body budget, and has been since before this change. Splitting
-// it is worth doing but is not this change's job; without the disable the error
-// fails every local build.
-// swiftlint:disable:next type_body_length
 class MapViewController: UIViewController,
     FloatingPanelControllerDelegate,
     LocationServiceDelegate,
@@ -475,6 +471,8 @@ class MapViewController: UIViewController,
 
     // MARK: - Long Press Gesture
 
+    var longPressGesture: UILongPressGestureRecognizer!
+
     @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
         // Only handle the began state to avoid multiple pins
         guard gesture.state == .began else { return }
@@ -490,185 +488,18 @@ class MapViewController: UIViewController,
 
     // MARK: - Trip Planner
 
-    private var semiModalTripPlannerController: FloatingPanelController?
+    var semiModalTripPlannerController: FloatingPanelController?
 
-    private var tripPlanner: TripPlanner?
-    private var tripPlannerHostingController: UIViewController?
-    private var longPressGesture: UILongPressGestureRecognizer!
+    var tripPlanner: TripPlanner?
+    var tripPlannerHostingController: UIViewController?
 
-    private lazy var tripPlannerMapView: MKMapView = {
+    lazy var tripPlannerMapView: MKMapView = {
         let mapView = MKMapView.autolayoutNew()
         mapView.alpha = 0
         view.insertSubview(mapView, belowSubview: mapRegionManager.mapView)
         mapView.pinToSuperview(.edges)
         return mapView
     }()
-
-    private func showTripPlannerMapView() {
-        tripPlannerMapView.mapType = mapRegionManager.mapView.mapType
-
-        tripPlannerMapView.isHidden = false
-
-        UIView.animate(withDuration: 0.3) {
-            self.mapRegionManager.mapView.alpha = 0
-            self.tripPlannerMapView.alpha = 1
-        } completion: { _ in
-            self.mapRegionManager.mapView.isHidden = true
-        }
-    }
-
-    private func hideTripPlannerMapView() {
-        mapRegionManager.mapView.mapType = tripPlannerMapView.mapType
-        mapRegionManager.mapView.region = tripPlannerMapView.region
-
-        mapRegionManager.mapView.isHidden = false
-
-        UIView.animate(withDuration: 0.3) {
-            self.mapRegionManager.mapView.alpha = 1
-            self.tripPlannerMapView.alpha = 0
-        } completion: { _ in
-            self.tripPlannerMapView.isHidden = true
-        }
-    }
-
-    private func buildTripPlanner(region: Region) -> TripPlanner? {
-        // GraphQL (OTP 2.x) is the preferred trip-planning API whenever the region
-        // provides it; OTP 1.x REST is the fallback. Only the GraphQL service can
-        // support vehicle rental features.
-        let serverURL: URL
-        let apiService: OTPKit.APIService
-        if let graphQLURL = region.openTripPlannerGraphQLURL {
-            serverURL = graphQLURL
-            apiService = GraphQLAPIService(baseURL: graphQLURL)
-        } else if let restURL = region.openTripPlannerURL {
-            serverURL = restURL
-            apiService = RestAPIService(baseURL: restURL)
-        } else {
-            return nil
-        }
-
-        var enabledModes: [TransportMode] = [.transit, .walk, .bike, .car]
-        if region.isBikeshareEnabled {
-            // The capability filter in OTPKit hides these again if the service
-            // can't actually plan rental trips (e.g. the REST fallback).
-            enabledModes.append(contentsOf: [.transitBikeRental, .bikeRental])
-        }
-
-        let searchRect = application.currentRegion?.serviceRect ?? mapRegionManager.mapView.visibleMapRect
-
-        let config = OTPConfiguration(
-            otpServerURL: serverURL,
-            enabledTransportModes: enabledModes,
-            themeConfiguration: .init(
-                primaryColor: Color(uiColor: ThemeColors().brand)
-            ),
-            searchRegion: MKCoordinateRegion(searchRect)
-        )
-
-        let mapViewProvider = MKMapViewAdapter(mapView: tripPlannerMapView)
-
-        let tripPlanner = TripPlanner(
-            otpConfig: config,
-            apiService: apiService,
-            mapProvider: mapViewProvider,
-            notificationCenter: application.notificationCenter
-        )
-
-        return tripPlanner
-    }
-
-    /// Presents the trip planner.
-    /// - Parameters:
-    ///   - destination: Optional prefilled destination.
-    ///   - viaPoint: Optional coordinate every planned trip must pass through — used by
-    ///     "Plan a trip using this bike" with the vehicle's location.
-    ///   - preselectedMode: Optional transport mode to preselect, e.g. `.transitBikeRental`.
-    func showTripPlanner(destination: MKMapItem? = nil, viaPoint: CLLocationCoordinate2D? = nil, preselectedMode: TransportMode? = nil) {
-        guard let currentRegion = application.regionsService.currentRegion,
-              currentRegion.supportsOTP,
-              application.userDataStore.isTripPlanningEnabled(for: currentRegion) else {
-            return
-        }
-
-        // Get current location for origin
-        var origin: Location?
-        if let currentLocation = application.locationService.currentLocation {
-            origin = Location(
-                title: "Current Location",
-                subTitle: "Your current location",
-                latitude: currentLocation.coordinate.latitude,
-                longitude: currentLocation.coordinate.longitude
-            )
-        }
-
-        // Convert MKMapItem destination to Location if provided
-        var destinationLocation: Location?
-        if let destination {
-            destinationLocation = Location(
-                title: destination.name ?? "Destination",
-                subTitle: destination.placemark.title ?? "",
-                latitude: destination.placemark.coordinate.latitude,
-                longitude: destination.placemark.coordinate.longitude
-            )
-        }
-
-        guard let tripPlanner = buildTripPlanner(region: currentRegion) else { return }
-
-        subscribeToTripPlannerNotifications()
-
-        let tripPlannerView = tripPlanner.createTripPlannerView(
-            origin: origin,
-            destination: destinationLocation,
-            viaPoint: viaPoint,
-            transportMode: preselectedMode
-        ) { [weak self] in
-            guard let self else { return }
-            self.dismissTripPlannerController()
-        }
-
-        self.floatingPanel.move(to: .tip, animated: true)
-
-        let hostingController = UIHostingController(rootView: tripPlannerView)
-        hostingController.view.backgroundColor = .clear
-
-        let semiModal = createSemiModalPanel(childController: hostingController)
-        semiModal.addPanel(toParent: self)
-        self.semiModalTripPlannerController = semiModal
-        self.tripPlanner = tripPlanner
-        self.tripPlannerHostingController = hostingController
-    }
-
-    private func dismissTripPlannerController() {
-        guard let tripPlannerHostingController else { return }
-        dismissModalController(tripPlannerHostingController)
-
-        self.semiModalTripPlannerController = nil
-        self.tripPlannerHostingController = nil
-        self.tripPlanner = nil
-        hideTripPlannerMapView()
-
-        unsubscribeFromTripPlannerNotifications()
-    }
-
-    private func subscribeToTripPlannerNotifications() {
-        application.notificationCenter.addObserver(self, selector: #selector(itinerariesUpdated), name: Notifications.itinerariesUpdated, object: nil)
-        application.notificationCenter.addObserver(self, selector: #selector(tripStarted), name: Notifications.tripStarted, object: nil)
-    }
-
-    private func unsubscribeFromTripPlannerNotifications() {
-        application.notificationCenter.removeObserver(self, name: Notifications.itinerariesUpdated, object: nil)
-        application.notificationCenter.removeObserver(self, name: Notifications.tripStarted, object: nil)
-    }
-
-    @objc private func itinerariesUpdated(_ note: NSNotification) {
-        semiModalTripPlannerController?.move(to: .full, animated: true)
-    }
-
-    @objc private func tripStarted(_ note: NSNotification) {
-        showTripPlannerMapView()
-
-        semiModalTripPlannerController?.move(to: .tip, animated: true)
-    }
 
     // MARK: - Map Type
     public lazy var toggleMapTypeButton: UIButton = {
@@ -1105,7 +936,7 @@ class MapViewController: UIViewController,
         return appearance
     }
 
-    private func createSemiModalPanel(childController: UIViewController) -> FloatingPanelController {
+    func createSemiModalPanel(childController: UIViewController) -> FloatingPanelController {
         let panel = FloatingPanelController()
         panel.surfaceView.appearance = createFloatingPanelSurfaceAppearance()
 
@@ -1143,7 +974,7 @@ class MapViewController: UIViewController,
     // MARK: - Floating Panel Controller
 
     /// The floating panel controller, which displays a drawer at the bottom of the map.
-    private lazy var floatingPanel: OBAFloatingPanelController = {
+    lazy var floatingPanel: OBAFloatingPanelController = {
         let panel = OBAFloatingPanelController(application, delegate: self)
         panel.isRemovalInteractionEnabled = false
         panel.surfaceView.appearance = createFloatingPanelSurfaceAppearance()

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -1,8 +1,14 @@
 # Adds support for Apple Silicon brew directory
 export PATH="$PATH:/opt/homebrew/bin"
 
+# CI runs SwiftLint as its own workflow step (errors fail the job; warnings
+# annotate). Skipping the build-phase copy here keeps Xcode from double-linting
+# and is why `scripts/swiftlint.sh` historically no-op'd when `$CI` was set —
+# that skip is also why a type_body_length error on main was invisible in
+# review. See .github/workflows/tests.yml and
+# https://github.com/OneBusAway/onebusaway-ios/issues/1303
 if [ "$CI" = true ]; then
-  echo "skipping swiftlint because in CI environment"
+  echo "skipping build-phase swiftlint; CI runs it as a dedicated step"
 elif which swiftlint >/dev/null; then
   swiftlint
 else


### PR DESCRIPTION
## Summary
- `MapViewController`'s type body crossed SwiftLint's error threshold (1000). Local builds failed; CI stayed green because `scripts/swiftlint.sh` no-ops when `$CI=true`.
- Trip planner methods move to `MapViewController+TripPlanner.swift`, same pattern as `+Camera` / `+MapLayers`. Type body is back under the warning line; the `type_body_length` disable on the class is gone.
- CI now runs `swiftlint lint --reporter github-actions-logging` after checkout. Errors fail the job. Warnings annotate and do not fail — `--strict` would collapse the warning/error split in `.swiftlint.yml`. The Xcode build phase still skips in CI so we do not double-lint.

The CLAUDE.md simulator destination is #1307, not this PR.

Addresses the SwiftLint half of #1303.

## Test plan
- [x] `swiftlint lint`: 0 errors; `MapViewController.swift` and `+TripPlanner.swift` clean
- [x] `build-for-testing` (scheme `App`, iPhone 17 Pro)
- [x] `FormattersTests` (14)
- [ ] Device: Map → trip planner → plan a trip. The overlay map still swaps in on `tripStarted`, and dismissing the planner restores the main map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added trip-planning support directly within the map experience.
  - Users can select transportation modes, view trip-planning results, and transition smoothly between the map and planner.
  - Added itinerary updates and trip-start handling, with GraphQL service support and REST fallback.

- **Chores**
  - Added dedicated SwiftLint error checks to the continuous integration workflow while allowing warnings to be reported without failing builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->