### PR TITLE
Refresh content when a re-Track promotes a running Live Activity

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -156,17 +156,27 @@ final class BookmarkActions {
         // cards and duplicate OBACloud push registrations. Re-Track still needs
         // to promote the existing activity: after A→B the Island is on B with A
         // demoted to 0, so tapping Track on A again must bump A (not just toast).
+        // Built before the duplicate check so a re-Track can install it: the rider
+        // has asked for this trip while the app holds current arrivals, and the
+        // running card would otherwise keep whatever the last push left (#1390).
+        // Still optional here — a nil simply leaves the promotion score-only,
+        // which is what it always was.
+        let freshContentState = Self.buildContentState(from: arrivalDepartures)
+
         if let existing = Activity<TripAttributes>.running(matching: staticData) {
             Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
             let existingID = existing.id
             Task {
-                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
+                await Activity<TripAttributes>.promoteToDynamicIsland(
+                    activityID: existingID,
+                    state: freshContentState
+                )
             }
             showLiveActivityStartedToast()
             return .promotedExisting
         }
 
-        guard let contentState = Self.buildContentState(from: arrivalDepartures) else {
+        guard let contentState = freshContentState else {
             // Shouldn't happen — the context menu only offers Track once arrival
             // data has loaded — but if data was cleared between the menu render
             // and the tap, tell the user rather than silently doing nothing.

--- a/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
+++ b/OBAKit/Stops/StopPage/StopPageActionPresenter.swift
@@ -595,17 +595,10 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
         // with two Lock Screen cards and two OBACloud push registrations. Re-Track
         // still needs to promote the existing activity: after A→B the Island is
         // on B with A demoted to 0, so tapping Track on A again must bump A.
-        if let existing = Activity<TripAttributes>.running(matching: staticData) {
-            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
-            let existingID = existing.id
-            Task {
-                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
-            }
-            // Re-show the confirmation rather than appearing to do nothing.
-            viewModel.signalLiveActivityStarted()
-            return
-        }
-
+        // Built before the duplicate check so a re-Track can install it: the rider
+        // has asked for this trip while the app holds current arrivals, and the
+        // running card would otherwise keep whatever the last push left (#1390).
+        //
         // Always yields content: the matching builder falls back to `departure`
         // itself when the stop list is stale or hasn't loaded yet, so there is
         // no failure branch to take here.
@@ -613,6 +606,20 @@ final class StopPageActionPresenter: NSObject, ObservableObject {
             from: viewModel.stopArrivals?.arrivalsAndDepartures ?? [],
             matching: departure
         )
+
+        if let existing = Activity<TripAttributes>.running(matching: staticData) {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
+            let existingID = existing.id
+            Task {
+                await Activity<TripAttributes>.promoteToDynamicIsland(
+                    activityID: existingID,
+                    state: contentState
+                )
+            }
+            // Re-show the confirmation rather than appearing to do nothing.
+            viewModel.signalLiveActivityStarted()
+            return
+        }
 
         do {
             let activity = try Activity<TripAttributes>.requestProminent(

--- a/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
+++ b/OBAKitCore/LiveActivities/TripLiveActivityRelevance.swift
@@ -45,6 +45,21 @@ public enum TripLiveActivityRelevance {
         ActivityContent(state: state, staleDate: staleDate, relevanceScore: relevanceScore)
     }
 
+    /// The stale marker a promotion should carry.
+    ///
+    /// A score-only promotion keeps whatever the push set: the content is
+    /// unchanged, so clearing it would leave a re-Tracked card unmarked as stale
+    /// until the next push arrived. Installing fresh content is the opposite —
+    /// a date set for the *previous* content could mark new arrivals stale the
+    /// moment they land. ``LiveActivityUpdateCoalescer`` clears it for that same
+    /// reason, and the next push re-arms it.
+    public static func promotionStaleDate(
+        installing state: TripAttributes.ContentState?,
+        existing: Date?
+    ) -> Date? {
+        state == nil ? existing : nil
+    }
+
     /// Rebuilds content for a local arrivals refresh while keeping the activity's
     /// current Dynamic Island ranking. Passing anything other than
     /// `existing.relevanceScore` here is how the Island used to snap back to the
@@ -66,20 +81,26 @@ extension Activity where Attributes == TripAttributes {
     ///
     /// Takes an id (not `Activity`) so callers can hop into a `Task` without
     /// sending a non-`Sendable` ActivityKit value across isolation.
-    public static func promoteToDynamicIsland(activityID: String) async {
+    /// - Parameter state: Fresh content to install alongside the score bump, when
+    ///   the caller has it. A re-Track happens with current arrivals already
+    ///   loaded, and the card would otherwise keep whatever the last push left
+    ///   (#1390). Omit it for a score-only promotion.
+    public static func promoteToDynamicIsland(
+        activityID: String,
+        state: TripAttributes.ContentState? = nil
+    ) async {
         guard let activity = activities.first(where: { $0.id == activityID }),
               LiveActivityRegistry.isLive(activity.activityState) else {
             return
         }
         let prominence = TripLiveActivityRelevance.prominenceScore()
-        // A promotion only touches the score; the content is unchanged, so the
-        // push-set stale marker must survive it — the server always sends
-        // `stale-date`, and clearing it here left a re-Tracked card unmarked as
-        // stale until the next push arrived. Mirrors `demoteLivePeers`.
         await activity.update(
             TripLiveActivityRelevance.content(
-                state: activity.content.state,
-                staleDate: activity.content.staleDate,
+                state: state ?? activity.content.state,
+                staleDate: TripLiveActivityRelevance.promotionStaleDate(
+                    installing: state,
+                    existing: activity.content.staleDate
+                ),
                 relevanceScore: prominence
             )
         )

--- a/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
+++ b/OBAKitTests/Models/TripLiveActivityRelevanceTests.swift
@@ -89,6 +89,31 @@ final class TripLiveActivityRelevanceTests {
         #expect(promoted.relevanceScore == 7)
     }
 
+    /// The two halves of a promotion's stale handling (#1390). A score-only
+    /// re-Track leaves the content alone, so dropping the push-set marker would
+    /// leave a stale card looking live until the next push. Installing fresh
+    /// arrivals inverts that: the existing date was set for content that no
+    /// longer exists, and carrying it forward could mark the new arrivals stale
+    /// the moment they land.
+    @Test func `A promotion keeps the stale marker only when content is unchanged`() {
+        let pushSet = Date(timeIntervalSince1970: 1_700_000_200)
+
+        #expect(
+            TripLiveActivityRelevance.promotionStaleDate(installing: nil, existing: pushSet) == pushSet,
+            "A score-only promotion must carry the push-set marker through"
+        )
+
+        let fresh = TripAttributes.ContentState(arrivals: [])
+        #expect(
+            TripLiveActivityRelevance.promotionStaleDate(installing: fresh, existing: pushSet) == nil,
+            "Fresh content must not inherit the previous content's stale date"
+        )
+
+        // Nothing to carry is still nothing, either way.
+        #expect(TripLiveActivityRelevance.promotionStaleDate(installing: nil, existing: nil) == nil)
+        #expect(TripLiveActivityRelevance.promotionStaleDate(installing: fresh, existing: nil) == nil)
+    }
+
     /// Pins the refresh path used by `updateRunningLiveActivities`: the new
     /// content state may change, but the score must come from the *existing*
     /// content — not a literal, and not the ActivityContent default of `0`.


### PR DESCRIPTION


Closes #1390. Follow-up from #1215.

Both start paths short-circuit a duplicate Track by promoting the running activity and returning. `promoteToDynamicIsland` only moves the score, so the card kept whatever the last push left — while both call sites were already holding current arrivals, a few lines above the `buildContentState` they never reached.

`promoteToDynamicIsland` now takes an optional `state`: pass it to install fresh content with the score bump, omit it for the score-only behaviour every other caller still gets. Both call sites build content before the duplicate check and hand it over. On the bookmark path a nil builder result simply leaves the promotion score-only, exactly as before.

The stale marker needs opposite handling in the two cases, so it's a named rule rather than an inline ternary: score-only carries the push-set date through (dropping it leaves a stale card looking live); fresh content clears it (the old date was set for content that no longer exists). `promotionStaleDate(installing:existing:)` — tested in all four combinations.

This matters most for unbookmarked trips. `BookmarksViewController.updateRunningLiveActivities()` is the only local content refresh in the app, runs solely off the Bookmarks tab, and schedules content only when a bookmark matches — so a stop-page Track on an unbookmarked trip is refreshed by the server push alone. Re-Track was its one local chance.

**Not built.** `promoteToDynamicIsland` still can't be reached from a test — `Activity.activities` needs a real ActivityKit host — which is why the stale-date rule was extracted into something that can.