### PR TITLE
Document simulator destinations by UDID in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,15 +79,31 @@ the single most expensive failure mode here. Install the CLI instead.
 
 Use these only when `xcodebuildmcp` genuinely cannot do the job.
 
+Prefer `id=` over `name=` for the destination — a fixed name like
+`iPhone 17 Pro` breaks when Xcode ships a new default or when multiple
+matching devices exist. CI in `.github/workflows/tests.yml` picks any
+available iPhone on the newest installed runtime and passes its UDID:
+
 ```bash
+# Resolve a simulator UDID (same idea as CI)
+UDID=$(xcrun simctl list devices available -j | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for runtime,devs in data.get('devices',{}).items():
+    if 'iOS' not in runtime: continue
+    for d in devs:
+        if d.get('isAvailable') and d['name'].startswith('iPhone'):
+            print(d['udid']); raise SystemExit
+")
+
 # Build for testing
-xcodebuild clean build-for-testing -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild clean build-for-testing -scheme 'App' -destination "platform=iOS Simulator,id=${UDID}"
 
 # Run unit tests
-xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests -project 'OBAKit.xcodeproj' -scheme 'App' -destination "platform=iOS Simulator,id=${UDID}"
 
 # Run specific test class
-xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild test-without-building -only-testing:OBAKitTests/SpecificTestClass -project 'OBAKit.xcodeproj' -scheme 'App' -destination "platform=iOS Simulator,id=${UDID}"
 ```
 
 ### Code Quality


### PR DESCRIPTION
## Summary
- Refs #1303 (docs half): replace stale `name=iPhone 17 Pro` examples with the CI-style UDID resolution.
- Lint/`MapViewController` body-length half already shipped in #1325.

## Test plan
- [x] `CLAUDE.md` no longer mentions `iPhone 17 Pro` as a destination name
- [ ] Skim that the python one-liner matches the intent of `.github/workflows/tests.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build and testing guidance to dynamically select an available iPhone simulator.
  * Replaced hardcoded simulator names with simulator UDIDs for more reliable local and CI test execution.
  * Added guidance explaining why UDIDs are preferred over fixed simulator names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->