### PR TITLE
Pin Live Activity Track to the selected trip

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -79,6 +79,45 @@ final class BookmarkActions {
         (bookmark.routeShortName ?? bookmark.name, bookmark.tripHeadsign ?? "")
     }
 
+    /// The `StaticData` stored when Track is tapped on a bookmark row.
+    ///
+    /// Bookmark identity is stop + route + headsign only. `tripID` is left empty
+    /// so duplicate guards reconcile across refresh rollovers and so refresh uses
+    /// the unpinned multi-arrival builder. Trip pinning belongs on the stop-page
+    /// start path, where the rider picks a specific vehicle.
+    static func liveActivityStaticData(
+        for bookmark: Bookmark,
+        regionID: Int,
+        arrivalDepartures: [ArrivalDeparture]
+    ) -> TripAttributes.StaticData {
+        let (routeShortName, routeHeadsign) = liveActivityKeys(for: bookmark)
+        return TripAttributes.StaticData(
+            routeShortName: routeShortName,
+            routeHeadsign: routeHeadsign,
+            stopID: bookmark.stopID,
+            routeColorHex: arrivalDepartures.first?.route.color?.toHex(),
+            regionID: regionID,
+            tripID: ""
+        )
+    }
+
+    /// Builds refreshed content for a running bookmark Live Activity.
+    ///
+    /// Stop-page activities carry a pinned `tripID` in `StaticData` and keep
+    /// following that vehicle. Bookmark activities leave `tripID` empty and show
+    /// up to the soonest three same-bookmark arrivals.
+    static func buildRefreshContentState(
+        for staticData: TripAttributes.StaticData,
+        arrivalDepartures: [ArrivalDeparture]
+    ) -> TripAttributes.ContentState? {
+        guard !arrivalDepartures.isEmpty else { return nil }
+        if !staticData.tripID.isEmpty,
+           let tracked = arrivalDepartures.first(where: { $0.tripID == staticData.tripID }) {
+            return buildContentState(from: arrivalDepartures, matching: tracked)
+        }
+        return buildContentState(from: arrivalDepartures)
+    }
+
     /// Builds content from whatever arrivals a bookmark row has loaded, or `nil`
     /// when it has none — the bookmark paths have no single departure to fall
     /// back on, so an empty list really is a failure for them.
