### PR TITLE
Title: Name the method that actually sets the map status shadow

### DIFF
--- a/OBAKit/Mapping/MapStatusView.swift
+++ b/OBAKit/Mapping/MapStatusView.swift
@@ -121,9 +121,10 @@ class MapStatusView: UIView {
         addSubview(visualEffectView)
 
         // Shadow on the outer view for the floating effect.
-        // Start with opacity 0 — the correct value is set in didMoveToWindow()
-        // because traitCollection is unreliable during init (view has no window yet,
-        // so userInterfaceStyle returns .unspecified regardless of actual appearance).
+        // Start with opacity 0 — `traitCollection` is unreliable during init (no
+        // window yet, so `userInterfaceStyle` reports `.unspecified` whatever the
+        // real appearance is). `layoutSubviews()` sets the first real value, and
+        // the `registerForTraitChanges` below keeps it right after that.
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOffset = CGSize(width: 0, height: 2)
         layer.shadowRadius = Layout.shadowBlur


### PR DESCRIPTION
The comment said the shadow's real opacity "is set in didMoveToWindow()". That method doesn't exist in this file — layoutSubviews() writes the first real value and registerForTraitChanges maintains it afterwards. Now names both.

Follow-up from your nit on #1070.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments to clarify how shadow opacity is initialized and maintained across layout and appearance changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->