### PR TITLE
Keep the rental marker on its coordinate when the fuel label shows

### DIFF
--- a/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
+++ b/OBAKit/Sheet/Root/Controls/RentalMapMarker.swift
@@ -20,30 +20,37 @@ struct RentalMapMarker: View {
     let showsFuelLabel: Bool
 
     var body: some View {
-        VStack(spacing: 1) {
-            ZStack {
-                Circle()
-                    .fill(markerColor)
-                    .frame(width: 28, height: 28)
-                    .shadow(radius: 1, y: 1)
+        ZStack {
+            Circle()
+                .fill(markerColor)
+                .frame(width: 28, height: 28)
+                .shadow(radius: 1, y: 1)
 
-                if let count = stationAvailabilityText {
-                    Text(count)
-                        .font(.system(size: 13, weight: .bold))
-                        .foregroundStyle(.white)
-                } else {
-                    Image(systemName: glyphName)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(.white)
-                }
+            if let count = stationAvailabilityText {
+                Text(count)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.white)
+            } else {
+                Image(systemName: glyphName)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
             }
-
+        }
+        // An overlay rather than a second `VStack` child: `Annotation` centres
+        // this view on the rental's coordinate, so anything that adds layout
+        // height pushes the circle off the point it is marking. An overlay does
+        // not change the frame, so the marker stays 28x28 whether or not the
+        // fuel figure is showing. The guide puts the label's top at the circle's
+        // bottom, reproducing the 1pt spacing the stack used to provide.
+        .overlay(alignment: .bottom) {
             if showsFuelLabel, let fuelText = RentalFormat.fuelLabelText(for: rental) {
                 Text(fuelText)
                     .font(.caption.bold())
                     .foregroundStyle(markerColor)
                     // A light halo keeps the figure legible over satellite.
                     .shadow(color: Color(uiColor: .systemBackground), radius: 2)
+                    .fixedSize()
+                    .alignmentGuide(.bottom) { $0[.top] - 1 }
             }
         }
         // VoiceOver ignores the zoom gate: a visual-density rule must not cost a


### PR DESCRIPTION
## PR Description

The fuel figure was a second `VStack` child, and `Annotation` centers its content. As a result, a marker showing fuel was drawn about 8pt above the rental's actual location, while markers without fuel were correctly positioned.

### Changes

- Moved the fuel label into an overlay so it adds no layout height.
- Added an alignment guide to reproduce the previous 1pt spacing.
- The marker remains `28×28` regardless of whether the fuel label is shown.

Refs #1350 (part 5).