### PR TITLE
Make the vehicle interpolation docs match the 500 m snap threshold

### DIFF
--- a/OBAKit/Mapping/VehicleCoordinateUpdate.swift
+++ b/OBAKit/Mapping/VehicleCoordinateUpdate.swift
@@ -15,9 +15,9 @@ import UIKit
 /// Whether a vehicle marker should interpolate to a new coordinate or jump.
 ///
 /// Arrival polls land every 15–30s. Assigning `coordinate` each time teleports
-/// the pin; interpolating every hop looks like motion. Distances larger than
-/// one or two polls at motorway speed are a new fix (or a trip change), not
-/// something to ease across the map.
+/// the pin; interpolating every hop looks like motion. Hops longer than
+/// `snapBeyondMeters` are a new fix (or a trip change), not something to ease
+/// across the map.
 ///
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/1109
 enum VehicleCoordinateUpdate {

--- a/OBAKitTests/Mapping/VehicleCoordinateUpdateTests.swift
+++ b/OBAKitTests/Mapping/VehicleCoordinateUpdateTests.swift
@@ -35,7 +35,7 @@ struct VehicleCoordinateUpdateTests {
         #expect(decision == .animate(duration: VehicleCoordinateUpdate.animationDuration))
     }
 
-    /// Farther than one or two polls at motorway speed is a new fix, not motion.
+    /// Farther than `snapBeyondMeters` is a new fix, not motion.
     @Test func `A kilometre jump snaps`() {
         let far = CLLocationCoordinate2D(latitude: 47.62, longitude: -122.33)
         #expect(VehicleCoordinateUpdate.decision(from: seattle, to: far) == .snap)


### PR DESCRIPTION
## Summary

Part 1 of #1341: `VehicleCoordinateUpdate`'s type doc contradicted the constant it describes.

The header said distances "larger than one or two polls at motorway speed" are treated as a new fix. At 100 km/h over a 30s poll that's 830–1670 m — but `snapBeyondMeters` is **500 m**, documented on its own line as "a bit over one 30s poll at ~50 km/h". `VehicleCoordinateUpdateTests`'s `A kilometre jump snaps` repeated the same motorway framing.

The constant is the truth, so both comments now point at `snapBeyondMeters` rather than restating a threshold that drifts from it.

## Changes

- `OBAKit/Mapping/VehicleCoordinateUpdate.swift` — header doc refers to `snapBeyondMeters` instead of "one or two polls at motorway speed".
- `OBAKitTests/Mapping/VehicleCoordinateUpdateTests.swift` — same fix on the `A kilometre jump snaps` doc comment.

`snapBeyondMeters`' own doc is left as-is; it already describes the 500 m value accurately.

## Scope

Comment-only. No behavior change, no test changes, nothing added or removed from the API.

Parts 2–4 of #1341 (the sub-60 km/h interpolation window, `apply` test coverage, and `TripViewController`'s teleporting marker) are deliberately left out — each is a separate change and will follow in its own PR.

## Testing

- `swiftlint` clean on both touched files.
- No behavioral surface to exercise: the diff is four lines of prose.
