### PR TITLE
Remove unreachable trip-map selection branches

### DIFF
--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -165,7 +165,13 @@ class TripFloatingPanelController: UIViewController,
     }
 
     // MARK: - Public Methods
-    public func highlightStopInList(_ matchingStop: Stop) {
+    /// Scrolls the trip stop list to `matchingStop`'s row and, by default, blinks it.
+    /// - Parameters:
+    ///   - matchingStop: The stop whose row should be brought into view.
+    ///   - blinksAfterScroll: Pass `false` when the caller is about to push another view
+    ///     controller. The blink is delayed until scrolling settles, so it would play
+    ///     underneath the pushed page and be finished before the rider returned to see it.
+    public func highlightStopInList(_ matchingStop: Stop, blinksAfterScroll: Bool = true) {
         let data = self.items(for: listView)
 
         var matchingIndexPath: IndexPath?
@@ -178,15 +184,17 @@ class TripFloatingPanelController: UIViewController,
             }
         }
 
-        if let matchingIndexPath = matchingIndexPath {
-            listView.scrollToItem(at: matchingIndexPath, at: .top, animated: true)
+        guard let matchingIndexPath else { return }
 
-            // There's no completionHandler for scrollToItem, so just wait 3/4 of
-            // a second for scrolling to hopefully finish.
-            // Note: If 750ms passes, but the cell is still not visible, then the `blink` won't appear.
-            scrollBlinkThrottler.throttle(deadline: .now() + .milliseconds(750)) { [weak self] in
-                (self?.listView.cellForItem(at: matchingIndexPath) as? OBAListViewCell)?.blink()
-            }
+        listView.scrollToItem(at: matchingIndexPath, at: .top, animated: true)
+
+        guard blinksAfterScroll else { return }
+
+        // There's no completionHandler for scrollToItem, so just wait 3/4 of
+        // a second for scrolling to hopefully finish.
+        // Note: If 750ms passes, but the cell is still not visible, then the `blink` won't appear.
+        scrollBlinkThrottler.throttle(deadline: .now() + .milliseconds(750)) { [weak self] in
+            (self?.listView.cellForItem(at: matchingIndexPath) as? OBAListViewCell)?.blink()
         }
     }
 

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -251,9 +251,8 @@ class TripViewController: UIViewController,
     }
 
     func showStopOnMap(_ tripStop: TripStopViewModel) {
-        self.floatingPanel.move(to: .half, animated: true) {
-            self.skipNextStopTimeHighlight = true
-            self.selectedStopTime = tripStop.stopTime
+        floatingPanel.move(to: .half, animated: true) { [weak self] in
+            self?.selectedStopTime = tripStop.stopTime
         }
     }
 
@@ -333,7 +332,13 @@ class TripViewController: UIViewController,
         return map
     }()
 
+    /// Armed by `selectedStopTime`'s `didSet` immediately before a programmatic
+    /// `selectAnnotation`, and consumed by the `didSelect` it provokes. Riders never
+    /// assign `selectedStopTime` — their taps arrive as `didSelect` — so every
+    /// selection this controller makes itself is one the rider did not ask for and
+    /// must not open a stop page.
     public var skipNextStopTimeHighlight = false
+
     public func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         guard let stopTime = view.annotation as? TripStopTime else { return }
         defer { skipNextStopTimeHighlight = false }
@@ -345,7 +350,10 @@ class TripViewController: UIViewController,
             return
         }
 
-        tripDetailsController.highlightStopInList(stopTime.stop)
+        // Scroll the list without blinking the row: `openStop` pushes the stop page on
+        // the next line, so the delayed blink would play underneath it and be over
+        // before the rider comes back. The scroll still leaves the row on screen for them.
+        tripDetailsController.highlightStopInList(stopTime.stop, blinksAfterScroll: false)
         openStop(stopTime, on: mapView)
     }
 
