### PR TITLE
Tick Live Activity countdown as 8m/NOW without a keepalive push

### DIFF
--- a/OBAKitCore/UI/CountdownView.swift
+++ b/OBAKitCore/UI/CountdownView.swift
@@ -13,17 +13,29 @@ public struct CountdownView: View {
     public let color: Color
     /// `true` = card-header size, `false` = compact.
     public var emphasized: Bool = true
+    /// When set, the number ticks on a Live Activity without a keepalive push.
+    /// Stop-page rows keep passing `minutes` only.
+    public var departure: Date?
 
     public init(minutes: Int, isRealTime: Bool, color: Color, emphasized: Bool = true) {
         self.minutes = minutes
         self.isRealTime = isRealTime
         self.color = color
         self.emphasized = emphasized
+        self.departure = nil
+    }
+
+    public init(departure: Date, isRealTime: Bool, color: Color, emphasized: Bool = true) {
+        self.minutes = 0
+        self.isRealTime = isRealTime
+        self.color = color
+        self.emphasized = emphasized
+        self.departure = departure
     }
 
     public var body: some View {
         HStack(alignment: .top, spacing: 2) {
-            Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
+            countdownLabel
                 .font(emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy))
                 .monospacedDigit()
                 .foregroundStyle(color)
@@ -31,5 +43,18 @@ public struct CountdownView: View {
                 .padding(.top, 1)
         }
         .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var countdownLabel: some View {
+        if let departure {
+            TickingCountdownText(
+                departure: departure,
+                font: emphasized ? .system(.title2, design: .rounded, weight: .heavy) : .system(.callout, design: .rounded, weight: .heavy),
+                color: color
+            )
+        } else {
+            Text(minutes == 0 ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now") : "\(minutes)m")
+        }
     }
 }

--- a/OBAKitCore/UI/TripCountdownFormatStyle.swift
+++ b/OBAKitCore/UI/TripCountdownFormatStyle.swift
@@ -1,0 +1,105 @@
+//
+//  TripCountdownFormatStyle.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import SwiftUI
+
+/// Live Activity countdown that keeps the `8m` / `NOW` typography and still
+/// ticks without a keepalive push.
+///
+/// `Text.timer` was tried in #1263 and rejected: `0:00` is not how this app
+/// shows a departure. A custom `DiscreteFormatStyle` is how SwiftUI schedules
+/// the next redraw (minute boundaries *anchored on `departure`*, not on the
+/// wall clock). Past departure it stays `NOW` rather than counting up.
+///
+/// Always-on display redacts unknown format styles. `TickingCountdownText`
+/// falls back to a static `format(Date())` when `isLuminanceReduced` is set,
+/// so dim Lock Screen shows dashes-free digits from the last evaluation.
+///
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1187
+public struct TripCountdownFormatStyle: DiscreteFormatStyle, Sendable {
+    public typealias FormatInput = Date
+    public typealias FormatOutput = String
+
+    public var departure: Date
+
+    public init(departure: Date) {
+        self.departure = departure
+    }
+
+    public func format(_ now: Date) -> String {
+        let minutes = Int(departure.timeIntervalSince(now) / 60.0)
+        if minutes <= 0 {
+            return OBALoc(
+                "stop_page.countdown.now",
+                value: "NOW",
+                comment: "Shown in place of the minutes countdown when the vehicle is departing now"
+            )
+        }
+        return "\(minutes)m"
+    }
+
+    public func discreteInput(after date: Date) -> Date? {
+        let minutes = Int(departure.timeIntervalSince(date) / 60.0)
+        guard minutes > 0 else { return nil }
+
+        let boundary = departure.addingTimeInterval(-TimeInterval(minutes) * 60)
+        if boundary > date { return boundary }
+
+        // Sitting on this minute's boundary. Next flip is the next lower
+        // minute, except 1m → NOW which starts the instant remaining < 60s.
+        if minutes == 1 {
+            return date.addingTimeInterval(1)
+        }
+        return departure.addingTimeInterval(-TimeInterval(minutes - 1) * 60)
+    }
+
+    public func discreteInput(before date: Date) -> Date? {
+        let minutes = Int(departure.timeIntervalSince(date) / 60.0)
+        if minutes < 0 { return nil }
+
+        if minutes == 0 {
+            let start = departure.addingTimeInterval(-60)
+            return start < date ? start : nil
+        }
+
+        let startOfCurrent = departure.addingTimeInterval(-TimeInterval(minutes + 1) * 60)
+        return startOfCurrent < date ? startOfCurrent : nil
+    }
+}
+
+/// `8m` / `NOW` that self-updates on a Live Activity. Dim Lock Screen uses a
+/// static snapshot so a custom format style is not redacted to dashes.
+public struct TickingCountdownText: View {
+    public let departure: Date
+    public let font: Font
+    public let color: Color
+
+    @Environment(\.isLuminanceReduced) private var isLuminanceReduced
+
+    public init(departure: Date, font: Font, color: Color) {
+        self.departure = departure
+        self.font = font
+        self.color = color
+    }
+
+    public var body: some View {
+        let style = TripCountdownFormatStyle(departure: departure)
+        Group {
+            if isLuminanceReduced {
+                Text(style.format(Date()))
+            } else {
+                Text(.currentDate, format: style)
+            }
+        }
+        .font(font)
+        .monospacedDigit()
+        .foregroundStyle(color)
+    }
+}

--- a/OBAKitCore/UI/TripCountdownFormatStyle.swift
+++ b/OBAKitCore/UI/TripCountdownFormatStyle.swift
@@ -42,7 +42,15 @@ public struct TripCountdownFormatStyle: DiscreteFormatStyle, Sendable {
                 comment: "Shown in place of the minutes countdown when the vehicle is departing now"
             )
         }
-        return "\(minutes)m"
+
+        // Same key as `Formatters.shortFormattedTime` so the Dynamic Island
+        // keeps ar/fr/ko/ru/vi/zh suffixes instead of a hardcoded English `m`.
+        let formatString = OBALoc(
+            "formatters.short_time_fmt",
+            value: "%dm",
+            comment: "Short formatted time text for arrivals/departures. Example: 7m means that this event happens 7 minutes in the future. -7m means 7 minutes in the past."
+        )
+        return String(format: formatString, minutes)
     }
 
     public func discreteInput(after date: Date) -> Date? {

--- a/OBAKitCore/UI/TripCountdownFormatStyle.swift
+++ b/OBAKitCore/UI/TripCountdownFormatStyle.swift
@@ -57,15 +57,16 @@ public struct TripCountdownFormatStyle: DiscreteFormatStyle, Sendable {
         let minutes = Int(departure.timeIntervalSince(date) / 60.0)
         guard minutes > 0 else { return nil }
 
+        // Truncating `format` flips from N → N-1 the instant remaining drops
+        // *below* N*60, i.e. just after `departure - N*60`. Returning the
+        // floor itself leaves TimeDataSource displaying `format(floor)` (== N)
+        // for a full minute — so 2m shows while only 61s remain (#1187 follow-up).
         let boundary = departure.addingTimeInterval(-TimeInterval(minutes) * 60)
         if boundary > date { return boundary }
 
-        // Sitting on this minute's boundary. Next flip is the next lower
-        // minute, except 1m → NOW which starts the instant remaining < 60s.
-        if minutes == 1 {
-            return date.addingTimeInterval(1)
-        }
-        return departure.addingTimeInterval(-TimeInterval(minutes - 1) * 60)
+        // On the floor: step one second into the lower bucket so `format` flips
+        // (same treatment for every N, including 1m → NOW).
+        return date.addingTimeInterval(1)
     }
 
     public func discreteInput(before date: Date) -> Date? {

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -33,7 +33,7 @@ public struct TripLiveActivityCardView: View {
         VStack(alignment: .leading, spacing: 10) {
             primaryRow(primary: primary, now: now)
             if !chips.isEmpty {
-                chipsRow(chips: chips, now: now)
+                chipsRow(chips: chips)
             }
         }
         .padding(.horizontal, 16)
@@ -59,7 +59,7 @@ public struct TripLiveActivityCardView: View {
             }
             Spacer(minLength: 8)
             if let primary {
-                countdownBadge(for: primary, now: now)
+                countdownBadge(for: primary)
             }
         }
     }
@@ -90,16 +90,16 @@ public struct TripLiveActivityCardView: View {
     }
 
     @ViewBuilder
-    private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+    private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo) -> some View {
         CountdownView(
-            minutes: Int(arrival.departureDate.timeIntervalSince(now) / 60.0),
+            departure: arrival.departureDate,
             isRealTime: arrival.scheduleStatus != .unknown,
             color: Color(uiColor: presenter.color(for: arrival))
         )
     }
 
     @ViewBuilder
