### PR TITLE
Soften #421 DiffableDataSource causality claim (#1338)

### DIFF
--- a/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
+++ b/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
@@ -89,9 +89,12 @@ nonisolated public struct OBAListViewSection: Hashable, Identifiable, @unchecked
     }
 
     public static func == (lhs: OBAListViewSection, rhs: OBAListViewSection) -> Bool {
-        // `id` belongs here: `hash(into:)` already combines it, and
-        // `NSDiffableDataSource` treats Hashable mismatch as "Failed to find
-        // index of item" on the header that uses this section's id (#421).
+        // `id` belongs in `==` because `hash(into:)` already combines it —
+        // Hashable requires equal values to share a hash. Two agency-alert
+        // sections can share a title and empty contents while differing only
+        // by id (#421 / #1327). Whether that mismatch alone caused the
+        // DiffableDataSource "Failed to find index of item" spam is unproven
+        // (#1338); including `id` is still required for a correct contract.
         return lhs.id == rhs.id &&
             lhs.title == rhs.title &&
             lhs.contents == rhs.contents

--- a/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
+++ b/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
@@ -90,11 +90,10 @@ nonisolated public struct OBAListViewSection: Hashable, Identifiable, @unchecked
 
     public static func == (lhs: OBAListViewSection, rhs: OBAListViewSection) -> Bool {
         // `id` belongs in `==` because `hash(into:)` already combines it —
-        // Hashable requires equal values to share a hash. Two agency-alert
-        // sections can share a title and empty contents while differing only
-        // by id (#421 / #1327). Whether that mismatch alone caused the
-        // DiffableDataSource "Failed to find index of item" spam is unproven
-        // (#1338); including `id` is still required for a correct contract.
+        // Hashable requires equal values to share a hash. Whether omitting
+        // `id` from `==` caused the DiffableDataSource "Failed to find index
+        // of item" spam is unproven (#1338); including `id` is still required
+        // for a correct contract.
         return lhs.id == rhs.id &&
             lhs.title == rhs.title &&
             lhs.contents == rhs.contents

--- a/OBAKitTests/Controls/OBAListViewSectionTests.swift
+++ b/OBAKitTests/Controls/OBAListViewSectionTests.swift
@@ -13,9 +13,11 @@ import Testing
 /// `NSDiffableDataSource` uses `Hashable` as identity. `hash(into:)` already
 /// combines `id`; `==` used not to, so two agency-alert sections with the same
 /// title and an empty row list compared equal while hashing differently —
-/// undefined behavior, and the source of
-/// "Failed to find index of item OBAListViewHeader".
-/// See: https://github.com/OneBusAway/onebusaway-ios/issues/421
+/// undefined behavior under the Hashable contract (#421 / #1327).
+///
+/// #1338: a causal link from that mismatch to the historical
+/// "Failed to find index of item OBAListViewHeader" spam is plausible but has
+/// not been re-confirmed on device; these tests only lock the contract.
 @Suite(.serialized)
 struct OBAListViewSectionTests {
 

--- a/OBAKitTests/Controls/OBAListViewSectionTests.swift
+++ b/OBAKitTests/Controls/OBAListViewSectionTests.swift
@@ -11,13 +11,12 @@ import Testing
 @testable import OBAKit
 
 /// `NSDiffableDataSource` uses `Hashable` as identity. `hash(into:)` already
-/// combines `id`; `==` used not to, so two agency-alert sections with the same
-/// title and an empty row list compared equal while hashing differently —
-/// undefined behavior under the Hashable contract (#421 / #1327).
+/// combines `id`; `==` used not to — undefined behavior under the Hashable
+/// contract (#421 / #1327).
 ///
 /// #1338: a causal link from that mismatch to the historical
-/// "Failed to find index of item OBAListViewHeader" spam is plausible but has
-/// not been re-confirmed on device; these tests only lock the contract.
+/// "Failed to find index of item OBAListViewHeader" spam is unproven; these
+/// tests only lock the contract.
 @Suite(.serialized)
 struct OBAListViewSectionTests {
 


### PR DESCRIPTION
## Summary

Addresses #1338 (does not close #421).

#1327 correctly put `id` into `OBAListViewSection.==` so it matches `hash(into:)`. The in-code comment claimed that mismatch caused DiffableDataSource `"Failed to find index of item"` spam on headers — that causal link was never device-verified (#1338).

This PR only softens the comments in production and tests so they state:

- `id` belongs in `==` for a correct Hashable contract
- a link to the historic spam is **plausible but unproven**

## Verification attempted

On Simulator (Puget Sound → More → Alerts), opened Community Transit and toggled the section header repeatedly while streaming logs for `Failed to find index` / `DiffableDataSource`. **No spam observed** on current `main` with the #1327 fix already present. That does **not** prove #421 is fixed historically — only that I could not reproduce the log today.

## Test plan

- [x] Comment-only change; existing `OBAListViewSectionTests` still describe the contract
- [ ] Optional: anyone with a device repro from #421 can confirm spam is gone and then close #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the requirements for consistent equality and hashing behavior.
  - Updated related test documentation to distinguish confirmed contract behavior from unverified historical logging causes.
  - No user-facing functionality or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->