### PR TITLE
Shorten the share escape's bar button title so it fits beside Cancel

### DIFF
--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "مشاركة الرحلة دون تحديد محطة وصول";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "مشاركة على أي حال";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "مشاركة دون وجهة";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Share trip without a destination stop";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Share Anyway";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Share Without Destination";
 

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "destination_stop_picker.share_without_destination_a11y_label" = "Compartir viaje sin parada de destino";
 
 /* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
-"destination_stop_picker.share_without_destination_bar_button" = "Compartir igualmente";
+"destination_stop_picker.share_without_destination_bar_button" = "Aun así";
 
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Compartir sin destino";

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Compartir viaje sin parada de destino";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Compartir igualmente";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Compartir sin destino";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Ibahagi ang biyahe nang walang hintuang patutunguhan";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Ibahagi pa rin";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Ibahagi nang Walang Destinasyon";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Partager le trajet sans arrêt de destination";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Partager quand même";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Partager sans destination";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Condividi l'itinerario senza fermata di destinazione";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Condividi comunque";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Condividi senza destinazione";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "목적지 정류장 없이 여정 공유";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "그래도 공유";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "목적지 없이 공유";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Udostępnij kurs bez przystanku docelowego";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Udostępnij mimo to";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Udostępnij bez celu podróży";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Compartilhar viagem sem parada de destino";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Compartilhar assim mesmo";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Compartilhar sem destino";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "destination_stop_picker.share_without_destination_a11y_label" = "Compartilhar viagem sem parada de destino";
 
 /* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
-"destination_stop_picker.share_without_destination_bar_button" = "Compartilhar assim mesmo";
+"destination_stop_picker.share_without_destination_bar_button" = "Mesmo assim";
 
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Compartilhar sem destino";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Поделиться поездкой без остановки назначения";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Всё равно поделиться";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Поделиться без пункта назначения";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "Chia sẻ chuyến đi mà không có điểm dừng đến";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "Vẫn chia sẻ";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "Chia sẻ không kèm điểm đến";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "不选择目的地站点，直接分享车程";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "仍然分享";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "不选目的地直接分享";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 /* VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded. */
 "destination_stop_picker.share_without_destination_a11y_label" = "不選擇目的地站牌，直接分享行程";
 