-    private func chipsRow(chips: [TripAttributes.ContentState.ArrivalInfo], now: Date) -> some View {
+    private func chipsRow(chips: [TripAttributes.ContentState.ArrivalInfo]) -> some View {
         HStack(spacing: 8) {
             // departureTime is NOT a safe identity here: the server can (and,
             // due to an upstream OBA bug, briefly did) emit duplicate
@@ -110,22 +110,20 @@ public struct TripLiveActivityCardView: View {
             // replaced on every content update, so positional identity is
             // safe and can't collide.
             ForEach(Array(chips.enumerated()), id: \.offset) { _, arrival in
-                departurePill(for: arrival, now: now)
+                departurePill(for: arrival)
             }
             Spacer()
         }
     }
 
     @ViewBuilder
-    private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
+    private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo) -> some View {
         let color = Color(uiColor: presenter.color(for: arrival))
-        let minutes = max(0, Int(arrival.departureDate.timeIntervalSince(now) / 60.0))
-        Text(minutes == 0
-             ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now")
-             : "\(minutes)m")
-            .font(.caption.weight(.heavy))
-            .monospacedDigit()
-            .foregroundStyle(color)
+        TickingCountdownText(
+            departure: arrival.departureDate,
+            font: .caption.weight(.heavy),
+            color: color
+        )
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
             .background(color.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))

--- a/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
+++ b/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
@@ -52,12 +52,15 @@ struct TripCountdownFormatStyleTests {
         #expect(next == departure.addingTimeInterval(-480))
     }
 
-    /// Already on a boundary: `after` must move forward, not return the same instant
-    /// (that would spin the renderer).
-    @Test func `discreteInput after an exact minute boundary advances to the next one`() {
+    /// Already on a boundary: `after` must step into the lower truncating
+    /// bucket so `format` flips. Returning the next whole-minute floor left
+    /// TimeDataSource showing N while remaining was already in N-1.
+    @Test func `discreteInput after an exact minute boundary flips format immediately`() {
         let now = departure.addingTimeInterval(-480)
+        #expect(style.format(now) == "8m")
         let next = style.discreteInput(after: now)
-        #expect(next == departure.addingTimeInterval(-420))
+        #expect(next == now.addingTimeInterval(1))
+        #expect(style.format(next!) == "7m")
     }
 
     @Test func `discreteInput after NOW is nil so it does not count up past departure`() {
@@ -65,15 +68,22 @@ struct TripCountdownFormatStyleTests {
         #expect(style.discreteInput(after: departure.addingTimeInterval(10)) == nil)
     }
 
-    /// At remaining == 60s the label is still `1m`. The next flip is NOW, which
-    /// starts the instant remaining drops below 60. Returning the same instant
-    /// would spin the renderer; returning `departure` would freeze `1m` for a
-    /// full minute.
+    /// At remaining == 60s the label is still `1m`. The next flip is NOW.
     @Test func `discreteInput after the 1m boundary advances into NOW`() {
         let now = departure.addingTimeInterval(-60)
         let next = style.discreteInput(after: now)
         #expect(next != nil)
         #expect(next! > now)
         #expect(style.format(next!) == "NOW")
+    }
+
+    /// The rider-facing bug: with 61s left the card must already read `1m`,
+    /// not sit on a precomputed `2m` until the 60s floor.
+    @Test func `discreteInput after the 2m boundary flips to 1m not the next floor`() {
+        let now = departure.addingTimeInterval(-120)
+        #expect(style.format(now) == "2m")
+        let next = try #require(style.discreteInput(after: now))
+        #expect(style.format(next) == "1m")
+        #expect(next < departure.addingTimeInterval(-60))
     }
 }

--- a/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
+++ b/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
@@ -82,8 +82,9 @@ struct TripCountdownFormatStyleTests {
     @Test func `discreteInput after the 2m boundary flips to 1m not the next floor`() {
         let now = departure.addingTimeInterval(-120)
         #expect(style.format(now) == "2m")
-        let next = try #require(style.discreteInput(after: now))
-        #expect(style.format(next) == "1m")
-        #expect(next < departure.addingTimeInterval(-60))
+        let next = style.discreteInput(after: now)
+        #expect(next != nil)
+        #expect(style.format(next!) == "1m")
+        #expect(next! < departure.addingTimeInterval(-60))
     }
 }

--- a/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
+++ b/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
@@ -1,0 +1,66 @@
+//
+//  TripCountdownFormatStyleTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+/// `discreteInput(after:)` is how SwiftUI knows when to redraw a Live Activity
+/// `Text`. Wrong boundaries → the card never ticks, or it re-renders constantly.
+/// Minute boundaries are anchored on `departure`, not on wall-clock minutes.
+/// See: https://github.com/OneBusAway/onebusaway-ios/issues/1187
+@Suite(.serialized)
+struct TripCountdownFormatStyleTests {
+
+    private let departure = Date(timeIntervalSince1970: 1_700_000_000)
+    private var style: TripCountdownFormatStyle { TripCountdownFormatStyle(departure: departure) }
+
+    @Test func `Eight and a half minutes formats as 8m`() {
+        let now = departure.addingTimeInterval(-510)
+        #expect(style.format(now) == "8m")
+    }
+
+    @Test func `Under a minute formats as NOW`() {
+        #expect(style.format(departure.addingTimeInterval(-30)) == "NOW")
+        #expect(style.format(departure) == "NOW")
+        #expect(style.format(departure.addingTimeInterval(90)) == "NOW")
+    }
+
+    /// Next redraw is the instant `Int(remaining/60)` drops, i.e. remaining == 8*60.
+    @Test func `discreteInput after a city-block wait is the next whole minute before departure`() {
+        let now = departure.addingTimeInterval(-510)
+        let next = style.discreteInput(after: now)
+        #expect(next == departure.addingTimeInterval(-480))
+    }
+
+    /// Already on a boundary: `after` must move forward, not return the same instant
+    /// (that would spin the renderer).
+    @Test func `discreteInput after an exact minute boundary advances to the next one`() {
+        let now = departure.addingTimeInterval(-480)
+        let next = style.discreteInput(after: now)
+        #expect(next == departure.addingTimeInterval(-420))
+    }
+
+    @Test func `discreteInput after NOW is nil so it does not count up past departure`() {
+        #expect(style.discreteInput(after: departure.addingTimeInterval(-30)) == nil)
+        #expect(style.discreteInput(after: departure.addingTimeInterval(10)) == nil)
+    }
+
+    /// At remaining == 60s the label is still `1m`. The next flip is NOW, which
+    /// starts the instant remaining drops below 60. Returning the same instant
+    /// would spin the renderer; returning `departure` would freeze `1m` for a
+    /// full minute.
+    @Test func `discreteInput after the 1m boundary advances into NOW`() {
+        let now = departure.addingTimeInterval(-60)
+        let next = style.discreteInput(after: now)
+        #expect(next != nil)
+        #expect(next! > now)
+        #expect(style.format(next!) == "NOW")
+    }
+}

--- a/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
+++ b/OBAKitTests/LiveActivities/TripCountdownFormatStyleTests.swift
@@ -26,6 +26,19 @@ struct TripCountdownFormatStyleTests {
         #expect(style.format(now) == "8m")
     }
 
+    /// The Dynamic Island used to go through `presenter.minuteText` →
+    /// `Formatters.shortFormattedTime` → `formatters.short_time_fmt`. Keep that
+    /// coupling so ar/fr/ko/ru/vi/zh don't fall back to a hardcoded English `m`.
+    @Test func `Future minutes match Formatters.shortFormattedTime`() {
+        let now = departure.addingTimeInterval(-510)
+        let formatters = Formatters(
+            locale: Locale(identifier: "en_US"),
+            calendar: Calendar(identifier: .gregorian),
+            themeColors: ThemeColors.shared
+        )
+        #expect(style.format(now) == formatters.shortFormattedTime(untilMinutes: 8, temporalState: .future))
+    }
+
     @Test func `Under a minute formats as NOW`() {
         #expect(style.format(departure.addingTimeInterval(-30)) == "NOW")
         #expect(style.format(departure) == "NOW")

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -57,12 +57,12 @@ struct TripLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     if let primary {
-                        let primaryMinuteText = presenter.minuteText(for: primary)
-                        Text(primaryMinuteText)
-                            .font(.system(size: 32, weight: .bold, design: .rounded))
-                            .foregroundColor(Color(presenter.color(for: primary)))
-                            .contentTransition(.numericText(value: Double(primaryMinuteText.filter("0123456789".contains)) ?? 0))
-                            .padding(.trailing, 6)
+                        TickingCountdownText(
+                            departure: primary.departureDate,
+                            font: .system(size: 32, weight: .bold, design: .rounded),
+                            color: Color(presenter.color(for: primary))
+                        )
+                        .padding(.trailing, 6)
                     }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
@@ -96,10 +96,11 @@ struct TripLiveActivity: Widget {
                             VStack(alignment: .trailing, spacing: 4) {
                                 let nextDepartures = upcoming.dropFirst().prefix(2)
                                 ForEach(Array(nextDepartures.enumerated()), id: \.offset) { _, arrivalInfo in
-                                    Text(presenter.minuteText(for: arrivalInfo))
-                                        .font(.system(.callout, design: .rounded))
-                                        .fontWeight(.bold)
-                                        .foregroundColor(Color(presenter.color(for: arrivalInfo)))
+                                    TickingCountdownText(
+                                        departure: arrivalInfo.departureDate,
+                                        font: .system(.callout, design: .rounded, weight: .bold),
+                                        color: Color(presenter.color(for: arrivalInfo))
+                                    )
                                 }
                             }
                             .padding(.trailing, 6)
@@ -115,18 +116,20 @@ struct TripLiveActivity: Widget {
                     .padding(.leading, 4)
             } compactTrailing: {
                 if let primary {
-                    Text(presenter.minuteText(for: primary))
-                        .font(.system(.body, design: .rounded))
-                        .fontWeight(.bold)
-                        .foregroundColor(Color(presenter.color(for: primary)))
-                        .frame(minWidth: 20)
+                    TickingCountdownText(
+                        departure: primary.departureDate,
+                        font: .system(.body, design: .rounded, weight: .bold),
+                        color: Color(presenter.color(for: primary))
+                    )
+                    .frame(minWidth: 20)
                 }
             } minimal: {
                 if let primary {
-                    Text(presenter.minuteText(for: primary))
-                        .font(.system(.callout, design: .rounded))
-                        .fontWeight(.heavy)
-                        .foregroundColor(Color(presenter.color(for: primary)))
+                    TickingCountdownText(
+                        departure: primary.departureDate,
+                        font: .system(.callout, design: .rounded, weight: .heavy),
+                        color: Color(presenter.color(for: primary))
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Live Activity minutes were a snapshot from `let now = Date()` in `TripLiveActivityCardView`. They only moved when a keepalive push arrived.
- `TripCountdownFormatStyle` is a custom `DiscreteFormatStyle` that still renders `8m` / `NOW` (not `Text.timer` / `0:00`, which #1263 already ruled out). Minute boundaries are anchored on `departure`, not wall-clock minutes. After departure it stays `NOW` instead of counting up.
- Bright Lock Screen and Dynamic Island use `Text(.currentDate, format:)`. Dim Lock Screen (`isLuminanceReduced`) falls back to a static `format(Date())` so a custom style is not redacted to dashes.
- `CountdownView` gained a `departure: Date` init; stop-page rows keep passing `minutes`.
- Chips on the card also tick. `upcomingArrivals(now:)` and the deviation label are still snapshots from the last push — a departed bus still needs a content update to drop off the card. obacloud keepalive relaxations stay out of this PR.

Device confirmation of always-on redaction is still the first item on #1187; this is approach A from that issue.

Addresses #1187.

## Test plan
- [x] `TripCountdownFormatStyleTests` (6/6), including `discreteInput` boundaries and the 1m → NOW step
- [ ] Device: start a Live Activity, leave the phone locked. Bright Lock Screen and Dynamic Island should tick `8m` → `7m` → `NOW` with no keepalive. Dim always-on should show digits, not `—m`.
- [ ] Device: chips next to the headline should tick with it. A bus that has already left should stay on the card until the next push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live-updating departure countdowns to trip cards and Live Activities.
  * Countdown displays refresh at minute boundaries and show “NOW” at departure time.
  * Countdown text uses localized minute formatting.
  * Lock Screen countdowns remain readable when the display is dimmed.

* **Bug Fixes**
  * Replaced static minute labels with accurate, continuously updating countdowns across supported trip views.

* **Tests**
  * Added coverage for countdown formatting, minute boundaries, localization, and departure transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->