### PR TITLE
Make the trip page promote on re-Track and share the content mapping

### DIFF
--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -121,11 +121,17 @@ final class BookmarkActions {
 
     /// Maps the soonest three arrivals into the Live Activity payload.
     ///
-    /// - Precondition: `arrivalDepartures` is non-empty. Both entry points above
-    ///   establish that — one by guarding, the other by falling back to the
-    ///   tracked departure — which is why only the guarding one returns an
-    ///   `Optional`.
-    private static func contentState(from arrivalDepartures: [ArrivalDeparture]) -> TripAttributes.ContentState {
+    /// Internal rather than private because the trip page starts from a single
+    /// `ArrivalDeparture` with no stop list to filter (#1393). It wants this
+    /// mapping and not `buildContentState(from:matching:)`, whose headsign warning
+    /// describes a direction-mixing risk that a one-element list cannot have —
+    /// logging it there would assert something permanently untrue.
+    ///
+    /// - Precondition: `arrivalDepartures` is non-empty. Every entry point
+    ///   establishes that — by guarding, by falling back to the tracked
+    ///   departure, or by passing that departure directly — which is why only the
+    ///   guarding one returns an `Optional`.
+    static func contentState(from arrivalDepartures: [ArrivalDeparture]) -> TripAttributes.ContentState {
         let arrivals = arrivalDepartures.prefix(3).map { arrDep in
             TripAttributes.ContentState.ArrivalInfo(
                 departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),

--- a/OBAKit/Bookmarks/BookmarkActions.swift
+++ b/OBAKit/Bookmarks/BookmarkActions.swift
@@ -132,6 +132,12 @@ final class BookmarkActions {
     ///   departure, or by passing that departure directly — which is why only the
     ///   guarding one returns an `Optional`.
     static func contentState(from arrivalDepartures: [ArrivalDeparture]) -> TripAttributes.ContentState {
+        // Documented above, and unenforced until this became internal: the
+        // guarding wrapper used to be the only way in. An empty array yields a
+        // card with no arrivals rather than being refused, so say so in debug
+        // rather than shipping a blank Live Activity.
+        assert(!arrivalDepartures.isEmpty, "contentState(from:) needs at least one arrival")
+
         let arrivals = arrivalDepartures.prefix(3).map { arrDep in
             TripAttributes.ContentState.ArrivalInfo(
                 departureTime: Int(arrDep.arrivalDepartureDate.timeIntervalSince1970),

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -433,24 +433,29 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             regionID: application.currentRegion?.regionIdentifier ?? 0
         )
 
+        // Shares the mapping with the bookmark and stop paths rather than
+        // hand-rolling a third copy (#1393). Still one arrival: this screen holds
+        // a single `departure` and no stop arrival list, so there is no second one
+        // to offer — what changes is that a future edit to the mapping reaches
+        // here too.
+        let contentState = BookmarkActions.contentState(from: [departure])
+
         // The same trip can be started from here, the stop page, and the
         // bookmarks list. Without this guard one stop ends up with two Lock
-        // Screen cards and two OBACloud push registrations.
-        if Activity<TripAttributes>.running(matching: staticData) != nil {
-            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); not starting a duplicate.")
+        // Screen cards and two OBACloud push registrations. Re-Track still has to
+        // promote, as the other two paths do: after tracking A then B the Island
+        // is on B with A demoted to `demotedScore`, so tapping Track on A again
+        // must bump A back rather than only re-rendering this screen.
+        if let existing = Activity<TripAttributes>.running(matching: staticData) {
+            Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
+            let existingID = existing.id
+            Task {
+                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
+            }
             isTrackingLiveActivity = true
             render()
             return
         }
-
-        let contentState = TripAttributes.ContentState(arrivals: [
-            TripAttributes.ContentState.ArrivalInfo(
-                departureTime: Int(departure.arrivalDepartureDate.timeIntervalSince1970),
-                scheduleStatus: .init(departure.scheduleStatus),
-                scheduleDeviation: departure.deviationFromScheduleInMinutes * 60,
-                isArrival: departure.arrivalDepartureStatus == .arriving
-            )
-        ])
 
         do {
             let activity = try Activity<TripAttributes>.requestProminent(

--- a/OBAKit/Trip/TripPage/TripPageViewController.swift
+++ b/OBAKit/Trip/TripPage/TripPageViewController.swift
@@ -450,7 +450,10 @@ final class TripPageViewController: UIHostingController<TripPageView>,
             Logger.info("Live Activity already running for stop \(staticData.stopID) route \(staticData.routeShortName); promoting instead of duplicating.")
             let existingID = existing.id
             Task {
-                await Activity<TripAttributes>.promoteToDynamicIsland(activityID: existingID)
+                await Activity<TripAttributes>.promoteToDynamicIsland(
+                    activityID: existingID,
+                    state: contentState
+                )
             }
             isTrackingLiveActivity = true
             render()

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -110,6 +110,30 @@ final class BookmarkActionsTests: OBATestCase {
         #expect(BookmarkActions.buildContentState(from: []) == nil)
     }
 
+    /// The trip page's entry point (#1393). It holds one `ArrivalDeparture` and no
+    /// stop list, so it calls the mapping directly rather than
+    /// `buildContentState(from:matching:)`, whose headsign warning describes a
+    /// direction-mixing risk a one-element list cannot have.
+    ///
+    /// Pins that this produces exactly what the trip page used to build by hand,
+    /// field for field — the change is meant to be a no-op there.
+    @Test @MainActor func `Content state from a single departure maps that departure`() throws {
+        let departure = try arrivalDeparture(
+            routeID: "40_100479",
+            headsign: "Angle Lake",
+            tripID: "trip_south",
+            departureEpoch: 1_700_000_120
+        )
+
+        let state = BookmarkActions.contentState(from: [departure])
+
+        let arrival = try #require(state.arrivals.first)
+        #expect(state.arrivals.count == 1)
+        #expect(arrival.departureTime == Int(departure.arrivalDepartureDate.timeIntervalSince1970))
+        #expect(arrival.scheduleDeviation == departure.deviationFromScheduleInMinutes * 60)
+        #expect(arrival.isArrival == (departure.arrivalDepartureStatus == .arriving))
+    }
+
     /// With arrivals, at most the first three are carried into the activity.
     @Test @MainActor func `Content state carries at most three arrivals`() throws {
         let stopArrivals = try Fixtures.loadRESTAPIPayload(

--- a/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
+++ b/OBAKitTests/Bookmarks/BookmarkActionsTests.swift
@@ -127,11 +127,17 @@ final class BookmarkActionsTests: OBATestCase {
 
         let state = BookmarkActions.contentState(from: [departure])
 
-        let arrival = try #require(state.arrivals.first)
-        #expect(state.arrivals.count == 1)
-        #expect(arrival.departureTime == Int(departure.arrivalDepartureDate.timeIntervalSince1970))
-        #expect(arrival.scheduleDeviation == departure.deviationFromScheduleInMinutes * 60)
-        #expect(arrival.isArrival == (departure.arrivalDepartureStatus == .arriving))
+        // `ArrivalInfo` is `Hashable`, so one comparison pins every field — including
+        // `scheduleStatus`, which field-by-field assertions had left out while the
+        // docstring claimed otherwise.
+        let expected = TripAttributes.ContentState.ArrivalInfo(
+            departureTime: Int(departure.arrivalDepartureDate.timeIntervalSince1970),
+            scheduleStatus: .init(departure.scheduleStatus),
+            scheduleDeviation: departure.deviationFromScheduleInMinutes * 60,
+            isArrival: departure.arrivalDepartureStatus == .arriving
+        )
+
+        #expect(state.arrivals == [expected])
     }
 
     /// With arrivals, at most the first three are carried into the activity.


### PR DESCRIPTION
Closes #1393. Follow-up from #1377.

**1. Re-Track now promotes.** `TripPageViewController` was the one start path whose duplicate guard logged and returned. The other two call `promoteToDynamicIsland` there, for the reason their comments give: after tracking A then B the Island sits on B with A demoted to `demotedScore`, so tapping Track on A again has to bump A back. Here it only set `isTrackingLiveActivity` and re-rendered, leaving the Island where it was.

Same path that was missing `relevanceScore` and `demoteLivePeers` until #1377 — this was the remaining half.

**2. The content mapping is shared**, rather than a third hand-rolled copy.

It calls `BookmarkActions.contentState(from:)`, not `buildContentState(from:matching:)`, which needed that method to become internal. The distinction matters: `buildContentState` warns that a missing headsign can let the filter readmit the opposite direction. This screen holds one `ArrivalDeparture` and no stop list, so there is no filtering and no direction to mix — that warning would assert something permanently untrue. Same false-claim shape flagged on #1354 when a tripID key made the warning unreachable.

**Item 2 is a no-op for riders.** Still one arrival — there is no second one on this screen. The mapping is field-for-field what was there, and `prefix(3)` over one element is one element. A test pins that equivalence. What changes is that a future edit to the mapping reaches all three paths instead of two.

## Sequencing

Built against `main`, so it calls `promoteToDynamicIsland(activityID:)`. Open PR #1391 adds an optional `state:` there, with a default — so this compiles either way, but once #1391 lands this call site should pass the `contentState` built directly above it. Happy to fold that in on rebase.

#1381 also touches this file, though not this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Existing trip Live Activities can now be promoted to the Dynamic Island when started again for the same trip.
  - Trip Live Activity information is now presented consistently across trip and bookmark entry points.

- **Tests**
  - Added coverage verifying that departure details, including timing, schedule deviation, and arrival status, are accurately reflected in Live Activity updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->