### PR TITLE
Test the proximity expiry guard and region stash for real

### DIFF
--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -715,18 +715,22 @@ final class ApplicationTests: OBATestCase {
 
     @Test func `Push service proximity alert tap is never dropped`() {
         let (app, pushService) = makeAppAndPushService()
+        // A region left behind by an earlier navigation. Without it the assertion
+        // below is inert: `pendingStopRegionID` starts nil on a freshly built
+        // `Application`, so deleting the handler's explicit clear would leave this
+        // test green.
+        app.pendingStopRegionID = 999
 
         app.pushService(pushService, receivedProximityAlertForStopID: "1_75403", regionID: nil)
 
         // The tap that matters is the one into a terminated app, where neither a
-        // root controller nor a region exists yet. Both branches must stash: with
-        // no region the handler stashes region-less, and with one `queueOrOpenStop`
-        // stashes it alongside the region. Dropping it would strand the rider on
-        // whatever screen the app happened to open to.
+        // root controller nor a region exists yet. Dropping it would strand the
+        // rider on whatever screen the app happened to open to, with no second
+        // chance — the notification is gone once tapped.
         #expect(app.pendingStopID == "1_75403")
-        // Whatever region was stashed must be the one actually current, or the
-        // drain will refuse the stop as belonging somewhere else.
-        #expect(app.pendingStopRegionID == app.regionsService.currentRegion?.regionIdentifier)
+        // Cleared, not merely absent: a stale region would make the drain refuse
+        // this stop as belonging somewhere else.
+        #expect(app.pendingStopRegionID == nil)
     }
 
     @Test func `Push service proximity alert tap stashes the region the alert carries`() {

--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -598,11 +598,13 @@ final class ProximityAlertManagerTests: OBATestCase {
             stop: stop,
             createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
         )
-        store.add(proximityAlert: expired)
         let manager = makeManager()
-        // Reconciliation reaped it on construction, so put it back to reach the
-        // guard under test: the crossing arriving before anything reconciles.
-        store.add(proximityAlert: expired)
+        // Assigned, not `add`ed. `add` posts `.proximityAlertsDidChange`, which
+        // this manager observes with the selector form — `NotificationCenter`
+        // invokes that inline, so reconciliation reaps the alert before the
+        // crossing arrives and the test passes through the no-longer-stored
+        // branch instead of the expiry guard it names.
+        store.proximityAlerts = [expired]
         #expect(locationService.startMonitoringProximity(for: expired) == .started)
 
         enterRegion(for: expired)


### PR DESCRIPTION
Items 1 and 3 of #1347, rebased onto current main. Tests only.

Both tests stayed green with the behavior they name deleted.

**`Entering the geofence of an expired alert delivers nothing`** never reached `guard !alert.isExpired`. The second `store.add` posts `.proximityAlertsDidChange`, the observer fires inline, and reconciliation reaps the alert before the crossing arrives — so it landed on the "no longer stored" branch, which another test already covers. Assigning `store.proximityAlerts` directly bypasses the notification and reaches the guard.

**`Push service proximity alert tap is never dropped`** asserted `pendingStopRegionID == currentRegion?.regionIdentifier`, which held in both branches. It stayed inert after the last round too: `pendingStopRegionID` starts nil on a freshly built `Application`, so asserting it is nil proved nothing. Seeding a stale `999` first makes the handler's explicit clear the only reason the assertion passes.

Items 2 and 4 landed separately in ebfca83b, and the region-present branch is covered by the tests added there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded proximity-alert coverage for launches without a loaded region, stale region state, explicit or fallback regions, and alerts targeting another region.
  * Added validation for duplicate stops, expired alerts, different stops, lost location authorization, and region recording.
  * Verified that alert notifications include region details when available and omit them when unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->