### PR TITLE
Correct what the region-monitoring radius comment claims

### DIFF
--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -593,10 +593,19 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
             return .regionLimitReached(limit: Self.maximumMonitoredRegions)
         }
 
-        // `CLCircularRegion` clamps an oversize radius without reporting it, so
-        // the alert would fire at a distance the user never chose. Clamp
-        // deliberately and say so. A non-positive device maximum means the value
-        // is unavailable rather than zero, so honor the request in that case.
+        // Clamp deliberately and report it. Core Location answers an oversize
+        // radius with `CLError.regionMonitoringFailure`, which arrives
+        // asynchronously through `monitoringDidFailFor` carrying no radius — too
+        // late, and too vague, to tell the rider their alert would have fired
+        // somewhere other than where they asked.
+        //
+        // `-1` is not an unknown limit. Apple documents it as region monitoring
+        // being unavailable or unsupported on this device, so honouring the
+        // request in that case hands the caller `.started` for an alert that can
+        // never fire. Left that way for now — the failure does still surface
+        // through `monitoringDidFailFor` — but refusing up front wants an
+        // `isMonitoringAvailable(for:)` check and a result case to carry it.
+        // Both points flagged in review of #1292.
         let requestedRadius = alert.radiusMeters
         let deviceMaximum = locationManager.maximumRegionMonitoringDistance
         let radius = deviceMaximum > 0 ? min(requestedRadius, deviceMaximum) : requestedRadius


### PR DESCRIPTION
## Description

Two of the three follow-ups left on #1292 were based on incorrect statements in the same comment, so they are corrected together here.

### Changes

- **Corrected the `CLCircularRegion` radius explanation**
  - The comment previously said that `CLCircularRegion` clamps an oversized radius without reporting it.
  - Current documentation says an oversized region results in `CLError.regionMonitoringFailure`.
  - The existing clamping behavior remains correct; only the stated reason was wrong.

- **Corrected the device maximum explanation**
  - The comment previously said that a non-positive device maximum means the value is unavailable rather than zero.
  - Apple documents `-1` as indicating that region monitoring is unavailable or unsupported on the device, which is more specific than simply "unknown".

- **Documented the remaining gap**
  - The comment now explicitly records that when the device maximum is `-1`, we still arm the alert and return `.started` even though the alert can never fire.

### Scope

**Comment-only on purpose.**

The `isMonitoringAvailable(for:)` guard needs a new case on both `ProximityMonitoringResult` and `ProximityAlertActivationResult`.

#1368 already adds `case alreadyActive` to `ProximityAlertActivationResult`, so this follow-up should land after that change.

Follow-up from #1292.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified proximity-monitoring behavior when the requested radius is unavailable or unsupported on a device.
  * Documented that such requests remain honored and that any failures are reported asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->