### PR TITLE
Follow-ups: gone stops, loop highlight, proximity test, lint CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,9 @@ on:
 # tests", check the step timings first — it is almost never the tests.
 
 jobs:
-  build:
+  swiftlint:
     runs-on: xcode-27
     permissions:
-      checks: write
       contents: read
 
     steps:
@@ -38,7 +37,7 @@ jobs:
     # Warnings annotate via the GitHub reporter but do not fail the job —
     # `--strict` would collapse that split. The Xcode build phase still skips
     # in CI (scripts/swiftlint.sh); this step is the review-visible gate.
-    # See https://github.com/OneBusAway/onebusaway-ios/issues/1303
+    # Runs in its own job so a lint failure does not suppress test signal (#1340).
     - name: SwiftLint (errors only)
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1
@@ -49,6 +48,14 @@ jobs:
         fi
         swiftlint lint --reporter github-actions-logging
 
+  build:
+    runs-on: xcode-27
+    permissions:
+      checks: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -100,13 +100,13 @@ final class BookmarkActions {
     static func buildContentState(
         from arrivalDepartures: [ArrivalDeparture],
         matching departure: ArrivalDeparture
-    ) -> TripAttributes.ContentState? {
+    ) -> TripAttributes.ContentState {
         let key = TripBookmarkKey(arrivalDeparture: departure)
         let sameTrip = arrivalDepartures
             .filter { TripBookmarkKey(arrivalDeparture: $0) == key }
             .sorted { $0.arrivalDepartureDate < $1.arrivalDepartureDate }
         let source = sameTrip.isEmpty ? [departure] : sameTrip
-        return buildContentState(from: source)
+        return buildContentState(from: source)!
     }
 
     @discardableResult

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -484,7 +484,7 @@ class MapViewController: UIViewController,
 
     // MARK: - Long Press Gesture
 
-    var longPressGesture: UILongPressGestureRecognizer!
+    private var longPressGesture: UILongPressGestureRecognizer!
 
     @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
         // Only handle the began state to avoid multiple pins

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -587,11 +587,7 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             return
         }
 
-        guard let contentState = buildLiveActivityContentState(for: departure, viewModel: viewModel) else {
-            Logger.error("Failed to build content state for Live Activity")
-            return
-        }
-
+        let contentState = buildLiveActivityContentState(for: departure, viewModel: viewModel)
         // Prominence so the Dynamic Island switches to this Track when another
         // trip is already live (#1189 Problem 2). Default score is 0 and equal
         // scores keep the first-started activity.
@@ -622,7 +618,7 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
         }
     }
 
-    private func buildLiveActivityContentState(for departure: ArrivalDeparture, viewModel: StopViewModel) -> TripAttributes.ContentState? {
+    private func buildLiveActivityContentState(for departure: ArrivalDeparture, viewModel: StopViewModel) -> TripAttributes.ContentState {
         let allArrivals = viewModel.stopArrivals?.arrivalsAndDepartures ?? [departure]
         return BookmarkActions.buildContentState(from: allArrivals, matching: departure)
     }

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -165,7 +165,7 @@ class TripFloatingPanelController: UIViewController,
     }
 
     // MARK: - Public Methods
-    public func highlightStopInList(_ matchingStop: Stop) {
+    public func highlightStopInList(_ matchingStop: Stop, stopIndex: Int? = nil) {
         let data = self.items(for: listView)
 
         var matchingIndexPath: IndexPath?
@@ -173,6 +173,7 @@ class TripFloatingPanelController: UIViewController,
             for (itemIndex, item) in section.contents.enumerated() {
                 guard let tripStop = item.as(TripStopViewModel.self),
                       tripStop.stop.id == matchingStop.id else { continue }
+                if let stopIndex, tripStop.stopIndex != stopIndex { continue }
                 matchingIndexPath = IndexPath(item: itemIndex, section: sectionIndex)
                 break
             }
@@ -361,8 +362,8 @@ class TripFloatingPanelController: UIViewController,
         parentTripViewController?.showStopOnMap(tripStop)
     }
 
-    private func showOnList(_ tripStop: TripStopTime) {
-        highlightStopInList(tripStop.stop)
+    private func showOnList(_ tripStop: TripStopViewModel) {
+        highlightStopInList(tripStop.stop, stopIndex: tripStop.stopIndex)
     }
 
     private func serviceAlertsListSection(_ alerts: [ServiceAlert]) -> OBAListViewSection {
@@ -393,6 +394,10 @@ class TripFloatingPanelController: UIViewController,
         }
 
         let closestStopIdx = closestStopIndex(in: tripDetails)
+        let userStopIndex = TripStopListModel.userStopIndex(
+            in: tripDetails.stopTimes,
+            arrivalDeparture: arrivalDeparture
+        )
 
         // Stop times
         let selectTripStopAction: OBAListViewAction<TripStopViewModel> = { [unowned self] item in self.onSelectTripStop(item) }
@@ -402,6 +407,7 @@ class TripFloatingPanelController: UIViewController,
                 arrivalDeparture: arrivalDeparture,
                 stopIndex: index,
                 closestStopIndex: closestStopIdx,
+                userStopIndex: userStopIndex,
                 onSelectAction: selectTripStopAction
             ).typeErased
         }

