### PR TITLE
Fix UIKit loop-route stop highlight and destination (#1346)

### DIFF
--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -168,10 +168,11 @@ class TripFloatingPanelController: UIViewController,
     /// Scrolls the trip stop list to `matchingStop`'s row and, by default, blinks it.
     /// - Parameters:
     ///   - matchingStop: The stop whose row should be brought into view.
+    ///   - stopIndex: When the trip revisits a stop, disambiguates which visit to scroll to.
     ///   - blinksAfterScroll: Pass `false` when the caller is about to push another view
     ///     controller. The blink is delayed until scrolling settles, so it would play
     ///     underneath the pushed page and be finished before the rider returned to see it.
-    public func highlightStopInList(_ matchingStop: Stop, blinksAfterScroll: Bool = true) {
+    public func highlightStopInList(_ matchingStop: Stop, stopIndex: Int? = nil, blinksAfterScroll: Bool = true) {
         let data = self.items(for: listView)
 
         var matchingIndexPath: IndexPath?
@@ -179,6 +180,7 @@ class TripFloatingPanelController: UIViewController,
             for (itemIndex, item) in section.contents.enumerated() {
                 guard let tripStop = item.as(TripStopViewModel.self),
                       tripStop.stop.id == matchingStop.id else { continue }
+                if let stopIndex, tripStop.stopIndex != stopIndex { continue }
                 matchingIndexPath = IndexPath(item: itemIndex, section: sectionIndex)
                 break
             }
@@ -369,8 +371,8 @@ class TripFloatingPanelController: UIViewController,
         parentTripViewController?.showStopOnMap(tripStop)
     }
 
-    private func showOnList(_ tripStop: TripStopTime) {
-        highlightStopInList(tripStop.stop)
+    private func showOnList(_ tripStop: TripStopViewModel) {
+        highlightStopInList(tripStop.stop, stopIndex: tripStop.stopIndex)
     }
 
     private func serviceAlertsListSection(_ alerts: [ServiceAlert]) -> OBAListViewSection {
@@ -401,6 +403,10 @@ class TripFloatingPanelController: UIViewController,
         }
 
         let closestStopIdx = closestStopIndex(in: tripDetails)
+        let userStopIndex = TripStopListModel.userStopIndex(
+            in: tripDetails.stopTimes,
+            arrivalDeparture: arrivalDeparture
+        )
 
         // Stop times
         let selectTripStopAction: OBAListViewAction<TripStopViewModel> = { [unowned self] item in self.onSelectTripStop(item) }
@@ -410,6 +416,7 @@ class TripFloatingPanelController: UIViewController,
                 arrivalDeparture: arrivalDeparture,
                 stopIndex: index,
                 closestStopIndex: closestStopIdx,
+                userStopIndex: userStopIndex,
                 onSelectAction: selectTripStopAction
             ).typeErased
         }
@@ -437,9 +444,10 @@ class TripFloatingPanelController: UIViewController,
         }
 
         let arrivalDeparture = tripConvertible?.arrivalDeparture
