### PR TITLE
Run SwiftLint beside the build instead of ahead of it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,16 @@ on:
 # tests", check the step timings first — it is almost never the tests.
 
 jobs:
-  build:
+  # Its own job, not a step inside `build`. As a step it ran before
+  # build-for-testing in the same job, so one lint error failed the job and took
+  # every test result for that run with it — the two answer different questions
+  # and a PR wants both. Parallel jobs also overlap lint with the build instead
+  # of serialising them. No `needs:`: neither gates the other, and GitHub still
+  # requires both to pass.
+  # See https://github.com/OneBusAway/onebusaway-ios/issues/1340
+  lint:
     runs-on: xcode-27
     permissions:
-      checks: write
       contents: read
 
     steps:
@@ -37,7 +43,7 @@ jobs:
     # type_body_length breach cannot land on main while staying green on GitHub.
     # Warnings annotate via the GitHub reporter but do not fail the job —
     # `--strict` would collapse that split. The Xcode build phase still skips
-    # in CI (scripts/swiftlint.sh); this step is the review-visible gate.
+    # in CI (scripts/swiftlint.sh); this job is the review-visible gate.
     # See https://github.com/OneBusAway/onebusaway-ios/issues/1303
     - name: SwiftLint (errors only)
       env:
@@ -49,6 +55,14 @@ jobs:
         fi
         swiftlint lint --reporter github-actions-logging
 
+  build:
+    runs-on: xcode-27
+    permissions:
+      checks: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/OBAKit/Mapping/MapViewController+Camera.swift
+++ b/OBAKit/Mapping/MapViewController+Camera.swift
@@ -14,8 +14,7 @@ import UIKit
 /// Where the camera goes while a sheet owns the bottom of the screen.
 ///
 /// An extension rather than more of `MapViewController`: framing is one concern
-/// with one shared question — which part of the map is still visible — and the
-/// class it hangs off is already at SwiftLint's body-length ceiling.
+/// with one shared question — which part of the map is still visible.
 extension MapViewController {
 
     /// Keeps the tapped stop visible in the strip of map above the sheet. Without

--- a/OBAKit/Mapping/MapViewController+TripPlanner.swift
+++ b/OBAKit/Mapping/MapViewController+TripPlanner.swift
@@ -14,8 +14,10 @@ import OTPKit
 import SwiftUI
 import UIKit
 
-/// Trip planner presentation. An extension rather than more of `MapViewController`:
-/// the class it hangs off is already at SwiftLint's body-length ceiling.
+/// Trip planner presentation. An extension rather than more of `MapViewController`
+/// because presenting one feature is a separate concern from the map state that
+/// class holds — not because of a lint limit. `type_body_length` reports nothing
+/// on `MapViewController` today; only `file_length` is suppressed there.
 /// See: https://github.com/OneBusAway/onebusaway-ios/issues/1303
 extension MapViewController {
 

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -484,7 +484,7 @@ class MapViewController: UIViewController,
 
     // MARK: - Long Press Gesture
 
-    var longPressGesture: UILongPressGestureRecognizer!
+    private var longPressGesture: UILongPressGestureRecognizer!
 
     @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
         // Only handle the began state to avoid multiple pins


### PR DESCRIPTION

- **Run SwiftLint as a separate job**
  - Lint is now its own job instead of a step that runs ahead of `build-for-testing` in the same job.
  - Previously, a single lint error could prevent the build and tests from running, costing all test signal for that run.
  - The jobs now run in parallel instead of serializing lint and build/test work.
  - Workflow permissions remain minimal: `contents: read` is used for checkout, while `checks: write` is required by `xcresulttool`.

- **Make `longPressGesture` private again**
  - Restored `longPressGesture` to `private`.
  - All five references are inside `MapViewController.swift`.
  - Unlike the other de-privatizations in #1325, no extension in another file needs access to it.

- **Correct the SwiftLint body-length justification**
  - The previous "already at SwiftLint's body-length ceiling" justification was incorrect, not merely stale.
  - SwiftLint reports **zero violations** for `MapViewController.swift`, against a `900/1000` threshold.
  - Only `file_length` is suppressed in that file.
  - The same incorrect sentence appears in `+Camera.swift`, so both comments are corrected.

### Left out

- **Pinning `brew install swiftlint`**
  - This was left unchanged as a house-style question.
  - `xcodegen` is also unpinned in the same workflow, so it would be better to decide on pinning for both together.
  - Happy to add it either way.

Refs #1340.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Linting now runs as a separate parallel job from the build, allowing test results to remain available even when lint checks fail.

* **Code Quality**
  * Updated developer-facing documentation around map camera and trip-planning behavior.
  * Restricted long-press gesture implementation details to the map view controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->