### PR TITLE
Keep every route on bookmark map callouts (#1342)

### DIFF
--- a/OBAKit/Extensions/ModelExtensions.swift
+++ b/OBAKit/Extensions/ModelExtensions.swift
@@ -66,6 +66,15 @@ nonisolated extension Stop: @retroactive MKAnnotation {
     public var mapCalloutText: String {
         ["#\(code)", mapTitle].compactMap { $0 }.joined(separator: "\n")
     }
+
+    /// Callout text for a **bookmark** pin. The pin title is `bookmark.name`, not
+    /// the route list, so truncating routes in the callout would hide information
+    /// with no pin/callout consistency benefit (#1342). Same compact style as
+    /// `mapCalloutText`, but every route (`limit: .max`).
+    public var bookmarkCalloutText: String {
+        let routes = Formatters.formattedMapRoutes(self.routes, limit: .max)
+        return ["#\(code)", routes].compactMap { $0 }.joined(separator: "\n")
+    }
 }
 
 // MARK: - TripStatus/MKAnnotation

--- a/OBAKit/Mapping/StopAnnotationView.swift
+++ b/OBAKit/Mapping/StopAnnotationView.swift
@@ -146,7 +146,7 @@ class StopAnnotationView: MKAnnotationView {
         labelStack.isHidden = delegate.shouldHideExtraStopAnnotationData
         image = delegate.iconFactory.buildIcon(for: bookmark.stop, isBookmarked: true, traits: traitCollection)
         titleLabel.attributedText = strokedText(bookmark.name)
-        detailCalloutAccessoryView = buildDetailLabel(text: bookmark.stop.mapCalloutText)
+        detailCalloutAccessoryView = buildDetailLabel(text: bookmark.stop.bookmarkCalloutText)
     }
 
     private func prepareForDisplay(stop: Stop, delegate: StopAnnotationDelegate) {

--- a/OBAKitTests/Application/FormattersTests.swift
+++ b/OBAKitTests/Application/FormattersTests.swift
@@ -251,7 +251,6 @@ final class FormattersTests: OBATestCase {
         #expect(label == "10, 20, 30…")
         #expect(label.contains("\u{2026}"))
         #expect(!label.contains("..."))
-        #expect(!label.contains("more"))
         #expect(!label.hasPrefix("Routes:"))
     }
 
@@ -271,6 +270,18 @@ final class FormattersTests: OBATestCase {
         #expect(subtitle.contains("Routes:"))
         #expect(subtitle.contains("62"))
         #expect(!subtitle.contains("\u{2026}"))
+    }
+
+    /// Bookmark pins title with `bookmark.name`, so the callout is the only
+    /// place routes appear — keep every route (#1342).
+    @Test func `Bookmark callout lists every route without truncating`() throws {
+        let stop = try #require(Fixtures.loadSomeStops().first)
+        stop.routes = try makeRoutes(shortNames: ["10", "20", "30", "40", "62"])
+
+        let callout = stop.bookmarkCalloutText
+        #expect(callout == "#\(stop.code)\n10, 20, 30, 40, 62")
+        #expect(!callout.contains("\u{2026}"))
+        #expect(!callout.hasPrefix("Routes:"))
     }
 
     private func makeRoutes(shortNames: [String]) throws -> [Route] {

--- a/docs/map-route-labels.md
+++ b/docs/map-route-labels.md
@@ -5,14 +5,18 @@ and the same list in the callout (`Stop.mapCalloutText`):
 
 - Up to three short names, comma-separated, no `"Routes:"` prefix.
 - Overflow is marked with a single ellipsis glyph (`…`, U+2026), e.g. `"10, 12, 49…"`.
-- The marker is inside `OBALoc("formatters.map_routes_overflow_fmt")` so a
-  translator can substitute a locale-conventional overflow mark.
+- The marker is inside `OBALoc("formatters.map_routes_overflow_fmt")` (all 13
+  OBAKitCore catalogs). zh-Hans / zh-Hant use `……`.
 
 UIKit's own tail truncation also renders `…`. Using three ASCII periods (`...`)
 for the overflow hint made a pin that fit look different from one that UIKit
 truncated — the inconsistency #514 reported.
 
+**Bookmark pins** are different: the title is `bookmark.name`, not the route
+list, so truncating the callout would hide routes with no pin/callout consistency
+win. They use `Stop.bookmarkCalloutText` (same compact style, `limit: .max`).
+
 `Stop.subtitle` is unchanged. Home, Recent, and Nearby list rows still show
 `"Routes: 10, 12, 49"` with every route. That is not a map surface.
 
-See also #132 (pin-label overflow hint) and #1267 (`formattedMapRoutes`).
+See also #132 (pin-label overflow hint), #1267 (`formattedMapRoutes`), #1342.


### PR DESCRIPTION
## Summary

Closes #1342 (remaining after #1359).

#1359 already localized `formatters.map_routes_overflow_fmt` and dropped the callout/subtitle vacuous asserts. What was still open:

1. **Product decision:** bookmark pin titles are `bookmark.name`, not the route list — truncating the callout hid routes with no pin/callout consistency benefit. Bookmarks now use `Stop.bookmarkCalloutText` (`formattedMapRoutes` with `limit: .max`). Stop pins keep the 3 + `…` callout.
2. Removed the remaining vacuous `#expect(!label.contains("more"))` on the map-routes formatter test.
3. Updated `docs/map-route-labels.md` so it matches the code.

## Test plan

- [x] `FormattersTests` — bookmark callout lists every route; stop callout still truncates
- [ ] Simulator: bookmark a multi-route stop, tap the pin, confirm callout shows all routes
- [ ] Same stop (unbookmarked) still shows `10, 12, 49…` under the pin and in the callout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bookmark stop callouts now list every route served by the stop without truncation.
  - Bookmark callouts display the rider-visible stop code alongside the complete route list.

- **Documentation**
  - Updated map and bookmark route-label documentation to clarify overflow markers and full route visibility in bookmark callouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->