### PR TITLE
Give route-grouped departures the same long-press menu as chronological

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -28,6 +28,10 @@ struct GroupedListView: View {
     /// hide the alarm affordance when a new alarm can't be created — while still
     /// showing it for a departure that already has one, so it can be cancelled.
     let canAlarm: (ArrivalDeparture) -> Bool
+    /// Supplies the same long-press menu the chronological rows get. Grouped mode
+    /// renders its own rows rather than reusing `DepartureRowView`, so without
+    /// this the menu simply wasn't there — see `departureRowActions(_:)`.
+    let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
     let onToggleRoute: (RouteID) -> Void
     let onSelectDeparture: (ArrivalDeparture) -> Void
     let onAlarmToggle: (ArrivalDeparture) -> Void
@@ -114,6 +118,11 @@ struct GroupedListView: View {
                 }
             }
         }
+        // Applied outside the accessibility element, matching how
+        // `ChronologicalListView` composes it onto `DepartureRowView`. The header
+        // is the route's next departure and is all a rider sees while the card is
+        // collapsed, so the menu has to reach it too — not just expanded rows.
+        .departureRowActions(actionsProvider(next))
     }
 
     private func alarmActionName(for alarm: Alarm?) -> String {
@@ -319,6 +328,7 @@ struct GroupedListView: View {
                     }
                 }
             }
+            .departureRowActions(actionsProvider(departure))
         }
     }
 

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -225,6 +225,7 @@ struct StopDeparturesSections: View {
                 alarmLookup: alarmLookup,
                 alarmLeadTime: alarmLeadTime,
                 canAlarm: canAlarm,
+                actionsProvider: actionsProvider,
                 onToggleRoute: onToggleRoute,
                 onSelectDeparture: onSelectDeparture,
                 onAlarmToggle: onAlarmToggle


### PR DESCRIPTION
Follow-up from #1120.

Long-pressing a departure in route-grouped mode did nothing. `ChronologicalListView` renders through `DepartureRowView`, which carries `.departureRowActions(_:)`; `GroupedListView` builds its own rows and never received the provider, so the menu wasn't there.

Three actions were unreachable in that mode:

| Action | Chronological | Grouped (before) |
|---|---|---|
| Show Trip Details | long-press | tap already works |
| Alarm | long-press | bell icon already works |
| **Schedules** | long-press | **unreachable** |
| **Add Bookmark** | long-press | **unreachable** |
| **Share Trip** | long-press | **unreachable** |

Sort mode is a persisted per-stop preference, so a rider who prefers grouped mode lost those three permanently — and had no way to discover they existed.

## The change

`actionsProvider` was already in scope at the call site; `StopDeparturesSections.swift:221` passes it to `ChronologicalListView` twelve lines above and simply didn't pass it to `GroupedListView`. Threading it through and applying the existing `departureRowActions(_:)` modifier is the whole fix — no new menu, no duplicated action list, no new strings. All five labels are already localized.

Applied to **both** the card header and the expanded rows. The header is the route's next departure and is the only thing on screen while a card is collapsed, so a menu on expanded rows alone would still leave a rider one tap short of sharing a trip.

Placement matches `ChronologicalListView`: outside the accessibility element, after the custom actions, so the existing VoiceOver composition is untouched.

## Tests

None. `GroupedListView` and `DepartureRowActions` have no existing coverage, and there's no snapshot infrastructure in this target — a context menu's presence isn't reachable from a unit test here. The change is a parameter and two modifier applications, so it's reviewable on inspection, but I'd rather say that outright than imply coverage that doesn't exist.

Verified by reading instead: one construction site (`StopDeparturesSections.swift:221`, patched), no previews to update, SwiftLint clean on both files.

closes #1383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added row actions to grouped departure views, including collapsed route headers and expanded departure rows.
  * Grouped and chronological departure lists now provide consistent row actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->