### PR TITLE
Render Live Activity staleness on lock screen and Island

### DIFF
--- a/OBAKitCore/LiveActivities/LiveActivityStaleChrome.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityStaleChrome.swift
@@ -1,0 +1,32 @@
+//
+//  LiveActivityStaleChrome.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// User-visible treatment when ActivityKit marks a Live Activity stale.
+///
+/// Promote/demote and push paths carefully preserve `staleDate` (#1215), but
+/// until the widget reads `context.isStale` a frozen countdown looks identical
+/// to a live one (#1376). Keep the copy and dimming here so lock-screen and
+/// Dynamic Island stay in sync without duplicating literals.
+public enum LiveActivityStaleChrome {
+    /// Same tone as the rental-map freshness footer: orange warning, plain language.
+    public static var warningText: String {
+        OBALoc(
+            "live_activity.stale_warning",
+            value: "This data may be out of date.",
+            comment: "Shown on a Live Activity when ActivityKit marks it stale (no recent update)."
+        )
+    }
+
+    /// Dim the minutes/route chrome so a stale card cannot be mistaken for live.
+    public static func contentOpacity(isStale: Bool) -> Double {
+        isStale ? 0.55 : 1.0
+    }
+}

--- a/OBAKitCore/Strings/ar.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ar.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "اعرض جدول مواعيد خطك";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "قد تكون هذه البيانات غير حديثة.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "الآن";
 

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "View Your Route's Schedule";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "This data may be out of date.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NOW";
 

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Vea el Horario de su Ruta";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Estos datos pueden no estar actualizados.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "AHORA";
 

--- a/OBAKitCore/Strings/fil.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fil.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Tingnan ang Iskedyul ng Iyong Ruta";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Maaaring luma na ang data na ito.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NGAYON";
 

--- a/OBAKitCore/Strings/fr.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/fr.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Consultez les horaires de votre ligne";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Ces données peuvent être obsolètes.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "MAINT.";
 

--- a/OBAKitCore/Strings/it.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/it.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Visualizza l'orario della tua linea";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Questi dati potrebbero non essere aggiornati.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "ADESSO";
 

--- a/OBAKitCore/Strings/ko.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ko.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "노선 시간표 보기";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "이 데이터가 오래되었을 수 있습니다.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "지금";
 

--- a/OBAKitCore/Strings/pl.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pl.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Zobacz rozkład swojej linii";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Te dane mogą być nieaktualne.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "TERAZ";
 

--- a/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/pt-BR.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Veja os Horários da Sua Linha";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Estes dados podem estar desatualizados.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "AGORA";
 

--- a/OBAKitCore/Strings/ru.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/ru.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Смотрите расписание маршрута";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Эти данные могут быть устаревшими.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "СЕЙЧАС";
 

--- a/OBAKitCore/Strings/vi.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/vi.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "Xem lịch trình tuyến của bạn";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "Dữ liệu này có thể đã lỗi thời.";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NGAY";
 

--- a/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hans.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "查看您所乘线路的时刻表";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "此数据可能已过期。";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "现在";
 