@@ -366,6 +374,14 @@ class TripViewController: UIViewController,
         // Same reason as `MapViewController`: leaving the tapped pin selected
         // only strands a highlight. MapKit will not fire `didSelect` again.
         mapView.deselectAnnotation(stopTime, animated: false)
+
+        // Callouts are off here, so selection is the open gesture — the same case
+        // `MapViewController` reports when a stop annotation has no chevron to tap.
+        application.analytics?.reportEvent(
+            pageURL: "app://localhost/trip",
+            label: AnalyticsLabels.mapStopAnnotationTapped,
+            value: nil
+        )
 
         application.viewRouter.navigateTo(stop: stopTime.stop, from: self, transferContext: transferContext)
     }
@@ -437,13 +453,6 @@ class TripViewController: UIViewController,
         didSet {
             guard !isBeingPreviewed else { return }
 
-            // Value-equal write (30s refresh of the same stop): nothing to
-            // select. Drop a leaked skip so the next pin tap still opens.
-            if oldValue == selectedStopTime {
-                skipNextStopTimeHighlight = false
-                return
-            }
-
             var animated = true
             if isFirstStopTimeLoad {
                 animated = false
@@ -457,28 +466,31 @@ class TripViewController: UIViewController,
             if let annotation = self.mapView.annotations
                 .filter(type: TripStopTime.self)
                 .filter({ $0.stopID == selectedStopTime.stopID }).first {
+                // Arm the skip here rather than at the call sites: this is the only
+                // statement that can provoke `didSelect`, so an arm can never outlive
+                // an assignment that found no annotation to select.
+                skipNextStopTimeHighlight = true
                 self.mapView.selectAnnotation(annotation, animated: true)
             }
         }
     }
     private var isFirstStopTimeLoad = true
+    private var hasAppliedOriginStopSelection = false
 
-    /// Auto-selects the rider's origin stop when trip details first load.
-    /// Later `$tripDetails` emissions (30s refresh) must not write origin
-    /// back if the rider deselected or picked another stop — that
-    /// `selectAnnotation` would fire `didSelect` → `openStop`.
+    /// Selects the rider's origin stop when trip details first arrive, and only then.
+    ///
+    /// `$tripDetails` republishes about every 30 seconds. A second programmatic select
+    /// would fire `didSelect` → `openStop` and push the stop page out from under
+    /// whatever the rider is doing. There is no rider selection to compare against
+    /// either: the load-time select is torn down inside its own call stack, because
+    /// `didSelect` consumes the skip, deselects the pin, and `didDeselect` clears
+    /// `selectedStopTime`.
     func applyOriginStopSelection(from details: TripDetails) {
+        guard !hasAppliedOriginStopSelection else { return }
         guard let arrivalDeparture = tripConvertible.arrivalDeparture else { return }
         guard let origin = details.stopTimes.first(where: { $0.stopID == arrivalDeparture.stopID }) else { return }
 
-        if let current = selectedStopTime, current.stopID != origin.stopID {
-            return
-        }
-        if selectedStopTime == nil && !isFirstStopTimeLoad {
-            return
-        }
-
-        skipNextStopTimeHighlight = true
+        hasAppliedOriginStopSelection = true
         selectedStopTime = origin
     }
 }

--- a/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
+++ b/OBAKitTests/Trip/TripMapAnnotationPolicyTests.swift
@@ -29,6 +29,25 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         ).entry
     }
 
+    /// An `ArrivalDeparture` with its references resolved. `Fixtures.arrivalDeparture()`
+    /// leaves `route` nil, and anything that reaches `openStop` reads it through
+    /// `TransferContext.from` — that crashed CI at `ArrivalDeparture.swift:221`.
+    private func loadReferencedArrivalDeparture() throws -> ArrivalDeparture {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        return try #require(stopArrivals.arrivalsAndDepartures.first)
+    }
+
+    private func analytics(for controller: TripViewController) throws -> AnalyticsMock {
+        try #require(controller.application.analytics as? AnalyticsMock)
+    }
+
+    private func stopAnnotationTapCount(_ analytics: AnalyticsMock) -> Int {
+        analytics.reportedEvents.filter { $0.label == AnalyticsLabels.mapStopAnnotationTapped }.count
+    }
+
     /// `viewFor` only applies the policy when `arrivalDeparture` is set. Building
     /// the controller from `TripConvertible(tripDetails:)` skipped that branch,
     /// so `canShowCallout` was just MKAnnotationView's default `false`.