@@ -130,16 +169,10 @@ final class BookmarkActions {
 
     @discardableResult
     func startLiveActivity(for bookmark: Bookmark, arrivalDepartures: [ArrivalDeparture]) -> TrackResult {
-        let (routeShortName, routeHeadsign) = Self.liveActivityKeys(for: bookmark)
-
-        let routeColorHex = arrivalDepartures.first?.route.color?.toHex()
-        let staticData = TripAttributes.StaticData(
-            routeShortName: routeShortName,
-            routeHeadsign: routeHeadsign,
-            stopID: bookmark.stopID,
-            routeColorHex: routeColorHex,
+        let staticData = Self.liveActivityStaticData(
+            for: bookmark,
             regionID: application.currentRegion?.regionIdentifier ?? 0,
-            tripID: arrivalDepartures.first?.tripID ?? ""
+            arrivalDepartures: arrivalDepartures
         )
 
         // Tapping Track again on a bookmark that is already tracked — or tracking

--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -89,9 +89,11 @@ final class BookmarkActions {
         return contentState(from: arrivalDepartures)
     }
 
-    /// Builds content for the trip the rider actually tracked: same stop, route,
-    /// and destination as `departure`. Route-only matching mixes both directions
-    /// at a transit center and shows the opposite bus's countdown (#1326).
+    /// Builds content for the trip the rider actually tracked.
+    ///
+    /// Pins by `tripID` so Track follows that vehicle's ETA (#1334), not the
+    /// next same-route/headsign arrival. If the stop list no longer contains
+    /// that trip, fall back to the tapped departure alone.
     ///
     /// Non-optional on purpose. When the stop list no longer contains the tracked
     /// trip — stale data, or a list that never loaded — this falls back to
@@ -101,19 +103,8 @@ final class BookmarkActions {
         from arrivalDepartures: [ArrivalDeparture],
         matching departure: ArrivalDeparture
     ) -> TripAttributes.ContentState {
-        let key = TripBookmarkKey(arrivalDeparture: departure)
-
-        if (departure.tripHeadsign ?? "").isEmpty {
-            // `TripBookmarkKey` substitutes "" for a missing headsign, so the
-            // filter below degrades to stop + route and can readmit the opposite
-            // direction — the very symptom this method exists to prevent. Still
-            // better than showing no trip at all, but it must not be silent.
-            // See: https://github.com/OneBusAway/onebusaway-ios/issues/1326
-            Logger.warn("Departure \(departure.tripID) at stop \(departure.stopID) has no trip headsign; Live Activity arrivals match on stop and route only and may mix directions.")
-        }
-
         let sameTrip = arrivalDepartures
-            .filter { TripBookmarkKey(arrivalDeparture: $0) == key }
+            .filter { $0.id == departure.id }
             .sorted { $0.arrivalDepartureDate < $1.arrivalDepartureDate }
         let source = sameTrip.isEmpty ? [departure] : sameTrip
         return contentState(from: source)
@@ -147,7 +138,8 @@ final class BookmarkActions {
             routeHeadsign: routeHeadsign,
             stopID: bookmark.stopID,
             routeColorHex: routeColorHex,
-            regionID: application.currentRegion?.regionIdentifier ?? 0
+            regionID: application.currentRegion?.regionIdentifier ?? 0,
+            tripID: arrivalDepartures.first?.tripID ?? ""
         )
 
         // Tapping Track again on a bookmark that is already tracked — or tracking

--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -101,11 +101,31 @@ final class BookmarkActions {
         )
     }
 
+    /// The arrival that should drive OBACloud re-registration metadata for a
+    /// running activity on relaunch.
+    ///
+    /// Prefer the pinned `staticData.tripID` when present and still in the list;
+    /// otherwise the soonest bookmark arrival. Kept in lockstep with
+    /// `buildRefreshContentState`'s pin lookup so push registration can't drift
+    /// onto a different vehicle than the Lock Screen card while the pin holds.
+    static func refreshPrimaryArrival(
+        for staticData: TripAttributes.StaticData,
+        arrivalDepartures: [ArrivalDeparture]
+    ) -> ArrivalDeparture? {
+        if !staticData.tripID.isEmpty,
+           let tracked = arrivalDepartures.first(where: { $0.tripID == staticData.tripID }) {
+            return tracked
+        }
+        return arrivalDepartures.first
+    }
+
     /// Builds refreshed content for a running bookmark Live Activity.
     ///
     /// Stop-page activities carry a pinned `tripID` in `StaticData` and keep
     /// following that vehicle. Bookmark activities leave `tripID` empty and show
-    /// up to the soonest three same-bookmark arrivals.
+    /// up to the soonest three same-bookmark arrivals. When a pin is set but
+    /// that trip has left the list, fall back to the unpinned builder
+    /// (degradation) rather than silently re-pinning the soonest arrival.
     static func buildRefreshContentState(
         for staticData: TripAttributes.StaticData,
         arrivalDepartures: [ArrivalDeparture]

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -215,12 +215,11 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
             let arrivalDepartures = matchingBookmark.map { viewModel.arrivalDepartures(for: $0) } ?? []
 
             let contentState: TripAttributes.ContentState? = {
-                guard matchingBookmark != nil, !arrivalDepartures.isEmpty else { return nil }
-                if !staticData.tripID.isEmpty,
-                   let tracked = arrivalDepartures.first(where: { $0.tripID == staticData.tripID }) {
-                    return BookmarkActions.buildContentState(from: arrivalDepartures, matching: tracked)
-                }
-                return BookmarkActions.buildContentState(from: arrivalDepartures)
+                guard matchingBookmark != nil else { return nil }
+                return BookmarkActions.buildRefreshContentState(
+                    for: staticData,
+                    arrivalDepartures: arrivalDepartures
+                )
             }()
 
             if matchingBookmark != nil, let contentState {

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -207,13 +207,23 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 let bookmarkIdentity = TripAttributes.StaticData(
                     routeShortName: keys.routeShortName,
                     routeHeadsign: keys.routeHeadsign,
-                    stopID: bookmark.stopID
+                    stopID: bookmark.stopID,
+                    tripID: staticData.tripID
                 )
                 return bookmarkIdentity.tracksSameTrip(as: staticData)
             })
             let arrivalDepartures = matchingBookmark.map { viewModel.arrivalDepartures(for: $0) } ?? []
 
-            if matchingBookmark != nil, let contentState = BookmarkActions.buildContentState(from: arrivalDepartures) {
+            let contentState: TripAttributes.ContentState? = {
+                guard matchingBookmark != nil, !arrivalDepartures.isEmpty else { return nil }
+                if !staticData.tripID.isEmpty,
+                   let tracked = arrivalDepartures.first(where: { $0.tripID == staticData.tripID }) {
+                    return BookmarkActions.buildContentState(from: arrivalDepartures, matching: tracked)
+                }
+                return BookmarkActions.buildContentState(from: arrivalDepartures)
+            }()
+
+            if matchingBookmark != nil, let contentState {
                 // Re-arm the push token/lifecycle observers on relaunch. `startLiveActivity`
                 // only tracks activities it creates in-session, so without this a Live Activity
                 // that's still running after a relaunch would never re-establish its observers

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -201,18 +201,24 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
         for activity in activities {
             let staticData = activity.attributes.staticData
             let matchingBookmark = application.userDataStore.bookmarks.first(where: { bookmark in
-                // Delegates to the shared identity rule so this match can't
-                // drift from the start paths' duplicate guard.
+                // Bookmark identity is unpinned (`tripID: ""`). Empty tripID is a
+                // wildcard in `tracksSameTrip`, so this still reconciles with a
+                // stop-page activity that carries a concrete trip — same rule the
+                // start paths' duplicate guards use.
                 let keys = BookmarkActions.liveActivityKeys(for: bookmark)
                 let bookmarkIdentity = TripAttributes.StaticData(
                     routeShortName: keys.routeShortName,
                     routeHeadsign: keys.routeHeadsign,
                     stopID: bookmark.stopID,
-                    tripID: staticData.tripID
+                    tripID: ""
                 )
                 return bookmarkIdentity.tracksSameTrip(as: staticData)
             })
             let arrivalDepartures = matchingBookmark.map { viewModel.arrivalDepartures(for: $0) } ?? []
+            let primaryArrival = BookmarkActions.refreshPrimaryArrival(
+                for: staticData,
+                arrivalDepartures: arrivalDepartures
+            )
 
             let contentState: TripAttributes.ContentState? = {
                 guard matchingBookmark != nil else { return nil }
@@ -234,10 +240,14 @@ class BookmarksViewController: UIHostingController<BookmarksRootView>,
                 // Deliberately keyed on the token task and not on `isTracking`: an activity that
                 // the sweep below could only lifecycle-observe (no matching bookmark at the time)
                 // must still be upgradable to a full registration once its bookmark reappears.
+                //
+                // Metadata must be the pinned arrival when `staticData.tripID` is set —
+                // `arrivalDepartures.first` is soonest-first and would re-POST the wrong
+                // vehicle to OBACloud after relaunch (#1334).
                 if !application.liveActivityTracker.isForwardingPushToken(activityID: activity.id) {
                     application.liveActivityTracker.track(
                         activity: activity,
-                        metadata: .init(arrivalDepartures.first)
+                        metadata: .init(primaryArrival)
                     )
                 }
                 // Coalesce per activity ID. The worker re-fetches the activity

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -568,7 +568,8 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             routeHeadsign: departure.tripHeadsign ?? "",
             stopID: departure.stopID,
             routeColorHex: departure.route.color?.toHex(),
-            regionID: application.currentRegion?.regionIdentifier ?? 0
+            regionID: application.currentRegion?.regionIdentifier ?? 0,
+            tripID: departure.tripID
         )
 
         // The same trip can be started from here and from the bookmarks list, so

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -430,7 +430,8 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             routeHeadsign: departure.tripHeadsign ?? "",
             stopID: departure.stopID,
             routeColorHex: departure.route.color?.toHex(),
-            regionID: application.currentRegion?.regionIdentifier ?? 0
+            regionID: application.currentRegion?.regionIdentifier ?? 0,
+            tripID: departure.tripID
         )
 
         // The same trip can be started from here, the stop page, and the

--- a/OBAKitCore/LiveActivities/LiveActivityLookup.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityLookup.swift
@@ -12,7 +12,7 @@ import ActivityKit
 extension TripAttributes.StaticData {
 
     /// Whether two `StaticData` describe the same tracked trip: the same route,
-    /// with the same headsign, arriving at the same stop.
+    /// with the same headsign and trip ID, arriving at the same stop.
     ///
     /// This is the single definition of Live Activity identity — the start
     /// paths' duplicate guards and the bookmark-reconciliation match all
@@ -28,6 +28,7 @@ extension TripAttributes.StaticData {
         stopID == other.stopID
             && routeShortName == other.routeShortName
             && routeHeadsign == other.routeHeadsign
+            && tripID == other.tripID
     }
 }
 

--- a/OBAKitCore/LiveActivities/LiveActivityLookup.swift
+++ b/OBAKitCore/LiveActivities/LiveActivityLookup.swift
@@ -11,13 +11,19 @@ import ActivityKit
 
 extension TripAttributes.StaticData {
 
-    /// Whether two `StaticData` describe the same tracked trip: the same route,
-    /// with the same headsign and trip ID, arriving at the same stop.
+    /// Whether two `StaticData` describe the same tracked trip: the same route
+    /// and headsign arriving at the same stop, with compatible trip IDs.
     ///
     /// This is the single definition of Live Activity identity — the start
     /// paths' duplicate guards and the bookmark-reconciliation match all
     /// delegate to it, so "the same tracked trip" can't quietly come to mean
     /// two different things.
+    ///
+    /// An empty `tripID` is a wildcard. Bookmark Track leaves it blank so
+    /// identity stays stop + route + headsign; stop-page / trip-page Track
+    /// store a concrete `tripID`. Wildcarding empty lets those paths reconcile
+    /// with each other (and with legacy cards) without pinning bookmark
+    /// identity to whichever bus was soonest when Track was tapped.
     ///
     /// `routeColorHex` and `regionID` are excluded on purpose. Both are
     /// presentation/routing metadata rather than identity, and the colour in
@@ -25,16 +31,24 @@ extension TripAttributes.StaticData {
     /// arrivals load. Folding it into identity would let a duplicate through in
     /// exactly the case this guards against: a second tap before data arrives.
     public func tracksSameTrip(as other: TripAttributes.StaticData) -> Bool {
-        stopID == other.stopID
+        guard stopID == other.stopID
             && routeShortName == other.routeShortName
             && routeHeadsign == other.routeHeadsign
-            && tripID == other.tripID
+        else {
+            return false
+        }
+
+        if tripID.isEmpty || other.tripID.isEmpty {
+            return true
+        }
+        return tripID == other.tripID
     }
 }
 
 extension Activity where Attributes == TripAttributes {
 
-    /// The Live Activity already running for `staticData`'s stop and route, if any.
+    /// The Live Activity already running for `staticData`'s stop, route,
+    /// headsign, and (when set) trip, if any.
     ///
     /// Every `Activity.request` mints a brand-new activity with a fresh id, and
     /// nothing downstream dedupes by content: `LiveActivityTracker` and

--- a/OBAKitCore/Models/TripAttributes.swift
+++ b/OBAKitCore/Models/TripAttributes.swift
@@ -31,9 +31,13 @@ public struct TripAttributes: ActivityAttributes, Sendable {
         /// The region that hosts this stop, encoded in the widget URL so tapping
         /// the Live Activity opens the correct stop page.
         public let regionID: Int
+        /// The tracked trip. Distinguishes two vehicles on the same route and
+        /// headsign at one stop (#1334). Empty for activities started before
+        /// this field existed.
+        public let tripID: String
 
         enum CodingKeys: String, CodingKey {
-            case routeShortName, routeHeadsign, stopID, routeColorHex, regionID
+            case routeShortName, routeHeadsign, stopID, routeColorHex, regionID, tripID
         }
 
         public init(from decoder: Decoder) throws {
@@ -43,14 +47,23 @@ public struct TripAttributes: ActivityAttributes, Sendable {
             stopID = try c.decode(String.self, forKey: .stopID)
             routeColorHex = try c.decodeIfPresent(String.self, forKey: .routeColorHex)
             regionID = (try? c.decode(Int.self, forKey: .regionID)) ?? 0
+            tripID = (try? c.decode(String.self, forKey: .tripID)) ?? ""
         }
 
-        public init(routeShortName: String, routeHeadsign: String, stopID: String, routeColorHex: String? = nil, regionID: Int = 0) {
+        public init(
+            routeShortName: String,
+            routeHeadsign: String,
+            stopID: String,
+            routeColorHex: String? = nil,
+            regionID: Int = 0,
+            tripID: String = ""
+        ) {
             self.routeShortName = routeShortName
             self.routeHeadsign = routeHeadsign
             self.stopID = stopID
             self.routeColorHex = routeColorHex
             self.regionID = regionID
+            self.tripID = tripID
         }
     }
 

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -123,11 +123,10 @@ final class BookmarkActionsTests: OBATestCase {
         #expect(state.arrivals.count == 3)
     }
 
-    /// Transit-center case (#1326): the same route serves both directions at one
-    /// stop. Filtering on route ID alone would pick the opposite-direction bus
-    /// because it leaves sooner. Chips and the headline countdown must follow
-    /// the tracked destination, same key as trip bookmarks.
-    @Test @MainActor func `Content state matching a departure drops the opposite direction`() throws {
+    /// Transit-center case (#1326 + #1334): the same route serves both directions
+    /// and multiple vehicles share a headsign. Matching must pin the *selected*
+    /// tripID — not "next same-direction train" — so Track follows that vehicle.
+    @Test @MainActor func `Content state matching pins the selected tripID as primary`() throws {
         let oppositeSooner = try arrivalDeparture(
             routeID: "40_100479",
             headsign: "Angle Lake",
@@ -152,12 +151,35 @@ final class BookmarkActionsTests: OBATestCase {
             matching: tracked
         )
 
-        #expect(state.arrivals.count == 2)
-        #expect(state.arrivals.map(\.departureTime) == [
-            Int(tracked.arrivalDepartureDate.timeIntervalSince1970),
-            Int(laterSameDirection.arrivalDepartureDate.timeIntervalSince1970)
-        ])
+        #expect(state.arrivals.count == 1)
+        #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))
         #expect(!state.arrivals.map(\.departureTime).contains(Int(oppositeSooner.arrivalDepartureDate.timeIntervalSince1970)))
+        #expect(!state.arrivals.map(\.departureTime).contains(Int(laterSameDirection.arrivalDepartureDate.timeIntervalSince1970)))
+    }
+
+    /// Picking a later same-direction vehicle must not surface the earlier one
+    /// as the headline countdown (#1334).
+    @Test @MainActor func `Content state matching a later vehicle does not surface an earlier same-direction trip`() throws {
+        let earlier = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north",
+            departureEpoch: 1_700_000_480
+        )
+        let later = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Lynnwood City Center",
+            tripID: "trip_north_2",
+            departureEpoch: 1_700_000_840
+        )
+
+        let state = try #require(BookmarkActions.buildContentState(
+            from: [earlier, later],
+            matching: later
+        ))
+
+        #expect(state.arrivals.count == 1)
+        #expect(state.arrivals[0].departureTime == Int(later.arrivalDepartureDate.timeIntervalSince1970))
     }
 
     /// If the stop list is stale and no longer contains the tapped trip, still
@@ -200,48 +222,6 @@ final class BookmarkActionsTests: OBATestCase {
 
         #expect(state.arrivals.count == 1)
         #expect(state.arrivals[0].departureTime == Int(tracked.arrivalDepartureDate.timeIntervalSince1970))
-    }
-
-    /// A feed that omits `trip_headsign` collapses the `TripBookmarkKey` headsign
-    /// to `""`, so matching falls back to stop and route and readmits the opposite
-    /// direction — the #1326 symptom, from the other end. Pinned rather than
-    /// fixed: matching on the departure alone would leave the card showing a
-    /// single arrival, so the production path keeps the grouping and logs.
-    @Test @MainActor func `Content state matching degrades to route only without a headsign`() throws {
-        let tracked = try arrivalDeparture(
-            routeID: "40_100479",
-            headsign: nil,
-            tripID: "trip_north",
-            departureEpoch: 1_700_000_480
-        )
-        let oppositeDirection = try arrivalDeparture(
-            routeID: "40_100479",
-            headsign: nil,
-            tripID: "trip_south",
-            departureEpoch: 1_700_000_120
-        )
-        let namedDirection = try arrivalDeparture(
-            routeID: "40_100479",
-            headsign: "Lynnwood City Center",
-            tripID: "trip_north_2",
-            departureEpoch: 1_700_000_240
-        )
-
-        // Neither the departure nor its trip reference supplies one, which is the
-        // condition the production warning fires on.
-        #expect(tracked.tripHeadsign == nil)
-
-        let state = BookmarkActions.buildContentState(
-            from: [oppositeDirection, namedDirection, tracked],
-            matching: tracked
-        )
-
-        // Both headsign-less trips match, soonest first — including the one going
-        // the other way. The trip that does carry a headsign is the one dropped.
-        #expect(state.arrivals.map(\.departureTime) == [
-            Int(oppositeDirection.arrivalDepartureDate.timeIntervalSince1970),
-            Int(tracked.arrivalDepartureDate.timeIntervalSince1970)
-        ])
     }
 
     /// Tracking a bookmark with no loaded arrivals can't build a content state,

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -104,6 +104,79 @@ final class BookmarkActionsTests: OBATestCase {
         #expect(keys.routeHeadsign == (bookmark.tripHeadsign ?? ""))
     }
 
+    /// Bookmark Track must not pin a tripID in StaticData — identity is
+    /// stop+route+headsign only, so refresh rollovers can't break dedupe.
+    @Test @MainActor func `Bookmark static data leaves trip ID empty`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let bookmark = try makeTripBookmark(application: application)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals-and-departures-for-stop-1_10914.json"
+        )
+        try #require(stopArrivals.arrivalsAndDepartures.first?.tripID.isEmpty == false)
+
+        let staticData = BookmarkActions.liveActivityStaticData(
+            for: bookmark,
+            regionID: Fixtures.pugetSoundRegion.regionIdentifier,
+            arrivalDepartures: stopArrivals.arrivalsAndDepartures
+        )
+
+        #expect(staticData.tripID.isEmpty)
+    }
+
+    /// Two bookmark activities with empty tripID still reconcile on
+    /// stop/route/headsign — the duplicate guard's bookmark identity rule.
+    @Test @MainActor func `Bookmark static data with empty trip ID tracks same trip`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let bookmark = try makeTripBookmark(application: application)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals_and_departures_for_stop_1_29261.json"
+        )
+        let regionID = Fixtures.pugetSoundRegion.regionIdentifier
+
+        let first = BookmarkActions.liveActivityStaticData(
+            for: bookmark,
+            regionID: regionID,
+            arrivalDepartures: Array(stopArrivals.arrivalsAndDepartures.prefix(1))
+        )
+        let second = BookmarkActions.liveActivityStaticData(
+            for: bookmark,
+            regionID: regionID,
+            arrivalDepartures: stopArrivals.arrivalsAndDepartures
+        )
+
+        #expect(first.tripID.isEmpty)
+        #expect(second.tripID.isEmpty)
+        #expect(first.tracksSameTrip(as: second))
+    }
+
+    /// Bookmark refresh with empty tripID uses the unpinned builder, not the
+    /// stop-page matching branch that collapses to one arrival.
+    @Test @MainActor func `Refresh with empty trip ID builds multi-arrival content`() throws {
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals_and_departures_for_stop_1_29261.json"
+        )
+        try #require(stopArrivals.arrivalsAndDepartures.count >= 3)
+
+        let staticData = TripAttributes.StaticData(
+            routeShortName: "43",
+            routeHeadsign: "Montlake",
+            stopID: "1_29261",
+            tripID: ""
+        )
+
+        let state = try #require(BookmarkActions.buildRefreshContentState(
+            for: staticData,
+            arrivalDepartures: stopArrivals.arrivalsAndDepartures
+        ))
+
+        #expect(state.arrivals.count == 3)
+    }
+
     /// No arrivals means no content state, which is what makes `startLiveActivity`
     /// report failure instead of requesting an empty activity.
     @Test @MainActor func `Content state is nil without arrivals`() {

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -153,6 +153,66 @@ final class BookmarkActionsTests: OBATestCase {
         #expect(first.tracksSameTrip(as: second))
     }
 
+    /// Cross-path duplicate guard: bookmark StaticData (`tripID: ""`) must
+    /// still reconcile with a stop-page activity that stores a concrete trip.
+    @Test @MainActor func `Empty bookmark trip ID tracks same trip as stop-page pin`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let bookmark = try makeTripBookmark(application: application)
+        let stopArrivals = try Fixtures.loadRESTAPIPayload(
+            type: StopArrivals.self,
+            fileName: "arrivals_and_departures_for_stop_1_29261.json"
+        )
+        let pinned = try #require(stopArrivals.arrivalsAndDepartures.first)
+        try #require(!pinned.tripID.isEmpty)
+
+        let bookmarkStatic = BookmarkActions.liveActivityStaticData(
+            for: bookmark,
+            regionID: Fixtures.pugetSoundRegion.regionIdentifier,
+            arrivalDepartures: stopArrivals.arrivalsAndDepartures
+        )
+        let stopPageStatic = TripAttributes.StaticData(
+            routeShortName: bookmarkStatic.routeShortName,
+            routeHeadsign: bookmarkStatic.routeHeadsign,
+            stopID: bookmarkStatic.stopID,
+            tripID: pinned.tripID
+        )
+
+        #expect(bookmarkStatic.tripID.isEmpty)
+        #expect(bookmarkStatic.tracksSameTrip(as: stopPageStatic))
+        #expect(stopPageStatic.tracksSameTrip(as: bookmarkStatic))
+    }
+
+    /// Relaunch metadata must prefer the pinned trip over the soonest arrival.
+    @Test @MainActor func `Refresh primary arrival prefers pinned trip ID`() throws {
+        let base = 1_700_000_000
+        let sooner = try arrivalDeparture(
+            routeID: "1_100479",
+            headsign: "Downtown",
+            tripID: "trip_soon",
+            departureEpoch: base + 120
+        )
+        let pinned = try arrivalDeparture(
+            routeID: "1_100479",
+            headsign: "Downtown",
+            tripID: "trip_pinned",
+            departureEpoch: base + 480
+        )
+        let staticData = TripAttributes.StaticData(
+            routeShortName: "1 Line",
+            routeHeadsign: "Downtown",
+            stopID: Self.stopID,
+            tripID: "trip_pinned"
+        )
+
+        let primary = BookmarkActions.refreshPrimaryArrival(
+            for: staticData,
+            arrivalDepartures: [sooner, pinned]
+        )
+        #expect(primary?.tripID == "trip_pinned")
+        #expect(primary?.tripID != sooner.tripID)
+    }
+
     /// Bookmark refresh with empty tripID uses the unpinned builder, not the
     /// stop-page matching branch that collapses to one arrival.
     @Test @MainActor func `Refresh with empty trip ID builds multi-arrival content`() throws {

--- a/OBAKitTests/Models/TripAttributesIdentityTests.swift
+++ b/OBAKitTests/Models/TripAttributesIdentityTests.swift
@@ -24,14 +24,16 @@ final class TripAttributesIdentityTests {
         routeHeadsign: String = "Downtown",
         stopID: String = "1_75403",
         routeColorHex: String? = nil,
-        regionID: Int = 1
+        regionID: Int = 1,
+        tripID: String = "trip_1"
     ) -> TripAttributes.StaticData {
         TripAttributes.StaticData(
             routeShortName: routeShortName,
             routeHeadsign: routeHeadsign,
             stopID: stopID,
             routeColorHex: routeColorHex,
-            regionID: regionID
+            regionID: regionID,
+            tripID: tripID
         )
     }
 
@@ -51,6 +53,24 @@ final class TripAttributesIdentityTests {
     /// tracking one must not suppress starting the other.
     @Test func `Does not match on different headsign`() {
         #expect(!staticData().tracksSameTrip(as: staticData(routeHeadsign: "University District")))
+    }
+
+    /// Two vehicles on the same route and headsign at one stop are different
+    /// trips, so tracking one must not suppress or promote the other (#1334).
+    @Test func `Does not match on different trip ID`() {
+        #expect(!staticData(tripID: "trip_a").tracksSameTrip(as: staticData(tripID: "trip_b")))
+    }
+
+    /// Legacy activities without a stored trip ID still compare equal when both
+    /// sides are empty.
+    @Test func `Matches when both trip IDs are empty`() {
+        #expect(staticData(tripID: "").tracksSameTrip(as: staticData(tripID: "")))
+    }
+
+    /// A new activity keyed by trip ID must not reconcile against a legacy card.
+    @Test func `Does not match when only one trip ID is empty`() {
+        #expect(!staticData(tripID: "").tracksSameTrip(as: staticData(tripID: "trip_a")))
+        #expect(!staticData(tripID: "trip_a").tracksSameTrip(as: staticData(tripID: "")))
     }
 
     /// The route colour arrives with the first arrivals payload and is nil until

--- a/OBAKitTests/Models/TripAttributesIdentityTests.swift
+++ b/OBAKitTests/Models/TripAttributesIdentityTests.swift
@@ -61,16 +61,18 @@ final class TripAttributesIdentityTests {
         #expect(!staticData(tripID: "trip_a").tracksSameTrip(as: staticData(tripID: "trip_b")))
     }
 
-    /// Legacy activities without a stored trip ID still compare equal when both
-    /// sides are empty.
+    /// Legacy / bookmark activities without a stored trip ID still compare equal
+    /// when both sides are empty.
     @Test func `Matches when both trip IDs are empty`() {
         #expect(staticData(tripID: "").tracksSameTrip(as: staticData(tripID: "")))
     }
 
-    /// A new activity keyed by trip ID must not reconcile against a legacy card.
-    @Test func `Does not match when only one trip ID is empty`() {
-        #expect(!staticData(tripID: "").tracksSameTrip(as: staticData(tripID: "trip_a")))
-        #expect(!staticData(tripID: "trip_a").tracksSameTrip(as: staticData(tripID: "")))
+    /// Empty tripID is a wildcard so bookmark Track (`""`) reconciles with a
+    /// stop-page activity that carries a concrete trip — restoring the
+    /// cross-path duplicate guard without pinning bookmark identity.
+    @Test func `Matches when only one trip ID is empty`() {
+        #expect(staticData(tripID: "").tracksSameTrip(as: staticData(tripID: "trip_a")))
+        #expect(staticData(tripID: "trip_a").tracksSameTrip(as: staticData(tripID: "")))
     }
 
     /// The route colour arrives with the first arrivals payload and is nil until
@@ -101,6 +103,11 @@ final class TripAttributesIdentityTests {
         let colored = staticData(routeColorHex: "FF0000")
         #expect(plain.tracksSameTrip(as: colored))
         #expect(colored.tracksSameTrip(as: plain))
+
+        let empty = staticData(tripID: "")
+        let pinned = staticData(tripID: "trip_a")
+        #expect(empty.tracksSameTrip(as: pinned))
+        #expect(pinned.tracksSameTrip(as: empty))
     }
 
     /// Empty headsign is the fallback both start paths use when a bookmark or

--- a/docs/live-activity-track-selected-trip.md
+++ b/docs/live-activity-track-selected-trip.md
@@ -1,13 +1,20 @@
 # Track pins the selected trip (#1334)
 
-Stop-page / trip-panel Track used to build Live Activity content from every
-same-route/headsign arrival (up to three), sorted soonest-first. Picking a
-later vehicle still showed the earlier “next train” as the headline.
+Stop-page / trip-panel Track builds Live Activity content from the selected
+departure via `BookmarkActions.buildContentState(from:matching:)`, filtering by
+that departure's identity (`$0.id == departure.id`, which includes `tripID`).
+The stop-page start path stores that `tripID` in `TripAttributes.StaticData` so
+`Activity.running(matching:)` and refresh can keep following the same vehicle.
 
-`BookmarkActions.buildContentState(from:matching:)` filters by the tracked
-departure's identity (`$0.id == departure.id`, which includes tripID). Bookmark
-refresh and `Activity.running(matching:)` thread the same `tripID` through
-`TripAttributes.StaticData` and `tracksSameTrip`, so a foreground reload or a
-second Track tap cannot clobber or promote the wrong vehicle.
+Bookmark Track does **not** pin a `tripID` in `StaticData` — identity is
+stop + route + headsign only — and refresh uses the unpinned multi-arrival
+builder (up to three, soonest-first). Setting `tripID` from the first arrival
+would roll over on refresh, break the duplicate guard, and collapse the card to
+a single pinned arrival.
 
-Opposite-direction mixing (#1326) cannot happen once the key is the trip itself.
+When a stop-page activity's pinned trip leaves the arrivals list, refresh falls
+back to rebuilding from the unpinned list (degradation): the card may show a
+different vehicle until the user re-Tracks from the stop page.
+
+Opposite-direction mixing (#1326) cannot happen once the stop-page key is the
+trip itself.

--- a/docs/live-activity-track-selected-trip.md
+++ b/docs/live-activity-track-selected-trip.md
@@ -1,0 +1,13 @@
+# Track pins the selected trip (#1334)
+
+Stop-page / trip-panel Track used to build Live Activity content from every
+same-route/headsign arrival (up to three), sorted soonest-first. Picking a
+later vehicle still showed the earlier “next train” as the headline.
+
+`BookmarkActions.buildContentState(from:matching:)` filters by the tracked
+departure's identity (`$0.id == departure.id`, which includes tripID). Bookmark
+refresh and `Activity.running(matching:)` thread the same `tripID` through
+`TripAttributes.StaticData` and `tracksSameTrip`, so a foreground reload or a
+second Track tap cannot clobber or promote the wrong vehicle.
+
+Opposite-direction mixing (#1326) cannot happen once the key is the trip itself.

--- a/docs/live-activity-track-selected-trip.md
+++ b/docs/live-activity-track-selected-trip.md
@@ -12,9 +12,25 @@ builder (up to three, soonest-first). Setting `tripID` from the first arrival
 would roll over on refresh, break the duplicate guard, and collapse the card to
 a single pinned arrival.
 
+Empty `tripID` is a wildcard in `tracksSameTrip`: if either side is empty, the
+comparison falls back to stop + route + headsign. That keeps bookmark identity
+unpinned while still letting `Activity.running(matching:)` reconcile a bookmark
+card with a stop-page card for the same stop/route/headsign (the cross-path
+guard from 89a47ff).
+
 When a stop-page activity's pinned trip leaves the arrivals list, refresh falls
 back to rebuilding from the unpinned list (degradation): the card may show a
-different vehicle until the user re-Tracks from the stop page.
+different vehicle. Re-Tracking from the stop page currently promotes relevance
+score only via `running(matching:)` — it does not rewrite content state — so
+degradation is repaired on the next successful pinned refresh (or a new activity
+if the existing one has ended), not by the promote alone.
+
+Relaunch re-registration in `updateRunningLiveActivities()` passes the same
+primary arrival `buildRefreshContentState` uses (pinned trip when present) as
+`LiveActivityTracker` metadata, so OBACloud push stays on the tracked vehicle
+rather than the soonest bookmark arrival.
 
 Opposite-direction mixing (#1326) cannot happen once the stop-page key is the
-trip itself.
+trip itself. Loop routes that visit a stop twice under the same `tripID` can
+still match the wrong visit on refresh until `StaticData` carries more identity
+fields; that is out of scope here.


### PR DESCRIPTION
## Summary
- Closes #1334: `buildContentState(from:matching:)` pins by `tripID` so Track follows the vehicle the rider tapped, not the next same-headsign arrival.
- Opposite-direction mixing (#1326) stays impossible under a tripID key.
- Bookmark Track (no `matching:`) still packs up to three same-key arrivals.

## Test plan
- [x] `BookmarkActionsTests` — pins selected trip; later vehicle does not surface earlier; fallback when trip missing from list
- [ ] On device: open a stop with two same-route same-direction vehicles, Track the later one → Lock Screen shows that ETA, not the earlier “next train”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live Activities now continue tracking the selected vehicle when multiple vehicles share the same route and destination.
  * Prevented updates from displaying the wrong vehicle or mixing information between opposing directions.
  * Bookmark Live Activities now refresh with multiple upcoming arrivals, while explicitly tracked trips remain pinned.
  * Improved reliability when refreshing bookmarks or selecting Track again.
  * Existing Live Activities continue working after the update.

* **Documentation**
  * Added guidance explaining selected-trip tracking and Live Activity refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->