### PR TITLE
Filter Live Activity arrivals by route and destination

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -94,6 +94,21 @@ final class BookmarkActions {
         return TripAttributes.ContentState(arrivals: Array(arrivals))
     }
 
+    /// Builds content for the trip the rider actually tracked: same stop, route,
+    /// and destination as `departure`. Route-only matching mixes both directions
+    /// at a transit center and shows the opposite bus's countdown (#1326).
+    static func buildContentState(
+        from arrivalDepartures: [ArrivalDeparture],
+        matching departure: ArrivalDeparture
+    ) -> TripAttributes.ContentState? {
+        let key = TripBookmarkKey(arrivalDeparture: departure)
+        let sameTrip = arrivalDepartures
+            .filter { TripBookmarkKey(arrivalDeparture: $0) == key }
+            .sorted { $0.arrivalDepartureDate < $1.arrivalDepartureDate }
+        let source = sameTrip.isEmpty ? [departure] : sameTrip
+        return buildContentState(from: source)
+    }
+
     @discardableResult
     func startLiveActivity(for bookmark: Bookmark, arrivalDepartures: [ArrivalDeparture]) -> TrackResult {
         let (routeShortName, routeHeadsign) = Self.liveActivityKeys(for: bookmark)

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -624,17 +624,7 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
 
     private func buildLiveActivityContentState(for departure: ArrivalDeparture, viewModel: StopViewModel) -> TripAttributes.ContentState? {
         let allArrivals = viewModel.stopArrivals?.arrivalsAndDepartures ?? [departure]
-        let sameRoute = allArrivals.filter { $0.routeID == departure.routeID }
-        let upcoming = sameRoute.isEmpty ? [departure] : Array(sameRoute.prefix(3))
-        let arrivals = upcoming.map { arrDep in
-            TripAttributes.ContentState.ArrivalInfo(
-                departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),
-                scheduleStatus: .init(arrDep.scheduleStatus),
-                scheduleDeviation: arrDep.deviationFromScheduleInMinutes * 60,
-                isArrival: arrDep.arrivalDepartureStatus == .arriving
-            )
-        }
-        return TripAttributes.ContentState(arrivals: arrivals)
+        return BookmarkActions.buildContentState(from: allArrivals, matching: departure)
     }
 
     // MARK: - User Activity

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -123,6 +123,68 @@ final class BookmarkActionsTests: OBATestCase {
         #expect(state.arrivals.count == 3)
     }
 
+    /// Transit-center case (#1326): the same route serves both directions at one
+    /// stop. Filtering on route ID alone would pick the opposite-direction bus
+    /// because it leaves sooner. Chips and the headline countdown must follow
+    /// the tracked destination, same key as trip bookmarks.
+    @Test @MainActor func `Content state matching a departure drops the opposite direction`() throws {
+        let oppositeSooner = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Angle Lake",
+            tripID: "trip_south",
+            departureEpoch: 1_700_000_120
+        )
+        let tracked = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north",
+            departureEpoch: 1_700_000_480
+        )
+        let laterSameDirection = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north_2",
+            departureEpoch: 1_700_000_840
+        )
+
+        let state = try #require(BookmarkActions.buildContentState(
+            from: [oppositeSooner, tracked, laterSameDirection],
+            matching: tracked
+        ))
+
+        #expect(state.arrivals.count == 2)
+        #expect(state.arrivals.map(\.departureTime) == [
+            Int(tracked.arrivalDepartureDate.timeIntervalSince1970),
+            Int(laterSameDirection.arrivalDepartureDate.timeIntervalSince1970)
+        ])
+        #expect(!state.arrivals.map(\.departureTime).contains(Int(oppositeSooner.arrivalDepartureDate.timeIntervalSince1970)))
+    }
+
+    /// If the stop list is stale and no longer contains the tapped trip, still
+    /// start an activity for that trip rather than failing or picking a stranger.
+    @Test @MainActor func `Content state matching falls back to the selected departure`() throws {
+        let tracked = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north",
+            departureEpoch: 1_700_000_480
+        )
+        let otherRoute = try arrivalDeparture(
+            routeID: "1_100002",
+            headsign: "Downtown Seattle",
+            tripID: "trip_other",
+            departureEpoch: 1_700_000_100
+        )
+
+        let state = try #require(BookmarkActions.buildContentState(
+            from: [otherRoute],
+            matching: tracked
+        ))
+
+        #expect(state.arrivals.count == 1)
+        #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))
+    }
+
     /// Tracking a bookmark with no loaded arrivals can't build a content state,
     /// so it reports failure rather than requesting a contentless activity.
     @Test @MainActor func `Tracking without arrivals fails`() throws {
@@ -162,6 +224,41 @@ final class BookmarkActionsTests: OBATestCase {
 
         #expect(delegate.cancelledCount == 1)
         #expect(delegate.editedCount == 0)
+    }
+
+    /// Minimal `ArrivalDeparture` for Live Activity content-state tests. Times are
+    /// JSON numbers; `JSONDecoder`'s default Date strategy is seconds-since-2001,
+    /// which is fine — we compare through `arrivalDepartureDate`, not the raw ints.
+    private func arrivalDeparture(
+        routeID: String,
+        headsign: String,
+        tripID: String,
+        departureEpoch: Int
+    ) throws -> ArrivalDeparture {
+        try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
+            "arrivalEnabled": true,
+            "blockTripSequence": 1,
+            "departureEnabled": true,
+            "distanceFromStop": 100.0,
+            "lastUpdateTime": departureEpoch,
+            "numberOfStopsAway": 1,
+            "predicted": true,
+            "predictedArrivalTime": departureEpoch,
+            "predictedDepartureTime": departureEpoch,
+            "routeId": routeID,
+            "routeShortName": "1 Line",
+            "scheduledArrivalTime": departureEpoch,
+            "scheduledDepartureTime": departureEpoch,
+            "serviceDate": departureEpoch,
+            "situationIds": [] as [String],
+            "status": "default",
+            "stopId": "1_mtc",
+            "stopSequence": 10,
+            "totalStopsInTrip": 20,
+            "tripHeadsign": headsign,
+            "tripId": tripID,
+            "vehicleId": "vehicle_\(tripID)"
+        ])
     }
 }
 


### PR DESCRIPTION
## Summary
- Tracking from a stop at a transit center built Live Activity content with `filter { \$0.routeID == departure.routeID }`. The card title used the tapped headsign; the countdown and chips used whichever direction left first.
- Content state now uses the same `TripBookmarkKey` as trip bookmarks: stop + route + headsign, soonest first, at most three. If the stop list no longer contains that trip, it falls back to the tapped departure.
- Bookmark Track was already keyed this way. OBACloud registration already sends `trip_headsign`; this PR does not change the push payload shape. If a keepalive still mixes directions after this, that is server-side.

Closes #1326.

## Test plan
- [x] `BookmarkActionsTests` (9/9), including opposite-direction drop and stale-list fallback
- [ ] Device: at a stop that serves the same route both ways (e.g. Mountlake Terrace), Track one destination. Lock Screen headline and chips should only be that direction, even if the other way leaves sooner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Live activity updates now show only arrivals matching the selected departure’s stop, route, and destination.
  - Arrivals are displayed in chronological order.
  - If the tracked departure is no longer listed, the activity continues displaying that departure instead of selecting an unrelated arrival.
- **Tests**
  - Added coverage for filtering opposite-direction arrivals and preserving the selected departure as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->