### PR TITLE
Log the region-mismatched tap that queueOrOpenStop drops

### DIFF
--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -696,6 +696,11 @@ public class Application: CoreApplication, PushServiceDelegate {
     /// region exist. Does not fetch this stop against a different region's API.
     func queueOrOpenStop(_ destination: AppLinksRouter.StopDestination) {
         if let current = currentRegion?.regionIdentifier, current != destination.regionID {
+            // Dropped on purpose — fetching this stop against another region's API
+            // would return the wrong stop or nothing — but say so. This is the end
+            // of the line for something the rider actually tapped, and the
+            // no-region branch that defers instead already logs its reasoning.
+            Logger.warn("Stop \(destination.stopID) belongs to region \(destination.regionID) but region \(current) is selected; dropping the tap.")
             return
         }
 


### PR DESCRIPTION

Follow-up from #1368, which Aaron asked for in review:

> the region-mismatch branch in `queueOrOpenStop` drops the tap with no log at
> all, which is out of step with the deliberate `Logger.info` right next to it.

`Application.swift:698` returns silently when the selected region doesn't match the destination's. That's the end of the line for something the rider actually tapped — a proximity alert notification — and nothing anywhere records that it happened.

Its sibling branch at `Application.swift:403` already logs when it *defers* a tap that arrived with no region, and explains why. This one discarded the tap and said nothing.

The drop itself is right and doesn't change: fetching the stop against another region's API returns the wrong stop or nothing, which is what the method's doc comment says it avoids. Only the silence was wrong. The new comment says the drop is deliberate, so nobody later "fixes" it by navigating anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer warning logs when a stop from another region is discarded instead of being requested through the wrong regional API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->