### PR TITLE
Document MoreTab white-label keys

### DIFF
--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -171,3 +171,28 @@ Stop pages can hide departures that lack real-time data, or hide the real-time o
 * `scheduledOnly` - Show only departures without real-time data.
 
 This is a starting value, not a lock: riders can change it in Settings under Arrival & Departure Display, or from the Departure Type menu on any stop page, and their choice is remembered from then on. An unrecognized value is ignored and treated as `all`.
+
+### More Tab
+
+* `MoreTab` - Optional dictionary. Customizes the More (settings) tab header and menu items without forking the UI. Omit the whole key to keep OneBusAway defaults. KiedyBus is a working example.
+
+Nested keys (all optional):
+
+* `HeaderSupportText` - String shown in the branded header box. Omit or leave empty to keep the default volunteer-support copy.
+* `ShowHelpOutSection` - Boolean. Defaults to `true`. Set `false` to hide the "Help make the app better" section (translate / develop rows).
+* `TranslateURL` - URL for "Help Translate the App". Omit to hide that row. OneBusAway currently omits it; white-label apps can opt in.
+* `DevelopURL` - URL for "Help Fix Bugs & Build New Features". Defaults to the OneBusAway iOS GitHub repo when omitted. An empty string hides the row.
+* `TutorialURL`, `PhoneURL`, `TextURL` - Optional. When set, they appear under "Contact & Help" as Tutorials, Call Agency, and Text Agency. `tel:` and `sms:` URLs are valid. Empty strings are ignored.
+* `CustomLinks` - Array of `{Title, URL}` dictionaries. Shown under "Resources". A row is dropped if `Title` or `URL` is missing or the URL is empty.
+
+Example (KiedyBus-style):
+
+```yaml
+OBAKitConfig:
+  MoreTab:
+    HeaderSupportText: "Powered by goEuropa"
+    ShowHelpOutSection: false
+    CustomLinks:
+      - Title: "goEuropa Website"
+        URL: "https://www.goeuropa.eu"
+```

--- a/OBAKitTests/Extensions/FoundationExtensionsTests.swift
+++ b/OBAKitTests/Extensions/FoundationExtensionsTests.swift
@@ -216,6 +216,46 @@ final class BundleFeedbackConfigTests {
         #expect(!bundle.feedbackPromptEnabled)
     }
 
+    // MARK: - OBAKitConfig.MoreTab
+
+    @Test func `More tab configuration uses defaults when MoreTab is absent`() throws {
+        let bundle = try FeedbackConfigBundle.create(config: [:])
+        let more = bundle.moreTabConfiguration
+        #expect(more.headerSupportText == nil)
+        #expect(more.showHelpOutSection)
+        #expect(more.translateURL == nil)
+        #expect(more.developURL?.absoluteString == "https://github.com/oneBusAway/onebusaway-ios")
+        #expect(more.customLinks.isEmpty)
+    }
+
+    @Test func `More tab configuration reads nested MoreTab from OBAKitConfig`() throws {
+        let bundle = try FeedbackConfigBundle.create(config: [
+            "MoreTab": [
+                "HeaderSupportText": "Powered by TestAgency",
+                "ShowHelpOutSection": false,
+                "TranslateURL": "https://example.com/translate",
+                "DevelopURL": "https://example.com/develop",
+                "TutorialURL": "https://example.com/tutorials",
+                "PhoneURL": "tel:+1234567890",
+                "TextURL": "sms:+1234567890",
+                "CustomLinks": [
+                    ["Title": "Agency Site", "URL": "https://example.com"]
+                ]
+            ]
+        ])
+        let more = bundle.moreTabConfiguration
+        #expect(more.headerSupportText == "Powered by TestAgency")
+        #expect(!more.showHelpOutSection)
+        #expect(more.translateURL?.absoluteString == "https://example.com/translate")
+        #expect(more.developURL?.absoluteString == "https://example.com/develop")
+        #expect(more.tutorialURL?.absoluteString == "https://example.com/tutorials")
+        #expect(more.phoneURL?.absoluteString == "tel:+1234567890")
+        #expect(more.textURL?.absoluteString == "sms:+1234567890")
+        #expect(more.customLinks.count == 1)
+        #expect(more.customLinks[0].title == "Agency Site")
+        #expect(more.customLinks[0].url.absoluteString == "https://example.com")
+    }
+
     // MARK: - String.normalizedSearchQuery
 
     /// Nil means "match everything". `.searchable` hands a view the empty string


### PR DESCRIPTION
## Summary
- `OBAKitConfig.MoreTab` already drives the More tab header, Help Out section, agency contact rows, and custom Resources links. WhiteLabel.md did not list any of those keys, so agencies still treated the settings tab as a fork.
- Adds the missing `MoreTab` section (with a KiedyBus-style example) and Bundle tests that read the nested dictionary the same way `project.yml` ships it.

Closes #666.

## Test plan
- [x] `BundleFeedbackConfigTests` (9/9), including the two new MoreTab cases
- [x] `MoreTabConfigurationTests` already covered dictionary parsing; this PR only adds the Bundle → `MoreTab` path
- [ ] Open WhiteLabel.md in DocC / GitHub and confirm the YAML example matches `Apps/KiedyBus/project.yml`