### PR TITLE
Cover the ignored-jitter and animated branches of StopVehicleAnnotation.update

### DIFF
--- a/OBAKitTests/Mapping/StopRouteFocus/StopVehicleAnnotationTests.swift
+++ b/OBAKitTests/Mapping/StopRouteFocus/StopVehicleAnnotationTests.swift
@@ -110,6 +110,71 @@ final class StopVehicleAnnotationTests {
         #expect(annotation.routeColor == .systemGreen)
     }
 
+    /// #1341 item 3. The test above jumps (47.6, -122.3) → (48.1, -121.9) — about
+    /// 60 km, or 120× `snapBeyondMeters` — so it only ever reaches `.snap`. The
+    /// other two branches of `VehicleCoordinateUpdate.decision`, and the
+    /// restore-then-apply ordering they depend on, had no coverage at all.
+    ///
+    /// This is the branch that proves the ordering. Below `ignoreBelowMeters`
+    /// `apply` is a no-op, so whatever sits in `coordinate` when it runs is what
+    /// the rider keeps. `tripStatus`'s `didSet` has just overwritten that with the
+    /// fixture's `lastKnownLocation`; without `update`'s `self.coordinate = from`
+    /// restore, every poll too small to matter would teleport the pin there.
+    @Test func `A sub-threshold jitter leaves the coordinate where it was`() throws {
+        let origin = CLLocationCoordinate2D(latitude: 47.6100, longitude: -122.3300)
+        let annotation = StopVehicleAnnotation(
+            id: "6821", routeID: "H", routeColor: .systemRed, departureID: "dep1",
+            tripStatus: try makeTripStatus(),
+            coordinate: origin
+        )
+
+        // ~1.1 m. Asserted rather than assumed so the test can't go vacuous if
+        // the threshold is ever retuned.
+        let jitter = CLLocationCoordinate2D(latitude: 47.610010, longitude: -122.3300)
+        #expect(origin.distance(from: jitter) < VehicleCoordinateUpdate.ignoreBelowMeters)
+
+        annotation.update(
+            tripStatus: try makeTripStatus(),
+            coordinate: jitter,
+            routeColor: .systemGreen
+        )
+
+        #expect(annotation.coordinate.latitude == origin.latitude)
+        #expect(annotation.coordinate.longitude == origin.longitude)
+
+        // The value the didSet wrote, and the one the restore has to defeat.
+        let fixtureLocation = try #require(makeTripStatus().lastKnownLocation?.coordinate)
+        #expect(annotation.coordinate.latitude != fixtureLocation.latitude)
+    }
+
+    /// The middle branch, which the 60 km fixture skips. `apply` performs the
+    /// assignment inside `UIView.animate`, so the coordinate arrives
+    /// synchronously here — what this pins is that a city-block hop is *routed*
+    /// through the animated branch instead of being discarded as jitter.
+    @Test func `A city-block hop moves the annotation to the new coordinate`() throws {
+        let origin = CLLocationCoordinate2D(latitude: 47.6100, longitude: -122.3300)
+        let annotation = StopVehicleAnnotation(
+            id: "6821", routeID: "H", routeColor: .systemRed, departureID: "dep1",
+            tripStatus: try makeTripStatus(),
+            coordinate: origin
+        )
+
+        // ~100 m: above `ignoreBelowMeters`, well below `snapBeyondMeters`.
+        let hop = CLLocationCoordinate2D(latitude: 47.610900, longitude: -122.3300)
+        let meters = origin.distance(from: hop)
+        #expect(meters > VehicleCoordinateUpdate.ignoreBelowMeters)
+        #expect(meters < VehicleCoordinateUpdate.snapBeyondMeters)
+
+        annotation.update(
+            tripStatus: try makeTripStatus(),
+            coordinate: hop,
+            routeColor: .systemGreen
+        )
+
+        #expect(annotation.coordinate.latitude == hop.latitude)
+        #expect(annotation.coordinate.longitude == hop.longitude)
+    }
+
     @Test func `Markers are not selectable by default, preserving the trip screen`() {
         let view = PulsingVehicleAnnotationView(annotation: nil, reuseIdentifier: "test")
         #expect(view.isUserInteractionEnabled == false)


### PR DESCRIPTION
Refs #1341 (item 3).

`StopVehicleAnnotation.update` had one test, and it moved the vehicle from (47.6, -122.3) to (48.1, -121.9) — roughly 60 km, or **120× `snapBeyondMeters`**. So it only ever reached `.snap`. The other two branches of `VehicleCoordinateUpdate.decision`, and the restore-then-apply ordering they depend on, had no coverage at all.

| Branch | Condition | Covered before |
|---|---|---|
| `.unchanged` | < 2 m | no |
| `.animate` | 2–500 m | no |
| `.snap` | > 500 m | yes |

## The one that matters

The sub-threshold test is the one that pins the ordering. Below `ignoreBelowMeters`, `apply` is a no-op — so whatever sits in `coordinate` when it runs is what the rider keeps. `tripStatus`'s `didSet` has just overwritten that with the fixture's `lastKnownLocation`, and `update`'s `self.coordinate = from` restore is the only thing putting it back. Delete that line and every poll too small to matter teleports the pin to the fixture's location.

The test asserts the coordinate is unchanged *and* that it isn't `lastKnownLocation`, so it fails for the right reason rather than passing on a coincidence.

Both tests assert their distance falls in the intended band rather than assuming it, so neither can quietly go vacuous if the thresholds are retuned — the same guard `#1366` added after a fixture change had silently defanged a test.

## Scope

Item 3 also names `VehicleCoordinateUpdate.apply`'s own branches. Those tests belong in `VehicleCoordinateUpdateTests.swift`, which **#1356** is already editing, so they're deliberately left out to avoid two open PRs touching one file. They can follow once #1356 lands.

Items 1 (docs) is #1356. Items 2 and 4 remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for vehicle annotation coordinate updates when movement is below the ignore threshold.
  * Added coverage for city-block-scale movement, confirming annotations move to the updated coordinate.
  * Tests validate distance assumptions against configured movement thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->