@@ -84,21 +103,14 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
 
         #expect(nav.viewControllers.count == 1)
         #expect(nav.viewControllers.first === controller)
+        #expect(stopAnnotationTapCount(try analytics(for: controller)) == 0)
     }
 
-    /// A rider tap with callouts off still opens the stop.
-    ///
-    /// Needs a referenced `ArrivalDeparture`: `openStop` builds `TransferContext.from`,
-    /// which reads `routeShortName`. `Fixtures.arrivalDeparture()` leaves `route` nil
-    /// and crashed CI at `ArrivalDeparture.swift:221`.
+    /// A rider tap with callouts off still opens the stop, and reports the open —
+    /// `MapViewController` reports the identical "selection is the open gesture" case.
     @Test @MainActor
     func `User tap opens the stop when callouts are hidden`() throws {
-        let stopArrivals = try Fixtures.loadRESTAPIPayload(
-            type: StopArrivals.self,
-            fileName: "arrivals-and-departures-for-stop-1_10914.json"
-        )
-        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
-        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let controller = makeController(arrivalDeparture: try loadReferencedArrivalDeparture())
         let nav = UINavigationController(rootViewController: controller)
 
         let stopTime = try #require(try loadTripDetails().stopTimes.first)
@@ -109,34 +121,20 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         controller.mapView(MKMapView(), didSelect: annotationView)
 
         #expect(nav.viewControllers.count == 2)
+
+        let reported = try #require(try analytics(for: controller).reportedEvents.first)
+        #expect(reported.label == AnalyticsLabels.mapStopAnnotationTapped)
+        #expect(reported.pageURL == "app://localhost/trip")
     }
 
-    /// `$tripDetails` republishes every 30s. Re-assigning origin on every
-    /// emission is a value-equal write, so `didSet` must drop a leaked skip
-    /// arm — otherwise the next pin tap is swallowed. Do not load `.view`.
-    /// Does not tap-to-open: `Fixtures.arrivalDeparture` leaves `route` nil.
+    /// `$tripDetails` republishes every 30s, and the origin select is applied on the
+    /// first emission only. `selectedStopTime = nil` is the production teardown: the
+    /// load-time select fires `didSelect`, which consumes the skip, deselects the pin,
+    /// and `didDeselect` clears the property. A later emission must leave that nil
+    /// alone — writing origin back would fire `didSelect` → `openStop` and push the
+    /// stop page out from under the rider. Do not load `.view`.
     @Test @MainActor
