### PR TITLE
Label onboarding regions by how they were actually chosen

### DIFF
--- a/OBAKit/Onboarding/Views/OnboardingRegionSelection.swift
+++ b/OBAKit/Onboarding/Views/OnboardingRegionSelection.swift
@@ -1,0 +1,83 @@
+//
+//  OnboardingRegionSelection.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import OBAKitCore
+
+/// The region the onboarding card displays, paired with how the app arrived at it.
+///
+/// Both the card's eyebrow and the screen's body text are derived from `source`, so
+/// they can't drift into describing the region two different ways.
+/// See https://github.com/OneBusAway/onebusaway-ios/issues/1345
+struct OnboardingRegionSelection {
+
+    /// Where the displayed region came from.
+    enum Source {
+        /// The rider's location resolves to this region.
+        case detected
+
+        /// The rider tapped this region in the list on the onboarding screen.
+        case chosen
+
+        /// The app already had this region selected and the rider's location doesn't
+        /// corroborate it — a fixed region from `OBAKitConfig`, the sole-active-region
+        /// fallback, or a pick that predates this run of onboarding.
+        case preselected
+    }
+
+    let region: Region
+    let source: Source
+
+    /// The region the rider's location resolves to: the one whose service area contains
+    /// them, else the one with the closest center.
+    ///
+    /// Containment is checked first to match how `RegionsService` auto-selects a region.
+    /// `distanceFrom(location:)` measures to a region's *center*, so a rider well inside a
+    /// large region can still sit closer to a small neighbor's center; picking by distance
+    /// alone would disagree with the region the app actually selected for them.
+    ///
+    /// - Returns: `nil` when there is no location, which is what distinguishes a genuinely
+    ///   detected region from one that merely happens to be current.
+    static func locatedRegion(in regions: [Region], location: CLLocation?) -> Region? {
+        guard let location else { return nil }
+
+        if let containing = regions.first(where: { $0.contains(location: location) }) {
+            return containing
+        }
+
+        return regions.min { $0.distanceFrom(location: location) < $1.distanceFrom(location: location) }
+    }
+
+    /// Resolves which region the card shows and how it got there.
+    ///
+    /// - Parameters:
+    ///   - chosen: The region the rider tapped on the onboarding screen, if any.
+    ///   - current: `RegionProvider.currentRegion`.
+    ///   - located: The result of ``locatedRegion(in:location:)``.
+    /// - Returns: `nil` when there is nothing to show: no pick, no current region, no location.
+    static func resolve(chosen: Region?, current: Region?, located: Region?) -> OnboardingRegionSelection? {
+        if let chosen {
+            return OnboardingRegionSelection(region: chosen, source: .chosen)
+        }
+
+        if let current {
+            // `RegionsService` also assigns `currentRegion` from paths that have nothing to
+            // do with the rider's location, so it only earns the "detected" label when the
+            // location independently resolves to that same region.
+            let source: Source = current.id == located?.id ? .detected : .preselected
+            return OnboardingRegionSelection(region: current, source: source)
+        }
+
+        if let located {
+            return OnboardingRegionSelection(region: located, source: .detected)
+        }
+
+        return nil
+    }
+}

--- a/OBAKit/Onboarding/Views/OnboardingRegionView.swift
+++ b/OBAKit/Onboarding/Views/OnboardingRegionView.swift
@@ -21,17 +21,16 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
     @State private var error: Error?
     @State private var isSettingRegion = false
 
