### PR TITLE
Make the trip-stop id uniqueness test able to fail

### DIFF
--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -102,10 +102,25 @@ final class TripStopViewModelIdentityTests {
         #expect(first != second)
     }
 
-    @Test func `List ids stay unique across the whole trip`() throws {
+    /// The whole-trip version of the test above. The fixture is an ordinary
+    /// point-to-point trip whose stops are all distinct, so running it as-is
+    /// proves nothing: the ids would come out unique under the bare `stop.id`
+    /// this replaced. Doubling it out-and-back gives every stop a second visit,
+    /// which is the shape a loop route actually has — and which halves the id
+    /// count the moment `stopIndex` stops qualifying them.
+    @Test func `List ids stay unique when a trip revisits every stop`() throws {
         let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
         let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
-        let ids = response.entry.stopTimes.enumerated().map { index, stopTime in
+        let outbound = response.entry.stopTimes
+        let loop = outbound + outbound.reversed()
+
+        // Pins the premise rather than trusting it. If the doubling is ever dropped,
+        // or a future fixture stops producing repeats, this fails here — instead of
+        // the test quietly going back to passing for the wrong reason, which is what
+        // it did before.
+        #expect(Set(loop.map(\.stopID)).count < loop.count)
+
+        let ids = loop.enumerated().map { index, stopTime in
             TripStopViewModel(
                 stopTime: stopTime,
                 arrivalDeparture: nil,
@@ -114,7 +129,8 @@ final class TripStopViewModelIdentityTests {
                 onSelectAction: nil
             ).id
         }
-        #expect(Set(ids).count == ids.count)
+
+        #expect(Set(ids).count == loop.count)
     }
 }
 

--- a/docs/duplicate-trip-stop-ids.md
+++ b/docs/duplicate-trip-stop-ids.md
@@ -11,4 +11,8 @@ list now uses the same format.
 `Equatable` includes `id`, matching the protocol's "all values, including
 the identifier" rule. Two visits to one stop are no longer equal.
 
-Tests do not load `TripViewController.view`.
+The tests exercise `TripStopViewModel` directly and do not load
+`TripViewController.view`, so they pin the identifier contract rather than
+the `NSDiffableDataSource` apply that #538 crashed in. The whole-trip test
+doubles the fixture out-and-back, because the fixture's own stops are all
+distinct and would satisfy a bare `stop.id` identifier too.


### PR DESCRIPTION
## PR Description

Make the trip-stop ID uniqueness test able to fail.

### Changes

- The **List IDs stay unique across the whole trip** test loaded a fixture whose 53 stops were all distinct.
  - As a result, the assertion held even with the bare `stop.id` identifier it was intended to guard.
  - The test passed for the wrong reason.

- The trip is now doubled out-and-back to represent the shape of a loop route.
  - 106 rows.
  - 106 IDs using `"\(stopIndex)-\(stop.id)"`.
  - Only 53 IDs under the old bare identifier, so the test now fails against the buggy implementation.

- Added a premise guard:
  ```swift
  Set(loop.map(\.stopID)).count < loop.count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip stop identification for loop routes, preventing duplicate stops from causing list display crashes.
  * Ensured repeated stops remain uniquely distinguishable based on their position in the trip.

* **Documentation**
  * Clarified identifier behavior and added coverage details for loop-trip scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->