### PR TITLE
Document that an empty DevelopURL can hide the whole Help Out section

### DIFF
--- a/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
+++ b/OBAKit/OBAKit.docc/Articles/WhiteLabel.md
@@ -181,7 +181,7 @@ Nested keys (all optional):
 * `HeaderSupportText` - String shown in the branded header box. Omit or leave empty to keep the default volunteer-support copy.
 * `ShowHelpOutSection` - Boolean. Defaults to `true`. Set `false` to hide the "Help make the app better" section (translate / develop rows).
 * `TranslateURL` - URL for "Help Translate the App". Omit to hide that row. OneBusAway currently omits it; white-label apps can opt in.
-* `DevelopURL` - URL for "Help Fix Bugs & Build New Features". Defaults to the OneBusAway iOS GitHub repo when omitted. An empty string hides the row.
+* `DevelopURL` - URL for "Help Fix Bugs & Build New Features". Defaults to the OneBusAway iOS GitHub repo when omitted. An empty string hides the row — and because the section is dropped when it has no rows left, an empty `DevelopURL` also hides the "Help make the app better" header whenever `TranslateURL` is absent, which is the OneBusAway default. Set `ShowHelpOutSection` to `false` when hiding the whole section is the intent.
 * `TutorialURL`, `PhoneURL`, `TextURL` - Optional. When set, they appear under "Contact & Help" as Tutorials, Call Agency, and Text Agency. `tel:` and `sms:` URLs are valid. Empty strings are ignored.
 * `CustomLinks` - Array of `{Title, URL}` dictionaries. Shown under "Resources". A row is dropped if `Title` or `URL` is missing or the URL is empty.
 


### PR DESCRIPTION
## Description

`helpOutSection` returns `nil` when it has no rows. This means `DevelopURL: ""` doesn't just hide the Develop row — when `TranslateURL` is absent, which is the OneBusAway default, it also removes the **"Help make the app better"** header.

The documentation only promised that the row would be hidden.

The docs now also point to `ShowHelpOutSection: false` as the intended way to deliberately hide the entire section.

Closes #1339.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how an empty `DevelopURL` value affects the More tab.
  * Documented that the “Help make the app better” section may be hidden when no other links are available.
  * Added guidance to disable `ShowHelpOutSection` when the entire section should remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->