+/* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
+"destination_stop_picker.share_without_destination_bar_button" = "仍然分享";
+
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "不選目的地直接分享";
 

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -251,6 +251,15 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
             value: "Share trip without a destination stop",
             comment: "VoiceOver label for the navigation bar button that shares the trip when no destination could be loaded."
         )
+        // Voice Control matches the spoken phrase against these rather than the
+        // accessibility label, which is deliberately longer than the title. Without
+        // them, "Tap Share Anyway" — the words actually on screen — matches nothing,
+        // and the gap is widest in the locales where the short title shares no words
+        // with the full phrase.
+        item.accessibilityUserInputLabels = [
+            Self.shareWithoutDestinationBarButtonTitle,
+            Self.shareWithoutDestinationTitle
+        ]
         return item
     }()
 

--- a/OBAKit/Trip/DestinationStopPickerController.swift
+++ b/OBAKit/Trip/DestinationStopPickerController.swift
@@ -218,20 +218,30 @@ class DestinationStopPickerController: UIViewController, AppContext, OBAListView
 
     // MARK: - Share Escape
 
-    /// One string for two surfaces: the empty state's body button and the error
-    /// state's navigation bar escape. A second key for the same words is the
-    /// defect this change set exists to remove.
+    /// The empty state's body button, which has a full row to itself.
     private static let shareWithoutDestinationTitle = OBALoc(
         "destination_stop_picker.share_without_destination_button",
         value: "Share Without Destination",
         comment: "Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination."
     )
 
+    /// The navigation bar shares its width with the title and Cancel, where the
+    /// full phrase does not fit — Russian runs to 32 characters. A distinct key
+    /// because this is a shorter phrase for a narrower surface, not a second key
+    /// for the same words. The bar button's accessibility label still carries the
+    /// full phrase, so the shorter visible title costs VoiceOver nothing.
+    /// See: https://github.com/OneBusAway/onebusaway-ios/issues/1348
+    private static let shareWithoutDestinationBarButtonTitle = OBALoc(
+        "destination_stop_picker.share_without_destination_bar_button",
+        value: "Share Anyway",
+        comment: "Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit."
+    )
+
     /// Built once rather than per state change: the item carries no state, so
     /// there is nothing to rebuild.
     private lazy var shareWithoutDestinationButton: UIBarButtonItem = {
         let item = UIBarButtonItem(
-            title: Self.shareWithoutDestinationTitle,
+            title: Self.shareWithoutDestinationBarButtonTitle,
             style: .plain,
             target: self,
             action: #selector(shareWithoutDestinationTapped)

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -482,6 +482,13 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         let shareItem = try #require(controller.navigationItem.rightBarButtonItem)
         #expect(shareItem.title == "Share Anyway")
         #expect(shareItem.accessibilityLabel == "Share trip without a destination stop")
+        // Voice Control matches the spoken phrase against these, not the label. The
+        // visible title and the label deliberately differ, so both have to be here
+        // or "Tap Share Anyway" matches nothing.
+        #expect(shareItem.accessibilityUserInputLabels == [
+            "Share Anyway",
+            "Share Without Destination"
+        ])
         #expect(
             standardEmptyData(controller, listView)?.buttonConfig?.text == "Try Again",
             "The escape must not cost the error state its retry button"

--- a/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
+++ b/OBAKitTests/Trip/DestinationStopPickerControllerTests.swift
@@ -451,6 +451,11 @@ final class DestinationStopPickerControllerTests: OBATestCase {
     /// empty state does — from the navigation bar, because
     /// `StandardEmptyDataViewModel` holds exactly one `buttonConfig` and `.error`
     /// must keep its retry.
+    ///
+    /// The bar carries the short title while the empty state's body button keeps
+    /// the long one (asserted separately) — the bar shares its width with the
+    /// title and Cancel, where the full phrase does not fit. The accessibility
+    /// label still speaks the full phrase, which is why shortening it is safe.
     @Test @MainActor
     func `Error state offers a share escape without giving up the retry button`() async throws {
         let arrivalDeparture = try makeArrivalDeparture()
@@ -475,7 +480,7 @@ final class DestinationStopPickerControllerTests: OBATestCase {
         )
 
         let shareItem = try #require(controller.navigationItem.rightBarButtonItem)
-        #expect(shareItem.title == "Share Without Destination")
+        #expect(shareItem.title == "Share Anyway")
         #expect(shareItem.accessibilityLabel == "Share trip without a destination stop")
         #expect(
             standardEmptyData(controller, listView)?.buttonConfig?.text == "Try Again",


### PR DESCRIPTION
## PR Description

The bar button reused the body button's **"Share Without Destination"** title, which reaches 32 characters in Russian and 27 in Polish. That's too long when sharing the bar with **"Select Destination"** and **Cancel**.

It now uses the shorter **"Share Anyway"** key:
- Russian: 20 characters
- Polish: 18 characters

The body button keeps the full phrase since it has a row to itself.

### Why a separate key?

I went with a shorter localized title rather than adding a second `buttonConfig` to `StandardEmptyDataViewModel`. That control is used app-wide, while the constraint is specific to this screen.

The button's accessibility label already carries the full phrase in all 13 locales, so no information is lost for VoiceOver users.

This is intentionally a **distinct localization key**, not a key reuse: it's a shorter phrase for a narrower UI surface.

Also updated the doc comment, which previously stated that using a second key would be a defect.

Closes #1348.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shorter “Share Anyway” navigation-bar action when sharing a trip without selecting a destination.
  * Added localized labels for this action across supported languages.

* **Accessibility**
  * Preserved the existing accessibility label for the sharing action.

* **Tests**
  * Updated coverage to reflect the new navigation-bar button title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->