-    /// The already-selected region if one exists, else the nearest region to the user's location.
-    private var detectedRegion: Region? {
-        if let current = regionProvider.currentRegion { return current }
-        guard let location = regionProvider.currentLocation else { return nil }
-        return regionProvider.allRegions.min {
-            $0.distanceFrom(location: location) < $1.distanceFrom(location: location)
-        }
+    /// The region the card shows and how the app arrived at it.
+    private var selection: OnboardingRegionSelection? {
+        OnboardingRegionSelection.resolve(
+            chosen: selectedRegion,
+            current: regionProvider.currentRegion,
+            located: OnboardingRegionSelection.locatedRegion(in: regionProvider.allRegions, location: regionProvider.currentLocation))
     }
 
-    private func shortList(excluding resolved: Region?) -> [Region] {
-        var candidates = regionProvider.allRegions.filter { $0.id != resolved?.id }
+    private func shortList(excluding displayed: Region?) -> [Region] {
+        var candidates = regionProvider.allRegions.filter { $0.id != displayed?.id }
         if let location = regionProvider.currentLocation {
             candidates.sort { $0.distanceFrom(location: location) < $1.distanceFrom(location: location) }
         }
@@ -39,25 +38,22 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
     }
 
     var body: some View {
-        // Hoisted once per render: `detectedRegion` is an O(n) distance scan and
-        // `shortList` re-filters allRegions; the body references them repeatedly.
-        let detected = detectedRegion
-        let resolved = selectedRegion ?? detected
-        let shortList = shortList(excluding: resolved)
+        // Hoisted once per render: resolving the selection is an O(n) scan over allRegions
+        // and `shortList` re-filters it; the body references both repeatedly.
+        let selection = self.selection
+        let shortList = shortList(excluding: selection?.region)
 
         OnboardingScaffold(
             progress: progress,
             title: OBALoc("onboarding.region.title", value: "Your region", comment: "Title of the region onboarding screen"),
-            bodyText: detected == nil
-                ? OBALoc("onboarding.region.body_no_location", value: "Choose the transit network you ride.", comment: "Body of the region onboarding screen when no location is available")
-                : OBALoc("onboarding.region.body", value: "We found the transit network closest to you.", comment: "Body of the region onboarding screen"),
+            bodyText: bodyText(for: selection?.source),
             primaryTitle: Strings.continue,
-            primaryDisabled: resolved == nil,
+            primaryDisabled: selection == nil,
             primaryAction: confirmSelection
         ) {
             VStack(spacing: 0) {
-                if let region = resolved {
-                    selectedCard(for: region, isDetected: region.id == detected?.id)
+                if let selection {
+                    selectedCard(for: selection)
                         .padding(.top, 22)
                 }
 
@@ -114,33 +110,28 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
         .errorAlert(error: $error)
     }
 
-    private func selectedCard(for region: Region, isDetected: Bool) -> some View {
+    private func selectedCard(for selection: OnboardingRegionSelection) -> some View {
         VStack(spacing: 0) {
             // Live map preview, preferred over MKMapSnapshotter because snapshots
             // don't adapt to dark mode.
-            RegionPickerMap(mapRect: .constant(region.serviceRect), mapHeight: 108)
+            RegionPickerMap(mapRect: .constant(selection.region.serviceRect), mapHeight: 108)
                 .allowsHitTesting(false)
                 .frame(height: 108)
                 .clipped()
-            cardFooter(for: region, isDetected: isDetected)
+            cardFooter(for: selection)
         }
         .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 20))
         .clipShape(RoundedRectangle(cornerRadius: 20))
     }
 
-    private func cardFooter(for region: Region, isDetected: Bool) -> some View {
+    private func cardFooter(for selection: OnboardingRegionSelection) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 3) {
-                // The same card renders a region the rider picked from the list
-                // below, and calling that one "detected near you" would claim
-                // something untrue about how it got there.
-                Text(isDetected
-                     ? OBALoc("onboarding.region.detected_label", value: "Detected near you", comment: "Label on the detected-region card")
-                     : OBALoc("onboarding.region.selected_label", value: "Your selection", comment: "Label on the region card when the rider chose the region from the list rather than it being detected from their location"))
+                Text(eyebrow(for: selection.source))
                     .font(.caption.weight(.bold))
                     .foregroundStyle(Color.accentColor)
                     .textCase(.uppercase)
-                Text(region.name)
+                Text(selection.region.name)
                     .font(.title3.weight(.bold))
             }
             Spacer()
@@ -154,8 +145,33 @@ struct OnboardingRegionView<Provider: RegionProvider>: View {
         .accessibilityAddTraits(.isSelected)
     }
 
+    /// The card's eyebrow. Each `Source` names how the region got onto the card, so the
+    /// label can't claim detection for a region the rider's location never produced.
+    private func eyebrow(for source: OnboardingRegionSelection.Source) -> String {
+        switch source {
+        case .detected:
+            return OBALoc("onboarding.region.detected_label", value: "Detected near you", comment: "Label on the detected-region card")
+        case .chosen:
+            return OBALoc("onboarding.region.selected_label", value: "Your selection", comment: "Label on the region card when the rider chose the region from the list rather than it being detected from their location")
+        case .preselected:
+            return OBALoc("onboarding.region.current_label", value: "Current region", comment: "Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location")
+        }
+    }
+
+    /// The screen's body text. Detection is the only state where the app can claim it found
+    /// the region; the others get the standing instruction, which stays true whether the
+    /// rider picked the card's region or is about to replace it.
+    private func bodyText(for source: OnboardingRegionSelection.Source?) -> String {
+        switch source {
+        case .detected:
+            return OBALoc("onboarding.region.body", value: "We found the transit network closest to you.", comment: "Body of the region onboarding screen when the region was detected from the rider's location")
+        case .chosen, .preselected, nil:
+            return OBALoc("onboarding.region.body_choose", value: "Choose the transit network you ride.", comment: "Body of the region onboarding screen prompting the rider to choose a transit network")
+        }
+    }
+
     private func confirmSelection() {
-        guard let region = selectedRegion ?? detectedRegion else { return }
+        guard let region = selection?.region else { return }
         isSettingRegion = true
         Task {
             defer { isSettingRegion = false }

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "تقدّم التهيئة";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "وجدنا شبكة النقل الأقرب إليك.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "اختر شبكة النقل التي تستقلّها.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "اختر شبكة النقل التي تستقلّها.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "المنطقة الحالية";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "تم اكتشافها بالقرب منك";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Onboarding progress";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "We found the transit network closest to you.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Choose the transit network you ride.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Choose the transit network you ride.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Current region";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Detected near you";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Progreso de la incorporación";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Encontramos la red de transporte más cercana a ti.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Elige la red de transporte que usas.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Elige la red de transporte que usas.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Región actual";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Detectada cerca de ti";

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Progreso ng onboarding";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Nahanap namin ang pinakamalapit na transit network sa iyo.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Piliin ang transit network na ginagamit mo.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Piliin ang transit network na ginagamit mo.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Kasalukuyang rehiyon";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Napansin malapit sa iyo";

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Progression de la découverte";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Nous avons trouvé le réseau de transport le plus proche de vous.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Choisissez le réseau de transport que vous utilisez.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Choisissez le réseau de transport que vous utilisez.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Région actuelle";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Détecté près de vous";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Avanzamento dell'introduzione";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Abbiamo trovato la rete di trasporto più vicina a te.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Scegli la rete di trasporto che usi.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Scegli la rete di trasporto che usi.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Regione attuale";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Rilevata vicino a te";

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "온보딩 진행률";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "가장 가까운 교통 네트워크를 찾았습니다.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "이용하는 교통 네트워크를 선택하세요.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "이용하는 교통 네트워크를 선택하세요.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "현재 지역";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "내 근처에서 감지됨";
@@ -799,7 +802,7 @@
 "onboarding.region.see_all_button" = "모든 지역 보기";
 
 /* Label on the region card when the rider chose the region from the list rather than it being detected from their location */
-"onboarding.region.selected_label" = "내가 선택함";
+"onboarding.region.selected_label" = "내 선택";
 
 /* Title of the region onboarding screen */
 "onboarding.region.title" = "내 지역";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Postęp wprowadzenia";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Znaleźliśmy sieć transportu najbliższą Tobie.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Wybierz sieć transportu, z której korzystasz.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Wybierz sieć transportu, z której korzystasz.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Bieżący region";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Wykryto w pobliżu";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Progresso da integração";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Encontramos a rede de trânsito mais próxima de você.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Escolha a rede de trânsito que você usa.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Escolha a rede de trânsito que você usa.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Região atual";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Detectada perto de você";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Прогресс знакомства с приложением";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Мы нашли транспортную сеть ближе всего к вам.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Выберите транспортную сеть, которой вы пользуетесь.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Выберите транспортную сеть, которой вы пользуетесь.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Текущий регион";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Обнаружено рядом с вами";

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "Tiến trình hướng dẫn";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "Chúng tôi đã tìm thấy mạng lưới giao thông gần bạn nhất.";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "Chọn mạng lưới giao thông bạn sử dụng.";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "Chọn mạng lưới giao thông bạn sử dụng.";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "Khu vực hiện tại";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "Phát hiện gần bạn";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "引导进度";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "我们找到了离你最近的交通网络。";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "选择你乘坐的交通网络。";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "选择你乘坐的交通网络。";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "当前地区";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "在你附近检测到";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -783,11 +783,14 @@
 /* Accessibility label for the onboarding progress bar */
 "onboarding.progress.accessibility_label" = "導覽進度";
 
-/* Body of the region onboarding screen */
+/* Body of the region onboarding screen when the region was detected from the rider's location */
 "onboarding.region.body" = "我們找到離你最近的運輸網路。";
 
-/* Body of the region onboarding screen when no location is available */
-"onboarding.region.body_no_location" = "選擇你搭乘的運輸網路。";
+/* Body of the region onboarding screen prompting the rider to choose a transit network */
+"onboarding.region.body_choose" = "選擇你搭乘的運輸網路。";
+
+/* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
+"onboarding.region.current_label" = "目前地區";
 
 /* Label on the detected-region card */
 "onboarding.region.detected_label" = "在你附近偵測到";

--- a/OBAKitTests/Onboarding/OnboardingRegionSelectionTests.swift
+++ b/OBAKitTests/Onboarding/OnboardingRegionSelectionTests.swift
@@ -1,0 +1,128 @@
+//
+//  OnboardingRegionSelectionTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import Testing
+@testable import OBAKit
+@testable import OBAKitCore
+
+/// Tests for `OnboardingRegionSelection`, which decides which region the onboarding
+/// card shows and whether the app may claim it detected that region.
+/// See https://github.com/OneBusAway/onebusaway-ios/issues/1345
+@MainActor
+@Suite(.serialized)
+final class OnboardingRegionSelectionTests {
+
+    private func makeRegion(id: RegionIdentifier, name: String, latitude: CLLocationDegrees, longitude: CLLocationDegrees, span: CLLocationDegrees) -> Region {
+        Region(
+            name: name,
+            OBABaseURL: URL(string: "https://www.example.com")!,
+            coordinateRegion: MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+                span: MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span)),
+            contactEmail: "contact@example.com",
+            regionIdentifier: id)
+    }
+
+    /// Spans latitude 45...49, longitude -124...-120.
+    private var pugetSound: Region {
+        makeRegion(id: 1, name: "Puget Sound", latitude: 47.0, longitude: -122.0, span: 4.0)
+    }
+
+    /// A pinprick region just north of `riderInPugetSound`, so its center is far closer
+    /// than Puget Sound's while its bounds exclude the rider.
+    private var smallNeighbor: Region {
+        makeRegion(id: 2, name: "Small Neighbor", latitude: 47.62, longitude: -122.30, span: 0.01)
+    }
+
+    private var tampaBay: Region {
+        makeRegion(id: 3, name: "Tampa Bay", latitude: 27.98, longitude: -82.45, span: 0.5)
+    }
+
+    private let riderInPugetSound = CLLocation(latitude: 47.60, longitude: -122.32)
+
+    /// Outside every test region, and roughly 270km from Tampa Bay's center versus
+    /// thousands of kilometers from Puget Sound's.
+    private let riderInNorthFlorida = CLLocation(latitude: 30.0, longitude: -84.0)
+
+    // MARK: - locatedRegion
+
+    @Test func `Located region is nil without a location`() {
+        #expect(OnboardingRegionSelection.locatedRegion(in: [pugetSound, tampaBay], location: nil) == nil)
+    }
+
+    @Test func `Located region is nil when no regions are known`() {
+        #expect(OnboardingRegionSelection.locatedRegion(in: [], location: riderInPugetSound) == nil)
+    }
+
+    /// `distanceFrom(location:)` measures to a region's center, so a rider well inside a
+    /// large region can sit closer to a small neighbor's center. Containment has to win,
+    /// or the label disagrees with the region `RegionsService` actually auto-selects.
+    @Test func `Located region prefers the containing region over a closer center`() throws {
+        let neighbor = smallNeighbor
+        let containing = pugetSound
+
+        // Guard the fixture itself: the test is meaningless if the neighbor isn't closer.
+        #expect(neighbor.distanceFrom(location: riderInPugetSound) < containing.distanceFrom(location: riderInPugetSound))
+        #expect(neighbor.contains(location: riderInPugetSound) == false)
+
+        // Neighbor first, so the containing region can't win by array order alone.
+        let located = try #require(OnboardingRegionSelection.locatedRegion(in: [neighbor, containing], location: riderInPugetSound))
+        #expect(located.regionIdentifier == 1)
+    }
+
+    @Test func `Located region falls back to the nearest center when none contains the rider`() throws {
+        let regions = [pugetSound, tampaBay]
+        #expect(regions.contains { $0.contains(location: riderInNorthFlorida) } == false)
+
+        let located = try #require(OnboardingRegionSelection.locatedRegion(in: regions, location: riderInNorthFlorida))
+        #expect(located.regionIdentifier == 3)
+    }
+
+    // MARK: - resolve
+
+    @Test func `Resolve reports a rider tap as chosen`() throws {
+        let selection = try #require(OnboardingRegionSelection.resolve(chosen: tampaBay, current: pugetSound, located: pugetSound))
+        #expect(selection.source == .chosen)
+        #expect(selection.region.regionIdentifier == 3)
+    }
+
+    @Test func `Resolve reports a location-corroborated current region as detected`() throws {
+        let selection = try #require(OnboardingRegionSelection.resolve(chosen: nil, current: pugetSound, located: pugetSound))
+        #expect(selection.source == .detected)
+        #expect(selection.region.regionIdentifier == 1)
+    }
+
+    /// The bug behind #1345: `RegionsService` also sets `currentRegion` from a fixed region
+    /// name and from the sole-active-region fallback, neither of which involves the rider's
+    /// location. Those must not be labelled "Detected near you".
+    @Test func `Resolve reports a current region the location contradicts as preselected`() throws {
+        let selection = try #require(OnboardingRegionSelection.resolve(chosen: nil, current: tampaBay, located: pugetSound))
+        #expect(selection.source == .preselected)
+        #expect(selection.region.regionIdentifier == 3)
+    }
+
+    @Test func `Resolve reports a current region as preselected when there is no location`() throws {
+        let selection = try #require(OnboardingRegionSelection.resolve(chosen: nil, current: tampaBay, located: nil))
+        #expect(selection.source == .preselected)
+        #expect(selection.region.regionIdentifier == 3)
+    }
+
+    @Test func `Resolve reports a located region as detected when nothing is current`() throws {
+        let selection = try #require(OnboardingRegionSelection.resolve(chosen: nil, current: nil, located: pugetSound))
+        #expect(selection.source == .detected)
+        #expect(selection.region.regionIdentifier == 1)
+    }
+
+    @Test func `Resolve returns nil without a tap a current region or a location`() {
+        #expect(OnboardingRegionSelection.resolve(chosen: nil, current: nil, located: nil) == nil)
+    }
+}


### PR DESCRIPTION
Fixes #1345.Follow-ups from #1316. Closes #1345.

1. detectedRegion returned currentRegion first, which RegionsService also sets from fixedRegionName and the sole-active-region fallback. A current region now only reads "Detected near you" when the rider's location resolves to it — otherwise the card reads "Current region" (new onboarding.region.current_label). That resolution checks service-area containment before nearest center, matching RegionsService: distanceFrom measures to a region's center, so a rider inside a large region can sit closer to a small neighbour's center.
2. The eyebrow and the body text now derive from one value, so they can't contradict each other. Only the detected state says "We found the transit network closest to you." body_no_location is re-keyed body_choose — same English value, so translations carry over — since it now shows for any non-detected state, not just a missing location.
3. Korean "내가 선택함" → "내 선택".

Tests in OnboardingRegionSelectionTests. "Current region" translated in all 13 catalogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved region selection during onboarding by distinguishing detected, chosen, and current regions.
  * Region detection now prioritizes regions containing the rider’s location, then selects the nearest available region.
  * Updated onboarding cards and guidance to clearly identify how each region was selected.

* **Localization**
  * Updated region-selection messaging and added “Current region” labels across supported languages.

* **Tests**
  * Added coverage for region detection, fallback selection, and selection-source behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->