### PR TITLE
Pin SwiftLint in CI to portable 0.65.1 (#1340)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,14 +46,15 @@ jobs:
     # in CI (scripts/swiftlint.sh); this job is the review-visible gate.
     # See https://github.com/OneBusAway/onebusaway-ios/issues/1303
     - name: SwiftLint (errors only)
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
-        if ! command -v swiftlint >/dev/null; then
-          brew install swiftlint
-        fi
-        swiftlint lint --reporter github-actions-logging
+        # Pin via the official portable release so a Homebrew formula bump cannot
+        # promote a new error-severity rule and turn main red with no app change
+        # (#1340). Bump SWIFTLINT_PIN deliberately after reviewing new rules.
+        SWIFTLINT_PIN="0.65.1"
+        curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_PIN}/portable_swiftlint.zip" -o /tmp/swiftlint.zip
+        unzip -qo /tmp/swiftlint.zip -d /tmp/swiftlint
+        /tmp/swiftlint/swiftlint version | grep -qx "$SWIFTLINT_PIN"
+        /tmp/swiftlint/swiftlint lint --reporter github-actions-logging
 
   build:
     runs-on: xcode-27

--- a/docs/swiftlint-ci-gate.md
+++ b/docs/swiftlint-ci-gate.md
@@ -1,0 +1,12 @@
+# SwiftLint CI gate (#1340)
+
+Follow-ups from #1325 / #1303:
+
+1. **`longPressGesture` is `private`** again — only used in `MapViewController.swift`.
+2. **Lint is its own job** (`lint:` beside `build:`), so a lint failure does not
+   erase test signal for the same run.
+3. **SwiftLint is version-pinned** in `.github/workflows/tests.yml`
+   (`SWIFTLINT_PIN`, official portable release). Bump the pin after reviewing
+   new error-tier rules — do not rely on unpinned `brew install`.
+4. Extension doc comments no longer claim a `type_body_length` ceiling that the
+   split already removed.


### PR DESCRIPTION
## Summary

Closes #1340.

Most of the issue is already on `main` from Divesh's follow-ups to #1325:

1. ~~`longPressGesture` → `private`~~ done
2. ~~Lint as its own job beside `build`~~ done
3. **This PR:** pin SwiftLint via the official **portable 0.65.1** release (`SWIFTLINT_PIN`), so an unpinned `brew install` cannot promote a new error-severity rule and turn main red with no app change
4. ~~Stale body-length ceiling comments~~ already fixed on the extension files

Doc: `docs/swiftlint-ci-gate.md`.

## Test plan

- [ ] CI `lint` job downloads portable 0.65.1 and passes
- [ ] Bumping `SWIFTLINT_PIN` without reviewing rules is a deliberate follow-up, not silent drift