### PR TITLE
Localize the map route overflow marker and drop two vacuous assertions

### DIFF
--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "غادرت في الموعد";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "الآن";
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "departed on time";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "NOW";
 

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "salió a tiempo";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "AHORA";
 

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "umalis sa oras";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "NGAYON";
 

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "parti à l'heure";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "MAINT.";
 

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "partito in orario";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "ADESSO";
 

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "정시에 출발함";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "지금";
 

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "odjechał na czas";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "TERAZ";
 

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "partiu no horário";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "AGORA";
 

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "отправился вовремя";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "СЕЙЧАС";
 

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "đã khởi hành đúng giờ";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@…";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "NGAY";
 

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "已准时离站";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@……";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "现在";
 

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -339,6 +339,9 @@
 /* Describes an on-time departure. e.g. departed on time. */
 "formatters.deviation.departure_past_on_time" = "已準點離站";
 
+/* Overflowing map-pin route list. The argument is the visible names; U+2026 marks that more routes exist. e.g. '10, 12, 49…' */
+"formatters.map_routes_overflow_fmt" = "%@……";
+
 /* Short formatted time text for arrivals/departures occurring now. */
 "formatters.now" = "現在";
 

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -193,9 +193,8 @@ final class FormattersTests: OBATestCase {
         let stop = try #require(Fixtures.loadSomeStops().first)
         stop.routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
 
-        let callout = try #require(stop.mapCalloutText)
+        let callout = stop.mapCalloutText
         #expect(callout == "#\(stop.code)\n10, 20, 30…")
-        #expect(!callout.contains("more"))
         #expect(!callout.contains("Routes:"))
 
         let subtitle = try #require(stop.subtitle)
@@ -203,7 +202,6 @@ final class FormattersTests: OBATestCase {
         #expect(subtitle.contains("Routes:"))
         #expect(subtitle.contains("62"))
         #expect(!subtitle.contains("\u{2026}"))
-        #expect(!subtitle.contains("more"))
     }
 
     private func makeRoutes(shortNames: [String]) throws -> [Route] {


### PR DESCRIPTION
## Description

`formatters.map_routes_overflow_fmt` was missing from all 13 OBAKitCore catalogs. As a result, every locale fell back to the `%@…` default, meaning the translator substitutability described in the doc comment was aspirational.

### Changes

- Added `formatters.map_routes_overflow_fmt` to all 13 catalogs.
  - `zh-Hans` / `zh-Hant` use `%@……`.
- Removed two assertions that can never fail.
- Removed the `try #require` on `mapCalloutText`, since it returns a non-optional `String`.
- Kept the `#require` on `subtitle`, since that value is optional.
- Added the localization entries by hand rather than running `scripts/extract_strings`, which would have rewritten unrelated keys in the OBAKit catalog.

Refr #1342.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map pins now indicate additional routes with an ellipsis when the full route list cannot be displayed.
  * Added localized support for this display across supported languages.

* **Tests**
  * Updated map callout coverage to reflect ellipsis-based overflow formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->