### PR TITLE
Silence Bookmarks-tab bulletin when a stop returns JSON null

### DIFF
--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -53,13 +53,14 @@ public class BookmarkDataLoader: NSObject {
     @MainActor private var batchContinuations: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
 
     /// Stops whose arrival fetch has finished this session — a successful
-    /// payload **or** a literal HTTP 404. Lets consumers distinguish "still
-    /// loading" from "loaded, but no upcoming departures". Empty HTTP 200
-    /// (also thrown as `APIError.requestNotFound`) is not recorded here.
+    /// payload, a literal HTTP 404, or HTTP 200 with body `null`. Lets
+    /// consumers distinguish "still loading" from "loaded, but no upcoming
+    /// departures". Empty HTTP 200 (also thrown as `APIError.requestNotFound`)
+    /// is not recorded here.
     @MainActor private var fetchedStopIDs = Set<StopID>()
 
     /// `true` once an arrival fetch for `stopID` has finished this session
-    /// (success or HTTP 404).
+    /// (success, HTTP 404, or JSON `null`).
     @MainActor public func hasFetchedData(forStopID stopID: StopID) -> Bool {
         fetchedStopIDs.contains(stopID)
     }
@@ -182,6 +183,26 @@ public class BookmarkDataLoader: NSObject {
         }
     }
 
+    /// Missing-stop shapes that must not bulletin on the Bookmarks tab.
+    ///
+    /// - Literal HTTP 404: the stop no longer resolves.
+    /// - HTTP 200 with body `null`: what many OBA servers send instead of a
+    ///   404. `APIService+GetData` throws that as `invalidContentType(...,
+    ///   "json", "nothing")` — the copy in #1331. Empty HTTP 200 is *not*
+    ///   included; a live San Diego stop is a full 200, so an empty body
+    ///   stays a transient error.
+    nonisolated private static func isGoneBookmarkStop(_ error: APIError) -> Bool {
+        switch error {
+        case .requestNotFound(let response) where response.statusCode == 404:
+            return true
+        case .invalidContentType(_, let expected, let actual)
+            where expected == "json" && actual == "nothing":
+            return true
+        default:
+            return false
+        }
+    }
+
     @MainActor
     private func loadData(bookmark: Bookmark, batchID: UInt64) {
         guard
@@ -215,8 +236,11 @@ public class BookmarkDataLoader: NSObject {
 
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
-            } catch APIError.requestNotFound(let response) where response.statusCode == 404 {
-                // Literal HTTP 404: the stop no longer exists in this region.
+            } catch let error as APIError where Self.isGoneBookmarkStop(error) {
+                // The stop no longer exists in this region. Don't bulletin —
+                // settle the card on "No upcoming departures" and drop any
+                // previous countdown for this stop.
+                //
                 // San Diego trace 2026-08-14 against realtime.sdmts.com: a live
                 // stop (`MTS_11589`) returns HTTP 200 with a full JSON body on
                 // the app URL (`/api/api/where/...`). Empty HTTP 200 — also

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -612,6 +612,33 @@ final class BookmarksViewModelTests: OBATestCase {
         #expect(viewModel.lastRefreshHadError)
     }
 
+    /// OBA servers that cannot 404 a missing stop answer HTTP 200 with the
+    /// literal body `null`. `APIService+GetData` throws that as
+    /// `invalidContentType(..., "json", "nothing")` — the copy riders see as
+    /// "Expected to receive json data from the server, but we received
+    /// nothing instead." Same terminal outcome as a literal 404: the stop
+    /// is gone, so the Bookmarks tab must not bulletin (#1331).
+    @Test @MainActor
+    func `JSON null body does not call display error`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(data: Data("null".utf8), statusCode: 200) {
+            $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+        }
+
+        let viewModel = BookmarksViewModel(application: app)
+        await viewModel.refreshAndWait()
+
+        #expect(app.displayErrorCallCount == 0)
+        #expect(!viewModel.lastRefreshHadError)
+
+        let rows = viewModel.sections.flatMap(\.rows)
+        let row = try #require(rows.first)
+        #expect(row.hasLoadedArrivalData)
+    }
+
     /// A 404 after a successful fetch must drop the previous departures rather
     /// than leave a frozen countdown on the card.
     @Test @MainActor
@@ -635,6 +662,42 @@ final class BookmarksViewModelTests: OBATestCase {
             stubAgenciesWithCoverage(dataLoader: staging, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
             Fixtures.stubAllAgencyAlerts(dataLoader: staging)
             staging.mock(data: Data(), statusCode: 404) {
+                $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            }
+        }
+
+        await viewModel.refreshAndWait()
+
+        #expect(app.displayErrorCallCount == 0)
+        #expect(!viewModel.lastRefreshHadError)
+        let row = try #require(viewModel.sections.flatMap(\.rows).first)
+        #expect(row.hasLoadedArrivalData)
+        #expect(row.arrivalDepartures.isEmpty)
+    }
+
+    /// JSON `null` after a successful fetch must drop the previous departures
+    /// the same way a later 404 does (#1331).
+    @Test @MainActor
+    func `JSON null after success clears stale departures`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createSpyApplication(dataLoader: dataLoader)
+        _ = try addTripBookmark(to: app)
+
+        dataLoader.mock(
+            data: Fixtures.loadData(file: "arrivals-and-departures-for-stop-1_10914.json")
+        ) { $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false }
+
+        let viewModel = BookmarksViewModel(application: app)
+        await viewModel.refreshAndWait()
+
+        let loaded = try #require(viewModel.sections.flatMap(\.rows).first)
+        #expect(!loaded.arrivalDepartures.isEmpty)
+
+        dataLoader.replaceMappedResponses { staging in
+            stubRegions(dataLoader: staging)
+            stubAgenciesWithCoverage(dataLoader: staging, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+            Fixtures.stubAllAgencyAlerts(dataLoader: staging)
+            staging.mock(data: Data("null".utf8), statusCode: 200) {
                 $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
             }
         }


### PR DESCRIPTION
## Summary
- HTTP 200 with body `null` on a trip bookmark is silent: no bulletin, no failure haptic, the card settles on "No upcoming departures", and any previous departures for that stop are cleared.
- That is the copy riders see as **"Expected to receive json data from the server, but we received nothing instead."** — `APIService+GetData` throws it as `invalidContentType(..., "json", "nothing")`. Many OBA servers send this instead of a 404 when a stop/route is gone.
- **Empty HTTP 200** still bulletins (San Diego live-stop finding from #1268). Literal HTTP 404 stays silent.

Closes #1331

## Why dismiss looked broken
The Bookmarks tab re-fetches on appear and every 30s. Each failed fetch called `displayError`, so tapping Dismiss was immediately followed by another bulletin. Stopping the false error is the fix; the bookmark itself is left for the rider to delete.

## Test plan
- [x] JSON `null` body — no `displayError`, `hasLoadedArrivalData == true`
- [x] JSON `null` after a successful fetch — stale departures cleared
- [x] Empty HTTP 200 — still `displayError`, `lastRefreshHadError`
- [x] Literal HTTP 404 — still silent
- [x] HTTP 500 — still `displayError`
- [ ] Manual: Bookmarks tab with a bookmark whose stop/route has been deleted — no blocking bulletin; card shows "No upcoming departures"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stops removed from the server when responses contain a JSON `null` value.
  * Removed stops no longer trigger an error message or mark refreshes as failed.
  * Previously loaded departures are cleared when a stop is confirmed to be unavailable.
  * Empty responses continue to be treated as temporary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->