--- a/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/zh-Hant.lproj/Localizable.strings
@@ -423,6 +423,9 @@
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "檢視您路線的時刻表";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "此資料可能已過期。";
+
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "現在";
 

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -16,12 +16,19 @@ import SwiftUI
 public struct TripLiveActivityCardView: View {
     public let staticData: TripAttributes.StaticData
     public let contentState: TripAttributes.ContentState
+    /// From `ActivityViewContext.isStale` — ActivityKit flips this after `staleDate`.
+    public let isStale: Bool
 
     private let presenter = TripActivityPresenter()
 
-    public init(staticData: TripAttributes.StaticData, contentState: TripAttributes.ContentState) {
+    public init(
+        staticData: TripAttributes.StaticData,
+        contentState: TripAttributes.ContentState,
+        isStale: Bool = false
+    ) {
         self.staticData = staticData
         self.contentState = contentState
+        self.isStale = isStale
     }
 
     public var body: some View {
@@ -35,7 +42,17 @@ public struct TripLiveActivityCardView: View {
             if !chips.isEmpty {
                 chipsRow(chips: chips, now: now)
             }
+            if isStale {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                    Text(LiveActivityStaleChrome.warningText)
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.orange)
+                .accessibilityElement(children: .combine)
+            }
         }
+        .opacity(LiveActivityStaleChrome.contentOpacity(isStale: isStale))
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(Color(uiColor: .systemBackground))

--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -38,10 +38,16 @@ public struct TripLiveActivityCardView: View {
         let chips = Array(upcoming.dropFirst())
 
         VStack(alignment: .leading, spacing: 10) {
-            primaryRow(primary: primary, now: now)
-            if !chips.isEmpty {
-                chipsRow(chips: chips, now: now)
+            // Dim arrival content only — the stale warning must stay full
+            // opacity or light-mode orange ~1.6:1 and becomes unreadable (#1376).
+            VStack(alignment: .leading, spacing: 10) {
+                primaryRow(primary: primary, now: now)
+                if !chips.isEmpty {
+                    chipsRow(chips: chips, now: now)
+                }
             }
+            .opacity(LiveActivityStaleChrome.contentOpacity(isStale: isStale))
+
             if isStale {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -52,7 +58,6 @@ public struct TripLiveActivityCardView: View {
                 .accessibilityElement(children: .combine)
             }
         }
-        .opacity(LiveActivityStaleChrome.contentOpacity(isStale: isStale))
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(Color(uiColor: .systemBackground))

--- a/OBAKitTests/Models/LiveActivityStaleChromeTests.swift
+++ b/OBAKitTests/Models/LiveActivityStaleChromeTests.swift
@@ -1,0 +1,35 @@
+//
+//  LiveActivityStaleChromeTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+/// Pins the user-visible consequence of `ActivityKit` marking a Live Activity
+/// stale (#1376). ActivityKit sets `context.isStale` from `staleDate`; the
+/// widget must render something when that flips, or a frozen "3m" looks live.
+@Suite(.serialized)
+struct LiveActivityStaleChromeTests {
+
+    @Test func `Warning copy is non-empty and distinct from a blank string`() {
+        let text = LiveActivityStaleChrome.warningText
+        #expect(!text.isEmpty)
+        #expect(text != " ")
+    }
+
+    @Test func `Fresh content stays fully opaque`() {
+        #expect(LiveActivityStaleChrome.contentOpacity(isStale: false) == 1.0)
+    }
+
+    @Test func `Stale content dims so a frozen countdown cannot look live`() {
+        let opacity = LiveActivityStaleChrome.contentOpacity(isStale: true)
+        #expect(opacity < 1.0)
+        #expect(opacity > 0.0)
+    }
+}

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -396,9 +396,13 @@ final class BookmarksViewModelTests: OBATestCase {
 
         let value = try #require(formatters.accessibilityValue(for: row))
 
-        let scheduled = formatters.timeFormatter.string(from: arrivalDep.scheduledDate)
-        let expected = formatters.timeFormatter.string(from: arrivalDep.arrivalDepartureDate)
-        #expect(value == formatters.accessibilityValue(for: arrivalDep) + " scheduled \(scheduled), now expected \(expected).")
+        // Build the clause the same way production does (`DepartureTimeDisplay`),
+        // not by re-assembling the English format string. Hardcoding the English
+        // template disagrees with `OBALoc` whenever the test host's preferred
+        // language is not English — which is how this assertion flakes on CI.
+        let timeDisplay = DepartureTimeDisplay(arrivalDeparture: arrivalDep, formatters: formatters)
+        #expect(timeDisplay.scheduledTimeText != nil)
+        #expect(value == formatters.accessibilityValue(for: arrivalDep) + " " + timeDisplay.accessibilityTimeDescription + ".")
     }
 
     /// Without a rendered correction there's nothing the strikethrough shows
@@ -439,9 +443,9 @@ final class BookmarksViewModelTests: OBATestCase {
 
         let value = try #require(formatters.accessibilityValue(for: row))
 
-        let scheduled = formatters.timeFormatter.string(from: first.scheduledDate)
-        let expected = formatters.timeFormatter.string(from: first.arrivalDepartureDate)
-        let prefix = formatters.accessibilityValue(for: first) + " scheduled \(scheduled), now expected \(expected)."
+        let timeDisplay = DepartureTimeDisplay(arrivalDeparture: first, formatters: formatters)
+        #expect(timeDisplay.scheduledTimeText != nil)
+        let prefix = formatters.accessibilityValue(for: first) + " " + timeDisplay.accessibilityTimeDescription + "."
         #expect(value.hasPrefix(prefix), "clause must directly follow the base value: \(value)")
         #expect(value.dropFirst(prefix.count).contains("Following"), "follow-up sentence must come after the clause: \(value)")
     }

--- a/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
+++ b/OBAKitTests/ViewModels/BookmarksViewModelTests.swift
@@ -396,13 +396,9 @@ final class BookmarksViewModelTests: OBATestCase {
 
         let value = try #require(formatters.accessibilityValue(for: row))
 
-        // Build the clause the same way production does (`DepartureTimeDisplay`),
-        // not by re-assembling the English format string. Hardcoding the English
-        // template disagrees with `OBALoc` whenever the test host's preferred
-        // language is not English — which is how this assertion flakes on CI.
-        let timeDisplay = DepartureTimeDisplay(arrivalDeparture: arrivalDep, formatters: formatters)
-        #expect(timeDisplay.scheduledTimeText != nil)
-        #expect(value == formatters.accessibilityValue(for: arrivalDep) + " " + timeDisplay.accessibilityTimeDescription + ".")
+        let scheduled = formatters.timeFormatter.string(from: arrivalDep.scheduledDate)
+        let expected = formatters.timeFormatter.string(from: arrivalDep.arrivalDepartureDate)
+        #expect(value == formatters.accessibilityValue(for: arrivalDep) + " scheduled \(scheduled), now expected \(expected).")
     }
 
     /// Without a rendered correction there's nothing the strikethrough shows
@@ -443,9 +439,9 @@ final class BookmarksViewModelTests: OBATestCase {
 
         let value = try #require(formatters.accessibilityValue(for: row))
 
-        let timeDisplay = DepartureTimeDisplay(arrivalDeparture: first, formatters: formatters)
-        #expect(timeDisplay.scheduledTimeText != nil)
-        let prefix = formatters.accessibilityValue(for: first) + " " + timeDisplay.accessibilityTimeDescription + "."
+        let scheduled = formatters.timeFormatter.string(from: first.scheduledDate)
+        let expected = formatters.timeFormatter.string(from: first.arrivalDepartureDate)
+        let prefix = formatters.accessibilityValue(for: first) + " scheduled \(scheduled), now expected \(expected)."
         #expect(value.hasPrefix(prefix), "clause must directly follow the base value: \(value)")
         #expect(value.dropFirst(prefix.count).contains("Following"), "follow-up sentence must come after the clause: \(value)")
     }

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -75,6 +75,7 @@ struct TripLiveActivity: Widget {
                             .fill(Color.white.opacity(0.15))
                             .frame(height: 1)
                             .padding(.vertical, 8)
+                        // Dim headsign/minutes only; warning stays full opacity (#1376).
                         HStack(alignment: .top, spacing: 0) {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text(context.attributes.staticData.routeHeadsign)
@@ -94,11 +95,6 @@ struct TripLiveActivity: Widget {
                                         .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                                 }
                                 .padding(.top, 2)
-                                if context.isStale {
-                                    Text(LiveActivityStaleChrome.warningText)
-                                        .font(.caption.weight(.semibold))
-                                        .foregroundStyle(.orange)
-                                }
                             }
                             .padding(.leading, 6)
                             Spacer(minLength: 12)
@@ -114,6 +110,15 @@ struct TripLiveActivity: Widget {
                             .padding(.trailing, 6)
                         }
                         .opacity(staleOpacity)
+
+                        if context.isStale {
+                            Text(LiveActivityStaleChrome.warningText)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.orange)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.leading, 6)
+                                .padding(.top, 4)
+                        }
                     }
                 }
             } compactLeading: {
@@ -124,6 +129,7 @@ struct TripLiveActivity: Widget {
                             .font(.system(.body, design: .rounded))
                             .fontWeight(.bold)
                             .foregroundColor(.orange)
+                            .accessibilityLabel(LiveActivityStaleChrome.warningText)
                     } else {
                         Text(context.attributes.staticData.routeShortName)
                             .font(.system(.body, design: .rounded))
@@ -142,16 +148,24 @@ struct TripLiveActivity: Widget {
                         .frame(minWidth: 20)
                 }
             } minimal: {
-                if context.isStale {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(.callout, design: .rounded))
-                        .fontWeight(.heavy)
-                        .foregroundColor(.orange)
-                } else if let primary {
+                // Keep the countdown when stale — minimal has no room for both
+                // a warning glyph and minutes, and minutes are the only ETA the
+                // rider gets here. Compact leading already shows the triangle.
+                if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.callout, design: .rounded))
                         .fontWeight(.heavy)
-                        .foregroundColor(Color(presenter.color(for: primary)))
+                        .foregroundColor(
+                            context.isStale
+                                ? .orange
+                                : Color(presenter.color(for: primary))
+                        )
+                        .opacity(staleOpacity)
+                        .accessibilityLabel(
+                            context.isStale
+                                ? "\(LiveActivityStaleChrome.warningText), \(presenter.minuteText(for: primary))"
+                                : presenter.minuteText(for: primary)
+                        )
                 }
             }
         }

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -47,15 +47,22 @@ struct TripLiveActivity: Widget {
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     HStack(spacing: 8) {
-                        Image(systemName: context.isStale ? "exclamationmark.triangle.fill" : "bus.fill")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(context.isStale ? .orange : Color(presenter.primaryColor(for: context.state)))
+                        if context.isStale {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(.orange)
+                                .accessibilityLabel(LiveActivityStaleChrome.warningText)
+                        } else {
+                            Image(systemName: "bus.fill")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(Color(presenter.primaryColor(for: context.state)))
+                        }
                         Text(context.attributes.staticData.routeShortName)
                             .font(.system(.title3, design: .rounded))
                             .fontWeight(.heavy)
                             .foregroundColor(.white)
+                            .opacity(staleOpacity)
                     }
-                    .opacity(staleOpacity)
                     .padding(.leading, 6)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
@@ -150,7 +157,8 @@ struct TripLiveActivity: Widget {
             } minimal: {
                 // Keep the countdown when stale — minimal has no room for both
                 // a warning glyph and minutes, and minutes are the only ETA the
-                // rider gets here. Compact leading already shows the triangle.
+                // rider gets here. Compact and minimal are mutually exclusive
+                // presentations, so there is no compact leading triangle to lean on.
                 if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.callout, design: .rounded))