-        let userStopIndex = arrivalDeparture.flatMap { ad in
-            tripDetails.stopTimes.firstIndex { $0.stopID == ad.stopID }
-        }
+        let userStopIndex = TripStopListModel.userStopIndex(
+            in: tripDetails.stopTimes,
+            arrivalDeparture: arrivalDeparture
+        )
 
         guard let vm = TripProgressViewModel(
             closestStopIndex: currentIndex,

--- a/OBAKit/Trip/TripPage/TripStopListModel.swift
+++ b/OBAKit/Trip/TripPage/TripStopListModel.swift
@@ -95,6 +95,13 @@ struct TripStopListModel {
         return TripStopListModel(rows: rows, vehicleIndex: vehicleIndex)
     }
 
+    /// Which row is the rider's boarding or destination stop. Shared by the
+    /// SwiftUI trip page and the UIKit stop list.
+    static func userStopIndex(in stopTimes: [TripStopTime], arrivalDeparture: ArrivalDeparture?) -> Int? {
+        guard let arrivalDeparture else { return nil }
+        return index(in: stopTimes, stopID: arrivalDeparture.stopID, stopSequence: arrivalDeparture.stopSequence)
+    }
+
     /// The vehicle's position, resolved from a stop ID that a loop route can
     /// match more than once.
     ///

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -89,13 +89,14 @@ nonisolated struct TripStopViewModel: OBAListViewItem {
         arrivalDeparture: ArrivalDeparture?,
         stopIndex: Int,
         closestStopIndex: Int?,
+        userStopIndex: Int?,
         onSelectAction: OBAListViewAction<TripStopViewModel>?
     ) {
         self.stopTime = stopTime
 
         stop = stopTime.stop
 
-        isUserDestination = arrivalDeparture.map { stopTime.stopID == $0.stopID } ?? false
+        isUserDestination = userStopIndex.map { stopIndex == $0 } ?? false
 
         // Derive isCurrentVehicleLocation from the same closestStopIndex used for
         // temporalState so both properties always agree on which stop is "current".

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -353,7 +353,12 @@ class TripViewController: UIViewController,
         // Scroll the list without blinking the row: `openStop` pushes the stop page on
         // the next line, so the delayed blink would play underneath it and be over
         // before the rider comes back. The scroll still leaves the row on screen for them.
-        tripDetailsController.highlightStopInList(stopTime.stop, blinksAfterScroll: false)
+        if let stopTimes = tripDetailsController.tripDetails?.stopTimes,
+           let stopIndex = stopTimes.firstIndex(where: { $0 == stopTime }) {
+            tripDetailsController.highlightStopInList(stopTime.stop, stopIndex: stopIndex, blinksAfterScroll: false)
+        } else {
+            tripDetailsController.highlightStopInList(stopTime.stop, blinksAfterScroll: false)
+        }
         openStop(stopTime, on: mapView)
     }
 

--- a/OBAKitTests/ViewModels/TripStopListItemTests.swift
+++ b/OBAKitTests/ViewModels/TripStopListItemTests.swift
@@ -63,6 +63,7 @@ final class TripStopTemporalStateTests {
             arrivalDeparture: nil,
             stopIndex: 0,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
         #expect(viewModel.temporalState == .future)
@@ -87,6 +88,7 @@ final class TripStopViewModelIdentityTests {
             arrivalDeparture: nil,
             stopIndex: 0,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
         let second = TripStopViewModel(
@@ -94,6 +96,7 @@ final class TripStopViewModelIdentityTests {
             arrivalDeparture: nil,
             stopIndex: 5,
             closestStopIndex: nil,
+            userStopIndex: nil,
             onSelectAction: nil
         )
 
@@ -126,11 +129,50 @@ final class TripStopViewModelIdentityTests {
                 arrivalDeparture: nil,
                 stopIndex: index,
                 closestStopIndex: nil,
+                userStopIndex: nil,
                 onSelectAction: nil
             ).id
         }
 
         #expect(Set(ids).count == loop.count)
+    }
+
+    /// Bare stop ID alone marks every occurrence on a loop; `stopSequence` picks
+    /// the rider's boarding visit (#1346).
+    @Test func `User destination uses stop sequence on a loop`() throws {
+        let data = Fixtures.loadData(file: "trip_details_1_18196913_no_status.json")
+        let response = try JSONDecoder.RESTDecoder().decode(RESTAPIResponse<TripDetails>.self, from: data)
+        var stopTimes = response.entry.stopTimes
+        let repeated = stopTimes[1]
+        stopTimes.insert(repeated, at: 4)
+
+        let arrivalDeparture = try Fixtures.arrivalDeparture(
+            stopSequence: 4,
+            stopID: repeated.stopID
+        )
+        let userStopIndex = try #require(
+            TripStopListModel.userStopIndex(in: stopTimes, arrivalDeparture: arrivalDeparture)
+        )
+        #expect(userStopIndex == 4)
+
+        let firstVisit = TripStopViewModel(
+            stopTime: repeated,
+            arrivalDeparture: arrivalDeparture,
+            stopIndex: 1,
+            closestStopIndex: nil,
+            userStopIndex: userStopIndex,
+            onSelectAction: nil
+        )
+        let secondVisit = TripStopViewModel(
+            stopTime: repeated,
+            arrivalDeparture: arrivalDeparture,
+            stopIndex: 4,
+            closestStopIndex: nil,
+            userStopIndex: userStopIndex,
+            onSelectAction: nil
+        )
+        #expect(!firstVisit.isUserDestination)
+        #expect(secondVisit.isUserDestination)
     }
 }
 


### PR DESCRIPTION
## Summary
- Resolve the rider's stop by `stopSequence` for UIKit `highlightStopInList` and `isUserDestination`, matching `TripStopListModel` (loop routes no longer highlight the first visit).
- Make the list-id uniqueness regression able to fail by injecting a repeated stop.
- Doc cleanup for `docs/duplicate-trip-stop-ids.md`.

Scoped to the half of #1346 Divesh noted was uncovered; his #1366 covers the vacuous-test half.

## Test plan
- [x] `TripStopViewModelIdentityTests` (including `User destination uses stop sequence on a loop`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stop selection on loop routes by distinguishing repeated visits to the same stop.
  - Map selections now highlight the corresponding stop occurrence in the trip list.
  - Boarding and destination indicators now apply to the correct stop visit.

- **Tests**
  - Added coverage for repeated stop IDs and loop-route destination selection.

- **Documentation**
  - Updated guidance for handling duplicate stop IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->