### PR TITLE
Finish consolidating the schedule-only deviation gate

### DIFF
--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
@@ -198,14 +198,11 @@ nonisolated struct ArrivalDepartureContentConfiguration: OBAContentConfiguration
 
     var accessibilityScheduleDeviationText: String? {
         guard let formatters = formatters else { return nil }
-        if viewModel.scheduleStatus == .unknown {
-            return Strings.scheduledNotRealTime
-        } else {
-            return formatters.formattedScheduleDeviation(
-                temporalState: viewModel.temporalState,
-                arrivalDepartureStatus: viewModel.arrivalDepartureStatus,
-                scheduleDeviation: viewModel.deviationFromScheduleInMinutes)
-        }
+        return formatters.deviationLabel(
+            scheduleStatus: viewModel.scheduleStatus,
+            temporalState: viewModel.temporalState,
+            arrivalDepartureStatus: viewModel.arrivalDepartureStatus,
+            scheduleDeviation: viewModel.deviationFromScheduleInMinutes)
     }
 
     var accessibilityScheduleDeviationLabelTextColor: UIColor? {

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -126,13 +126,11 @@ public class Formatters: NSObject {
 
         let arrDepTime = timeFormatter.string(from: arrivalDepartureDate)
 
-        let explanationText: String
-        if scheduleStatus == .unknown {
-            explanationText = Strings.scheduledNotRealTime
-        }
-        else {
-            explanationText = formattedScheduleDeviation(temporalState: temporalState, arrivalDepartureStatus: arrivalDepartureStatus, scheduleDeviation: scheduleDeviationInMinutes)
-        }
+        let explanationText = deviationLabel(
+            scheduleStatus: scheduleStatus,
+            temporalState: temporalState,
+            arrivalDepartureStatus: arrivalDepartureStatus,
+            scheduleDeviation: scheduleDeviationInMinutes)
 
         let scheduleStatusColor = colorForScheduleStatus(scheduleStatus)
         let timeExplanationFont = UIFont.preferredFont(forTextStyle: .footnote)
@@ -292,9 +290,33 @@ public class Formatters: NSObject {
     /// `TripActivityPresenter.deviationLabel(for:now:)` applies for Live
     /// Activity content states.
     public func deviationLabel(for arrivalDeparture: ArrivalDeparture) -> String {
-        guard arrivalDeparture.predicted else { return Strings.scheduledNotRealTime }
+        deviationLabel(
+            scheduleStatus: arrivalDeparture.scheduleStatus,
+            temporalState: arrivalDeparture.temporalState,
+            arrivalDepartureStatus: arrivalDeparture.arrivalDepartureStatus,
+            scheduleDeviation: arrivalDeparture.deviationFromScheduleInMinutes)
+    }
 
-        return formattedScheduleDeviation(for: arrivalDeparture)
+    /// The component form, for callers holding a view model rather than the
+    /// `ArrivalDeparture` it came from — `ArrivalDepartureItem` carries these four
+    /// values and not the model.
+    ///
+    /// Gating on `scheduleStatus == .unknown` rather than `predicted` is the same
+    /// condition, not a looser one: `ArrivalDeparture.scheduleStatus` opens with
+    /// `guard predicted else { return .unknown }`. Expressing it once here is what
+    /// stops the two forms drifting apart.
+    public func deviationLabel(
+        scheduleStatus: ScheduleStatus,
+        temporalState: TemporalState,
+        arrivalDepartureStatus: ArrivalDepartureStatus,
+        scheduleDeviation: Int
+    ) -> String {
+        guard scheduleStatus != .unknown else { return Strings.scheduledNotRealTime }
+
+        return formattedScheduleDeviation(
+            temporalState: temporalState,
+            arrivalDepartureStatus: arrivalDepartureStatus,
+            scheduleDeviation: scheduleDeviation)
     }
 
     public func formattedScheduleDeviation(temporalState: TemporalState, arrivalDepartureStatus: ArrivalDepartureStatus, scheduleDeviation: Int) -> String {

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -148,6 +148,57 @@ final class FormattersTests: OBATestCase {
         #expect(formatters.deviationLabel(for: arrivalDeparture) == Strings.scheduledNotRealTime)
     }
 
+    /// The component overload exists for callers holding a view model rather than
+    /// the `ArrivalDeparture` it came from — `ArrivalDepartureItem` carries the
+    /// four values and not the model. Same gate, so `.unknown` must produce the
+    /// same string the model form does.
+    @Test func `Deviation label component form says scheduled for unknown status`() {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+
+        let label = formatters.deviationLabel(
+            scheduleStatus: .unknown,
+            temporalState: .future,
+            arrivalDepartureStatus: .arriving,
+            scheduleDeviation: 0)
+
+        #expect(label == Strings.scheduledNotRealTime)
+    }
+
+    /// And with a real prediction it must fall through to the deviation phrase
+    /// rather than short-circuiting — otherwise the gate would swallow every case.
+    @Test func `Deviation label component form uses the deviation phrase when predicted`() {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+
+        let label = formatters.deviationLabel(
+            scheduleStatus: .delayed,
+            temporalState: .future,
+            arrivalDepartureStatus: .arriving,
+            scheduleDeviation: 2)
+
+        #expect(label == "arrives 2 min late")
+    }
+
+    /// The two forms are one implementation, so they must agree on the same trip.
+    /// A drift here is exactly what the third hand-rolled copy in
+    /// `StopArrivalItem` used to allow.
+    @Test func `Deviation label forms agree on the same trip`() throws {
+        let formatters = Formatters(locale: usLocale, calendar: calendar, themeColors: ThemeColors())
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            predictedArrival: 1_700_000_120,
+            predictedDeparture: 1_700_000_120
+        )
+
+        let fromModel = formatters.deviationLabel(for: arrivalDeparture)
+        let fromComponents = formatters.deviationLabel(
+            scheduleStatus: arrivalDeparture.scheduleStatus,
+            temporalState: arrivalDeparture.temporalState,
+            arrivalDepartureStatus: arrivalDeparture.arrivalDepartureStatus,
+            scheduleDeviation: arrivalDeparture.deviationFromScheduleInMinutes)
+
+        #expect(fromModel == fromComponents)
+        #expect(fromModel == "arrives 2 min late")
+    }
+
     /// A payload can carry predicted timestamps while declaring
     /// `predicted: false`; the gate is the flag, not the fields — the same rule
     /// `DepartureTimeDisplay` applies before striking through a time.


### PR DESCRIPTION
## Description

Follow-up from #1270.

You closed #1270 noting that the consolidation was **2-of-3**. `Formatters.deviationLabel` now has the component overload that `StopArrivalItem` needed, and `deviationLabel(for:)` delegates to it, giving us a single gate instead of two.

- Gating on `scheduleStatus == .unknown` is equivalent to gating on `predicted`.
  - `ArrivalDeparture.scheduleStatus` starts with `guard predicted else { return .unknown }`.

It turned out to be **2-of-4**: `fullAttributedArrivalDepartureExplanation` had a fourth inline copy in `Formatters` itself. That has now been folded into the same consolidated path.

### Left unchanged

- The two copies in `TripActivityPresenter`, which `deviationLabel`'s documentation explicitly identifies as the mirror.
- The switch discriminant at `Formatters.swift:190`.

Follow-up from #1270.