### PR TITLE
Address weather map button follow-ups from #1344

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -439,6 +439,15 @@ class MapViewController: UIViewController,
         var config = UIButton.Configuration.plain()
         config.imagePlacement = .top
         config.title = "—"
+        // The toolbar pins this button to 42pt (see the width constraint above),
+        // and `.plain()` ships nonzero horizontal insets that the old
+        // `UIButton(type: .system)` did not have. That left the title too little
+        // room: a two-digit temperature already wrapped onto three lines
+        // ("1", "8", "°"). Zero the horizontal insets only — the vertical ones
+        // still separate the icon from the temperature under `imagePlacement`.
+        // See: https://github.com/OneBusAway/onebusaway-ios/issues/1344
+        config.contentInsets.leading = 0
+        config.contentInsets.trailing = 0
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
             outgoing.font = UIFont.preferredFont(forTextStyle: .body).bold
@@ -446,6 +455,12 @@ class MapViewController: UIViewController,
         }
 
         let button = UIButton(configuration: config)
+        // Restores what `7f2c1b8b` intended before the Configuration switch
+        // dropped it, with the scale factor that version omitted: without a
+        // `minimumScaleFactor`, `adjustsFontSizeToFitWidth` never shrinks
+        // anything. Three-digit temperatures scale down rather than wrap.
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.titleLabel?.minimumScaleFactor = 0.7
         button.addTarget(self, action: #selector(showWeather), for: .touchUpInside)
         button.accessibilityLabel = OBALoc("map_controller.show_weather_button", value: "Show Weather Forecast", comment: "Accessibility label for a button that provides the current forecast")
         return button

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -469,7 +469,6 @@ class MapViewController: UIViewController,
                 // Configuration-based buttons ignore `setTitle`/`setImage`. Update
                 // the configuration only so the stacked icon + temp actually show.
                 var config = weatherButton.configuration ?? .plain()
-                config.imagePlacement = .top
                 config.image = UIImage(systemName: WeatherFormatter.systemImageName(for: display.header.iconName))?
                     .withRenderingMode(.alwaysTemplate)
                 config.title = display.buttonTitle

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "وقت الوصول عند التبديل";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@، %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "احتمال هطول المطر: %d%%";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1658,6 +1658,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Transfer arrival time";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Chance of Rain: %d%%";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Hora de llegada del transbordo";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Probabilidad de lluvia: %d%%";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Oras ng pagdating ng transfer";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Tsansa ng Ulan: %d%%";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Heure d'arrivée de la correspondance";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Risque de pluie : %d %%";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Orario di arrivo della coincidenza";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Probabilità di pioggia: %d%%";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "환승 도착 시간";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "강수 확률: %d%%";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Godzina przyjazdu na przesiadkę";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Szansa opadów deszczu: %d%%";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Horário de chegada da baldeação";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Chance de Chuva: %d%%";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Время прибытия на пересадку";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Вероятность дождя: %d%%";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "Giờ đến khi chuyển tuyến";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@, %2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "Khả năng có mưa: %d%%";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "换乘到站时间";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@，%2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "降雨概率：%d%%";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1656,6 +1656,9 @@
 /* Accessibility label for the transfer arrival banner shown when navigating to a connecting stop. */
 "walk_time_view.transfer_accessibility_label" = "轉乘抵達時間";
 
+/* Spoken value for the map weather control. First %@ is the temperature, second is the weather condition. */
+"weather.button_accessibility_value_format" = "%1$@，%2$@";
+
 /* Format for the chance-of-rain percentage on the weather card header. %d is the integer percent. */
 "weather.chance_of_rain_format" = "降雨機率：%d%%";
 

--- a/OBAKit/ViewModels/MapViewModel/WeatherDisplay.swift
+++ b/OBAKit/ViewModels/MapViewModel/WeatherDisplay.swift
@@ -56,7 +56,14 @@ struct WeatherDisplay: Equatable {
     /// Unknown-icon placeholder "—" is still included so VoiceOver always
     /// has the temperature.
     var buttonAccessibilityValue: String {
-        "\(buttonTitle), \(header.conditionSummary)"
+        String(
+            format: OBALoc(
+                "weather.button_accessibility_value_format",
+                value: "%@, %@",
+                comment: "Spoken value for the map weather control. First %@ is the temperature, second is the weather condition."
+            ),
+            buttonTitle, header.conditionSummary
+        )
     }
 }
 

--- a/docs/weather-map-button.md
+++ b/docs/weather-map-button.md
@@ -1,8 +1,11 @@
 # Weather map button
 
-The map weather control shows a condition SF Symbol plus the temperature
-(for example a sun icon above `71°`). The full condition word is not used as
-the visible title because it will not fit the 42pt hover bar.
+The map weather control shows a condition SF Symbol plus the temperature.
+The two surfaces stack it differently: the UIKit hover-bar button
+(`MapViewController.weatherButton`) sets `imagePlacement = .top`, so the icon
+sits *above* `71°`, while the SwiftUI pill (`WeatherButton`) lays them out in
+an `HStack`, so the icon sits *beside* it. The full condition word is not used
+as the visible title on either because it will not fit the 42pt hover bar.
 
 VoiceOver still gets both pieces: the button's accessibility label stays
 "Show Weather Forecast", and the value is temperature plus condition


### PR DESCRIPTION
## PR Description

Parts 1–4 of #1344.

### Changes

- **Fix the 42pt toolbar button wrapping**
  - Part 1 was a real bug, and worse than expected: the 42pt toolbar button wrapped a two-digit temperature onto three lines — `18°` rendered as `1 / 8 / °`.

    | Before | After |
    |:---:|:---:|
    | <img width="250" alt="Before" src="https://github.com/user-attachments/assets/77048d73-6719-464b-a64f-f46036003790" /> | <img width="250" alt="After" src="https://github.com/user-attachments/assets/42c0b764-3027-482b-9934-142769872af1" /> |

  - The cause was `.plain()`, which adds horizontal `contentInsets` that `UIButton(type: .system)` did not have, leaving the title with significantly less than 42pt of usable width.
  - Zeroed the horizontal insets only. The vertical insets remain so the icon and temperature stay separated with `imagePlacement = .top`.
  - Restored `adjustsFontSizeToFitWidth` with a `minimumScaleFactor`. The existing 2019 flag was effectively a no-op without a minimum scale factor, so three-digit temperatures now scale instead of wrapping.

- **Localize `buttonAccessibilityValue`**
  - Routed it through `OBALoc` instead of hardcoding `", "`.
  - `zh-Hans` / `zh-Hant` now use `，`.
  - Arabic now uses `،`.
  - Added the key to all 13 catalogs.

- **Update weather map button documentation**
  - `docs/weather-map-button.md` now documents both surfaces:
    - `imagePlacement = .top` in UIKit.
    - `HStack` in the SwiftUI pill.

- **Remove duplicate configuration**
  - Dropped the duplicate `imagePlacement` assignment from `weatherDisplay`'s `didSet`.

Closes #1344.


