### PR TITLE
Make buildContentState(from:matching:) non-optional

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -79,10 +79,53 @@ final class BookmarkActions {
         (bookmark.routeShortName ?? bookmark.name, bookmark.tripHeadsign ?? "")
     }
 
+    /// Builds content from whatever arrivals a bookmark row has loaded, or `nil`
+    /// when it has none — the bookmark paths have no single departure to fall
+    /// back on, so an empty list really is a failure for them.
     static func buildContentState(from arrivalDepartures: [ArrivalDeparture]) -> TripAttributes.ContentState? {
         guard !arrivalDepartures.isEmpty else {
             return nil
         }
+        return contentState(from: arrivalDepartures)
+    }
+
+    /// Builds content for the trip the rider actually tracked: same stop, route,
+    /// and destination as `departure`. Route-only matching mixes both directions
+    /// at a transit center and shows the opposite bus's countdown (#1326).
+    ///
+    /// Non-optional on purpose. When the stop list no longer contains the tracked
+    /// trip — stale data, or a list that never loaded — this falls back to
+    /// `departure` itself, so there is always at least one arrival to show and
+    /// callers need no failure branch.
+    static func buildContentState(
+        from arrivalDepartures: [ArrivalDeparture],
+        matching departure: ArrivalDeparture
+    ) -> TripAttributes.ContentState {
+        let key = TripBookmarkKey(arrivalDeparture: departure)
+
+        if (departure.tripHeadsign ?? "").isEmpty {
+            // `TripBookmarkKey` substitutes "" for a missing headsign, so the
+            // filter below degrades to stop + route and can readmit the opposite
+            // direction — the very symptom this method exists to prevent. Still
+            // better than showing no trip at all, but it must not be silent.
+            // See: https://github.com/OneBusAway/onebusaway-ios/issues/1326
+            Logger.warn("Departure \(departure.tripID) at stop \(departure.stopID) has no trip headsign; Live Activity arrivals match on stop and route only and may mix directions.")
+        }
+
+        let sameTrip = arrivalDepartures
+            .filter { TripBookmarkKey(arrivalDeparture: $0) == key }
+            .sorted { $0.arrivalDepartureDate < $1.arrivalDepartureDate }
+        let source = sameTrip.isEmpty ? [departure] : sameTrip
+        return contentState(from: source)
+    }
+
+    /// Maps the soonest three arrivals into the Live Activity payload.
+    ///
+    /// - Precondition: `arrivalDepartures` is non-empty. Both entry points above
+    ///   establish that — one by guarding, the other by falling back to the
+    ///   tracked departure — which is why only the guarding one returns an
+    ///   `Optional`.
+    private static func contentState(from arrivalDepartures: [ArrivalDeparture]) -> TripAttributes.ContentState {
         let arrivals = arrivalDepartures.prefix(3).map { arrDep in
             TripAttributes.ContentState.ArrivalInfo(
                 departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),
@@ -92,21 +135,6 @@ final class BookmarkActions {
             )
         }
         return TripAttributes.ContentState(arrivals: Array(arrivals))
-    }
-
-    /// Builds content for the trip the rider actually tracked: same stop, route,
-    /// and destination as `departure`. Route-only matching mixes both directions
-    /// at a transit center and shows the opposite bus's countdown (#1326).
-    static func buildContentState(
-        from arrivalDepartures: [ArrivalDeparture],
-        matching departure: ArrivalDeparture
-    ) -> TripAttributes.ContentState? {
-        let key = TripBookmarkKey(arrivalDeparture: departure)
-        let sameTrip = arrivalDepartures
-            .filter { TripBookmarkKey(arrivalDeparture: $0) == key }
-            .sorted { $0.arrivalDepartureDate < $1.arrivalDepartureDate }
-        let source = sameTrip.isEmpty ? [departure] : sameTrip
-        return buildContentState(from: source)
     }
 
     @discardableResult

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -587,10 +587,13 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             return
         }
 
-        guard let contentState = buildLiveActivityContentState(for: departure, viewModel: viewModel) else {
-            Logger.error("Failed to build content state for Live Activity")
-            return
-        }
+        // Always yields content: the matching builder falls back to `departure`
+        // itself when the stop list is stale or hasn't loaded yet, so there is
+        // no failure branch to take here.
+        let contentState = BookmarkActions.buildContentState(
+            from: viewModel.stopArrivals?.arrivalsAndDepartures ?? [],
+            matching: departure
+        )
 
         // Prominence so the Dynamic Island switches to this Track when another
         // trip is already live (#1189 Problem 2). Default score is 0 and equal