--- a/OBAWidget/Widgets/TripLiveActivity.swift
+++ b/OBAWidget/Widgets/TripLiveActivity.swift
@@ -32,7 +32,8 @@ struct TripLiveActivity: Widget {
         ActivityConfiguration(for: TripAttributes.self) { context in
             TripLiveActivityCardView(
                 staticData: context.attributes.staticData,
-                contentState: context.state
+                contentState: context.state,
+                isStale: context.isStale
             )
             .activityBackgroundTint(Color(UIColor.systemBackground))
             .widgetURL(
@@ -42,17 +43,19 @@ struct TripLiveActivity: Widget {
         } dynamicIsland: { context in
             let upcoming = context.state.upcomingArrivals()
             let primary = upcoming.first
+            let staleOpacity = LiveActivityStaleChrome.contentOpacity(isStale: context.isStale)
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     HStack(spacing: 8) {
-                        Image(systemName: "bus.fill")
+                        Image(systemName: context.isStale ? "exclamationmark.triangle.fill" : "bus.fill")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(Color(presenter.primaryColor(for: context.state)))
+                            .foregroundColor(context.isStale ? .orange : Color(presenter.primaryColor(for: context.state)))
                         Text(context.attributes.staticData.routeShortName)
                             .font(.system(.title3, design: .rounded))
                             .fontWeight(.heavy)
                             .foregroundColor(.white)
                     }
+                    .opacity(staleOpacity)
                     .padding(.leading, 6)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
@@ -62,6 +65,7 @@ struct TripLiveActivity: Widget {
                             .font(.system(size: 32, weight: .bold, design: .rounded))
                             .foregroundColor(Color(presenter.color(for: primary)))
                             .contentTransition(.numericText(value: Double(primaryMinuteText.filter("0123456789".contains)) ?? 0))
+                            .opacity(staleOpacity)
                             .padding(.trailing, 6)
                     }
                 }
@@ -90,6 +94,11 @@ struct TripLiveActivity: Widget {
                                         .foregroundColor(Color(presenter.primaryColor(for: context.state)))
                                 }
                                 .padding(.top, 2)
+                                if context.isStale {
+                                    Text(LiveActivityStaleChrome.warningText)
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.orange)
+                                }
                             }
                             .padding(.leading, 6)
                             Spacer(minLength: 12)
@@ -104,25 +113,41 @@ struct TripLiveActivity: Widget {
                             }
                             .padding(.trailing, 6)
                         }