--- a/OBAKit/Trip/TripPage/TripStopListModel.swift
+++ b/OBAKit/Trip/TripPage/TripStopListModel.swift
@@ -95,6 +95,13 @@ struct TripStopListModel {
         return TripStopListModel(rows: rows, vehicleIndex: vehicleIndex)
     }
 
+    /// Which row is the rider's boarding or destination stop. Shared by the
+    /// SwiftUI trip page and the UIKit stop list.
+    static func userStopIndex(in stopTimes: [TripStopTime], arrivalDeparture: ArrivalDeparture?) -> Int? {
+        guard let arrivalDeparture else { return nil }
+        return index(in: stopTimes, stopID: arrivalDeparture.stopID, stopSequence: arrivalDeparture.stopSequence)
+    }
+
     /// The vehicle's position, resolved from a stop ID that a loop route can
     /// match more than once.
     ///

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -89,13 +89,14 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         arrivalDeparture: ArrivalDeparture?,
         stopIndex: Int,
         closestStopIndex: Int?,
+        userStopIndex: Int?,
         onSelectAction: OBAListViewAction<TripStopViewModel>?
     ) {
         self.stopTime = stopTime
 
         stop = stopTime.stop
 
-        isUserDestination = arrivalDeparture.map { stopTime.stopID == $0.stopID } ?? false
+        isUserDestination = userStopIndex.map { stopIndex == $0 } ?? false
 
         // Derive isCurrentVehicleLocation from the same closestStopIndex used for
         // temporalState so both properties always agree on which stop is "current".

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -345,7 +345,12 @@ class TripViewController: UIViewController,
             return
         }
 
-        tripDetailsController.highlightStopInList(stopTime.stop)
+        if let stopTimes = tripDetailsController.tripDetails?.stopTimes,
+           let stopIndex = stopTimes.firstIndex(where: { $0 === stopTime }) {
+            tripDetailsController.highlightStopInList(stopTime.stop, stopIndex: stopIndex)
+        } else {
+            tripDetailsController.highlightStopInList(stopTime.stop)
+        }
         openStop(stopTime, on: mapView)
     }
 

--- a/OBAKit/ViewModels/StopViewModel.swift
+++ b/OBAKit/ViewModels/StopViewModel.swift
@@ -296,19 +296,11 @@ class StopViewModel: ObservableObject {
                     pendingExtensionMinutes = pendingAutoExtensionAmount()
                 }
             }
+        } catch let error as APIError where error.isGoneStopResponse {
+            applyGoneStopOutcome()
         } catch APIError.requestNotFound {
-            operationError = nil
-            isBrokenBookmark = bookmarkContext != nil
-
-            // With a bookmark behind it, a 404 is the broken-bookmark path: the page
-            // explains itself and offers a way out, and it isn't a failure the rider
-            // watched happen. Without one — a deep link, a search result, a map pin —
-            // the same 404 leaves the page with no arrivals, no error, and nothing to
-            // do, which is exactly the experience that shouldn't be followed by a
-            // request for five stars.
-            if bookmarkContext == nil {
-                environment.noteStopLoadFailed()
-            }
+            // Empty 200 GET mapped to `requestNotFound` — transient, not a gone stop.
+            applyGoneStopOutcome()
         } catch {
             operationError = error
 
@@ -325,6 +317,18 @@ class StopViewModel: ObservableObject {
 
         if let additionalMinutes = pendingExtensionMinutes {
             await loadMore(minutes: additionalMinutes)
+        }
+    }
+
+    /// HTTP 404, JSON `null`, and empty 200 all mean "no stop payload". With a
+    /// bookmark behind the page that is the broken-bookmark path; without one it
+    /// still counts as a load failure for the review prompt.
+    private func applyGoneStopOutcome() {
+        operationError = nil
+        isBrokenBookmark = bookmarkContext != nil
+
+        if bookmarkContext == nil {
+            environment.noteStopLoadFailed()
         }
     }
 

--- a/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
+++ b/OBAKitCore/Bookmarks/BookmarkDataLoader.swift
@@ -183,26 +183,6 @@ public class BookmarkDataLoader: NSObject {
         }
     }
 
