### PR TITLE
Route all three Live Activity start paths through a shared prominence…

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -147,28 +147,12 @@ final class BookmarkActions {
         }
 
         let attributes = TripAttributes(staticData: staticData)
-        // Prominence so the Dynamic Island switches to this Track when another
-        // trip is already live (#1189 Problem 2). Default score is 0 and equal
-        // scores keep the first-started activity.
-        let prominence = TripLiveActivityRelevance.prominenceScore()
         do {
-            let activity = try Activity.request(
+            let activity = try Activity<TripAttributes>.requestProminent(
                 attributes: attributes,
-                content: TripLiveActivityRelevance.content(
-                    state: contentState,
-                    staleDate: nil,
-                    relevanceScore: prominence
-                ),
-                pushType: .token
+                state: contentState
             )
             trackLiveActivity(activity, arrivalDepartures: arrivalDepartures)
-            let activityID = activity.id
-            Task {
-                await Activity<TripAttributes>.demoteLivePeers(
-                    exceptActivityID: activityID,
-                    relativeTo: prominence
-                )
-            }
             Logger.info("Started Live Activity with ID: \(activity.id)")
             showLiveActivityStartedToast()
             return .started

--- a/OBAKit/LiveActivities/Activity+RequestProminent.swift
+++ b/OBAKit/LiveActivities/Activity+RequestProminent.swift
@@ -1,0 +1,61 @@
+//
+//  Activity+RequestProminent.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import ActivityKit
+import Foundation
+import OBAKitCore
+
+extension Activity where Attributes == TripAttributes {
+
+    /// Starts a trip Live Activity that takes over the Dynamic Island, demoting
+    /// any peers that are still live (#1189 Problem 2).
+    ///
+    /// One prominence score has to reach two places that must agree: the new
+    /// activity's `ActivityContent`, and the demotion the peers are measured
+    /// against. Assembling that pairing by hand is what let the trip page ship
+    /// with neither half — a bare `.init(state:staleDate:)` scores `0`, so the
+    /// Island stayed on whichever trip was already running (#1375).
+    ///
+    /// The pairing can't be caught by a test: `Activity.request` doesn't run in
+    /// this target, and no test in `OBAKitTests` reaches one. Owning both halves
+    /// in a single place is the substitute for coverage that can't exist, and is
+    /// what keeps the next start path from repeating the omission.
+    ///
+    /// Callers keep their own tracking and UI feedback — those are the parts
+    /// that legitimately differ between the bookmark, stop, and trip paths.
+    static func requestProminent(
+        attributes: TripAttributes,
+        state: TripAttributes.ContentState,
+        staleDate: Date? = nil
+    ) throws -> Activity<TripAttributes> {
+        let prominence = TripLiveActivityRelevance.prominenceScore()
+
+        let activity = try Activity.request(
+            attributes: attributes,
+            content: TripLiveActivityRelevance.content(
+                state: state,
+                staleDate: staleDate,
+                relevanceScore: prominence
+            ),
+            pushType: .token
+        )
+
+        // Hop with the id rather than the activity: `Activity` is not `Sendable`,
+        // and the demotion only ever needed the identity to skip.
+        let activityID = activity.id
+        Task {
+            await Activity<TripAttributes>.demoteLivePeers(
+                exceptActivityID: activityID,
+                relativeTo: prominence
+            )
+        }
+
+        return activity
+    }
+}

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -592,28 +592,12 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             return
         }
 
-        // Prominence so the Dynamic Island switches to this Track when another
-        // trip is already live (#1189 Problem 2). Default score is 0 and equal
-        // scores keep the first-started activity.
-        let prominence = TripLiveActivityRelevance.prominenceScore()
         do {
-            let activity = try Activity.request(
+            let activity = try Activity<TripAttributes>.requestProminent(
                 attributes: TripAttributes(staticData: staticData),
-                content: TripLiveActivityRelevance.content(
-                    state: contentState,
-                    staleDate: nil,
-                    relevanceScore: prominence
-                ),
-                pushType: .token
+                state: contentState
             )
             application.liveActivityTracker.track(activity: activity, metadata: .init(departure))
-            let activityID = activity.id
-            Task {
-                await Activity<TripAttributes>.demoteLivePeers(
-                    exceptActivityID: activityID,
-                    relativeTo: prominence
-                )
-            }
             Logger.info("Started Live Activity with ID: \(activity.id)")
             viewModel.signalLiveActivityStarted()
         } catch {

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -453,10 +453,9 @@ final class TripPageViewController: UIHostingController<TripPageView>,
         ])
 
         do {
-            let activity = try Activity.request(
+            let activity = try Activity<TripAttributes>.requestProminent(
                 attributes: TripAttributes(staticData: staticData),
-                content: .init(state: contentState, staleDate: nil),
-                pushType: .token
+                state: contentState
             )
             application.liveActivityTracker.track(activity: activity, metadata: .init(departure))
             Logger.info("Started Live Activity with ID: \(activity.id)")

--- a/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
+++ b/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// ActivityKit shows the Live Activity with the highest `relevanceScore` in the
 /// Dynamic Island. When scores are equal (or unset — default `0`), it keeps the
-/// first activity that was started. Both start paths previously built
+/// first activity that was started. The start paths originally built
 /// `ActivityContent` without a score, so tracking bookmark B after A left the
 /// Island on A.
 ///
@@ -22,6 +22,11 @@ import Foundation
 /// monotonic prominence score; peers are demoted to ``demotedScore``. Local
 /// content refreshes must go through ``contentPreservingRelevance`` — rebuilding
 /// with the default of `0` undoes prominence after the next arrivals poll.
+///
+/// Starting an activity is not done from here: `Activity.request` is unavailable
+/// to app extensions and this target is `APPLICATION_EXTENSION_API_ONLY`. The
+/// three start paths go through `Activity.requestProminent` in OBAKit, which
+/// pairs the score below with the matching ``demoteLivePeers`` call.
 public enum TripLiveActivityRelevance {
 
     /// Score assigned to activities that should yield the Dynamic Island.

--- a/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
+++ b/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
@@ -15,8 +15,9 @@ import Testing
 /// Pins the Dynamic Island prominence policy for #1189 Problem 2.
 ///
 /// ActivityKit itself isn't injectable, so these tests lock the score math and
-/// `ActivityContent` construction that the bookmark/stop start paths share —
-/// the same seam pattern as `TripAttributesIdentityTests` for Problem 1.
+/// `ActivityContent` construction that the three start paths share through
+/// `Activity.requestProminent` — the same seam pattern as
+/// `TripAttributesIdentityTests` for Problem 1.
 @MainActor
 @Suite(.serialized)
 final class TripLiveActivityRelevanceTests {
@@ -36,6 +37,25 @@ final class TripLiveActivityRelevanceTests {
             now: Date(timeIntervalSince1970: 1_700_000_100)
         )
         #expect(later > earlier)
+    }
+
+    /// The trip page's pre-#1375 construction didn't merely score low — a bare
+    /// `ActivityContent` scores `0`, which is exactly ``demotedScore``. A trip
+    /// tracked from that page was born indistinguishable from a peer that had
+    /// been deliberately demoted, so it could never take the Island from a
+    /// bookmark or stop Track scoring `prominenceScore()`.
+    @Test func `A bare content state is born at the demoted score`() {
+        let state = TripAttributes.ContentState(arrivals: [])
+        let bare = ActivityContent(state: state, staleDate: nil)
+
+        #expect(bare.relevanceScore == TripLiveActivityRelevance.demotedScore)
+
+        let started = TripLiveActivityRelevance.content(
+            state: state,
+            staleDate: nil,
+            relevanceScore: TripLiveActivityRelevance.prominenceScore()
+        )
+        #expect(started.relevanceScore > bare.relevanceScore)
     }
 
     @Test func `Content carries the supplied relevance score`() {
@@ -100,8 +120,10 @@ final class TripLiveActivityRelevanceTests {
         #expect(refreshed.relevanceScore == existing.relevanceScore)
         #expect(refreshed.relevanceScore == 1_700_000_050)
 
-        // Contrast: the default ActivityContent score is 0. If the call site
-        // ever drops back to `.init(state:staleDate:)`, this is what Island gets.
+        // Contrast: the default ActivityContent score is 0. This is what the
+        // Island got from the trip page, which built content with a bare
+        // `.init(state:staleDate:)` until #1375 routed all three start paths
+        // through `Activity.requestProminent`.
         let wiped = ActivityContent(state: refreshedState, staleDate: nil)
         #expect(wiped.relevanceScore == 0)
         #expect(wiped.relevanceScore != existing.relevanceScore)


### PR DESCRIPTION
Fixes #1375.

The trip page's Track path never picked up the Dynamic Island prominence handshake from #1243. It built content with a bare `.init(state:staleDate:)` — which scores `0` — and demoted no peers, so tracking a trip from that page left the Island on whichever trip was already running. That's the #1189 Problem 2 behaviour the bookmark and stop paths exist to prevent.

Neither PR is at fault: #1243 and the commit that added this call site were in flight on parallel branches a day apart, so neither could see the other.

## Why a helper instead of a third copy

The obvious fix is to paste the eight lines the other two sites use. I didn't, because the invariant here can't be tested.

One prominence score has to reach two places that must agree — the new activity's `ActivityContent`, and the demotion its peers are measured against. `Activity.request` doesn't run under test, and no test in `OBAKitTests` reaches one; the existing coverage stops at content-state building and the no-arrivals early return. So a third hand-assembled copy would be a third chance to get an unverifiable pairing wrong, and #1298 is already adding a fourth start path.

`Activity.requestProminent` now owns both halves. Callers keep their own tracking and UI feedback, which is the part that legitimately differs between the three paths. There is exactly one `Activity.request` in the codebase now.

It lives in OBAKit rather than beside its siblings in `TripLiveActivityRelevance`, because `Activity.request` is unavailable to app extensions and OBAKitCore is `APPLICATION_EXTENSION_API_ONLY`. I noted that in the enum's doc comment so the next person doesn't try to move it.

## Tests

Added one that pins the mechanism rather than restating the score math: a bare `ActivityContent` scores `0`, which is *exactly* `demotedScore`. A trip tracked from the trip page was born indistinguishable from a peer that had been deliberately demoted — it couldn't merely lose the Island, it could never win it.

Also corrected two comments that stopped being true: the enum doc and the test-suite header both still described two start paths, and the "Contrast" comment at `TripLiveActivityRelevanceTests.swift` predicted this exact regression ("if the call site ever drops back to `.init(state:staleDate:)`") while asserting against a locally built value instead of a call site.

## One thing I left alone

The trip page also hand-rolls its `ContentState` with a single arrival, where the bookmark and stop paths go through tested builders that carry up to three. That looks like a separate divergence rather than part of this bug, so I haven't touched it — happy to file it if you agree it's one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live Activities started from bookmarks, stops, and trip pages now use consistent prominence handling.
  * Newly started trip activities are prioritized in the Dynamic Island, while other active trip activities are demoted as appropriate.
  * Live Activity updates continue preserving their established relevance and tracking behavior.

* **Tests**
  * Added coverage for Dynamic Island prominence and demotion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->