### PR TITLE
 Record a proximity alert's region and refuse duplicates on one stop

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -114,7 +114,8 @@ public class Application: CoreApplication, PushServiceDelegate {
     @MainActor
     public private(set) lazy var proximityAlertManager = ProximityAlertManager(
         locationService: locationService,
-        userDataStore: userDataStore
+        userDataStore: userDataStore,
+        regionIDProvider: { [weak self] in self?.regionsService.currentRegion?.regionIdentifier }
     )
 
     @objc lazy var userActivityBuilder = UserActivityBuilder(application: self)
@@ -384,19 +385,21 @@ public class Application: CoreApplication, PushServiceDelegate {
         Task { await pushRegistrationManager.registerIfNeeded() }
     }
 
-    public func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID) {
-        // The current region is the right one by construction: the geofence that
-        // produced this notification is only crossed where the rider physically
-        // is. `queueOrOpenStop` still needs one named, because it refuses to open
-        // a stop against a different region's API.
-        guard let regionID = regionsService.currentRegion?.regionIdentifier else {
-            // No region yet — the ordinary case for a tap that relaunched a
+    public func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID, regionID: Int?) {
+        // The alert's own region wins where it has one. `currentRegion` is right
+        // only while it tracks the rider's location — the ordinary case, since the
+        // geofence is crossed where they are — and is wrong for a manually pinned
+        // region, which would send them to the pinned region's API for a stop they
+        // set somewhere else. Alerts stored before they carried a region still
+        // fall back to it, exactly as they always did.
+        guard let regionID = regionID ?? regionsService.currentRegion?.regionIdentifier else {
+            // Neither names one — the ordinary case for a tap that relaunched a
             // terminated app, since the regions list loads asynchronously. Stash
             // without one, exactly as the fired-alarm handler above does: the
             // drain navigates as soon as a root controller exists, and
             // `regionsService(_:updatedRegion:)` drains again once a region lands.
             // Returning here instead would drop the only thing the rider tapped.
-            Logger.info("Proximity alert tap for stop \(stopID) arrived before a region loaded; deferring navigation.")
+            Logger.info("Proximity alert tap for stop \(stopID) arrived with no region; deferring navigation.")
             pendingStopID = stopID
             // Cleared rather than left alone: a region stashed by an earlier
             // navigation would make the drain refuse this stop as belonging to
@@ -404,6 +407,11 @@ public class Application: CoreApplication, PushServiceDelegate {
             pendingStopRegionID = nil
             return
         }
+        // Through `queueOrOpenStop` on both branches, rather than a second copy of
+        // its deferral logic here: once the region can come from the alert instead
+        // of from `currentRegion`, its mismatch guard can finally disagree with
+        // itself, and a tap that relaunched the app stashes a region the drain can
+        // check instead of navigating against whatever loads first.
         queueOrOpenStop(AppLinksRouter.StopDestination(stopID: stopID, regionID: regionID))
     }
 

--- a/OBAKit/ProximityAlerts/ProximityAlertManager.swift
+++ b/OBAKit/ProximityAlerts/ProximityAlertManager.swift
@@ -36,6 +36,11 @@ public enum ProximityAlertActivationResult: Equatable {
     /// the rider yet; `.denied` means they have to be sent to Settings.
     case needsNotificationAuthorization(UNAuthorizationStatus)
 
+    /// Nothing was stored: this stop already has an unexpired alert, handed back
+    /// here. A second one would arm another geofence at the same coordinate, take
+    /// another of the twenty region slots, and fire alongside the first.
+    case alreadyActive(ProximityAlert)
+
     /// Nothing was stored: the app already monitors `limit` regions, which is all
     /// iOS allows. An existing alert has to go before another can arm.
     case regionLimitReached(limit: Int)
@@ -65,6 +70,14 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
     /// Mirrors ``PushRegistrationManager/AuthorizationStatusProvider``.
     public typealias AuthorizationStatusProvider = @Sendable () async -> UNAuthorizationStatus
 
+    /// Names the region the rider is in when they set an alert.
+    ///
+    /// A closure rather than a `RegionsService` dependency: this needs one integer
+    /// at one moment, and taking the service would hand the manager a collaborator
+    /// it has no other use for and every test a stand-in to build. `@MainActor`
+    /// because the real one reads `RegionsService`, which is.
+    public typealias RegionIDProvider = @MainActor () -> Int?
+
     /// Hands a notification request to the system.
     ///
     /// Deliberately the completion-handler form rather than the `async` one. The
@@ -78,12 +91,18 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
     /// `userInfo`, and the name `PushService` routes a tap on.
     static let notificationUserInfoKey = "proximity_alert"
 
+    /// Key under which the region the alert was set in travels alongside
+    /// ``notificationUserInfoKey``. Absent when the alert recorded none, which is
+    /// what every alert stored before this field existed looks like.
+    static let notificationRegionUserInfoKey = "proximity_alert_region"
+
     /// Namespaces the `UNNotificationRequest` identifier so a proximity
     /// notification can never collide with, or replace, one from another feature.
     static let notificationIdentifierPrefix = "oba.proximity-alert."
 
     private let locationService: LocationService
     private let userDataStore: UserDataStore
+    private let regionIDProvider: RegionIDProvider
     private let notificationCenter: NotificationCenter
     private let authorizationStatusProvider: AuthorizationStatusProvider
     private let scheduleNotification: NotificationScheduler
@@ -97,6 +116,10 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
     /// - Parameters:
     ///   - locationService: Arms and disarms the geofences, and reports crossings.
     ///   - userDataStore: Persists the alerts the geofences stand for.
+    ///   - regionIDProvider: Names the region an alert is being set in, recorded
+    ///     on the alert so a tap on its notification opens the stop against the
+    ///     region the rider actually set it in. Defaults to naming none, which
+    ///     leaves the tap falling back to whichever region is current.
     ///   - notificationCenter: Carries `.proximityAlertsDidChange`. `UserDataStore`
     ///     posts to `.default`, so an injected center only sees store changes if
     ///     it is that same center.
@@ -107,6 +130,7 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
     public init(
         locationService: LocationService,
         userDataStore: UserDataStore,
+        regionIDProvider: @escaping RegionIDProvider = { nil },
         notificationCenter: NotificationCenter = .default,
         authorizationStatusProvider: @escaping AuthorizationStatusProvider = {
             await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
@@ -117,6 +141,7 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
     ) {
         self.locationService = locationService
         self.userDataStore = userDataStore
+        self.regionIDProvider = regionIDProvider
         self.notificationCenter = notificationCenter
         self.authorizationStatusProvider = authorizationStatusProvider
         self.scheduleNotification = scheduleNotification
@@ -190,7 +215,23 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
             return .needsNotificationAuthorization(notificationStatus)
         }
 
-        let alert = ProximityAlert(stop: stop, radiusMeters: radiusMeters)
+        // A second alert on this stop would arm a second geofence at the same
+        // coordinate, hold another of the twenty slots the cap guard counts, and
+        // fire alongside the first. `activeAlert(for:)` ignores expired alerts, so
+        // a stale one does not block a new one.
+        //
+        // Checked after the authorization guards rather than before them: a
+        // downgrade from Always neither disarms nor deletes — see
+        // `locationService(_:authorizationStatusChanged:)`, which logs and returns
+        // — so a stored alert can look healthy here while no longer able to
+        // deliver. That rider needs `.needsLocationAuthorization`, which is both
+        // actionable and the explanation for why the alert they already have went
+        // quiet, rather than being told they already have one.
+        if let existing = activeAlert(for: stop.id) {
+            return .alreadyActive(existing)
+        }
+
+        let alert = ProximityAlert(stop: stop, radiusMeters: radiusMeters, regionID: regionIDProvider())
 
         switch locationService.startMonitoringProximity(for: alert) {
         case .started:
@@ -355,7 +396,13 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
             alert.stopName
         )
         content.sound = .default
-        content.userInfo = [Self.notificationUserInfoKey: alert.stopID]
+        // The stop travels alone when the alert has no region, keeping the shape
+        // `PushService` reads for an alert set before the region was recorded.
+        var userInfo: [String: Any] = [Self.notificationUserInfoKey: alert.stopID]
+        if let regionID = alert.regionID {
+            userInfo[Self.notificationRegionUserInfoKey] = regionID
+        }
+        content.userInfo = userInfo
 
         let request = UNNotificationRequest(
             identifier: Self.notificationIdentifierPrefix + alert.id.uuidString,

--- a/OBAKit/PushNotifications/PushService.swift
+++ b/OBAKit/PushNotifications/PushService.swift
@@ -61,7 +61,11 @@ public protocol PushServiceDelegate: NSObjectProtocol {
     /// fallback for an unrecognized payload re-presents the notification's own
     /// text in a modal alert, which for this one would tell the rider they are
     /// approaching their stop a second time and nothing else.
-    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID)
+    ///
+    /// - Parameter regionID: The region the alert was set in, or `nil` for an
+    ///   alert that recorded none — one stored before the field existed, or a
+    ///   notification delivered by an earlier build and tapped after the update.
+    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID, regionID: Int?)
 
     /// Called whenever APNs issues the device a (possibly rotated) push token.
     func pushService(_ pushService: PushService, receivedDeviceToken token: String)
@@ -92,6 +96,20 @@ public class PushService: NSObject {
     // MARK: - PushServiceProvider Callbacks
 
     private func notificationReceivedHandler(message: String, additionalData: [AnyHashable: Any]?) {
+        // Matched ahead of the single-custom-key routing below, which this payload
+        // cannot satisfy: a proximity alert carries the region it was set in
+        // alongside the stop, and that is two custom keys. It is also the one
+        // notification the app builds itself, so its shape is known here exactly
+        // rather than negotiated with a server.
+        if let additionalData, let stopID = additionalData[ProximityAlertManager.notificationUserInfoKey] as? StopID {
+            delegate?.pushService(
+                self,
+                receivedProximityAlertForStopID: stopID,
+                regionID: additionalData[ProximityAlertManager.notificationRegionUserInfoKey] as? Int
+            )
+            return
+        }
+
         // Remote-notification `userInfo` always includes an `aps` entry alongside
         // any custom data key (see OBACloudPushService.userNotificationCenter(_:didReceive:...),
         // which forwards the entire UNNotificationContent.userInfo). Routing must
@@ -117,9 +135,6 @@ public class PushService: NSObject {
         else if key == "donation" {
             let testID = additionalData["donation"] as? String
             delegate?.pushService(self, receivedDonationPrompt: testID)
-        }
-        else if key == ProximityAlertManager.notificationUserInfoKey, let stopID = additionalData[key] as? StopID {
-            delegate?.pushService(self, receivedProximityAlertForStopID: stopID)
         }
         else {
             displayMessage(message)

--- a/OBAKitCore/Models/UserData/ProximityAlert.swift
+++ b/OBAKitCore/Models/UserData/ProximityAlert.swift
@@ -20,6 +20,14 @@ public class ProximityAlert: NSObject, Codable {
     public let radiusMeters: Double
     public let createdAt: Date
 
+    /// The region the rider was looking at when they set this alert.
+    ///
+    /// Optional because alerts persisted before the field existed have no answer
+    /// and inventing one would be worse than admitting it: `nil` means "fall back
+    /// to whichever region is current when the notification is tapped", which is
+    /// exactly what every alert did before.
+    public let regionID: Int?
+
     /// The coordinate of the destination stop.
     public var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
@@ -65,7 +73,7 @@ public class ProximityAlert: NSObject, Codable {
         return clamped
     }
 
-    public init(stop: Stop, radiusMeters: CLLocationDistance = ProximityAlert.defaultRadiusMeters, createdAt: Date = Date()) {
+    public init(stop: Stop, radiusMeters: CLLocationDistance = ProximityAlert.defaultRadiusMeters, createdAt: Date = Date(), regionID: Int? = nil) {
         self.id = UUID()
         self.stopID = stop.id
         self.stopName = stop.name
@@ -73,12 +81,13 @@ public class ProximityAlert: NSObject, Codable {
         self.longitude = stop.location.coordinate.longitude
         self.radiusMeters = ProximityAlert.clampedRadius(radiusMeters)
         self.createdAt = createdAt
+        self.regionID = regionID
     }
 
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
-        case id, stopID, stopName, latitude, longitude, radiusMeters, createdAt
+        case id, stopID, stopName, latitude, longitude, radiusMeters, createdAt, regionID
     }
 
     /// Re-applies the radius clamp on the way in, so the invariant also holds for
@@ -94,6 +103,7 @@ public class ProximityAlert: NSObject, Codable {
         longitude = try container.decode(Double.self, forKey: .longitude)
         radiusMeters = ProximityAlert.clampedRadius(try container.decode(CLLocationDistance.self, forKey: .radiusMeters))
         createdAt = try container.decode(Date.self, forKey: .createdAt)
+        regionID = try container.decodeIfPresent(Int.self, forKey: .regionID)
     }
 
     /// Whether this alert has expired based on `expirationInterval`.

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -696,16 +696,21 @@ final class ApplicationTests: OBATestCase {
 
     // MARK: - Push Service Tests
 
-    @Test func `Push service proximity alert tap is never dropped`() {
+    /// The app and push service the proximity-tap tests below need.
+    private func makeAppAndPushService() -> (Application, PushService) {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
         let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
         let config = AppConfig(regionsBaseURL: regionsURL, apiKey: apiKey, appVersion: appVersion, userDefaults: userDefaults, analytics: AnalyticsMock(), queue: queue, locationService: locationService, bundledRegionsFilePath: bundledRegionsPath, regionsAPIPath: regionsAPIPath, dataLoader: dataLoader)
         let app = Application(config: config)
-        let pushService = PushService(serviceProvider: MockPushServiceProvider(), delegate: app)
+        return (app, PushService(serviceProvider: MockPushServiceProvider(), delegate: app))
+    }
 
-        app.pushService(pushService, receivedProximityAlertForStopID: "1_75403")
+    @Test func `Push service proximity alert tap is never dropped`() {
+        let (app, pushService) = makeAppAndPushService()
+
+        app.pushService(pushService, receivedProximityAlertForStopID: "1_75403", regionID: nil)
 
         // The tap that matters is the one into a terminated app, where neither a
         // root controller nor a region exists yet. Both branches must stash: with
@@ -718,6 +723,50 @@ final class ApplicationTests: OBATestCase {
         #expect(app.pendingStopRegionID == app.regionsService.currentRegion?.regionIdentifier)
     }
 
+    @Test func `Push service proximity alert tap stashes the region the alert carries`() {
+        let (app, pushService) = makeAppAndPushService()
+
+        // The case the carried region exists for: a geofence crossing relaunched a
+        // terminated app, so no region has loaded to fall back on yet.
+        #expect(app.regionsService.currentRegion == nil)
+
+        app.pushService(pushService, receivedProximityAlertForStopID: "1_75403", regionID: 12)
+
+        #expect(app.pendingStopID == "1_75403")
+        // Stashed rather than dropped as it was before the alert carried one: the
+        // drain now has a region to check the stop against, instead of whichever
+        // one happens to load first.
+        #expect(app.pendingStopRegionID == 12)
+    }
+
+    @Test func `Push service proximity alert tap falls back to the current region`() {
+        let (app, pushService) = makeAppAndPushService()
+        app.regionsService.currentRegion = Fixtures.tampaRegion
+
+        app.pushService(pushService, receivedProximityAlertForStopID: "1_75403", regionID: nil)
+
+        // An alert stored before it carried a region resolves exactly as it always
+        // did. Without this the fallback could be deleted and nothing would fail.
+        #expect(app.pendingStopID == "1_75403")
+        #expect(app.pendingStopRegionID == Fixtures.tampaRegion.regionIdentifier)
+    }
+
+    @Test func `Push service proximity alert tap refuses a stop from another region`() {
+        let (app, pushService) = makeAppAndPushService()
+        app.regionsService.currentRegion = Fixtures.tampaRegion
+
+        app.pushService(
+            pushService,
+            receivedProximityAlertForStopID: "1_75403",
+            regionID: Fixtures.pugetSoundRegion.regionIdentifier
+        )
+
+        // `queueOrOpenStop`'s mismatch guard, live from this call site for the
+        // first time: while the region came from `currentRegion` it was compared
+        // against itself. A pinned rider is no longer sent to the wrong API.
+        #expect(app.pendingStopID == nil)
+        #expect(app.pendingStopRegionID == nil)
+    }
 
     @Test func `Push service received donation prompt with no top view controller`() {
         let dataLoader = MockDataLoader(testName: name)

--- a/OBAKitTests/Application/ApplicationTests.swift
+++ b/OBAKitTests/Application/ApplicationTests.swift
@@ -700,6 +700,12 @@ final class ApplicationTests: OBATestCase {
     private func makeAppAndPushService() -> (Application, PushService) {
         let dataLoader = MockDataLoader(testName: name)
         stubRegions(dataLoader: dataLoader)
+        // Setting `currentRegion` refetches agencies-with-coverage and then one
+        // alerts feed per agency it names, and `MockDataLoader` traps on a URL
+        // nobody mocked. Same pairing as `MapLayerRegistrarTests`, which switches
+        // region the same way.
+        stubAgenciesWithCoverage(dataLoader: dataLoader, baseURL: Fixtures.tampaRegion.OBABaseURL)
+        Fixtures.stubAllAgencyAlerts(dataLoader: dataLoader)
         let locManager = LocationManagerMock()
         let locationService = LocationService(userDefaults: userDefaults, locationManager: locManager)
         let config = AppConfig(regionsBaseURL: regionsURL, apiKey: apiKey, appVersion: appVersion, userDefaults: userDefaults, analytics: AnalyticsMock(), queue: queue, locationService: locationService, bundledRegionsFilePath: bundledRegionsPath, regionsAPIPath: regionsAPIPath, dataLoader: dataLoader)

--- a/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
+++ b/OBAKitTests/Modeling/UserData/ProximityAlertTests.swift
@@ -44,6 +44,13 @@ final class ProximityAlertTests: OBATestCase {
         #expect(alert.radiusMeters == 500.0)
     }
 
+    @Test func `Init records the region the alert was set in`() {
+        #expect(ProximityAlert(stop: stop, regionID: 12).regionID == 12)
+        // Naming none is the default, and means the tap on this alert's
+        // notification falls back to whichever region is current by then.
+        #expect(ProximityAlert(stop: stop).regionID == nil)
+    }
+
     // MARK: - Radius Clamping
 
     @Test func `Init clamps radius below the minimum`() {
@@ -99,6 +106,28 @@ final class ProximityAlertTests: OBATestCase {
         #expect(decoded.radiusMeters == ProximityAlert.maximumRadiusMeters)
     }
 
+    @Test func `Decoding an alert persisted without a region yields nil`() throws {
+        let alert = ProximityAlert(stop: stop, regionID: 12)
+        let encoded = try JSONEncoder().encode(alert)
+
+        guard var dictionary = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+            Issue.record("Encoded proximity alert was not a JSON object.")
+            return
+        }
+
+        // Stands in for an alert written by a build that predates the field. It
+        // has to keep decoding — these are the rider's alerts, not disposable
+        // cache — and the missing region is what sends its tap back to whichever
+        // one is current.
+        dictionary.removeValue(forKey: "regionID")
+
+        let legacy = try JSONSerialization.data(withJSONObject: dictionary)
+        let decoded = try JSONDecoder().decode(ProximityAlert.self, from: legacy)
+
+        #expect(decoded.regionID == nil)
+        #expect(decoded.stopID == stop.id)
+    }
+
     @Test func `Coordinate returns correct value`() {
         let alert = ProximityAlert(stop: stop)
 
@@ -119,6 +148,14 @@ final class ProximityAlertTests: OBATestCase {
         #expect(roundtripped.longitude == alert.longitude)
         #expect(roundtripped.radiusMeters == 350.0)
         expectClose(roundtripped.createdAt.timeIntervalSince1970, alert.createdAt.timeIntervalSince1970, within: 1.0)
+        #expect(roundtripped.regionID == nil)
+    }
+
+    @Test func `Codable round trip preserves the region`() {
+        let alert = ProximityAlert(stop: stop, regionID: 12)
+        let roundtripped = try! Fixtures.roundtripCodable(type: ProximityAlert.self, model: alert)
+
+        #expect(roundtripped.regionID == 12)
     }
 
     @Test func `Codable round trip preserves coordinate`() {

--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -50,13 +50,20 @@ final class ProximityAlertManagerTests: OBATestCase {
 
     // MARK: - Helpers
 
-    /// - Parameter notificationStatus: what the manager sees when it checks
-    ///   whether a notification it posted could actually reach the rider.
-    private func makeManager(notificationStatus: UNAuthorizationStatus = .authorized) -> ProximityAlertManager {
+    /// - Parameters:
+    ///   - notificationStatus: what the manager sees when it checks whether a
+    ///     notification it posted could actually reach the rider.
+    ///   - regionID: the region the rider is in as the manager sees it, recorded
+    ///     onto every alert it creates.
+    private func makeManager(
+        notificationStatus: UNAuthorizationStatus = .authorized,
+        regionID: Int? = nil
+    ) -> ProximityAlertManager {
         let delivered = self.delivered!
         return ProximityAlertManager(
             locationService: locationService,
             userDataStore: store,
+            regionIDProvider: { regionID },
             authorizationStatusProvider: { notificationStatus },
             scheduleNotification: { request, completion in
                 delivered.value.append(request)
@@ -209,6 +216,99 @@ final class ProximityAlertManagerTests: OBATestCase {
         #expect(result == .regionLimitReached(limit: LocationService.maximumMonitoredRegions))
         #expect(self.store.proximityAlerts.isEmpty)
         #expect(self.locationService.monitoredProximityAlertIDs.isEmpty)
+    }
+
+    @Test func `Create refuses a second alert on the same stop`() async {
+        let manager = makeManager()
+        guard case .activated(let first) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        guard case .alreadyActive(let existing) = result else {
+            Issue.record("Expected .alreadyActive, got \(result)")
+            return
+        }
+        #expect(existing.id == first.id)
+        // The point of the guard. Asserting only the returned case would pass
+        // even if a second geofence had armed at the same coordinate, holding a
+        // second one of the twenty slots and firing alongside the first.
+        #expect(self.store.proximityAlerts.map(\.id) == [first.id])
+        #expect(self.locationService.monitoredProximityAlertIDs == [first.id])
+    }
+
+    @Test func `Create allows an alert on a stop whose old one expired`() async {
+        let manager = makeManager()
+        // Assigned rather than `add`ed. `add` posts `.proximityAlertsDidChange`,
+        // which this manager observes with the selector form — `NotificationCenter`
+        // invokes that inline, so reconciliation would reap the alert before the
+        // guard ever saw it and the test would pass without exercising the expiry
+        // filter it exists for.
+        store.proximityAlerts = [ProximityAlert(
+            stop: stop,
+            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
+        )]
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        // The filter is easy to lose in a refactor, and losing it is invisible
+        // until a rider cannot set today's alert on yesterday's stop.
+        guard case .activated(let alert) = result else {
+            Issue.record("Expected .activated, got \(result)")
+            return
+        }
+        #expect(self.locationService.monitoredProximityAlertIDs == [alert.id])
+    }
+
+    @Test func `Create allows an alert on a different stop`() async {
+        let manager = makeManager()
+        _ = await manager.createProximityAlert(for: stops[0])
+
+        let result = await manager.createProximityAlert(for: stops[1])
+
+        // The guard keys on the stop. One that dropped that predicate would pass
+        // every other test here while refusing every second alert the rider sets.
+        guard case .activated(let second) = result else {
+            Issue.record("Expected .activated, got \(result)")
+            return
+        }
+        #expect(second.stopID == self.stops[1].id)
+        #expect(self.store.proximityAlerts.count == 2)
+        #expect(self.locationService.monitoredProximityAlertIDs.count == 2)
+    }
+
+    @Test func `Create on a stop that already has an alert still reports lost authorization`() async {
+        let manager = makeManager()
+        guard case .activated = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+        // A downgrade from Always neither disarms nor deletes, so the stored alert
+        // still looks healthy to the duplicate guard while no longer able to
+        // deliver in the background.
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+
+        let result = await manager.createProximityAlert(for: stop)
+
+        // Ordering, asserted: "you already have one" would be true and useless
+        // here, because the one they have went quiet when Always did. This is the
+        // actionable answer, and the explanation.
+        #expect(result == .needsLocationAuthorization(.authorizedWhenInUse))
+    }
+
+    @Test func `Create records the region the alert was set in`() async {
+        let manager = makeManager(regionID: 12)
+
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+        #expect(alert.regionID == 12)
+        // Persisted, not merely returned: the tap that needs the region reads the
+        // stored alert, often from a process that did not create it.
+        #expect(self.store.proximityAlerts.first?.regionID == 12)
     }
 
     // MARK: - Cancelling Alerts
@@ -421,6 +521,41 @@ final class ProximityAlertManagerTests: OBATestCase {
         #expect(request?.identifier == ProximityAlertManager.notificationIdentifierPrefix + alert.id.uuidString)
         // The payload `PushService` routes a tap on, back to the stop page.
         #expect(request?.content.userInfo[ProximityAlertManager.notificationUserInfoKey] as? String == self.stop.id)
+    }
+
+    @Test func `The notification carries the region the alert was set in`() async {
+        let manager = makeManager(regionID: 12)
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        enterRegion(for: alert)
+
+        let userInfo = self.delivered.value.first?.content.userInfo
+        #expect(userInfo?[ProximityAlertManager.notificationRegionUserInfoKey] as? Int == 12)
+        // Beside a stop ID that is still bare, not repackaged into a dictionary
+        // with it: a notification delivered by an earlier build and tapped after
+        // the update routes on this key's shape alone, and reshaping it would drop
+        // that tap into the fallback that re-presents the notification's own text.
+        #expect(userInfo?[ProximityAlertManager.notificationUserInfoKey] as? String == self.stop.id)
+    }
+
+    @Test func `The notification omits the region key when the alert has none`() async {
+        let manager = makeManager()
+        guard case .activated(let alert) = await manager.createProximityAlert(for: stop) else {
+            Issue.record("Setup failed: alert did not activate")
+            return
+        }
+
+        enterRegion(for: alert)
+
+        // Absent rather than present and empty: `PushService` reads the key
+        // optionally, so an alert that named no region delivers the payload every
+        // alert delivered before the field existed did.
+        let userInfo = self.delivered.value.first?.content.userInfo
+        #expect(userInfo?.keys.contains(ProximityAlertManager.notificationRegionUserInfoKey) == false)
+        #expect(userInfo?[ProximityAlertManager.notificationUserInfoKey] as? String == self.stop.id)
     }
 
     @Test func `Entering the geofence clears the alert`() async {

--- a/OBAKitTests/PushNotifications/PushServiceTests.swift
+++ b/OBAKitTests/PushNotifications/PushServiceTests.swift
@@ -41,6 +41,7 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
     var receivedDonationPromptIDs: [String?] = []
     var receivedDeviceTokens: [String] = []
     var receivedProximityAlertStopIDs: [StopID] = []
+    var receivedProximityAlertRegionIDs: [Int?] = []
 
     func pushServicePresentingController(_ pushService: PushService) -> UIViewController? {
         nil
@@ -58,8 +59,9 @@ private class PushServiceDelegateRecorder: NSObject, PushServiceDelegate {
         receivedDeviceTokens.append(token)
     }
 
-    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID) {
+    func pushService(_ pushService: PushService, receivedProximityAlertForStopID stopID: StopID, regionID: Int?) {
         receivedProximityAlertStopIDs.append(stopID)
+        receivedProximityAlertRegionIDs.append(regionID)
     }
 }
 
@@ -223,6 +225,26 @@ final class PushServiceTests: OBATestCase {
         ])
 
         #expect(delegate.receivedProximityAlertStopIDs == ["1_75403"])
+        // No region named. The shape of every alert stored before the field
+        // existed, and of any notification an earlier build delivered that is
+        // still sitting untapped in Notification Center.
+        #expect(delegate.receivedProximityAlertRegionIDs == [nil])
+    }
+
+    /// Two custom keys, which `PushService`'s single-custom-key routing cannot
+    /// satisfy — so this payload has to be matched ahead of it, or the rider's tap
+    /// lands in the fallback that tells them a second time that they are near
+    /// their stop.
+    @Test func `Proximity alert payload forwards the region it carries`() {
+        provider.notificationReceivedHandler("You're getting close to 3rd & Pike", [
+            ProximityAlertManager.notificationUserInfoKey: "1_75403",
+            ProximityAlertManager.notificationRegionUserInfoKey: 12
+        ])
+
+        #expect(delegate.receivedProximityAlertStopIDs == ["1_75403"])
+        #expect(delegate.receivedProximityAlertRegionIDs == [12])
+        #expect(delegate.receivedAlarms.isEmpty)
+        #expect(delegate.receivedDonationPromptIDs.isEmpty)
     }
 
     /// Routing this at all is what keeps the fallback below from re-presenting


### PR DESCRIPTION
### Summary

Parts 2 and 4 of #1347. Parts 1 and 3 are #1353.

A stop could hold two alerts. `activeAlert(for:)` already existed, but `createProximityAlert` never consulted it. As a result, a second alert on the same stop could arm another geofence at the same coordinate, consume another of the 20 slots guarded by #1292, and fire alongside the first.

It now returns `.alreadyActive(existing)`.

The duplicate check runs **after** the authorization guards, not before. A downgrade from Always neither disarms nor deletes an existing alert, so a stored alert can appear healthy while no longer being able to deliver. That rider needs `.needsLocationAuthorization`, which is actionable and explains the problem, rather than "you already have one". Expired alerts still do not block a new alert.

### Region tracking

The proximity notification previously carried no region.

- `ProximityAlert` now gains `regionID: Int?`.
- The region is stamped at creation using an injected `regionIDProvider` closure.
- The region is carried in the notification's `userInfo`.
- When the rider taps the notification, the carried region is preferred over `currentRegion`.
- `nil` means "fall back to the current region", preserving the behavior of existing alerts and alerts persisted before this field existed.

This also makes `queueOrOpenStop`'s mismatch guard live from this call site for the first time. Previously, `destination.regionID` was derived from `currentRegion` three lines earlier, so it could never disagree with itself.

The comment claiming the current region was correct "by construction" has therefore been removed — that isn't true for a manually pinned region.

### Notification handling

`notificationReceivedHandler` now matches the proximity payload before its single-custom-key check.

A proximity notification contains both a stop and a region, so it has two keys. The previous ordering would have rejected it and fallen through to the fallback that re-presents the notification's own text.

The stop key retains its bare `StopID` shape, so notifications delivered by an earlier build continue to route correctly.

## Testing

14 tests covering:

- A duplicate returns the existing alert by ID.
- Neither the store nor monitored-region count grows when a duplicate is rejected.
- An expired alert does not block a new alert.
- An alert on a different stop is unaffected.
- A stop with an existing alert still reports lost location authorization.
- The region ID round-trips through persistence.
- Missing region IDs decode as `nil`.
- The region reaches the notification payload.
- Both the carried-region and `currentRegion` fallback paths are asserted.
- Cold-launch notification taps preserve the carried region, which previously lost it entirely.

This overlaps with #1353 in two test files. Happy to rebase onto #1353 once it lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Proximity alerts now retain the transit region where they were created.
  - Notifications carry region information so alerts open in the correct regional context.
  - Alerts without region information continue using the currently selected region.

- **Bug Fixes**
  - Prevented duplicate active proximity alerts for the same stop.
  - Improved handling when region information is unavailable or does not match the current region.
  - Preserved location-authorization warnings when creating alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->