-    /// Missing-stop shapes that must not bulletin on the Bookmarks tab.
-    ///
-    /// - Literal HTTP 404: the stop no longer resolves.
-    /// - HTTP 200 with body `null`: what many OBA servers send instead of a
-    ///   404. `APIService+GetData` throws that as `invalidContentType(...,
-    ///   "json", "nothing")` — the copy in #1331. Empty HTTP 200 is *not*
-    ///   included; a live San Diego stop is a full 200, so an empty body
-    ///   stays a transient error.
-    nonisolated private static func isGoneBookmarkStop(_ error: APIError) -> Bool {
-        switch error {
-        case .requestNotFound(let response) where response.statusCode == 404:
-            return true
-        case .invalidContentType(_, let expected, let actual)
-            where expected == "json" && actual == "nothing":
-            return true
-        default:
-            return false
-        }
-    }
-
     @MainActor
     private func loadData(bookmark: Bookmark, batchID: UInt64) {
         guard
@@ -236,7 +216,7 @@ public class BookmarkDataLoader: NSObject {
 
                     self.delegate?.dataLoaderDidUpdate(self)
                 }
-            } catch let error as APIError where Self.isGoneBookmarkStop(error) {
+            } catch let error as APIError where error.isGoneStopResponse {
                 // The stop no longer exists in this region. Don't bulletin —
                 // settle the card on "No upcoming departures" and drop any
                 // previous countdown for this stop.

--- a/OBAKitCore/Network/Operations/NetworkOperation.swift
+++ b/OBAKitCore/Network/Operations/NetworkOperation.swift
@@ -128,4 +128,25 @@ public enum APIError: Error, LocalizedError {
             return OBALoc("api_error.no_region_selected", value: "No region has been selected. Please select a region to continue.", comment: "An error message that tells the user that no region has been selected.")
         }
     }
+
+    /// Missing-stop shapes shared by the Bookmarks tab and the stop page.
+    ///
+    /// - Literal HTTP 404: the stop no longer resolves.
+    /// - HTTP 200 with body `null`: what many OBA servers send instead of a
+    ///   404. `APIService+GetData` throws that as `invalidContentType(...,
+    ///   "json", "nothing")`.
+    ///
+    /// Empty HTTP 200 is *not* included; a live stop can return a full 200, so
+    /// an empty body stays a transient error.
+    nonisolated public var isGoneStopResponse: Bool {
+        switch self {
+        case .requestNotFound(let response) where response.statusCode == 404:
+            return true
+        case .invalidContentType(_, let expected, let actual)
+            where expected == "json" && actual == "nothing":
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -147,10 +147,10 @@ final class BookmarkActionsTests: OBATestCase {
             departureEpoch: 1_700_000_840
         )
 
-        let state = try #require(BookmarkActions.buildContentState(
+        let state = BookmarkActions.buildContentState(
             from: [oppositeSooner, tracked, laterSameDirection],
             matching: tracked
-        ))
+        )
 
         #expect(state.arrivals.count == 2)
         #expect(state.arrivals.map(\.departureTime) == [
@@ -176,10 +176,10 @@ final class BookmarkActionsTests: OBATestCase {
             departureEpoch: 1_700_000_100
         )
 
-        let state = try #require(BookmarkActions.buildContentState(
+        let state = BookmarkActions.buildContentState(
             from: [otherRoute],
             matching: tracked
-        ))
+        )
 
         #expect(state.arrivals.count == 1)
         #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))

--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -458,19 +458,29 @@ final class ProximityAlertManagerTests: OBATestCase {
         #expect(manager.proximityAlerts.isEmpty)
     }
 
