### PR TITLE
Correct the three remaining "Core Location clamps silently" comments

### DIFF
--- a/OBAKitCore/Location/Location/LocationManagerProtocol.swift
+++ b/OBAKitCore/Location/Location/LocationManagerProtocol.swift
@@ -63,9 +63,11 @@ public protocol LocationManager {
 
     /// The largest radius, in meters, this device will actually monitor.
     ///
-    /// `CLCircularRegion` silently clamps an oversize radius, so a region built
-    /// past this limit fires at a different distance than the one requested with
-    /// no error to tell anyone. Reading the limit is what makes that detectable.
+    /// An oversize region is not silently clamped: Core Location answers it with
+    /// `CLError.regionMonitoringFailure`, delivered asynchronously through
+    /// `monitoringDidFailFor` and carrying no radius. Reading the limit up front
+    /// is what lets a caller clamp deliberately and report it, rather than learn
+    /// later that something failed without learning what.
     var maximumRegionMonitoringDistance: CLLocationDistance { get }
 }
 

--- a/OBAKitCore/Location/Location/ProximityMonitoring.swift
+++ b/OBAKitCore/Location/Location/ProximityMonitoring.swift
@@ -22,9 +22,10 @@ public enum ProximityMonitoringResult: Equatable, Sendable {
     case started
 
     /// Monitoring began, but at a smaller radius than requested, because the
-    /// device will not monitor one that large. Core Location clamps an oversize
-    /// radius silently, so this is the only signal that the alert will fire at a
-    /// different distance than the user chose.
+    /// device will not monitor one that large. Core Location would answer the
+    /// oversize region with `CLError.regionMonitoringFailure` — asynchronous, and
+    /// carrying no radius — so this case exists to state up front what that error
+    /// never would: the alert fires at a different distance than the user chose.
     case startedWithClampedRadius(requested: CLLocationDistance, monitored: CLLocationDistance)
 
     /// Monitoring did not begin: delivering geofence events in the background

--- a/OBAKitCore/Models/UserData/ProximityAlert.swift
+++ b/OBAKitCore/Models/UserData/ProximityAlert.swift
@@ -56,9 +56,10 @@ public class ProximityAlert: NSObject, Codable {
 
     /// Brings `radius` into the monitorable range, logging whenever it has to.
     ///
-    /// An out-of-range radius can't simply be passed along: `CLCircularRegion`
-    /// clamps it silently, so the alert would fire at a distance nobody asked for
-    /// with nothing anywhere recording that it had changed.
+    /// An out-of-range radius can't simply be passed along: Core Location rejects
+    /// an oversize region with `CLError.regionMonitoringFailure`, delivered
+    /// asynchronously and without the radius, so the alert would fail with nothing
+    /// anywhere recording what it had asked for.
     static func clampedRadius(_ radius: CLLocationDistance) -> CLLocationDistance {
         guard radius.isFinite else {
             Logger.warn("ProximityAlert radius \(radius) is not a finite number; using the \(defaultRadiusMeters)m default.")


### PR DESCRIPTION
## Description

Follow-up from #1370, which Aaron asked for in review:

> three other comments still assert the old "Core Location clamps silently"
> claim this one now contradicts — `ProximityMonitoring.swift` (the
> `startedWithClampedRadius` doc, which also calls it "the only signal"),
> `LocationManagerProtocol.swift` on `maximumRegionMonitoringDistance`, and
> `ProximityAlert.swift`. Same correction, three more places.

Core Location does not clamp an oversize region. It answers with `CLError.regionMonitoringFailure`, delivered asynchronously through `monitoringDidFailFor` and carrying no radius.

| File | Was |
|---|---|
| `LocationManagerProtocol.swift:66` | "silently clamps … with no error to tell anyone" |
| `ProximityMonitoring.swift:25` | "clamps … silently, so this is **the only signal**" |
| `ProximityAlert.swift:59` | "clamps it silently, so the alert would fire at a distance nobody asked for" |

`ProximityMonitoring`'s was wrong twice over — not silent, and not the only signal, since `monitoringDidFailFor` reports it too.

The clamping itself was never the problem and none of it changes; the reason each comment gave for it was wrong. Each now says what actually happens, and why clamping up front is still right: the real error is too late and too vague to tell a rider their alert would have fired somewhere other than where they asked.

Wording follows the corrected comment #1370 landed at `LocationService.swift:596`, so all four now describe one mechanism instead of contradicting each other.

Comments only — no code, no behaviour change, reviewable on inspection. SwiftLint clean.

Deliberately no Closes — this is a follow-up from a merged PR's review, not an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how Core Location handles proximity regions that exceed the supported monitoring distance.
  - Documented that oversized regions fail asynchronously with a region-monitoring error rather than being silently adjusted.
  - Explained that the failure does not include the requested radius, while clamped-radius results communicate when monitoring will occur at a different distance than requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->