@@ -620,11 +623,6 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             Logger.error("Failed to start Live Activity: \(error)")
             presentationHost(for: "live activity error")?.showLiveActivityErrorAlert()
         }
-    }
-
-    private func buildLiveActivityContentState(for departure: ArrivalDeparture, viewModel: StopViewModel) -> TripAttributes.ContentState? {
-        let allArrivals = viewModel.stopArrivals?.arrivalsAndDepartures ?? [departure]
-        return BookmarkActions.buildContentState(from: allArrivals, matching: departure)
     }
 
     // MARK: - User Activity

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -147,10 +147,10 @@ final class BookmarkActionsTests: OBATestCase {
             departureEpoch: 1_700_000_840
         )
 
-        let state = try #require(BookmarkActions.buildContentState(
+        let state = BookmarkActions.buildContentState(
             from: [oppositeSooner, tracked, laterSameDirection],
             matching: tracked
-        ))
+        )
 
         #expect(state.arrivals.count == 2)
         #expect(state.arrivals.map(\.departureTime) == [
@@ -176,13 +176,72 @@ final class BookmarkActionsTests: OBATestCase {
             departureEpoch: 1_700_000_100
         )
 
-        let state = try #require(BookmarkActions.buildContentState(
+        let state = BookmarkActions.buildContentState(
             from: [otherRoute],
             matching: tracked
-        ))
+        )
 
         #expect(state.arrivals.count == 1)
         #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))
+    }
+
+    /// The stop page hands over an empty list when arrivals haven't loaded yet.
+    /// The matching overload still produces content, from the tapped departure —
+    /// that guarantee is what lets its caller drop the failure branch entirely.
+    @Test @MainActor func `Content state matching an empty list uses the selected departure`() throws {
+        let tracked = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north",
+            departureEpoch: 1_700_000_480
+        )
+
+        let state = BookmarkActions.buildContentState(from: [], matching: tracked)
+
+        #expect(state.arrivals.count == 1)
+        #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))
+    }
+
+    /// A feed that omits `trip_headsign` collapses the `TripBookmarkKey` headsign
+    /// to `""`, so matching falls back to stop and route and readmits the opposite
+    /// direction — the #1326 symptom, from the other end. Pinned rather than
+    /// fixed: matching on the departure alone would leave the card showing a
+    /// single arrival, so the production path keeps the grouping and logs.
+    @Test @MainActor func `Content state matching degrades to route only without a headsign`() throws {
+        let tracked = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: nil,
+            tripID: "trip_north",
+            departureEpoch: 1_700_000_480
+        )
+        let oppositeDirection = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: nil,
+            tripID: "trip_south",
+            departureEpoch: 1_700_000_120
+        )
+        let namedDirection = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north_2",
+            departureEpoch: 1_700_000_240
+        )
+
+        // Neither the departure nor its trip reference supplies one, which is the
+        // condition the production warning fires on.
+        #expect(tracked.tripHeadsign == nil)
+
+        let state = BookmarkActions.buildContentState(
+            from: [oppositeDirection, namedDirection, tracked],
+            matching: tracked
+        )
+
+        // Both headsign-less trips match, soonest first — including the one going
+        // the other way. The trip that does carry a headsign is the one dropped.
+        #expect(state.arrivals.map(\.departureTime) == [
+            Int(oppositeDirection.arrivalDepartureDate.timeIntervalSince1970),
+            Int(tracked.arrivalDepartureDate.timeIntervalSince1970)
+        ])
     }
 
     /// Tracking a bookmark with no loaded arrivals can't build a content state,
