### PR TITLE
Include section id in OBAListViewSection equality

### DIFF
--- a/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
+++ b/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
@@ -89,7 +89,11 @@ nonisolated public struct OBAListViewSection: Hashable, Identifiable, @unchecked
     }
 
     public static func == (lhs: OBAListViewSection, rhs: OBAListViewSection) -> Bool {
-        return lhs.title == rhs.title &&
+        // `id` belongs here: `hash(into:)` already combines it, and
+        // `NSDiffableDataSource` treats Hashable mismatch as "Failed to find
+        // index of item" on the header that uses this section's id (#421).
+        return lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
             lhs.contents == rhs.contents
     }
 }

--- a/OBAKitTests/Controls/OBAListViewSectionTests.swift
+++ b/OBAKitTests/Controls/OBAListViewSectionTests.swift
@@ -1,0 +1,40 @@
+//
+//  OBAListViewSectionTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Testing
+@testable import OBAKit
+
+/// `NSDiffableDataSource` uses `Hashable` as identity. `hash(into:)` already
+/// combines `id`; `==` used not to, so two agency-alert sections with the same
+/// title and an empty row list compared equal while hashing differently —
+/// undefined behavior, and the source of
+/// "Failed to find index of item OBAListViewHeader".
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/421
+@Suite(.serialized)
+struct OBAListViewSectionTests {
+
+    private func section(id: String, title: String?) -> OBAListViewSection {
+        OBAListViewSection(id: id, title: title, contents: [OBAListRowView.DefaultViewModel]())
+    }
+
+    @Test func `Sections with the same title and contents but different ids are not equal`() {
+        let ferriesA = section(id: "agency_alerts_Washington State Ferries", title: "Washington State Ferries")
+        let ferriesB = section(id: "agency_alerts_Washington State Ferries (other)", title: "Washington State Ferries")
+
+        #expect(ferriesA != ferriesB)
+    }
+
+    @Test func `Equal sections include id and have matching hashes`() {
+        let a = section(id: "agency_alerts_Washington State Ferries", title: "Washington State Ferries")
+        let b = section(id: "agency_alerts_Washington State Ferries", title: "Washington State Ferries")
+
+        #expect(a == b)
+        #expect(a.hashValue == b.hashValue)
+    }
+}


### PR DESCRIPTION
## Summary
- `OBAListViewSection.hash(into:)` already combined `id`; `==` compared title, contents, and configuration only. Same title + empty contents with different ids hashed differently but compared equal, so `UICollectionViewDiffableDataSource` could not find `OBAListViewHeader` items (agency alerts used ids like `agency_alerts_Washington State Ferries`).
- Equality now includes `id`, matching `Hashable`.

The freeze-on-bookmarks reports in older comments were a separate issue (Alan + Aaron agreed at the time).

Closes #421.

## Test plan
- [x] `OBAListViewSectionTests` (2/2)
- [ ] Device: open a region with multiple agency-alert sections on the map/stop list; scrolling should not crash with "Failed to find index of item OBAListViewHeader"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list section comparisons to distinguish sections with different identifiers.
  * Ensured matching sections produce consistent equality and hash results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->