### PR TITLE
Match the Current Trip no-location button to the authorization

### DIFF
--- a/OBAKit/Theme/Icons.swift
+++ b/OBAKit/Theme/Icons.swift
@@ -118,6 +118,11 @@ nonisolated class Icons: NSObject {
         configureForButtonIcon(systemImage(named: "line.horizontal.3.decrease"))
     }
 
+    /// A gear icon, for controls that send the user to the system Settings app.
+    public class var settings: UIImage {
+        configureForButtonIcon(systemImage(named: "gearshape"))
+    }
+
     public class var addAlarm: UIImage {
         imageNamed("add_alarm")
     }

--- a/OBAKit/Trip/CurrentTripViewController.swift
+++ b/OBAKit/Trip/CurrentTripViewController.swift
@@ -65,12 +65,30 @@ class CurrentTripViewController: UIViewController,
         super.viewWillAppear(animated)
         disableIdleTimer()
         viewModel.start()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         enableIdleTimer()
         viewModel.deactivate()
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    /// Re-runs the search after a trip to Settings, which is the one way a rider
+    /// resolves `.noLocation` without touching this screen — and it fires no view
+    /// lifecycle callback, so `viewWillAppear` never sees it. The 20-second
+    /// refresh would normally catch up, but `shouldSkipProgrammaticRefresh`
+    /// suppresses that tick under VoiceOver, which would leave the riders the
+    /// Settings button exists for staring at an empty state that never recovers.
+    @objc private func applicationDidBecomeActive() {
+        guard viewModel.state == .noLocation else { return }
+        viewModel.findVehicle()
     }
 
     // MARK: - View Model Binding
@@ -136,13 +154,19 @@ class CurrentTripViewController: UIViewController,
         case .noLocation:
             // Recoverable like `.noResults` and `.error`: the rider can grant
             // location access in Settings and come back, and `findVehicle()`
-            // re-reads `currentLocation` on the way in. Without the button the
-            // only way to re-run it is to leave the screen and return.
+            // re-reads `currentLocation` on the way in.
+            //
+            // The button is not what makes the screen recover on its own:
+            // `CurrentTripViewModel.startRefreshTimer()` re-runs the search
+            // every 20 seconds while this screen is visible, in every state,
+            // `.noLocation` included. It matters under VoiceOver, where
+            // `shouldSkipProgrammaticRefresh` suppresses that tick — leaving
+            // the button as those riders' only in-screen recovery.
             return .standard(.init(
                 alignment: .center,
                 title: noLocationTitle,
                 body: nil,
-                buttonConfig: retryButtonConfig
+                buttonConfig: noLocationButtonConfig
             ))
 
         case .noResults:
@@ -214,7 +238,63 @@ class CurrentTripViewController: UIViewController,
         application.viewRouter.navigate(to: tripController, from: self)
     }
 