@@ -229,13 +288,18 @@ final class BookmarkActionsTests: OBATestCase {
     /// Minimal `ArrivalDeparture` for Live Activity content-state tests. Times are
     /// JSON numbers; `JSONDecoder`'s default Date strategy is seconds-since-2001,
     /// which is fine — we compare through `arrivalDepartureDate`, not the raw ints.
+    ///
+    /// Pass `headsign: nil` to model a feed that omits `trip_headsign`. That case
+    /// is why references are loaded here: `ArrivalDeparture.tripHeadsign` falls
+    /// through to `trip.headsign`, and `trip` is an implicitly unwrapped optional
+    /// that only `loadReferences` populates.
     private func arrivalDeparture(
         routeID: String,
-        headsign: String,
+        headsign: String?,
         tripID: String,
         departureEpoch: Int
     ) throws -> ArrivalDeparture {
-        try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: [
+        var dictionary: [String: Any] = [
             "arrivalEnabled": true,
             "blockTripSequence": 1,
             "departureEnabled": true,
@@ -252,13 +316,67 @@ final class BookmarkActionsTests: OBATestCase {
             "serviceDate": departureEpoch,
             "situationIds": [] as [String],
             "status": "default",
-            "stopId": "1_mtc",
+            "stopId": Self.stopID,
             "stopSequence": 10,
             "totalStopsInTrip": 20,
-            "tripHeadsign": headsign,
             "tripId": tripID,
             "vehicleId": "vehicle_\(tripID)"
-        ])
+        ]
+        // Omitted rather than encoded as a null: `JSONSerialization` rejects
+        // `nil as Any`, and an absent key is what a feed without a headsign sends.
+        if let headsign {
+            dictionary["tripHeadsign"] = headsign
+        }
+
+        let arrivalDeparture = try Fixtures.dictionaryToModel(type: ArrivalDeparture.self, dictionary: dictionary)
+        let references = try Self.references(routeID: routeID, tripID: tripID)
+        arrivalDeparture.loadReferences(references, regionIdentifier: Fixtures.pugetSoundRegion.regionIdentifier)
+        return arrivalDeparture
+    }
+
+    private static let stopID = "1_mtc"
+
+    /// The route, stop and trip that `ArrivalDeparture.loadReferences` force-unwraps.
+    /// The trip deliberately carries no `tripHeadsign`, so a departure built with
+    /// `headsign: nil` resolves to `nil` instead of inheriting one from the reference.
+    private static func references(routeID: String, tripID: String) throws -> References {
+        let referencesData: [String: Any] = [
+            "agencies": [[
+                "id": "1",
+                "name": "Test Agency",
+                "url": "https://example.com",
+                "timezone": "America/Los_Angeles",
+                "lang": "en",
+                "phone": "555-0123",
+                "privateService": false
+            ]],
+            "routes": [[
+                "id": routeID,
+                "agencyId": "1",
+                "shortName": "1 Line",
+                "type": 3
+            ]],
+            "stops": [[
+                "id": stopID,
+                "code": "mtc",
+                "name": "Transit Center",
+                "lat": 47.6097,
+                "lon": -122.3331,
+                "locationType": 0,
+                "routeIds": [routeID]
+            ]],
+            "trips": [[
+                "id": tripID,
+                "blockId": "block_\(tripID)",
+                "routeId": routeID,
+                "serviceId": "service_1",
+                "routeShortName": "1 Line",
+                "tripShortName": "Trip",
+                "timeZone": "America/Los_Angeles"
+            ]]
+        ]
+
+        return try Fixtures.dictionaryToModel(type: References.self, dictionary: referencesData)
     }
 }
 


### PR DESCRIPTION
## Description

`buildContentState(from:matching:)` could never return `nil` — `source` is non-empty by construction. This made the `Optional`, the `guard let` in `startLiveActivity`, and the `try #require` calls in both tests dead code.

### Changes

- Returns `TripAttributes.ContentState` directly; shared mapping logic was moved into a private `contentState(from:)` helper.
- Removed the now-redundant `buildLiveActivityContentState` wrapper from `StopPageActionPresenter`.
- Added a `Logger.warn` for the case also flagged in the issue: a missing trip headsign causes `matching` to silently collapse to stop + route.
  - Behavior is unchanged. Falling back to the tapped departure alone would show only one arrival.
  - The condition is now logged instead of being silent.
- Added two tests:
  - Empty-list fallback.
  - Missing-headsign / matching-collapse case.

Closes #1337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live Activities now continue displaying departure information even when no matching arrivals are available.
  * Departure matching is more resilient when trip headsign information is missing.
  * Live Activity content consistently includes the soonest three arrivals when available.
* **Tests**
  * Added coverage for empty arrival lists and missing trip headsign data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->