-    func `Value-equal origin refresh clears a leaked skip arm`() throws {
-        let details = try loadTripDetails()
-        let originID = try #require(details.stopTimes.first?.stopID)
-        let arrivalDeparture = try Fixtures.arrivalDeparture(stopID: originID)
-        let controller = makeController(arrivalDeparture: arrivalDeparture)
-
-        controller.applyOriginStopSelection(from: details)
-        #expect(controller.skipNextStopTimeHighlight)
-        #expect(controller.selectedStopTime?.stopID == originID)
-
-        controller.applyOriginStopSelection(from: details)
-        #expect(!controller.skipNextStopTimeHighlight)
-        #expect(controller.selectedStopTime?.stopID == originID)
-    }
-
-    /// After the rider deselects (or picks another stop), a 30s refresh must
-    /// not write the origin back. That re-select would fire `didSelect` →
-    /// `openStop`. Setting `selectedStopTime = nil` is the production
-    /// `didDeselect` assignment. Do not load `.view`.
-    @Test @MainActor
-    func `Refresh does not reselect origin after the rider deselects`() throws {
+    func `Refresh does not reselect the origin stop`() throws {
         let details = try loadTripDetails()
         let originID = try #require(details.stopTimes.first?.stopID)
         let arrivalDeparture = try Fixtures.arrivalDeparture(stopID: originID)
@@ -149,6 +147,22 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
         controller.applyOriginStopSelection(from: details)
 
         #expect(controller.selectedStopTime == nil)
+        #expect(!controller.skipNextStopTimeHighlight)
+    }
+
+    /// A trip with no stop time for the rider's boarding stop selects nothing — and,
+    /// just as importantly, arms nothing. `skipNextStopTimeHighlight` is armed at the
+    /// `selectAnnotation` call site, so an assignment that finds no annotation cannot
+    /// leave an arm behind to swallow the rider's next pin tap. Do not load `.view`.
+    @Test @MainActor
+    func `No origin selection when the trip has no matching stop`() throws {
+        let details = try loadTripDetails()
+        let controller = makeController(arrivalDeparture: try Fixtures.arrivalDeparture(stopID: "no_such_stop"))
+
+        controller.applyOriginStopSelection(from: details)
+
+        #expect(controller.selectedStopTime == nil)
+        #expect(!controller.skipNextStopTimeHighlight)
     }
 
     /// Callouts are off, so selection is the only open gesture. Leaving the
@@ -157,12 +171,7 @@ final class TripMapAnnotationPolicyTests: OBATestCase {
     /// passed in — not `self.mapView`, which would load `.view`.
     @Test @MainActor
     func `Opening a stop deselects the pin so a second tap still opens`() throws {
-        let stopArrivals = try Fixtures.loadRESTAPIPayload(
-            type: StopArrivals.self,
-            fileName: "arrivals-and-departures-for-stop-1_10914.json"
-        )
-        let arrivalDeparture = try #require(stopArrivals.arrivalsAndDepartures.first)
-        let controller = makeController(arrivalDeparture: arrivalDeparture)
+        let controller = makeController(arrivalDeparture: try loadReferencedArrivalDeparture())
         let nav = UINavigationController(rootViewController: controller)
         let mapView = MKMapView()
         let stopTime = try #require(try loadTripDetails().stopTimes.first)

--- a/docs/trip-map-callouts.md
+++ b/docs/trip-map-callouts.md
@@ -6,32 +6,53 @@ origin pin; that programmatic select must not push the stop back on top.
 
 ## Skip flag
 
-`TripViewController.skipNextStopTimeHighlight` is armed on every programmatic
-assignment of `selectedStopTime` (first load, and `showStopOnMap` from the
-list). `mapView(_:didSelect:)` consumes the flag and skips `openStop`. It
-still deselects the pin: MapKit will not re-fire `didSelect` for an
-already-selected annotation, and the first tap on the origin stop would
-otherwise do nothing.
+`TripViewController.skipNextStopTimeHighlight` is armed by `selectedStopTime`'s
+`didSet`, immediately before the `selectAnnotation` it is there to cover.
+`mapView(_:didSelect:)` consumes the flag and skips `openStop`. It still
+deselects the pin: MapKit will not re-fire `didSelect` for an already-selected
+annotation, and the first tap on the origin stop would otherwise do nothing.
 
-A value-equal assignment (same `TripStopTime` on a 30s refresh) clears the
-flag in `selectedStopTime`'s `didSet` so a leaked arm cannot swallow the next
-tap.
+Arming at the `selectAnnotation` call site rather than at the assignment's
+callers is what keeps the flag from leaking. An assignment that finds no
+matching annotation — a stop the map has not been given yet — makes no
+selection, so there is no `didSelect` to consume an arm, and a leftover arm
+would swallow the rider's next real pin tap.
 
 `didSelect` also skips `highlightStopInList` when the flag is set. The origin
 pin is not highlighted in the trip list on load.
 
+## What load actually does
+
+There are two programmatic assignments: `applyOriginStopSelection` on the first
+`$tripDetails` emission, and `showStopOnMap` from a "Show on map" list action.
+Both tear themselves down inside their own call stack — `didSelect` consumes the
+skip and deselects, and `didDeselect` sets `selectedStopTime = nil`. So
+`selectedStopTime` is nil at every point the rider can observe, and neither the
+origin pin nor its list row stays highlighted after load.
+
 ## Refresh
 
 `$tripDetails` republishes about every 30 seconds. `applyOriginStopSelection`
-writes the origin only on the first load, or while the origin is still the
-selected stop. After the rider deselects (`didDeselect` → `selectedStopTime =
-nil`) or picks another stop, a later emission leaves that choice alone.
+writes the origin on the first load only, tracked by
+`hasAppliedOriginStopSelection`. That flag is set after the origin stop time is
+found, so an early emission that cannot supply one does not burn the single
+attempt. Later emissions do nothing: re-selecting would fire `didSelect` →
+`openStop` and push the stop page out from under whatever the rider is doing.
 
 ## Deselect after open
 
 `openStop` deselects the annotation on the `MKMapView` MapKit passed into
 `didSelect` (same pattern as `MapViewController`). Come back from the stop
 page and the same pin can be tapped again.
+
+It also reports `AnalyticsLabels.mapStopAnnotationTapped` against
+`app://localhost/trip` — the same "selection is the open gesture" case
+`MapViewController` reports for callout-less stop annotations.
+
+`didSelect` scrolls the list to the tapped stop but passes
+`blinksAfterScroll: false`. The blink is delayed 750 ms for scrolling to settle,
+which is under the stop page it is about to push, so the rider would never see
+it. The scroll still leaves the row on screen for their return.
 
 Tests must not load `TripViewController.view` (`viewDidLoad` reads an
 unresolved `ArrivalDeparture.route`).


### PR DESCRIPTION
Fixes #1349. Follow-ups from #1259 — no behavior change a rider can see, except the blink.

- `selectedStopTime` is nil except transiently inside one call stack, so `applyOriginStopSelection`'s "rider picked another stop" fall-through and the `oldValue == selectedStopTime` branch in the `didSet` can never run. Both removed. Apply-once is now an explicit `hasAppliedOriginStopSelection`, set after the origin lookup succeeds so an emission that can't supply one doesn't burn the attempt.
- That value-equal branch was clearing a leaked skip arm, so rather than delete the band-aid and leave the wound, `skipNextStopTimeHighlight` is now armed in the `didSet` immediately before `selectAnnotation` — the only statement that can provoke `didSelect`. An assignment that finds no annotation can no longer leave an arm behind to swallow the next pin tap.
- `didSelect` now scrolls the list with `blinksAfterScroll: false`. The 750 ms blink played underneath the stop page it pushes on the next line and was over before the rider came back. The scroll stays, so the row is on screen on their return.
- `openStop` reports `mapStopAnnotationTapped`, matching what `MapViewController` reports for the same callout-less "selection is the open gesture" case.
- `docs/trip-map-callouts.md`'s Refresh section described the old state machine. Rewritten, plus a short section stating that neither the origin pin nor its list row stays highlighted after load — the correction #1259's test plan needs.

Tests: dropped the value-equal test (its branch is gone), reworked the refresh test around the real teardown, and added coverage for the no-matching-stop case and for analytics on both `didSelect` paths.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trip stop selection to prevent unintended re-selection of the origin stop during refreshes.
  - Ensured trips without a matching origin stop do not trigger an incorrect selection.
  - Refined map and list synchronization when opening a stop.

- **User Experience**
  - Selecting a stop on the map now scrolls to it in the list without an unnecessary blink.
  - Stop openings from map annotations are now tracked for analytics.

- **Documentation**
  - Updated trip map behavior documentation to reflect selection, refresh, and deselection flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->