-    // MARK: - Retry
+    // MARK: - Recovery Buttons
+
+    /// The `.noLocation` empty state's button, chosen from *why* there is no
+    /// location. "Try Again" can only ever flash a spinner for a rider whose
+    /// access is denied, and there is nothing to offer one whose device
+    /// restricts location outright.
+    private var noLocationButtonConfig: ActivityIndicatedButton.Configuration? {
+        switch viewModel.noLocationRecovery {
+        case .requestAuthorization: return requestLocationButtonConfig
+        case .openSettings: return openSettingsButtonConfig
+        case .retry: return retryButtonConfig
+        case .unavailable: return nil
+        }
+    }
+
+    /// Raises the system location prompt from the empty state.
+    ///
+    /// Deliberately reuses the onboarding key: identical wording and meaning —
+    /// tap to grant location access — and it is already translated in every
+    /// locale, where a new key would ship English to twelve of them.
+    ///
+    /// `showsActivityIndicatorOnTap` is `false` because iOS may decline to raise
+    /// the prompt at all (it only ever asks once), and nothing would then come
+    /// back to clear a spinner.
+    private lazy var requestLocationButtonConfig = ActivityIndicatedButton.Configuration(
+        text: OBALoc(
+            "onboarding.location.primary_button",
+            value: "Use My Location",
+            comment: "Button the user taps to grant access to their location."
+        ),
+        largeContentImage: Icons.nearMe,
+        showsActivityIndicatorOnTap: false
+    ) { [weak self] in
+        self?.viewModel.requestLocationAuthorization()
+    }
+
+    /// Sends the rider to the app's Settings page, matching the affordance
+    /// `MapViewController.didTapMapStatus` offers for the same state.
+    ///
+    /// `showsActivityIndicatorOnTap` is `false` because opening Settings
+    /// backgrounds the app; nothing replaces this configuration while it is gone,
+    /// so a spinner would still be turning when the rider came back.
+    private lazy var openSettingsButtonConfig = ActivityIndicatedButton.Configuration(
+        text: OBALoc(
+            "locationservices_alert_gotosettings.button",
+            value: "Turn On in Settings",
+            comment: "Button that opens iOS Settings so the user can enable location services for the app."
+        ),
+        largeContentImage: Icons.settings,
+        showsActivityIndicatorOnTap: false
+    ) { [weak self] in
+        guard let self, let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        self.application.open(url, options: [:]) { success in
+            guard !success else { return }
+            Logger.error("CurrentTripViewController: failed to open Settings for location authorization.")
+        }
+    }
 
     private lazy var retryButtonConfig = ActivityIndicatedButton.Configuration(
         text: OBALoc(

--- a/OBAKit/ViewModels/CurrentTripViewModel.swift
+++ b/OBAKit/ViewModels/CurrentTripViewModel.swift
@@ -190,6 +190,13 @@ class CurrentTripViewModel: ObservableObject {
         pendingNavigation = nil
     }
 
+    /// Prompts for when-in-use authorization. A thin wrapper so the view layer
+    /// doesn't reach into `application.locationService`, matching
+    /// `MapViewModel.requestLocationAuthorization()`.
+    func requestLocationAuthorization() {
+        application.locationService.requestInUseAuthorization()
+    }
+
     // MARK: - Refresh Timer
 
     private func startRefreshTimer() {
@@ -261,6 +268,56 @@ extension CurrentTripViewModel {
             default:
                 return false
             }
+        }
+    }
+}
+
+// MARK: - No-Location Recovery
+
+extension CurrentTripViewModel {
+    /// What the `.noLocation` empty state can usefully offer the rider.
+    ///
+    /// Mirrors the precedence `MapViewModel.topPillState` already applies to the
+    /// same authorization values, so the two screens agree on what a rider in a
+    /// given state can do about it. `LocationService.authorizationStatus` folds
+    /// "Location Services are off system-wide" into `.denied`, so that needs no
+    /// branch of its own.
+    enum NoLocationRecovery: Equatable {
+        /// Nobody has asked yet. Declining onboarding's location step lands here
+        /// rather than in `.denied` — "Not Now" never calls Core Location — so
+        /// this is the likeliest reason for an absent location. An in-app prompt
+        /// is a far shorter path than a trip to Settings.
+        case requestAuthorization
+
+        /// Access was refused, or Location Services are off system-wide. Nothing
+        /// in the app can undo either, so a retry would only flash a spinner.
+        case openSettings
+
+        /// Authorized, but no fix has arrived yet (cold start, indoors).
+        /// `findVehicle()` re-reads `currentLocation`, so this is the one case a
+        /// retry can actually resolve.
+        case retry
+
+        /// Parental controls or an MDM profile block location and the rider
+        /// cannot lift that from Settings, so every affordance would be a dead
+        /// end. The same call `MapViewModel` makes for `.restricted`.
+        case unavailable
+    }
+
+    /// The recovery affordance the `.noLocation` empty state should present.
+    var noLocationRecovery: NoLocationRecovery {
+        switch application.locationService.authorizationStatus {
+        case .notDetermined:
+            return .requestAuthorization
+        case .denied:
+            return .openSettings
+        case .restricted:
+            return .unavailable
+        case .authorizedAlways, .authorizedWhenInUse:
+            return .retry
+        @unknown default:
+            // A future denied-like status must not offer a retry that cannot work.
+            return .unavailable
         }
     }
 }

--- a/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
+++ b/OBAKitTests/ViewModels/CurrentTripViewModelTests.swift
@@ -84,6 +84,39 @@ final class CurrentTripViewModelTests: OBATestCase {
         return Application(config: config)
     }
 
