### PR TITLE
Stop a superseded toast task from dismissing the new toast

### DIFF
--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -825,6 +825,13 @@ class StopViewModel: ObservableObject {
         liveActivityToastDismissTask = Task { [weak self] in
             do {
                 try await Task.sleep(for: .seconds(2))
+                // `cancel()` only interrupts the sleep while it is still
+                // suspended. Once it has resumed, this continuation is already
+                // queued on the main actor behind the newer signal that cancelled
+                // it — and that signal has set the flag back to true. Clearing it
+                // here would dismiss the *new* toast a moment after it appeared,
+                // which is the behaviour the cancellation exists to prevent.
+                try Task.checkCancellation()
             } catch {
                 // Superseded by a newer signal; that signal's task owns the dismissal.
                 return

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -929,6 +929,31 @@ final class StopViewModelTests: OBATestCase {
         #expect(!app.userDataStore.alarms.isEmpty)
     }
 
+    // MARK: - Live Activity Toast
+
+    /// The toast's own contract: the flag goes up on demand, and a second signal
+    /// arriving inside the first one's window leaves it up rather than inheriting
+    /// that window's imminent dismissal.
+    ///
+    /// The race the `Task.checkCancellation()` in `signalLiveActivityStarted`
+    /// closes is not reachable from here. It needs `cancel()` to land after the
+    /// sleep has already resumed but before its continuation runs — a window the
+    /// scheduler owns, with no seam to force it from a test. Same limitation
+    /// `ProximityAlertTests` documents for the 24-hour expiry boundary.
+    @Test @MainActor
+    func `Signalling a Live Activity raises the toast and a second signal keeps it up`() {
+        let (viewModel, _) = buildViewModel(arrivalsFixture: "arrivals_and_departures_for_stop_1_10020.json")
+
+        #expect(!viewModel.liveActivityStarted)
+
+        viewModel.signalLiveActivityStarted()
+        #expect(viewModel.liveActivityStarted)
+
+        // The duplicate-Track path signals again; the rider must still see a toast.
+        viewModel.signalLiveActivityStarted()
+        #expect(viewModel.liveActivityStarted)
+    }
+
     // MARK: - Review prompt success recording
 
     @Test @MainActor


### PR DESCRIPTION

## PR Description

Follow-up from #1215, where this was flagged during approval:

> If the previous task's `Task.sleep` has already resumed and its continuation is sitting on the `MainActor` queue, `cancel()` arrives too late and that continuation sets `liveActivityStarted = false` right after the new signal set it to `true`.

- Added `try Task.checkCancellation()` after the sleep to close that race.
- `StopViewModel` is `@MainActor`, so the continuation queues behind the newer signal and now checks cancellation before dismissing the toast.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Live Activity notifications so a newer toast remains visible when another notification arrives before the previous display period ends.

* **Tests**
  * Added coverage confirming that successive Live Activity notifications keep the toast visible as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->