### PR TITLE
Correct the rental clustering marker bound and scope its test defaults

### DIFF
--- a/OBAKit/Mapping/Layers/RentalClustering.swift
+++ b/OBAKit/Mapping/Layers/RentalClustering.swift
@@ -31,10 +31,10 @@ import OTPKit
 /// vehicles to be rebucketed wholesale. Projected space eliminates this amplification.
 ///
 /// This is also what makes a density cap unnecessary. Marker count is bounded by
-/// *occupied cells* (screen area ÷ cell area, roughly 90 on an iPhone-sized
-/// map), not by how many vehicles the viewport holds, so `RentalMapLayer`'s
-/// 500-vehicle `densityBudget` never translates into 500 SwiftUI views — and no
-/// vehicle is ever silently dropped to stay under a limit.
+/// *occupied cells* (screen area ÷ cell area, roughly 36 at the default 100pt
+/// cell size on a 390×844 map), not by how many vehicles the viewport holds, so
+/// `RentalMapLayer`'s 500-vehicle `densityBudget` never translates into 500
+/// SwiftUI views — and no vehicle is ever silently dropped to stay under a limit.
 ///
 /// Cluster centroids are clamped to within `cellSize/4` (a quarter-cell) of
 /// their cell's centre. This guarantees that adjacent cells' markers are

--- a/OBAKitTests/Mapping/BackgroundAnnotationDeemphasisTests.swift
+++ b/OBAKitTests/Mapping/BackgroundAnnotationDeemphasisTests.swift
@@ -177,7 +177,7 @@ final class BackgroundAnnotationDeemphasisTests: OBATestCase {
         )
         let coordinator = RentalLayerCoordinator(
             service: StubVehicleRentalService(),
-            locationService: LocationService(userDefaults: UserDefaults(), locationManager: locationManager)
+            locationService: LocationService(userDefaults: userDefaults, locationManager: locationManager)
         )
         let layer = RentalMapLayer.bikesLayer(coordinator: coordinator)
         let rental = RentalAnnotation(rental: try RentalFixtures.vehicle())

--- a/OBAKitTests/Mapping/RentalAnnotationSyncerTests.swift
+++ b/OBAKitTests/Mapping/RentalAnnotationSyncerTests.swift
@@ -21,6 +21,11 @@ import OBAKitCore
 @Suite(.serialized)
 final class RentalAnnotationSyncerTests {
 
+    /// Suite-scoped rather than `UserDefaults()`, which is `.standard`: separate
+    /// suites run concurrently, so standard defaults let one suite observe
+    /// another's writes. Mirrors `OBATestCase.buildUserDefaults()`.
+    private let userDefaults = UserDefaults(suiteName: "RentalAnnotationSyncerTests.\(UUID().uuidString)")!
+
     private struct StubVehicleRentalService: VehicleRentalService {
         func fetchVehicleRentals(
             in boundingBox: VehicleRentalBoundingBox,
@@ -38,7 +43,7 @@ final class RentalAnnotationSyncerTests {
         )
         let coordinator = RentalLayerCoordinator(
             service: StubVehicleRentalService(),
-            locationService: LocationService(userDefaults: UserDefaults(), locationManager: locationManager)
+            locationService: LocationService(userDefaults: userDefaults, locationManager: locationManager)
         )
         return (RentalAnnotationSyncer(coordinator: coordinator, mapView: mapView), mapView)
     }

--- a/OBAKitTests/Mapping/RentalClusteringTests.swift
+++ b/OBAKitTests/Mapping/RentalClusteringTests.swift
@@ -144,7 +144,7 @@ struct RentalClusteringTests {
 
     /// The property that removes the need for a density cap: marker count is
     /// bounded by occupied cells, not by how many vehicles are in the viewport.
-    @Test func `Marker count is bounded by viewport cells at extreme density`() throws {
+    @Test func `Marker count stays far below vehicle count at extreme density`() throws {
         let crowd = try (0..<500).map { index in
             try RentalFixtures.vehicle(
                 id: "v\(index)",
@@ -155,8 +155,13 @@ struct RentalClusteringTests {
 
         let result = items(crowd)
 
-        let maxCells = Int(ceil(mapSize.width / 60)) * Int(ceil(mapSize.height / 60))
-        #expect(result.count <= maxCells)
+        // `result.count < 500` is the assertion that carries the property: 500
+        // vehicles collapse to a fraction of that. The cell count below is a
+        // sanity bound, not the real invariant — bucketing happens in global
+        // map-point space, so a viewport-derived figure only bounds the result
+        // because this fixture fits inside one viewport.
+        let viewportCells = Int(ceil(mapSize.width / 60)) * Int(ceil(mapSize.height / 60))
+        #expect(result.count <= viewportCells)
         #expect(result.count < 500)
     }
 

--- a/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
+++ b/OBAKitTests/Mapping/RentalLayerCoordinatorTests.swift
@@ -27,6 +27,11 @@ import OTPKit
 @Suite(.serialized)
 final class RentalLayerCoordinatorTests {
 
+    /// Suite-scoped rather than `UserDefaults()`, which is `.standard`: separate
+    /// suites run concurrently, so standard defaults let one suite observe
+    /// another's writes. Mirrors `OBATestCase.buildUserDefaults()`.
+    private let userDefaults = UserDefaults(suiteName: "RentalLayerCoordinatorTests.\(UUID().uuidString)")!
+
     /// Never actually called in these tests (no `await` reaches it), but the
     /// coordinator's initializer requires a `VehicleRentalService` to construct its
     /// `VehicleRentalSource`.
@@ -48,7 +53,7 @@ final class RentalLayerCoordinatorTests {
         )
         return RentalLayerCoordinator(
             service: StubVehicleRentalService(),
-            locationService: LocationService(userDefaults: UserDefaults(), locationManager: locationManager)
+            locationService: LocationService(userDefaults: userDefaults, locationManager: locationManager)
         )
     }
 


### PR DESCRIPTION
## PR Description

Parts 2–4 of #1350.

### Changes

- Corrected the class documentation:
  - The previous **"roughly 90"** figure came from the tests using `cellSize: 60`.
  - Production uses a default `cellSize` of `100`, which works out to roughly 36 cells on a 390×844 map.

- Renamed the marker-count test to reflect what it actually verifies.
  - The cell count remains as a sanity bound, with a comment explaining that it is **not the real invariant**, since bucketing happens in global map-point space.

- Updated the three new test helpers to use suite-scoped `UserDefaults` instead of `UserDefaults()` / `.standard`, matching `OBATestCase`.

Refs #1350.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the expected occupied-cell count for the default rental map grid on a 390×844 viewport.

* **Tests**
  * Improved test isolation by using unique, suite-scoped settings.
  * Clarified density-bound test naming and expectations without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->