+    /// Builds a view model over a location manager whose authorization status the
+    /// test controls. `createApplication(withLocation: false)` cannot: its plain
+    /// `LocationManagerMock` hardcodes `.notDetermined`.
+    private func makeViewModel(authorizationStatus status: CLAuthorizationStatus) -> CurrentTripViewModel {
+        let dataLoader = MockDataLoader(testName: name)
+        stubRegions(dataLoader: dataLoader)
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
+
+        let locManager = AuthorizableLocationManagerMock(
+            updateLocation: userLocation,
+            updateHeading: TestData.mockHeading
+        )
+        let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
+        locManager._authorizationStatus = status
+
+        let config = AppConfig(
+            regionsBaseURL: regionsURL,
+            apiKey: apiKey,
+            appVersion: appVersion,
+            userDefaults: userDefaults,
+            analytics: AnalyticsMock(),
+            queue: queue,
+            locationService: locationService,
+            bundledRegionsFilePath: bundledRegionsPath,
+            regionsAPIPath: regionsAPIPath,
+            dataLoader: dataLoader,
+            fixedRegionName: Fixtures.pugetSoundRegion.name
+        )
+
+        return CurrentTripViewModel(application: Application(config: config), route: route30())
+    }
+
     // MARK: - Fixtures
 
     private let arrivalsFixture = "arrivals_and_departures_for_stop_1_10020.json"
@@ -417,4 +450,42 @@ final class CurrentTripViewModelTests: OBATestCase {
         #expect((error as NSError).domain == "CurrentTripViewModel")
     }
 
+    // MARK: - No-Location Recovery
+
+    /// `.notDetermined` is where a rider who tapped "Not Now" during onboarding
+    /// lands — declining never calls Core Location — so the empty state must
+    /// raise the in-app prompt rather than send them to Settings.
+    @Test @MainActor
+    func `Recovery for undetermined authorization requests it in app`() throws {
+        #expect(makeViewModel(authorizationStatus: .notDetermined).noLocationRecovery == .requestAuthorization)
+    }
+
+    /// Retrying cannot undo a denial, so the empty state must point at Settings.
+    /// `LocationService` also reports Location Services being off system-wide as
+    /// `.denied`, and Settings is the only fix for that too.
+    @Test @MainActor
+    func `Recovery for denied authorization opens settings`() throws {
+        #expect(makeViewModel(authorizationStatus: .denied).noLocationRecovery == .openSettings)
+    }
+
+    /// A restricted device cannot be un-restricted by its rider, so every
+    /// affordance would be a dead end and the empty state offers none.
+    @Test @MainActor
+    func `Recovery for restricted authorization offers nothing`() throws {
+        #expect(makeViewModel(authorizationStatus: .restricted).noLocationRecovery == .unavailable)
+    }
+
+    /// Authorized but location-less means the fix simply hasn't landed yet, and
+    /// `findVehicle()` re-reads `currentLocation` — the one case a retry helps.
+    @Test @MainActor
+    func `Recovery for authorized when in use retries`() throws {
+        #expect(makeViewModel(authorizationStatus: .authorizedWhenInUse).noLocationRecovery == .retry)
+    }
+
+    /// Always authorization is no less usable here than When In Use; a rider who
+    /// upgraded for proximity alerts must not lose the retry button.
+    @Test @MainActor
+    func `Recovery for authorized always retries`() throws {
+        #expect(makeViewModel(authorizationStatus: .authorizedAlways).noLocationRecovery == .retry)
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes the comment you flagged. `CurrentTripViewModel.startRefreshTimer()` does re-run `findVehicle(resetState: false)` every 20 seconds in every state, including `.noLocation`. The old comment could have sent future readers looking for an auto-retry that was already there.
  - The comment now explains the actual reason the button matters: `shouldSkipProgrammaticRefresh` suppresses that timer tick under VoiceOver, making the button the only in-screen recovery path for those riders.

- Also took the enhancement you raised. **"Try Again"** now only appears when a retry can actually do something.

- Returning from Settings fires no view lifecycle callback, and under VoiceOver the 20-second tick that would otherwise catch up is disabled. The controller therefore re-runs the search on `didBecomeActive` while in `.noLocation`.
  - Without this, the Settings button would dead-end for exactly the riders it exists for.

- No new localization keys were added. Both labels reuse keys that already exist in all thirteen locales.

- Added five tests covering every branch of the mapping.

Closes #1343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the Current Trip experience when location access is unavailable.
  - Users can now request location permission, open system Settings to update access, retry vehicle lookup, or receive clear guidance when recovery isn’t possible.
  - Vehicle information automatically refreshes when returning from Settings after updating location access.
  - Added a Settings icon for controls that open the system Settings app.

- **Bug Fixes**
  - Improved handling of location authorization states to provide the appropriate recovery action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->