+                        .opacity(staleOpacity)
                     }
                 }
             } compactLeading: {
                 // MARK: - COMPACT LEADING
-                Text(context.attributes.staticData.routeShortName)
-                    .font(.system(.body, design: .rounded))
-                    .fontWeight(.bold)
-                    .foregroundColor(Color(presenter.primaryColor(for: context.state)))
-                    .padding(.leading, 4)
+                Group {
+                    if context.isStale {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(.body, design: .rounded))
+                            .fontWeight(.bold)
+                            .foregroundColor(.orange)
+                    } else {
+                        Text(context.attributes.staticData.routeShortName)
+                            .font(.system(.body, design: .rounded))
+                            .fontWeight(.bold)
+                            .foregroundColor(Color(presenter.primaryColor(for: context.state)))
+                    }
+                }
+                .padding(.leading, 4)
             } compactTrailing: {
                 if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.body, design: .rounded))
                         .fontWeight(.bold)
                         .foregroundColor(Color(presenter.color(for: primary)))
+                        .opacity(staleOpacity)
                         .frame(minWidth: 20)
                 }
             } minimal: {
-                if let primary {
+                if context.isStale {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(.callout, design: .rounded))
+                        .fontWeight(.heavy)
+                        .foregroundColor(.orange)
+                } else if let primary {
                     Text(presenter.minuteText(for: primary))
                         .font(.system(.callout, design: .rounded))
                         .fontWeight(.heavy)

--- a/docs/live-activity-stale-chrome.md
+++ b/docs/live-activity-stale-chrome.md
@@ -5,8 +5,9 @@ push paths already preserve that marker; the widget must show it.
 
 - Lock screen: `TripLiveActivityCardView(isStale:)` dims content and shows
   `LiveActivityStaleChrome.warningText` (orange warning).
-- Dynamic Island: same opacity helper; compact/minimal swap the route chip for
-  a warning glyph when stale.
+- Dynamic Island: same opacity helper; compact leading swaps the route chip for
+  a warning glyph when stale. Minimal keeps the countdown (orange + dimmed);
+  VoiceOver prepends the warning copy via `accessibilityLabel`.
 
 Copy and opacity live in `LiveActivityStaleChrome` so the two surfaces cannot
 drift. Creating an activity with `staleDate: nil` until the first push is

--- a/docs/live-activity-stale-chrome.md
+++ b/docs/live-activity-stale-chrome.md
@@ -1,0 +1,13 @@
+# Live Activity stale chrome (#1376)
+
+ActivityKit sets `context.isStale` once `staleDate` passes. Promote/demote and
+push paths already preserve that marker; the widget must show it.
+
+- Lock screen: `TripLiveActivityCardView(isStale:)` dims content and shows
+  `LiveActivityStaleChrome.warningText` (orange warning).
+- Dynamic Island: same opacity helper; compact/minimal swap the route chip for
+  a warning glyph when stale.
+
+Copy and opacity live in `LiveActivityStaleChrome` so the two surfaces cannot
+drift. Creating an activity with `staleDate: nil` until the first push is
+intentional and unchanged.


### PR DESCRIPTION
## Summary
- Closes #1376: lock-screen card and Dynamic Island now react to `context.isStale` (dim + orange warning), matching the rental-map freshness pattern.
- Shared `LiveActivityStaleChrome` owns copy and opacity so the two surfaces cannot drift; key added in all 13 OBAKitCore locales.
- Docs: `docs/live-activity-stale-chrome.md`.

Intentionally unchanged: creating with `staleDate: nil` until the first push (handoff noted in the issue).

## Test plan
- [x] `LiveActivityStaleChromeTests` (3) — opacity + non-empty warning
- [ ] On device: Track a trip, wait past `stale-date` (or airplane mode) → card dims and shows “This data may be out of date.” / Island warning glyph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live Activities now clearly indicate when trip data may be outdated.
  - Stale activities display localized warnings while dimming route and timing content for readability.
  - Warning indicators remain visible across lock-screen, Dynamic Island, and compact presentations, with improved accessibility labels.

- **Localization**
  - Added stale-data warnings in supported languages.

- **Documentation**
  - Documented stale Live Activity behavior and presentation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->