### PR TITLE
Fix/1336 stop screen missing stop

### DIFF
--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -177,6 +177,7 @@ struct StopDeparturesSections: View {
                 Section {
                     StopPageEmptyStateRow(
                         isBrokenBookmark: isBrokenBookmark,
+                        stopIsMissing: content.stopIsMissing,
                         errorText: errorText,
                         isFilteredEmpty: content.isFilteredEmpty,
                         isDepartureFilterEmpty: content.isDepartureFilterEmpty,

--- a/OBAKit/Stops/StopPage/Shared/StopPageContent.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopPageContent.swift
@@ -39,6 +39,11 @@ struct StopPageContent {
 
     let hasLoadedArrivals: Bool
     let showsLoadingState: Bool
+
+    /// The server has no stop at this ID. A terminal state: it suppresses the
+    /// loading row, which would otherwise spin forever because a missing stop
+    /// never produces arrivals (#1336).
+    let stopIsMissing: Bool
     /// `true` only when the route filter is what emptied the list.
     let isFilteredEmpty: Bool
     /// `true` only when the Departure Type filter is what emptied the list:
@@ -65,7 +70,8 @@ struct StopPageContent {
         arrivalDepartureFilter: ArrivalDepartureFilter,
         isLoading: Bool,
         hasError: Bool,
-        isBrokenBookmark: Bool
+        isBrokenBookmark: Bool,
+        stopIsMissing: Bool = false
     ) {
         let visible = isListFiltered ? allDepartures.filter(preferences: preferences) : allDepartures
         // Terminal dedup deliberately runs downstream, after the Departure Type
@@ -98,10 +104,14 @@ struct StopPageContent {
         self.listIsEmpty = isGrouped ? routeGroups.isEmpty : departures.isEmpty
 
         self.hasLoadedArrivals = hasLoadedArrivals
+        self.stopIsMissing = stopIsMissing
         // Any in-flight fetch, plus the pre-`.task` first frame (nothing
         // fetched, no error yet) so the page never flashes "No departures"
-        // before the first request has even started.
-        self.showsLoadingState = isLoading || (!hasLoadedArrivals && !hasError && !isBrokenBookmark)
+        // before the first request has even started. A missing stop is excluded
+        // for the opposite reason: it has finished, and it will never have
+        // arrivals, so without it the page spins forever.
+        self.showsLoadingState = isLoading
+            || (!hasLoadedArrivals && !hasError && !isBrokenBookmark && !stopIsMissing)
 
         // The stop has departures but none survive the route preferences.
         // Grouped mode can be empty while `allDepartures` isn't (every departure
@@ -142,7 +152,8 @@ extension StopPageContent {
             arrivalDepartureFilter: viewModel.arrivalDepartureFilter,
             isLoading: viewModel.isLoading,
             hasError: viewModel.operationError != nil,
-            isBrokenBookmark: viewModel.isBrokenBookmark
+            isBrokenBookmark: viewModel.isBrokenBookmark,
+            stopIsMissing: viewModel.stopIsMissing
         )
     }
 }

--- a/OBAKit/Stops/StopPage/StopPageView.swift
+++ b/OBAKit/Stops/StopPage/StopPageView.swift
@@ -542,6 +542,10 @@ struct StopPageEmptyStateRow: View {
     /// leaving them to conclude the bus simply isn't running (parity with
     /// `StopViewController.emptyData(for:)`).
     var isBrokenBookmark: Bool = false
+    /// The server has no stop at this ID and there is no bookmark to repair —
+    /// a deep link, a search result or a map pin pointing at a stop the agency
+    /// has since removed.
+    var stopIsMissing: Bool = false
     let errorText: String?
     let isFilteredEmpty: Bool
     /// The Departure Type filter (real-time only / scheduled only) removed
@@ -580,6 +584,7 @@ struct StopPageEmptyStateRow: View {
 
     private var symbolName: String {
         if isBrokenBookmark { return "bookmark.slash.fill" }
+        if stopIsMissing { return "mappin.slash" }
         if errorText != nil { return "exclamationmark.icloud" }
         if isFilteredEmpty { return "line.3.horizontal.decrease.circle" }
         if isDepartureFilterEmpty { return "antenna.radiowaves.left.and.right" }
@@ -589,6 +594,13 @@ struct StopPageEmptyStateRow: View {
     private var message: String {
         if isBrokenBookmark {
             return OBALoc("stop_controller.bad_bookmark_error_message", value: "This bookmark may not work anymore. Did your transit agency change something? Please delete and recreate the bookmark.", comment: "An error message displayed when a stop is shown by tapping on a bookmark—and the bookmark doesn't seem to point to a valid stop any longer. This problem will occur when a transit agency changes its stop IDs, perhaps as part of an annual transit system realignment.")
+        }
+        if stopIsMissing {
+            return OBALoc(
+                "stop_page.empty.stop_not_found",
+                value: "This stop isn't in the transit agency's data anymore. It may have been moved or removed.",
+                comment: "Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin."
+            )
         }
         if let errorText { return errorText }
         if isFilteredEmpty {
@@ -605,6 +617,9 @@ struct StopPageEmptyStateRow: View {
         // A broken bookmark has no retry: the stop ID itself is gone, so refetching
         // it just fails again. The message tells the user to recreate the bookmark.
         if isBrokenBookmark { return nil }
+        // Same reasoning as a broken bookmark: the stop ID itself is gone, so a
+        // retry re-runs the same failing request. The message is the whole answer.
+        if stopIsMissing { return nil }
         if errorText != nil {
             return OBALoc("stop_page.empty.retry", value: "Retry", comment: "Button that retries loading departures after an error.")
         }

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -112,6 +112,9 @@ public class StopViewController: UIViewController,
     var operationError: Error? { viewModel.operationError }
     var isBrokenBookmark: Bool { viewModel.isBrokenBookmark }
 
+    /// The server has no stop at this ID, with or without a bookmark behind it.
+    var stopIsMissing: Bool { viewModel.stopIsMissing }
+
     /// Controls whether departures before the transfer arrival time are visible (local UI state).
     private var showAllTransferDepartures = false
 
@@ -503,7 +506,10 @@ public class StopViewController: UIViewController,
 
     // MARK: - OBAListView
     public func items(for listView: OBAListView) -> [OBAListViewSection] {
-        if isBrokenBookmark { return [] }
+        // Both are terminal states for a stop the server doesn't have, so there is
+        // nothing to list. Returning no sections is what hands the screen to
+        // `emptyData(for:)`, which explains which of the two it is.
+        if isBrokenBookmark || stopIsMissing { return [] }
 
         guard stopArrivals != nil else {
             if let error = self.operationError {
@@ -560,6 +566,22 @@ public class StopViewController: UIViewController,
 
             let bookmarkBrokenImage = UIImage(systemName: "bookmark.slash.fill")?.withTintColor(.systemRed)    // iOS 14+ only.
             return .standard(.init(alignment: .center, title: "Broken Bookmark", body: message, image: bookmarkBrokenImage, buttonConfig: .none))
+        }
+
+        // No bookmark to repair, but the server still has no stop at this ID. Say so
+        // rather than leaving a bare header and no explanation (#1336).
+        if stopIsMissing {
+            let title = OBALoc(
+                "stop_controller.stop_not_found_title",
+                value: "Stop Not Found",
+                comment: "Title of the message shown when the server has no stop at the requested ID."
+            )
+            let message = OBALoc(
+                "stop_page.empty.stop_not_found",
+                value: "This stop isn't in the transit agency's data anymore. It may have been moved or removed.",
+                comment: "Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin."
+            )
+            return .standard(.init(title: title, body: message, image: UIImage(systemName: "mappin.slash")))
         }
 
         if let error = self.operationError {

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -296,16 +296,21 @@ class StopViewModel: ObservableObject {
                     pendingExtensionMinutes = pendingAutoExtensionAmount()
                 }
             }
-        } catch APIError.requestNotFound {
+        } catch let error as APIError where error.indicatesMissingStop {
             operationError = nil
             isBrokenBookmark = bookmarkContext != nil
 
-            // With a bookmark behind it, a 404 is the broken-bookmark path: the page
-            // explains itself and offers a way out, and it isn't a failure the rider
-            // watched happen. Without one — a deep link, a search result, a map pin —
-            // the same 404 leaves the page with no arrivals, no error, and nothing to
-            // do, which is exactly the experience that shouldn't be followed by a
-            // request for five stars.
+            // With a bookmark behind it, a server that has no stop at this ID is the
+            // broken-bookmark path: the page explains itself and offers a way out, and
+            // it isn't a failure the rider watched happen. Without one — a deep link, a
+            // search result, a map pin — the same response leaves the page with no
+            // arrivals, no error, and nothing to do, which is exactly the experience
+            // that shouldn't be followed by a request for five stars.
+            //
+            // `indicatesMissingStop` covers both shapes the servers use — a literal 404
+            // and HTTP 200 with body `null` — so this agrees with the Bookmarks tab
+            // (#1336). An empty HTTP 200 is not one of them; it falls through to the
+            // general catch as the transient error it is.
             if bookmarkContext == nil {
                 environment.noteStopLoadFailed()
             }

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -100,6 +100,17 @@ class StopViewModel: ObservableObject {
     /// `true` when a bookmark's stop ID no longer resolves.
     @Published private(set) var isBrokenBookmark = false
 
+    /// `true` when the server has no stop at this ID — a literal 404, or the
+    /// `null` body many OBA servers send instead.
+    ///
+    /// Distinct from `isBrokenBookmark`, which is the subset of this with a
+    /// bookmark to repair. A stop opened from a deep link, a search result or a
+    /// map pin has no bookmark, but the page still has to reach a terminal state:
+    /// without this flag the absence of arrivals is indistinguishable from a
+    /// fetch still in flight, and `StopPageContent.showsLoadingState` spins
+    /// forever (#1336).
+    @Published private(set) var stopIsMissing = false
+
     /// User-saved preferences for this stop (sort order, hidden routes).
     @Published private(set) var stopPreferences: StopPreferences
 
@@ -299,13 +310,21 @@ class StopViewModel: ObservableObject {
         } catch let error as APIError where error.indicatesMissingStop {
             operationError = nil
             isBrokenBookmark = bookmarkContext != nil
+            stopIsMissing = true
+
+            // A stop the server no longer has cannot have departures. Drop whatever an
+            // earlier refresh left behind so the page doesn't keep counting down to a
+            // bus that isn't coming — the same thing `BookmarkDataLoader` does for the
+            // card — and so the freshness label stops claiming a successful update.
+            stopArrivals = nil
+            lastUpdated = nil
+            updateStatus()
 
             // With a bookmark behind it, a server that has no stop at this ID is the
             // broken-bookmark path: the page explains itself and offers a way out, and
             // it isn't a failure the rider watched happen. Without one — a deep link, a
-            // search result, a map pin — the same response leaves the page with no
-            // arrivals, no error, and nothing to do, which is exactly the experience
-            // that shouldn't be followed by a request for five stars.
+            // search result, a map pin — there is no bookmark to repair, so the page
+            // says the stop is gone and the miss still counts against the prompt.
             //
             // `indicatesMissingStop` covers both shapes the servers use — a literal 404
             // and HTTP 200 with body `null` — so this agrees with the Bookmarks tab
@@ -336,6 +355,7 @@ class StopViewModel: ObservableObject {
     private func applySuccessfulFetch(stop: Stop, arrivals: StopArrivals) {
         operationError = nil
         isBrokenBookmark = false
+        stopIsMissing = false
         lastUpdated = Date()
         updateStatus()
         // Guard the @Published re-emit. The same VM is bound to a single stopID for

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -183,26 +183,6 @@ public class BookmarkDataLoader: NSObject {
         }
     }
 
-    /// Missing-stop shapes that must not bulletin on the Bookmarks tab.
-    ///
-    /// - Literal HTTP 404: the stop no longer resolves.
-    /// - HTTP 200 with body `null`: what many OBA servers send instead of a
-    ///   404. `APIService+GetData` throws that as `invalidContentType(...,
-    ///   "json", "nothing")` — the copy in #1331. Empty HTTP 200 is *not*
-    ///   included; a live San Diego stop is a full 200, so an empty body
-    ///   stays a transient error.
-    nonisolated private static func isGoneBookmarkStop(_ error: APIError) -> Bool {
-        switch error {
-        case .requestNotFound(let response) where response.statusCode == 404:
-            return true
-        case .invalidContentType(_, let expected, let actual)
-            where expected == "json" && actual == "nothing":
-            return true
-        default:
-            return false
-        }
-    }
-
     @MainActor
     private func loadData(bookmark: Bookmark, batchID: UInt64) {
         guard
@@ -236,16 +216,10 @@ public class BookmarkDataLoader: NSObject {
 
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
-            } catch let error as APIError where Self.isGoneBookmarkStop(error) {
+            } catch let error as APIError where error.indicatesMissingStop {
                 // The stop no longer exists in this region. Don't bulletin —
                 // settle the card on "No upcoming departures" and drop any
                 // previous countdown for this stop.
-                //
-                // San Diego trace 2026-08-14 against realtime.sdmts.com: a live
-                // stop (`MTS_11589`) returns HTTP 200 with a full JSON body on
-                // the app URL (`/api/api/where/...`). Empty HTTP 200 — also
-                // thrown as `requestNotFound` by `APIService+GetData` — is a
-                // transient blip and falls through to `displayError` below.
                 await MainActor.run {
                     guard batchID == self.currentBatchID else { return }
                     self.fetchedStopIDs.insert(bookmark.stopID)

--- a/OBAKitCore/Network/APIError+MissingStop.swift
+++ b/OBAKitCore/Network/APIError+MissingStop.swift
@@ -1,0 +1,42 @@
+//
+//  APIError+MissingStop.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+public extension APIError {
+
+    /// Whether this error means the server has no stop at the requested ID,
+    /// rather than that the request failed.
+    ///
+    /// Two transport shapes carry that meaning, and a caller that checks only one
+    /// of them disagrees with the surfaces that check the other (#1336):
+    ///
+    /// - A literal HTTP 404.
+    /// - HTTP 200 with the body `null`, which many OBA servers send instead of a
+    ///   404. `APIService+GetData` throws it as
+    ///   `invalidContentType(_, "json", "nothing")` — the shape in #1331.
+    ///
+    /// An empty HTTP 200 is deliberately excluded even though `APIService+GetData`
+    /// also throws that as `requestNotFound`: a live stop answers with a full 200
+    /// (traced against realtime.sdmts.com on 2026-08-14), so a blank body is a
+    /// transient blip rather than a missing stop. `ErrorClassifier` reclassifies it
+    /// as `.invalidResponseData` so the rider isn't told "404 Not found" about a
+    /// response that was a 200.
+    var indicatesMissingStop: Bool {
+        switch self {
+        case .requestNotFound(let response) where response.statusCode == 404:
+            return true
+        case .invalidContentType(_, let expected, let actual)
+            where expected == "json" && actual == "nothing":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/OBAKitCore/Network/ErrorClassifier.swift
+++ b/OBAKitCore/Network/ErrorClassifier.swift
@@ -77,8 +77,11 @@ public enum ErrorClassifier {
             // (url)" either way — a raw URL and a status code the server never sent.
             // The host answered; the body was unusable. Say that instead (#1336).
             guard let regionName else {
+                // Returning `apiError` here would hand back the very "404 Not found"
+                // copy this case exists to prevent, so fall back to the region-less
+                // wording instead — same treatment `classifyDecodingError` gives it.
                 logger.warning("Empty-body \(response.statusCode) but no region name available for user message.")
-                return apiError
+                return regionlessInvalidResponseError()
             }
             return APIError.invalidResponseData(regionName: regionName)
 
@@ -121,15 +124,21 @@ public enum ErrorClassifier {
 
     private static func classifyDecodingError(_ error: Error, regionName: String?) -> Error {
         guard let regionName else {
-            let message = OBALoc(
-                "api_error.decoding_failure",
-                value: "The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.",
-                comment: "An error shown when the server returns a body the app cannot decode and no region name is available to specialize the copy."
-            )
-            return UnstructuredError(message)
+            return regionlessInvalidResponseError()
         }
 
         return APIError.invalidResponseData(regionName: regionName)
+    }
+
+    /// The unusable-payload message for the two paths that reach it without a
+    /// region name to specialize the copy with.
+    private static func regionlessInvalidResponseError() -> Error {
+        let message = OBALoc(
+            "api_error.decoding_failure",
+            value: "The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.",
+            comment: "An error shown when the server returns a body the app cannot decode and no region name is available to specialize the copy."
+        )
+        return UnstructuredError(message)
     }
 
     // MARK: - Helpers

--- a/OBAKitCore/Network/ErrorClassifier.swift
+++ b/OBAKitCore/Network/ErrorClassifier.swift
@@ -71,6 +71,17 @@ public enum ErrorClassifier {
             }
             return APIError.serverUnavailable(regionName: regionName, statusCode: response.statusCode)
 
+        case .requestNotFound(let response) where response.statusCode != 404:
+            // `APIService+GetData` throws `requestNotFound` for a blank HTTP 200 as
+            // well as for a literal 404, but `errorDescription` says "404 Not found
+            // (url)" either way — a raw URL and a status code the server never sent.
+            // The host answered; the body was unusable. Say that instead (#1336).
+            guard let regionName else {
+                logger.warning("Empty-body \(response.statusCode) but no region name available for user message.")
+                return apiError
+            }
+            return APIError.invalidResponseData(regionName: regionName)
+
         case .networkFailure:
             if isCellularDataRestricted {
                 logger.info("Network failure reclassified as cellular data restriction.")

--- a/OBAKitTests/Networking/APIErrorMissingStopTests.swift
+++ b/OBAKitTests/Networking/APIErrorMissingStopTests.swift
@@ -1,0 +1,66 @@
+//
+//  APIErrorMissingStopTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+/// `APIError.indicatesMissingStop` is the single predicate the Bookmarks tab and the
+/// Stop screen share (#1336). The negative cases matter as much as the positive ones:
+/// each one is a `where` clause that, if dropped, silently widens the predicate and
+/// starts offering riders the "delete this bookmark" path for a transient failure.
+@MainActor
+@Suite(.serialized)
+final class APIErrorMissingStopTests {
+
+    private let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.json")!
+
+    private func response(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "2", headerFields: nil)!
+    }
+
+    @Test func `Literal 404 indicates a missing stop`() {
+        #expect(APIError.requestNotFound(response(statusCode: 404)).indicatesMissingStop)
+    }
+
+    /// The boundary the whole design turns on. `APIService+GetData` throws
+    /// `requestNotFound` for a blank HTTP 200 too, and that response carries a **200**.
+    /// A live stop answers with a full 200, so a blank body is a transient blip.
+    @Test func `Request not found carrying a 200 does not indicate a missing stop`() {
+        #expect(!APIError.requestNotFound(response(statusCode: 200)).indicatesMissingStop)
+    }
+
+    @Test func `JSON null body indicates a missing stop`() {
+        let error = APIError.invalidContentType(originalError: nil, expectedContentType: "json", actualContentType: "nothing")
+        #expect(error.indicatesMissingStop)
+    }
+
+    @Test func `HTML instead of JSON does not indicate a missing stop`() {
+        let error = APIError.invalidContentType(originalError: nil, expectedContentType: "json", actualContentType: "text/html")
+        #expect(!error.indicatesMissingStop)
+    }
+
+    /// `APIService+GetData` throws exactly this when a non-JSON response carries no
+    /// `Content-Type` header at all — a broken proxy, not a deleted stop.
+    @Test func `Missing content type does not indicate a missing stop`() {
+        let error = APIError.invalidContentType(originalError: nil, expectedContentType: "json", actualContentType: nil)
+        #expect(!error.indicatesMissingStop)
+    }
+
+    /// The `"nothing"` sentinel is only meaningful for the JSON decode path. A protobuf
+    /// endpoint returning it is a different failure and must not reach the stop UI.
+    @Test func `Non JSON expectation does not indicate a missing stop`() {
+        let error = APIError.invalidContentType(originalError: nil, expectedContentType: "protobuf", actualContentType: "nothing")
+        #expect(!error.indicatesMissingStop)
+    }
+
+    @Test func `Network failure does not indicate a missing stop`() {
+        #expect(!APIError.networkFailure(nil).indicatesMissingStop)
+    }
+}

--- a/OBAKitTests/Networking/ErrorClassifierTests.swift
+++ b/OBAKitTests/Networking/ErrorClassifierTests.swift
@@ -34,6 +34,8 @@ final class ErrorClassifierTests {
         }
     }
 
+    /// A literal 404 keeps `requestNotFound`'s own copy. Half of the boundary added
+    /// in #1336 — the other half is the empty-200 reclassification below.
     @Test func `Classify request not found passes through`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/stop/1_75403.json")!
         let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!
@@ -233,6 +235,51 @@ final class ErrorClassifierTests {
             #expect(resp.statusCode == 400)
         default:
             Issue.record("Expected .requestFailure for 4xx, got \(apiError)")
+        }
+    }
+
+    // MARK: - Empty HTTP 200 Thrown As Request Not Found (#1336)
+
+    /// `APIService+GetData` throws `requestNotFound` for a blank HTTP 200 as well as for
+    /// a literal 404, and `requestNotFound`'s description is hardcoded to "404 Not found
+    /// (url)". Riders must not be shown a status code the server never sent.
+    @Test func `Classify request not found carrying a 200 becomes invalid response data`() {
+        let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.json")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let error = APIError.requestNotFound(response)
+        let result = ErrorClassifier.classify(error, regionName: "Puget Sound")
+
+        guard let apiError = result as? APIError else {
+            Issue.record("Expected APIError, got \(type(of: result))")
+            return
+        }
+
+        switch apiError {
+        case .invalidResponseData(let regionName):
+            #expect(regionName == "Puget Sound")
+        default:
+            Issue.record("Expected .invalidResponseData, got \(apiError)")
+        }
+    }
+
+    /// `.invalidResponseData`'s copy names the region, so with no region there is nothing
+    /// better to say — mirrors the existing `.requestFailure` guards.
+    @Test func `Classify request not found carrying a 200 with no region passes through`() {
+        let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.json")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let error = APIError.requestNotFound(response)
+        let result = ErrorClassifier.classify(error, regionName: nil)
+
+        guard let apiError = result as? APIError else {
+            Issue.record("Expected APIError, got \(type(of: result))")
+            return
+        }
+
+        switch apiError {
+        case .requestNotFound(let resp):
+            #expect(resp.statusCode == 200)
+        default:
+            Issue.record("Expected .requestNotFound, got \(apiError)")
         }
     }
 

--- a/OBAKitTests/Networking/ErrorClassifierTests.swift
+++ b/OBAKitTests/Networking/ErrorClassifierTests.swift
@@ -262,25 +262,19 @@ final class ErrorClassifierTests {
         }
     }
 
-    /// `.invalidResponseData`'s copy names the region, so with no region there is nothing
-    /// better to say — mirrors the existing `.requestFailure` guards.
-    @Test func `Classify request not found carrying a 200 with no region passes through`() {
+    /// `.invalidResponseData`'s copy names the region, so with no region the classifier
+    /// falls back to the region-less wording. Handing the error back unchanged would
+    /// re-emit the "404 Not found" copy this case exists to prevent.
+    @Test func `Classify request not found carrying a 200 with no region uses neutral copy`() {
         let url = URL(string: "https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.json")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         let error = APIError.requestNotFound(response)
         let result = ErrorClassifier.classify(error, regionName: nil)
 
-        guard let apiError = result as? APIError else {
-            Issue.record("Expected APIError, got \(type(of: result))")
-            return
-        }
-
-        switch apiError {
-        case .requestNotFound(let resp):
-            #expect(resp.statusCode == 200)
-        default:
-            Issue.record("Expected .requestNotFound, got \(apiError)")
-        }
+        #expect(!(result is APIError))
+        let description = result.localizedDescription
+        #expect(!description.contains("404"))
+        #expect(description.contains("can't read"))
     }
 
     // MARK: - Cellular Data Restriction (Injectable)

--- a/OBAKitTests/Stops/StopPage/StopPageContentTests.swift
+++ b/OBAKitTests/Stops/StopPage/StopPageContentTests.swift
@@ -46,7 +46,8 @@ final class StopPageContentTests: OBATestCase {
         hasLoadedArrivals: Bool = true,
         isLoading: Bool = false,
         hasError: Bool = false,
-        isBrokenBookmark: Bool = false
+        isBrokenBookmark: Bool = false,
+        stopIsMissing: Bool = false
     ) -> StopPageContent {
         StopPageContent(
             stop: nil,
@@ -57,7 +58,8 @@ final class StopPageContentTests: OBATestCase {
             arrivalDepartureFilter: arrivalDepartureFilter,
             isLoading: isLoading,
             hasError: hasError,
-            isBrokenBookmark: isBrokenBookmark
+            isBrokenBookmark: isBrokenBookmark,
+            stopIsMissing: stopIsMissing
         )
     }
 
@@ -323,4 +325,35 @@ final class StopPageContentTests: OBATestCase {
 
         #expect(!content.fillsPage)
     }
+
+    // MARK: - Missing stop (#1336)
+
+    /// A stop the server doesn't have never produces arrivals, so the loading branch
+    /// would spin forever: nil arrivals, no error, no broken bookmark and no in-flight
+    /// fetch is exactly the shape `showsLoadingState` otherwise reads as "still loading".
+    @Test func `A missing stop is a terminal state, not a loading one`() {
+        let content = makeContent(allDepartures: [], hasLoadedArrivals: false, stopIsMissing: true)
+
+        #expect(content.stopIsMissing)
+        #expect(!content.showsLoadingState)
+        #expect(content.listIsEmpty)
+    }
+
+    /// The same shape without the flag is what the loading row is for — a first frame
+    /// before the fetch has resolved.
+    @Test func `No arrivals yet without a missing stop still shows loading`() {
+        let content = makeContent(allDepartures: [], hasLoadedArrivals: false)
+
+        #expect(!content.stopIsMissing)
+        #expect(content.showsLoadingState)
+    }
+
+    /// An in-flight refresh still wins: a stop marked missing by the previous cycle
+    /// must not suppress the spinner for the retry the rider just triggered.
+    @Test func `An in-flight fetch still shows loading even when the stop was missing`() {
+        let content = makeContent(allDepartures: [], hasLoadedArrivals: false, isLoading: true, stopIsMissing: true)
+
+        #expect(content.showsLoadingState)
+    }
+
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -122,6 +122,17 @@ final class StopViewModelTests: OBATestCase {
         return (viewModel, app)
     }
 
+    /// Builds a `StopViewModel` whose arrivals fetch answers HTTP 200 with the literal
+    /// body `null` — what OBA servers that cannot 404 send for a stop that isn't there.
+    /// `APIService+GetData` throws that as `invalidContentType(_, "json", "nothing")`.
+    @MainActor
+    private func buildViewModelWithNullArrivals(bookmarkContext: Bookmark? = nil) -> (StopViewModel, Application) {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock(), arrivalsData: Data("null".utf8))
+        let viewModel = StopViewModel(application: app, stopID: testStopID, bookmarkContext: bookmarkContext)
+        return (viewModel, app)
+    }
+
     /// Hides every route present in `arrivals_and_departures_for_stop_1_10020.json`
     /// (routes `1_30` and `1_65`) so the rider never sees a real-time row from that
     /// fixture. Writes straight to the view model's in-memory `stopPreferences` via
@@ -1024,5 +1035,67 @@ final class StopViewModelTests: OBATestCase {
         let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 404)
         await viewModel.refresh()
         #expect(application.promptCoordinator.sawErrorThisSession)
+    }
+
+    // MARK: - Missing Stop Shapes (#1336)
+
+    /// The #1336 fix. A `null` body means the same thing to the server as a 404, so the
+    /// Stop screen must offer the deletion rather than a generic error with no way out.
+    @Test @MainActor
+    func `JSON null with bookmark context flags broken bookmark`() async throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        let bookmark = Bookmark(name: "Broken", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+        let (viewModel, application) = buildViewModelWithNullArrivals(bookmarkContext: bookmark)
+        await viewModel.refresh()
+
+        #expect(viewModel.isBrokenBookmark)
+        #expect(viewModel.operationError == nil)
+        #expect(!application.promptCoordinator.sawErrorThisSession)
+    }
+
+    /// With no bookmark to repair, a `null` body behaves like the 404 above: no
+    /// broken-bookmark UI, but the stranding still counts against the review prompt.
+    @Test @MainActor
+    func `JSON null without bookmark context flags error`() async {
+        let (viewModel, application) = buildViewModelWithNullArrivals()
+        await viewModel.refresh()
+
+        #expect(!viewModel.isBrokenBookmark)
+        #expect(viewModel.operationError == nil)
+        #expect(application.promptCoordinator.sawErrorThisSession)
+    }
+
+    /// Deliberate behaviour change. An empty HTTP 200 is also thrown as
+    /// `requestNotFound`, but a live stop answers with a full body — so a blank one is a
+    /// transient blip. It used to prompt the rider to delete a bookmark that works.
+    /// It is now a retryable error, and the copy must not claim a 404 the server never
+    /// sent: `ErrorClassifier` reclassifies it as `.invalidResponseData`.
+    @Test @MainActor
+    func `Empty 200 with bookmark context shows an error instead of a broken bookmark`() async throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        let bookmark = Bookmark(name: "Blank", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+        let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 200, bookmarkContext: bookmark)
+        await viewModel.refresh()
+
+        #expect(!viewModel.isBrokenBookmark)
+        #expect(viewModel.operationError != nil)
+        #expect(application.promptCoordinator.sawErrorThisSession)
+
+        let message = try #require(viewModel.operationErrorMessage)
+        #expect(!message.contains("404"))
+    }
+
+    /// Deliberate behaviour change. An empty 200 with no bookmark behind it used to
+    /// render a bare header and nothing else — no arrivals, no error, nothing to do.
+    @Test @MainActor
+    func `Empty 200 without bookmark context shows an error`() async throws {
+        let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 200)
+        await viewModel.refresh()
+
+        #expect(viewModel.operationError != nil)
+        #expect(application.promptCoordinator.sawErrorThisSession)
+
+        let message = try #require(viewModel.operationErrorMessage)
+        #expect(!message.contains("404"))
     }
 }

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -1049,20 +1049,76 @@ final class StopViewModelTests: OBATestCase {
         await viewModel.refresh()
 
         #expect(viewModel.isBrokenBookmark)
+        #expect(viewModel.stopIsMissing)
         #expect(viewModel.operationError == nil)
         #expect(!application.promptCoordinator.sawErrorThisSession)
     }
 
     /// With no bookmark to repair, a `null` body behaves like the 404 above: no
-    /// broken-bookmark UI, but the stranding still counts against the review prompt.
+    /// broken-bookmark UI and no error card, but `stopIsMissing` still has to be set
+    /// so the page reaches a terminal state instead of the loading row, and the
+    /// stranding still counts against the review prompt.
+    ///
+    /// Named for what it asserts: `operationError` stays nil here, so "flags error"
+    /// would describe the opposite of the check.
     @Test @MainActor
-    func `JSON null without bookmark context flags error`() async {
+    func `JSON null without bookmark context marks the stop missing without an error`() async {
         let (viewModel, application) = buildViewModelWithNullArrivals()
         await viewModel.refresh()
 
         #expect(!viewModel.isBrokenBookmark)
+        #expect(viewModel.stopIsMissing)
         #expect(viewModel.operationError == nil)
         #expect(application.promptCoordinator.sawErrorThisSession)
+    }
+
+    /// The blocking case from review: without this the page has nil arrivals, no
+    /// error, no broken bookmark and `isLoading == false`, which `StopPageContent`
+    /// reads as a fetch still in flight — a spinner that never resolves.
+    @Test @MainActor
+    func `JSON null without bookmark context does not leave the page loading`() async {
+        let (viewModel, _) = buildViewModelWithNullArrivals()
+        await viewModel.refresh()
+
+        let content = StopPageContent(viewModel: viewModel)
+        #expect(!content.showsLoadingState)
+        #expect(content.stopIsMissing)
+    }
+
+    /// A stop that vanishes between refreshes must drop what the previous fetch left
+    /// behind — otherwise the page keeps counting down to a bus that isn't coming.
+    @Test @MainActor
+    func `Stop going missing after a successful refresh clears stale departures`() async throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            analytics: AnalyticsMock(),
+            arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json"
+        )
+        let viewModel = StopViewModel(application: app, stopID: testStopID)
+
+        await viewModel.refresh()
+        #expect(viewModel.stopArrivals != nil)
+        #expect(viewModel.lastUpdated != nil)
+
+        // replaceMappedResponses swaps the *entire* table, so re-register the mocks
+        // the Application's background tasks still rely on.
+        dataLoader.replaceMappedResponses { staging in
+            stubRegions(dataLoader: staging)
+            stubAgenciesWithCoverage(dataLoader: staging, baseURL: Fixtures.pugetSoundRegion.OBABaseURL)
+            Fixtures.stubAllAgencyAlerts(dataLoader: staging)
+            stubSurveys(dataLoader: staging)
+            staging.mock(data: Data("null".utf8)) {
+                $0.url?.path.contains("/api/where/arrivals-and-departures-for-stop") ?? false
+            }
+        }
+
+        await viewModel.refresh()
+
+        #expect(viewModel.stopIsMissing)
+        #expect(viewModel.stopArrivals == nil)
+        #expect(viewModel.lastUpdated == nil)
+        #expect(viewModel.statusText.isEmpty)
     }
 
     /// Deliberate behaviour change. An empty HTTP 200 is also thrown as


### PR DESCRIPTION
## Summary

The Bookmarks tab and the Stop screen disagreed about what a missing stop looks
like, in both directions.

`APIService+GetData` throws three different errors for "the server has no stop at
this ID": a real 404 (`:38`), an empty HTTP 200 on a GET, thrown as
`requestNotFound` carrying a **200** response (`:56`), and HTTP 200 with the body
`null`, thrown as `invalidContentType(_, "json", "nothing")` (`:90`). (A GET with
an empty body and no `Content-Length` header throws `noResponseBody` instead —
that one is a generic error on both surfaces, before and after this PR.)

`BookmarkDataLoader.isGoneBookmarkStop` matched the 404 and the `null`, and
deliberately excluded the empty 200. `StopViewModel` matched `requestNotFound`
with no status filter — so it matched the 404 **and the empty 200**, and missed
the `null`. Both now share `APIError.indicatesMissingStop`.

### What changes for the rider

| Server response | Bookmarks tab | Stop screen, from a bookmark | Stop screen, from a deep link / search / map pin |
|---|---|---|---|
| Real 404 | unchanged | unchanged | spinner → **"stop not found"** |
| Empty HTTP 200 | **bulletin copy fixed** | broken-bookmark UI → **retryable error** | spinner → **retryable error** |
| HTTP 200 + `null` | unchanged | generic error → **broken-bookmark UI** | generic error → **"stop not found"** |

The "spinner" in that last column is a bug on `main`, not something this PR
introduces: a 404 with no bookmark behind it already set `operationError = nil`
with nil arrivals, which is the exact shape `StopPageContent.showsLoadingState`
reads as a fetch still in flight. It renders `StopPageLoadingRow` forever while
the refresh timer re-throws every cycle. Widening the catch would have extended
that to the `null` body, so this PR fixes the underlying state instead.

- **The #1336 fix:** a `null` body on a bookmarked stop now sets
  `isBrokenBookmark` and offers the rider the deletion, instead of a generic
  error with no way out.
- **New terminal state.** A stop the server doesn't have now says so. The view
  model exposes `stopIsMissing`, which `StopPageContent` uses to suppress the
  loading branch and the empty-state row uses to render "This stop isn't in the
  transit agency's data anymore." A `null` body with no bookmark behind it lands
  here rather than on a generic error, matching a real 404 — and the 404 path
  gets the fix too, since it had the same spinner on `main`. The
  review-prompt suppression (`noteStopLoadFailed()`) still fires, so the app
  won't ask for five stars after it. `StopViewController` gets the same state so
  the legacy surface doesn't disagree with the new one.
- **Stale departures are dropped.** A stop that goes missing between refreshes
  now clears `stopArrivals` and `lastUpdated`, so the page can't keep counting
  down to a bus that isn't coming — the same thing `BookmarkDataLoader` already
  does for the card.
- **Deliberate change:** an empty HTTP 200 no longer shows the broken-bookmark UI
  on the Stop screen. That path could previously prompt someone to delete a
  working bookmark because the server returned a blank body once. A live stop
  answers with a full 200, so a blank one is a blip, not a deleted stop.
- **Copy fix, required by the above.** `requestNotFound`'s `errorDescription` is
  hardcoded to `"404 Not found (%@)"` and never reads `statusCode`
  (`NetworkOperation.swift:90`), and `ErrorClassifier` had no case for it — so an
  empty 200 rendered a raw URL and a status code the server never sent. It now
  classifies as `.invalidResponseData`, whose copy already says the right thing
  ("returned data this app can't read… try again shortly") and is already present
  in all 13 catalogs, so this adds no new strings. `Application.displayError`
  runs the same classifier, so this also fixes the identical wrong bulletin on
  the Bookmarks tab, which ships today.

`isGoneBookmarkStop` is deleted; the predicate is now a computed property on
`APIError` so both modules reach it. Renamed to `indicatesMissingStop` because
the Stop screen reaches this path from deep links, search results and map pins
where no bookmark exists — and because the empty-200 exclusion is itself evidence
these servers don't reliably report a stop as *deleted*, only that this response
had no stop in it.

Left alone: the `requestNotFound` catch in `cancelAlarm` (an Obaco DELETE, where
a 404 means the alarm already fired — and the empty-200 heuristic is GET-only, so
it can't reach that path), and `ScheduleForRouteViewModel` /
`OBAEmptyDataSetItem` / `OBAListViewEmptyDataViewModel`, which inspect
`requestNotFound` for their own purposes and aren't stop fetches. The empty-200
error icon does change, as a consequence of the reclassification.

One thing I deliberately did not touch: throwing `requestNotFound` for a blank
200 at all is arguably the root confusion here, but changing that moves every
consumer at once. This PR corrects the presentation without touching the throw.

If you'd rather keep today's Stop-screen behaviour for the empty 200, I'm happy
to put it back — it's a small change, though it means either duplicating the
catch body or writing `where indicatesMissingStop || <any requestNotFound>`,
which puts the divergence back inside the code written to remove it. The copy fix
stands on its own either way.

Closes #1336.

## Testing

- Seven tests on the predicate covering every shape and its negatives, including
  `requestNotFound` carrying a 200 — the boundary the whole design turns on — and
  `invalidContentType(_, "json", nil)`, which `APIService+GetData:83` really does
  throw.
- Six new `StopViewModel` tests: `null` and empty-200, each with and without a
  bookmark context; one asserting a `null` body with no bookmark doesn't leave the
  page in the loading state; and one for a stop that goes missing after a
  successful refresh, checking the arrivals and the freshness label are both
  cleared. All but the first pin behaviour changes, so a future reader doesn't
  "fix" them back.
- Two new `ErrorClassifier` tests for the empty-200 case, alongside the existing
  404 pass-through test that pins its other half. A region-less empty 200 now
  falls back to the neutral "can't read" wording rather than re-emitting the
  "404 Not found" copy the case exists to prevent.
- Three `StopPageContent` tests pinning the loading branch: a missing stop is
  terminal, the same shape without the flag still shows the spinner, and an
  in-flight refresh still wins so a retry isn't swallowed.
- The existing Bookmarks-tab tests from #1331/#1332 pass untouched — including
  `Empty 200 still calls display error`, which is the guard that the hoist didn't
  quietly widen the predicate.

Full suite: 2545 tests, no new failures.
