### PR TITLE
Highlight transfer trip on new stop page (#1277)

### DIFF
--- a/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/ChronologicalListView.swift
@@ -17,6 +17,7 @@ struct ChronologicalListView: View {
     let partition: StopPageListBuilder.ChronologicalPartition<ArrivalDeparture>
     let walkMinutes: Int?
     let showPast: Bool
+    let highlightedTripID: TripIdentifier?
     let statusProvider: (ArrivalDeparture) -> DepartureStatus
     let alarmLookup: (ArrivalDeparture) -> Alarm?
     let actionsProvider: (ArrivalDeparture) -> DepartureRowActions
@@ -56,6 +57,7 @@ struct ChronologicalListView: View {
         // Identity: ArrivalDeparture.id (stable across prediction refreshes).
         ForEach(departures, id: \.id) { departure in
             let actions = actionsProvider(departure)
+            let isTransferTrip = highlightedTripID == departure.tripID
             DepartureRowView(
                 departure: departure,
                 status: statusProvider(departure),
@@ -63,9 +65,11 @@ struct ChronologicalListView: View {
                 canAlarm: actions.canAlarm,
                 onAlarmToggle: actions.onAlarmToggle,
                 style: style,
+                isTransferHighlight: isTransferTrip,
                 onTap: { onSelectDeparture(departure) }
             )
             .departureRowActions(actions)
+            .listRowBackground(DepartureTransferHighlight.rowBackground(isHighlighted: isTransferTrip))
         }
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -31,6 +31,9 @@ struct DepartureRowView: View {
     let canAlarm: Bool
     let onAlarmToggle: () -> Void
     var style: Style = .normal
+    /// True when this row is the rider's inbound transfer trip and should
+    /// read as visually selected (background tint is applied by the list).
+    var isTransferHighlight: Bool = false
     let onTap: () -> Void
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -88,6 +91,14 @@ struct DepartureRowView: View {
             }
         }
         .opacity(dimmed ? 0.55 : 1.0)
+        .overlay(alignment: .leading) {
+            if isTransferHighlight {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color(uiColor: ThemeColors.shared.brand))
+                    .frame(width: 4)
+                    .padding(.vertical, 4)
+            }
+        }
         .contentShape(Rectangle())
         .onTapGesture(perform: onTap)
         .accessibilityElement(children: .ignore)
@@ -174,6 +185,10 @@ struct DepartureRowView: View {
 
     private var accessibilityText: String {
         var extras: [String] = []
+
+        if isTransferHighlight {
+            extras.append(OBALoc("stop_page.row.a11y_transfer_trip", value: "your transfer trip", comment: "VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip."))
+        }
 
         if style == .missed {
             extras.append(OBALoc("stop_page.row.a11y_missed", value: "likely missed — departs sooner than your walk to the stop", comment: "VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves."))

--- a/OBAKit/Stops/StopPage/Departures/DepartureTransferHighlight.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureTransferHighlight.swift
@@ -1,0 +1,23 @@
+//
+//  DepartureTransferHighlight.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import OBAKitCore
+
+/// Shared visual treatment for a departure row that matches the rider's
+/// inbound transfer trip (`TransferTripHighlight`).
+enum DepartureTransferHighlight {
+    static func rowBackground(isHighlighted: Bool) -> Color {
+        if isHighlighted {
+            Color(uiColor: ThemeColors.shared.brand).opacity(0.14)
+        } else {
+            Color(uiColor: .secondarySystemGroupedBackground)
+        }
+    }
+}

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -20,6 +20,7 @@ import OBAKitCore
 struct GroupedListView: View {
     let groups: [StopPageListBuilder.RouteGroup<ArrivalDeparture>]
     let expandedRouteID: RouteID?
+    let highlightedTripID: TripIdentifier?
     let statusProvider: (ArrivalDeparture) -> DepartureStatus
     let alarmLookup: (ArrivalDeparture) -> Alarm?
     let alarmLeadTime: (Alarm) -> Int
@@ -45,6 +46,10 @@ struct GroupedListView: View {
     /// layout): badge + countdown become glance tokens on the first line and
     /// everything else flows below at full width.
     private var isAccessibilitySize: Bool { dynamicTypeSize.isAccessibilitySize }
+
+    private func isTransferTrip(_ departure: ArrivalDeparture) -> Bool {
+        highlightedTripID == departure.tripID
+    }
 
     /// Whether this departure should show an alarm affordance: it can take a new
     /// alarm, or it already has one that can be cancelled. Shared by the header
@@ -85,7 +90,15 @@ struct GroupedListView: View {
             headerChipsRow(group)
         }
         .padding(.vertical, 4)
-        .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
+        .overlay(alignment: .leading) {
+            if isTransferTrip(next) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color(uiColor: ThemeColors.shared.brand))
+                    .frame(width: 4)
+                    .padding(.vertical, 4)
+            }
+        }
+        .listRowBackground(DepartureTransferHighlight.rowBackground(isHighlighted: isTransferTrip(next)))
         .contentShape(Rectangle())
         .onTapGesture { onToggleRoute(group.routeID) }
         .accessibilityElement(children: .ignore)
@@ -300,7 +313,15 @@ struct GroupedListView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture { onSelectDeparture(departure) }
-            .listRowBackground(Color(uiColor: .secondarySystemGroupedBackground))
+            .overlay(alignment: .leading) {
+                if isTransferTrip(departure) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(uiColor: ThemeColors.shared.brand))
+                        .frame(width: 4)
+                        .padding(.vertical, 4)
+                }
+            }
+            .listRowBackground(DepartureTransferHighlight.rowBackground(isHighlighted: isTransferTrip(departure)))
             // Make the whole expanded row a single VoiceOver activation target
             // that opens the trip screen, mirroring the card
             // header (`children: .ignore` + explicit label + `.isButton`). The
@@ -349,20 +370,29 @@ struct GroupedListView: View {
     /// headsign, minutes, live/scheduled status, and occupancy when present.
     private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
+        var extras: [String] = []
+        if isTransferTrip(departure) {
+            extras.append(OBALoc("stop_page.row.a11y_transfer_trip", value: "your transfer trip", comment: "VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip."))
+        }
         return DepartureAccessibility.label(
             identity: String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", departure.arrivalDepartureMinutes, status.accessibilityStatusDescription),
             departure: departure,
             status: status,
-            timeDisplay: timeDisplay(departure)
+            timeDisplay: timeDisplay(departure),
+            extraClauses: extras
         )
     }
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
         let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
-        let label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
+        var label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
         // Appended after the sentence rather than comma-joined like the row
         // labels: this format string ends in a full stop, and VoiceOver's pause
         // there keeps the time attached to the card rather than to the count.
-        return label + " " + timeDisplay(group.next).accessibilityTimeDescription
+        label += " " + timeDisplay(group.next).accessibilityTimeDescription
+        if isTransferTrip(group.next) {
+            label += ", " + OBALoc("stop_page.row.a11y_transfer_trip", value: "your transfer trip", comment: "VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip.")
+        }
+        return label
     }
 }

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -369,13 +369,6 @@ struct GroupedListView: View {
     /// Self-describing VoiceOver label for one expanded departure row: route,
     /// headsign, minutes, live/scheduled status, and occupancy when present.
     private func expandedRowAccessibilityLabel(_ departure: ArrivalDeparture, status: DepartureStatus) -> String {
-<<<<<<< HEAD
-        let fmt = OBALoc("stop_page.grouped.expanded_row.a11y_fmt", value: "Route %@ to %@, departs in %d minutes, %@", comment: "VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status.")
-        var extras: [String] = []
-        if isTransferTrip(departure) {
-            extras.append(OBALoc("stop_page.row.a11y_transfer_trip", value: "your transfer trip", comment: "VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip."))
-        }
-=======
         let identity = StopPageAccessibilityCopy.upcomingIdentity(
             routeShortName: departure.routeShortName,
             headsign: departure.tripHeadsign ?? "",
@@ -383,7 +376,10 @@ struct GroupedListView: View {
             arrivalDepartureStatus: departure.arrivalDepartureStatus,
             adherence: status.accessibilityStatusDescription
         )
->>>>>>> origin/main
+        var extras: [String] = []
+        if isTransferTrip(departure) {
+            extras.append(OBALoc("stop_page.row.a11y_transfer_trip", value: "your transfer trip", comment: "VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip."))
+        }
         return DepartureAccessibility.label(
             identity: identity,
             departure: departure,
@@ -394,11 +390,7 @@ struct GroupedListView: View {
     }
 
     private func groupAccessibilityLabel(_ group: StopPageListBuilder.RouteGroup<ArrivalDeparture>, status: DepartureStatus) -> String {
-<<<<<<< HEAD
-        let fmt = OBALoc("stop_page.grouped.a11y_fmt", value: "Route %@ to %@, next departure in %d minutes, %@. %d more departures loaded.", comment: "VoiceOver label for a grouped route card")
-        var label = String(format: fmt, group.next.routeShortName, group.next.tripHeadsign ?? "", group.next.arrivalDepartureMinutes, status.accessibilityStatusDescription, group.upcoming.count)
-=======
-        let label = StopPageAccessibilityCopy.groupedCardIdentity(
+        var label = StopPageAccessibilityCopy.groupedCardIdentity(
             routeShortName: group.next.routeShortName,
             headsign: group.next.tripHeadsign ?? "",
             minutes: group.next.arrivalDepartureMinutes,
@@ -406,7 +398,6 @@ struct GroupedListView: View {
             adherence: status.accessibilityStatusDescription,
             moreCount: group.upcoming.count
         )
->>>>>>> origin/main
         // Appended after the sentence rather than comma-joined like the row
         // labels: this format string ends in a full stop, and VoiceOver's pause
         // there keeps the time attached to the card rather than to the count.

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesBuilder.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesBuilder.swift
@@ -57,6 +57,7 @@ struct StopDeparturesBuilder {
             isLoading: viewModel.isLoading,
             pastCollapsed: pastCollapsed,
             expandedRouteID: expandedRouteID,
+            highlightedTripID: TransferTripHighlight.tripID(from: viewModel.transferContext),
             statusProvider: { DepartureStatus(arrivalDeparture: $0) },
             alarmLookup: { viewModel.alarm(for: $0) },
             alarmLeadTime: { viewModel.alarmLeadTimeMinutes($0) },

--- a/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopDeparturesSections.swift
@@ -38,6 +38,10 @@ struct StopDeparturesSections: View {
     let pastCollapsed: Bool
     let expandedRouteID: RouteID?
 
+    /// Trip ID of the rider's inbound transfer trip, when this stop was opened
+    /// as a transfer destination. Matching departure rows receive a highlight.
+    let highlightedTripID: TripIdentifier?
+
     let statusProvider: (ArrivalDeparture) -> DepartureStatus
     let alarmLookup: (ArrivalDeparture) -> Alarm?
     let alarmLeadTime: (Alarm) -> Int
@@ -212,6 +216,7 @@ struct StopDeparturesSections: View {
                 partition: chronologicalPartition,
                 walkMinutes: walkMinutes,
                 showPast: !pastCollapsed,
+                highlightedTripID: highlightedTripID,
                 statusProvider: statusProvider,
                 alarmLookup: alarmLookup,
                 actionsProvider: actionsProvider,
@@ -221,6 +226,7 @@ struct StopDeparturesSections: View {
             GroupedListView(
                 groups: content.routeGroups,
                 expandedRouteID: expandedRouteID,
+                highlightedTripID: highlightedTripID,
                 statusProvider: statusProvider,
                 alarmLookup: alarmLookup,
                 alarmLeadTime: alarmLeadTime,

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -100,15 +100,14 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     ///
     /// - Parameter showToolbarOnBottom: Pass `true` when the caller will present the result as a
     ///   sheet rather than push it, which swaps the redesigned page's dark map header for a light
-    ///   one and moves its chrome into a bottom toolbar. Ignored when the flag or a transfer
-    ///   context routes to the legacy `StopViewController`, which has only the pushed layout.
+    ///   one and moves its chrome into a bottom toolbar. Ignored when the flag is off and the
+    ///   legacy `StopViewController` is used (pushed layout only). Transfer context is still
+    ///   gated by `displayedTransferContext` — on the new page it drives trip highlighting;
+    ///   on the legacy page it drives the arrival banner.
     public func makeStopController(stop: Stop, bookmark: Bookmark? = nil, transferContext: TransferContext? = nil, showToolbarOnBottom: Bool = false) -> UIViewController {
-        // Transfer UX is not on the new stop page yet. The banner toggle can
-        // drop the context — use the same helper the page will, or a trip→stop
-        // tap with the toggle off lands on the legacy screen for nothing.
         let effective = application.userDataStore.displayedTransferContext(transferContext)
         let stopController: StopContextConfigurable
-        if effective == nil, FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
+        if FeatureFlags.isNewStopPageEnabled(userDefaults: application.userDefaults) {
             stopController = StopPageViewController(application: application, stop: stop, showToolbarOnBottom: showToolbarOnBottom)
         } else {
             stopController = StopViewController(application: application, stop: stop)

--- a/OBAKitCore/Models/ViewModels/TransferContext.swift
+++ b/OBAKitCore/Models/ViewModels/TransferContext.swift
@@ -21,6 +21,11 @@ public struct TransferContext: Equatable, Hashable {
     /// The headsign of the originating route (e.g., "Capitol Hill").
     public let fromTripHeadsign: String
 
+    /// The trip the rider is transferring from. Used on the redesigned stop
+    /// page to highlight the matching departure row. Nil when constructed
+    /// without a known trip (tests, legacy call sites).
+    public let fromTripID: TripIdentifier?
+
     /// Combined route and headsign for display (e.g., "10 - Capitol Hill").
     /// Derived from `fromRouteShortName` and `fromTripHeadsign` so it can
     /// never contradict the component fields.
@@ -30,10 +35,16 @@ public struct TransferContext: Equatable, Hashable {
             .joined(separator: " - ")
     }
 
-    public init(arrivalTime: Date, fromRouteShortName: String, fromTripHeadsign: String) {
+    public init(
+        arrivalTime: Date,
+        fromRouteShortName: String,
+        fromTripHeadsign: String,
+        fromTripID: TripIdentifier? = nil
+    ) {
         self.arrivalTime = arrivalTime
         self.fromRouteShortName = fromRouteShortName
         self.fromTripHeadsign = fromTripHeadsign
+        self.fromTripID = fromTripID
     }
 
     /// Convenience factory that extracts route info from an `ArrivalDeparture`.
@@ -41,7 +52,8 @@ public struct TransferContext: Equatable, Hashable {
         TransferContext(
             arrivalTime: arrivalDate,
             fromRouteShortName: arrivalDeparture.routeShortName,
-            fromTripHeadsign: arrivalDeparture.tripHeadsign ?? ""
+            fromTripHeadsign: arrivalDeparture.tripHeadsign ?? "",
+            fromTripID: arrivalDeparture.tripID
         )
     }
 

--- a/OBAKitCore/Models/ViewModels/TransferTripHighlight.swift
+++ b/OBAKitCore/Models/ViewModels/TransferTripHighlight.swift
@@ -1,0 +1,32 @@
+//
+//  TransferTripHighlight.swift
+//  OBAKitCore
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Pure helpers that decide which departure trip (if any) should be visually
+/// highlighted when a stop is opened as a transfer destination.
+///
+/// Kept free of UI so the selection rule can be unit-tested without hosting a
+/// stop page. The redesigned stop page highlights the matching row; it does
+/// not reintroduce relative NOW/−5m banner timing.
+public enum TransferTripHighlight {
+
+    /// The trip ID to highlight for `context`, or `nil` when there is no
+    /// transfer / no known originating trip.
+    public static func tripID(from context: TransferContext?) -> TripIdentifier? {
+        context?.fromTripID
+    }
+
+    /// Whether a departure whose `tripID` is `tripID` should receive the
+    /// transfer highlight for `context`.
+    public static func shouldHighlight(tripID: TripIdentifier, context: TransferContext?) -> Bool {
+        guard let highlighted = context?.fromTripID else { return false }
+        return highlighted == tripID
+    }
+}

--- a/OBAKitTests/Modeling/Model Unit Tests/TransferContextTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/TransferContextTests.swift
@@ -142,10 +142,21 @@ final class TransferContextTests: OBATestCase {
         #expect(context.arrivalTime == arrivalTime)
         #expect(context.fromRouteShortName == arrDep.routeShortName)
         #expect(context.fromTripHeadsign == (arrDep.tripHeadsign ?? ""))
+        #expect(context.fromTripID == arrDep.tripID)
         // fromRouteDisplay is now computed from the component fields.
         let expectedDisplay = [arrDep.routeShortName, arrDep.tripHeadsign ?? ""]
             .filter { !$0.isEmpty }
             .joined(separator: " - ")
         #expect(context.fromRouteDisplay == expectedDisplay)
+    }
+
+    @Test func `Init stores fromTripID`() {
+        let context = TransferContext(
+            arrivalTime: Date(timeIntervalSince1970: 1_000_000),
+            fromRouteShortName: "10",
+            fromTripHeadsign: "Capitol Hill",
+            fromTripID: "1_trip_abc"
+        )
+        #expect(context.fromTripID == "1_trip_abc")
     }
 }

--- a/OBAKitTests/Modeling/Model Unit Tests/TransferTripHighlightTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/TransferTripHighlightTests.swift
@@ -1,0 +1,51 @@
+//
+//  TransferTripHighlightTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import Testing
+@testable import OBAKitCore
+
+@Suite(.serialized)
+struct TransferTripHighlightTests {
+
+    @Test func `Trip ID from nil context is nil`() {
+        #expect(TransferTripHighlight.tripID(from: nil) == nil)
+    }
+
+    @Test func `Trip ID from context without trip ID is nil`() {
+        let context = TransferContext(
+            arrivalTime: Date(),
+            fromRouteShortName: "10",
+            fromTripHeadsign: "Capitol Hill"
+        )
+        #expect(TransferTripHighlight.tripID(from: context) == nil)
+    }
+
+    @Test func `Trip ID from context with trip ID returns that ID`() {
+        let context = TransferContext(
+            arrivalTime: Date(),
+            fromRouteShortName: "10",
+            fromTripHeadsign: "Capitol Hill",
+            fromTripID: "trip_42"
+        )
+        #expect(TransferTripHighlight.tripID(from: context) == "trip_42")
+    }
+
+    @Test func `Should highlight matching trip ID`() {
+        let context = TransferContext(
+            arrivalTime: Date(),
+            fromRouteShortName: "10",
+            fromTripHeadsign: "Capitol Hill",
+            fromTripID: "trip_42"
+        )
+        #expect(TransferTripHighlight.shouldHighlight(tripID: "trip_42", context: context))
+        #expect(!TransferTripHighlight.shouldHighlight(tripID: "other", context: context))
+        #expect(!TransferTripHighlight.shouldHighlight(tripID: "trip_42", context: nil))
+    }
+}

--- a/OBAKitTests/ViewModels/StopViewModelTests.swift
+++ b/OBAKitTests/ViewModels/StopViewModelTests.swift
@@ -810,14 +810,13 @@ final class StopViewModelTests: OBATestCase {
         #expect(presented.count == 1)
     }
 
-    // MARK: - Router transfer fallback (final-review FIX 1)
+    // MARK: - Router transfer routing (#1277)
 
-    /// A transfer (non-nil `TransferContext`) must always resolve to the legacy
-    /// `StopViewController`, even with the new-stop-page flag ON (its default),
-    /// because the transfer UX isn't built on the new page yet. A plain open with
-    /// the flag ON resolves to the new `StopPageViewController`.
+    /// With the new-stop-page flag ON, a transfer opens the new stop page and
+    /// keeps the effective context (highlight UX). The legacy banner screen is
+    /// only for when the flag is off.
     @Test @MainActor
-    func `Make stop controller transfer context falls back to legacy screen`() throws {
+    func `Make stop controller transfer context uses new stop page when flag on`() throws {
         let dataLoader = MockDataLoader(testName: name)
         let app = createApplication(dataLoader: dataLoader, analytics: AnalyticsMock())
 
@@ -826,18 +825,23 @@ final class StopViewModelTests: OBATestCase {
 
         let stop = try #require(try Fixtures.loadSomeStops().first)
 
-        let transfer = TransferContext(arrivalTime: Date(), fromRouteShortName: "1", fromTripHeadsign: "Downtown")
+        let transfer = TransferContext(
+            arrivalTime: Date(),
+            fromRouteShortName: "1",
+            fromTripHeadsign: "Downtown",
+            fromTripID: "trip_transfer"
+        )
         let transferController = app.viewRouter.makeStopController(stop: stop, transferContext: transfer)
-        #expect(transferController is StopViewController)
+        #expect(transferController is StopPageViewController)
+        #expect((transferController as? StopPageViewController)?.transferContext == transfer)
 
         let plainController = app.viewRouter.makeStopController(stop: stop, transferContext: nil)
         #expect(plainController is StopPageViewController)
     }
 
-    /// The banner toggle drops the effective transfer context. Routing must use
-    /// that same helper: a raw non-nil context with the toggle off is ordinary
-    /// stop UX, so it belongs on the new page (flag default ON). Leave the
-    /// router on the raw value and this fails — legacy screen, no banner.
+    /// The banner/highlight toggle drops the effective transfer context. Routing
+    /// must use that same helper so a raw non-nil context with the toggle off
+    /// lands as an ordinary stop (no highlight).
     @Test @MainActor
     func `Make stop controller ignores transfer context when the banner toggle is off`() throws {
         let dataLoader = MockDataLoader(testName: name)
@@ -847,7 +851,12 @@ final class StopViewModelTests: OBATestCase {
         app.userDataStore.showTransferArrivalBanner = false
 
         let stop = try #require(try Fixtures.loadSomeStops().first)
-        let transfer = TransferContext(arrivalTime: Date(), fromRouteShortName: "1", fromTripHeadsign: "Downtown")
+        let transfer = TransferContext(
+            arrivalTime: Date(),
+            fromRouteShortName: "1",
+            fromTripHeadsign: "Downtown",
+            fromTripID: "trip_transfer"
+        )
         let controller = app.viewRouter.makeStopController(stop: stop, transferContext: transfer)
 
         #expect(controller is StopPageViewController)

--- a/docs/transfer-arrival-banner.md
+++ b/docs/transfer-arrival-banner.md
@@ -1,26 +1,37 @@
-# Transfer arrival banner
+# Transfer arrival banner / trip highlight
 
-When a rider taps a stop on a trip, the stop page can treat that stop as a
-transfer: it shows an **Arriving at HH:MM via ROUTENAME** banner, hides
-departures that already left before the rider arrives, and prints remaining
-times relative to that arrival instead of the clock.
-
-That is useful for connections. It is also the behavior #1277 asked to turn
-off — relative "NOW" / "-5m" times and a filtered list are easy to misread as
-the live stop.
+When a rider taps a stop on a trip, that stop can be treated as a transfer
+destination. How that looks depends on which stop page is showing and whether
+the Settings toggle is on.
 
 ## Setting
 
 Settings → Arrival & Departure Display → **Show transfer arrival banner**.
-Default **on**, so existing riders keep the current trip-to-stop flow. The
+Default **on**, so existing riders keep transfer UX unless they opt out. The
 footer in every locale starts with that switch title verbatim.
 
 When the switch is off, `UserDataStore.displayedTransferContext(_:)` (a Swift
 protocol extension — `TransferContext` cannot appear on the `@objc` protocol)
-returns `nil` and `StopViewController` renders the stop as a normal stop:
-wall-clock times, walk-time row, full departure list.
+returns `nil`. Routers and stop screens then treat the stop as ordinary:
+wall-clock times, walk-time row, full departure list, no highlight.
 
-The new stop page still does not implement transfer UX. With the toggle **on**,
-`Router.makeStopController` sends a real transfer to the legacy screen. With it
-**off**, `displayedTransferContext` is nil at the routing boundary too, so a
-trip→stop tap uses the new stop page like any other stop.
+## New stop page (feature flag on)
+
+`Router.makeStopController` always builds `StopPageViewController` when
+`FeatureFlags.isNewStopPageEnabled` is true, and passes the *effective*
+transfer context (nil when the toggle is off).
+
+On that page, a non-nil context with `fromTripID` **highlights** departure rows
+whose `tripID` matches — brand-tint background plus a leading accent bar. Times
+stay absolute (live stop clocks). Relative “NOW” / “-5m” banner timing is not
+used here.
+
+`TransferContext.from(arrivalDeparture:arrivalDate:)` copies
+`arrivalDeparture.tripID` into `fromTripID`. Selection is pure:
+`TransferTripHighlight.tripID(from:)` / `shouldHighlight(tripID:context:)`.
+
+## Legacy stop page (feature flag off)
+
+The same effective context still drives the legacy **Arriving at HH:MM via
+ROUTENAME** banner on `StopViewController`: it hides departures that left before
+the rider arrives and prints remaining times relative to that arrival.


### PR DESCRIPTION
## Summary
- Carry optional `fromTripID` on `TransferContext` (populated from `ArrivalDeparture.tripID`) so transfer navigation can identify the inbound trip.
- When the new stop page flag is on, `Router.makeStopController` always uses `StopPageViewController` and passes the effective transfer context (still nil when the Settings toggle is off).
- Highlight matching departure rows on the redesigned stop page (tint + leading accent); do not reintroduce relative NOW/−5m banner timing there. Legacy banner remains only when the new-stop-page flag is off.

Closes #1277

## Test plan
- [x] `TransferContextTests` / `TransferTripHighlightTests` (tripID factory + highlight selection)
- [x] `StopViewModelTests` router cases (new page with transfer; toggle off drops context)
- [x] `ArrivalDepartureItemTransferTests` / `StopPagePresentationTests`
- [ ] Manual: trip → another stop with toggle ON → matching trip row highlighted on new stop page (absolute times)
- [ ] Manual: toggle OFF → ordinary stop page, no highlight
- [ ] Manual: disable new-stop-page flag → legacy banner behavior still works with toggle ON