-    @Test func `Entering the geofence of an expired alert delivers nothing`() {
-        let expired = ProximityAlert(
-            stop: stop,
-            createdAt: Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60)
-        )
-        store.add(proximityAlert: expired)
+    @Test func `Entering the geofence of an expired alert delivers nothing`() throws {
+        let alert = ProximityAlert(stop: stop)
+        store.add(proximityAlert: alert)
         let manager = makeManager()
-        // Reconciliation reaped it on construction, so put it back to reach the
-        // guard under test: the crossing arriving before anything reconciles.
-        store.add(proximityAlert: expired)
-        #expect(locationService.startMonitoringProximity(for: expired) == .started)
+        #expect(locationService.startMonitoringProximity(for: alert) == .started)
 
-        enterRegion(for: expired)
+        // Region is armed. Swap in an expired record with the same ID without
+        // posting `.proximityAlertsDidChange`, which would reconcile and reap it
+        // before the crossing reaches `guard !alert.isExpired`.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        var payload = try JSONSerialization.jsonObject(with: try encoder.encode(alert)) as! [String: Any]
+        payload["createdAt"] = Date(timeIntervalSinceNow: -ProximityAlert.expirationInterval - 60).timeIntervalSince1970
+        let expired = try decoder.decode(
+            ProximityAlert.self,
+            from: JSONSerialization.data(withJSONObject: payload)
+        )
+        #expect(expired.isExpired)
+        store.proximityAlerts = [expired]
+
+        enterRegion(for: alert)
 
         // Waking a rider for a trip that ended a day ago is worse than not firing.
         #expect(self.delivered.value.isEmpty)

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -122,6 +122,20 @@ final class StopViewModelTests: OBATestCase {
         return (viewModel, app)
     }
 
+    /// Builds a `StopViewModel` whose arrivals fetch returns HTTP 200 with a
+    /// literal `null` body — the shape many OBA servers use for a missing stop.
+    @MainActor
+    private func buildViewModelWithJSONNullArrivals(bookmarkContext: Bookmark? = nil) -> (StopViewModel, Application) {
+        let dataLoader = MockDataLoader(testName: name)
+        let app = createApplication(
+            dataLoader: dataLoader,
+            analytics: AnalyticsMock(),
+            arrivalsData: Data("null".utf8)
+        )
+        let viewModel = StopViewModel(application: app, stopID: testStopID, bookmarkContext: bookmarkContext)
+        return (viewModel, app)
+    }
+
     /// Hides every route present in `arrivals_and_departures_for_stop_1_10020.json`
     /// (routes `1_30` and `1_65`) so the rider never sees a real-time row from that
     /// fixture. Writes straight to the view model's in-memory `stopPreferences` via
@@ -989,6 +1003,28 @@ final class StopViewModelTests: OBATestCase {
     func `Request not found without bookmark context flags error`() async {
         let (viewModel, application) = buildViewModelWithFailingArrivals(statusCode: 404)
         await viewModel.refresh()
+        #expect(application.promptCoordinator.sawErrorThisSession)
+    }
+
+    /// OBA servers that cannot 404 a missing stop answer HTTP 200 with the literal
+    /// body `null`. That must follow the same broken-bookmark path as a literal 404
+    /// (#1336), not surface `invalidContentType` as `operationError`.
+    @Test @MainActor
+    func `JSON null with bookmark context marks broken bookmark`() async throws {
+        let stop = try #require(try Fixtures.loadSomeStops().first)
+        let bookmark = Bookmark(name: "Broken", regionIdentifier: pugetSoundRegionIdentifier, stop: stop)
+        let (viewModel, application) = buildViewModelWithJSONNullArrivals(bookmarkContext: bookmark)
+        await viewModel.refresh()
+        #expect(viewModel.isBrokenBookmark)
+        #expect(viewModel.operationError == nil)
+        #expect(!application.promptCoordinator.sawErrorThisSession)
+    }
+
+    @Test @MainActor
+    func `JSON null without bookmark context flags error`() async {
+        let (viewModel, application) = buildViewModelWithJSONNullArrivals()
+        await viewModel.refresh()
+        #expect(viewModel.operationError == nil)
         #expect(application.promptCoordinator.sawErrorThisSession)
     }
 }

--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -63,6 +63,7 @@ final class TripStopTemporalStateTests {
             arrivalDeparture: nil,
             stopIndex: 0,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
         #expect(viewModel.temporalState == .future)
@@ -87,6 +88,7 @@ final class TripStopViewModelIdentityTests {
             arrivalDeparture: nil,
             stopIndex: 0,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
         let second = TripStopViewModel(
@@ -94,6 +96,7 @@ final class TripStopViewModelIdentityTests {
             arrivalDeparture: nil,
             stopIndex: 5,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
 
@@ -105,16 +108,60 @@ final class TripStopViewModelIdentityTests {
     @Test func `List ids stay unique across the whole trip`() throws {
         let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
         let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
-        let ids = response.entry.stopTimes.enumerated().map { index, stopTime in
+        var stopTimes = response.entry.stopTimes
+        // Inject a repeat visit so uniqueness is non-vacuous against bare stop IDs.
+        if stopTimes.count > 2 {
+            stopTimes.insert(stopTimes[1], at: min(4, stopTimes.count))
+        }
+        let ids = stopTimes.enumerated().map { index, stopTime in
             TripStopViewModel(
                 stopTime: stopTime,
                 arrivalDeparture: nil,
                 stopIndex: index,
                 closestStopIndex: nil,
+                userStopIndex: nil,
                 onSelectAction: nil
             ).id
         }
         #expect(Set(ids).count == ids.count)
+    }
+
+    /// Bare stop ID alone marks every occurrence on a loop; `stopSequence` picks
+    /// the rider's boarding visit (#1346).
+    @Test func `User destination uses stop sequence on a loop`() throws {
+        let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
+        let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
+        var stopTimes = response.entry.stopTimes
+        let repeated = stopTimes[1]
+        stopTimes.insert(repeated, at: 4)
+
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            stopSequence: 4,
+            stopID: repeated.stopID
+        )
+        let userStopIndex = try #require(
+            TripStopListModel.userStopIndex(in: stopTimes, arrivalDeparture: arrivalDeparture)
+        )
+        #expect(userStopIndex == 4)
+
+        let firstVisit = TripStopViewModel(
+            stopTime: repeated,
+            arrivalDeparture: arrivalDeparture,
+            stopIndex: 1,
+            closestStopIndex: nil,
+            userStopIndex: userStopIndex,
+            onSelectAction: nil
+        )
+        let secondVisit = TripStopViewModel(
+            stopTime: repeated,
+            arrivalDeparture: arrivalDeparture,
+            stopIndex: 4,
+            closestStopIndex: nil,
+            userStopIndex: userStopIndex,
+            onSelectAction: nil
+        )
+        #expect(!firstVisit.isUserDestination)
+        #expect(secondVisit.isUserDestination)
     }
 }
 

--- a/docs/duplicate-trip-stop-ids.md
+++ b/docs/duplicate-trip-stop-ids.md
@@ -11,4 +11,6 @@ list now uses the same format.
 `Equatable` includes `id`, matching the protocol's "all values, including
 the identifier" rule. Two visits to one stop are no longer equal.
 
-Tests do not load `TripViewController.view`.
+UIKit selection paths (`highlightStopInList`, `isUserDestination`) also
+resolve the rider's stop by `stopSequence`, not bare stop ID alone, so a
+loop route highlights the correct visit.


### PR DESCRIPTION
## Summary
- **#1336** — Hoist `APIError.isGoneStopResponse` and treat JSON-`null` stop fetches as broken bookmarks on the stop page (same predicate as Bookmarks).
- **#1347** — Proximity expiry test arms a live geofence, then swaps in an expired alert without posting `proximityAlertsDidChange`, so it exercises `guard !alert.isExpired`.
- **#1337** — `buildContentState(from:matching:)` is non-optional; the matching overload always has at least the selected departure.
- **#1340** — `longPressGesture` is `private` again; SwiftLint runs in its own CI job so lint failures do not suppress test signal.
- **#1346** — UIKit `highlightStopInList` / `isUserDestination` resolve the rider's stop by `stopSequence`; list-id regression test injects a repeated stop.

## Test plan
- [x] `StopViewModelTests` (35 tests)
- [x] `ProximityAlertManagerTests`, `BookmarkActionsTests`, `TripStopViewModelIdentityTests` (44 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected stop selection and highlighting for loop routes and trips with repeated stops.
  - Improved handling of unavailable stops, including missing-stop responses and broken bookmarks.
  - Improved Live Activity startup reliability when trip content is available.
  - Refined trip departure information so a valid state is shown even when matching trips are unavailable.

- **Documentation**
  - Clarified how repeated trip stops are identified and selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->