### PR TITLE
Pluralize rental cluster titles to avoid “1 vehicles here”

### DIFF
--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -331,7 +331,7 @@ struct RentalClusterListView: View {
                 .buttonStyle(.plain)
             }
             .listStyle(.plain)
-            .navigationTitle(String(format: OBALoc("rental_cluster.title_fmt", value: "%d vehicles here", comment: "Title of the sheet listing the members of a rental cluster"), rentals.count))
+            .navigationTitle(String(format: OBALoc("rental_cluster.title_fmt", value: "%d vehicles here", comment: "Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), rentals.count))
             .navigationBarTitleDisplayMode(.inline)
             .sheet(item: $selectedRental) { rental in
                 RentalDetailView(

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -331,7 +331,12 @@ struct RentalClusterListView: View {
                 .buttonStyle(.plain)
             }
             .listStyle(.plain)
-            .navigationTitle(String(format: OBALoc("rental_cluster.title_fmt", value: "%d vehicles here", comment: "Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), rentals.count))
+            // `localizedStringWithFormat`, not `String(format:)`: the latter expands
+            // `%#@count@` but always resolves it against the root plural rule, so the
+            // `few`/`many`/`zero`/`two` forms in the ar, pl, and ru entries could never
+            // be selected. A cluster always holds at least two, so this is the common
+            // case, not an edge one. Same trap as `SearchResultsSheetView`.
+            .navigationTitle(String.localizedStringWithFormat(OBALoc("rental_cluster.title_fmt", value: "%d vehicles here", comment: "Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."), rentals.count))
             .navigationBarTitleDisplayMode(.inline)
             .sheet(item: $selectedRental) { rental in
                 RentalDetailView(

--- a/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
+++ b/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
@@ -107,8 +107,11 @@ struct RentalClusterMapMarker: View {
                 .foregroundStyle(.white)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(String(
-            format: OBALoc(
+        // `localizedStringWithFormat`, not `String(format:)` — see the note on the
+        // sheet's `navigationTitle`; VoiceOver would otherwise read the root plural
+        // form for every count.
+        .accessibilityLabel(Text(String.localizedStringWithFormat(
+            OBALoc(
                 "rental_cluster.title_fmt",
                 value: "%d vehicles here",
                 comment: "Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."

--- a/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
+++ b/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
@@ -111,7 +111,7 @@ struct RentalClusterMapMarker: View {
             format: OBALoc(
                 "rental_cluster.title_fmt",
                 value: "%d vehicles here",
-                comment: "Title of the sheet listing the members of a rental cluster"
+                comment: "Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback."
             ),
             count
         )))

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "الإبلاغ عن مشكلة";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d مركبة هنا";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "الإبلاغ عن مشكلة في الموقف عند %@";
 

--- a/OBAKit/Strings/ar.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ar.lproj/Localizable.stringsdict
@@ -74,6 +74,30 @@
 			<string>%2$d طبقة مفعّلة</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>لا توجد مركبات هنا</string>
+			<key>one</key>
+			<string>مركبة واحدة هنا</string>
+			<key>two</key>
+			<string>مركبتان هنا</string>
+			<key>few</key>
+			<string>%d مركبات هنا</string>
+			<key>many</key>
+			<string>%d مركبة هنا</string>
+			<key>other</key>
+			<string>%d مركبة هنا</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Report a Problem";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d vehicles here";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Report a problem with the stop at %@";
 

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d layers on</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 vehicle here</string>
+			<key>other</key>
+			<string>%d vehicles here</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Informar un problema";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d vehículos aquí";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Informar un problema con la parada %@";
 

--- a/OBAKit/Strings/es.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/es.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d capas activadas</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 vehículo aquí</string>
+			<key>other</key>
+			<string>%d vehículos aquí</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Mag-ulat ng Problema";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d na sasakyan dito";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Mag-ulat ng problema sa hintuan sa %@";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -61,7 +61,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>1 sasakyan dito</string>
+			<string>%d sasakyan dito</string>
 			<key>other</key>
 			<string>%d na sasakyan dito</string>
 		</dict>

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d na layer ang naka-on</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 sasakyan dito</string>
+			<key>other</key>
+			<string>%d na sasakyan dito</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Signaler un problème";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d véhicules ici";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Signaler un problème concernant l'arrêt %@";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fr.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d couches activées</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d véhicule ici</string>
+			<key>other</key>
+			<string>%d véhicules ici</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Segnala un problema";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d veicoli qui";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Segnala un problema con la fermata %@";
 

--- a/OBAKit/Strings/it.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/it.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d livelli attivi</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 veicolo qui</string>
+			<key>other</key>
+			<string>%d veicoli qui</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "문제 신고";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "여기에 차량 %d대";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "%@ 정류장의 문제 신고";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ko.lproj/Localizable.stringsdict
@@ -44,6 +44,20 @@
 			<string>레이어 %2$d개 켜짐</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>여기에 차량 %d대</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Zgłoś problem";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d pojazdów tutaj";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Zgłoś problem z przystankiem przy %@";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pl.lproj/Localizable.stringsdict
@@ -62,6 +62,26 @@
 			<string>%2$d warstwy włączonej</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 pojazd tutaj</string>
+			<key>few</key>
+			<string>%d pojazdy tutaj</string>
+			<key>many</key>
+			<string>%d pojazdów tutaj</string>
+			<key>other</key>
+			<string>%d pojazdu tutaj</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Relatar um Problema";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d veículos aqui";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Relatar um problema com a parada %@";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -61,7 +61,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>1 veículo aqui</string>
+			<string>%d veículo aqui</string>
 			<key>other</key>
 			<string>%d veículos aqui</string>
 		</dict>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -50,6 +50,22 @@
 			<string>%2$d camadas ativadas</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>1 veículo aqui</string>
+			<key>other</key>
+			<string>%d veículos aqui</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Сообщить о проблеме";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "Здесь %d транспортных средств";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Сообщить о проблеме с остановкой %@";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ru.lproj/Localizable.stringsdict
@@ -62,6 +62,26 @@
 			<string>включено %2$d слоя</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Здесь %d транспортное средство</string>
+			<key>few</key>
+			<string>Здесь %d транспортных средства</string>
+			<key>many</key>
+			<string>Здесь %d транспортных средств</string>
+			<key>other</key>
+			<string>Здесь %d транспортного средства</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "Báo cáo sự cố";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "%d phương tiện ở đây";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Báo cáo sự cố với điểm dừng tại %@";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/vi.lproj/Localizable.stringsdict
@@ -44,6 +44,20 @@
 			<string>%2$d lớp đang bật</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d phương tiện ở đây</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "报告一个问题";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "这里有 %d 辆车";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "报告%@车站的问题";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
@@ -44,6 +44,20 @@
 			<string>已开启 %2$d 个图层</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>这里有 %d 辆车</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -900,6 +900,9 @@
 /* Title of the Report Problem view controller. */
 "report_problem.title" = "回報問題";
 
+/* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"rental_cluster.title_fmt" = "這裡有 %d 輛車";
+
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "回報「%@」站牌的問題";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
@@ -44,6 +44,20 @@
 			<string>已開啟 %2$d 個圖層</string>
 		</dict>
 	</dict>
+	<key>rental_cluster.title_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>這裡有 %d 輛車</string>
+		</dict>
+	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -39,7 +39,8 @@ final class LocalizationTests {
         "data_migration_bulletin.report_summary_number_of_failures",
         "data_migration_bulletin.report_summary_number_of_successes",
         "map_controller.map_type.accessibility_value_with_layers_fmt",
-        "search_results_sheet.result_count_fmt"
+        "search_results_sheet.result_count_fmt",
+        "rental_cluster.title_fmt"
     ]
 
     /// `%@`, `%d`, `%1$@`, `%2$d`, … and the escaped `%%`.


### PR DESCRIPTION
## PR Description

`rental_cluster.title_fmt` had no `.stringsdict` entry and wasn't present in any `.strings` catalog, so every locale fell back to `%d vehicles here`. Since `rentals(withIDs:)` drops members that have left the feed, `count == 1` is reachable.

### Changes

- Added the plural entry across all 13 locales, plus the not-found fallback, matching the existing `data_migration_bulletin.*` setup.
- Both call sites — `RentalDetailViewController` and `RentalMapMarker` — use the key, so both are covered.
- French keeps `%d` in one plural category because that category covers both 0 and 1, and 0 is reachable here.
- Arabic's zero/one/two forms carry the number in the localized word, matching the existing entries in that catalog.

closes #1350.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added localized rental-cluster titles with accurate vehicle-count pluralization across supported languages.
  * Improved plural handling for languages with complex grammatical rules.
  * Updated region onboarding wording and added current-region labels.
  * Added localized accessibility text for arrival announcements and weather controls.

* **Accessibility**
  * VoiceOver now announces rental-cluster vehicle counts using the correct plural forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->