### PR TITLE
Drop the inert autoshrink on the weather button

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -455,12 +455,16 @@ class MapViewController: UIViewController,
         }
 
         let button = UIButton(configuration: config)
-        // Restores what `7f2c1b8b` intended before the Configuration switch
-        // dropped it, with the scale factor that version omitted: without a
-        // `minimumScaleFactor`, `adjustsFontSizeToFitWidth` never shrinks
-        // anything. Three-digit temperatures scale down rather than wrap.
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
-        button.titleLabel?.minimumScaleFactor = 0.7
+        // No `adjustsFontSizeToFitWidth` here, deliberately. Autoshrink only acts
+        // on a label pinned to one line, and a `UIButton.Configuration` title is
+        // not — which is exactly how `18°` came to render as "1"/"8"/"°" in the
+        // screenshot on #1344. Setting it (as this did until #1357) shrinks
+        // nothing and reads as though the width problem were handled.
+        //
+        // Making it real needs `titleLabel?.numberOfLines = 1` alongside it, which
+        // trades wrapping for truncation when the scale floor still doesn't fit.
+        // That is a visible change to a 42pt toolbar button and wants a device.
+        // The zeroed horizontal insets above are what actually bought the room.
         button.addTarget(self, action: #selector(showWeather), for: .touchUpInside)
         button.accessibilityLabel = OBALoc("map_controller.show_weather_button", value: "Show Weather Forecast", comment: "Accessibility label for a button that provides the current forecast")
         return button

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -457,14 +457,16 @@ class MapViewController: UIViewController,
         let button = UIButton(configuration: config)
         // No `adjustsFontSizeToFitWidth` here, deliberately. Autoshrink only acts
         // on a label pinned to one line, and a `UIButton.Configuration` title is
-        // not — which is exactly how `18°` came to render as "1"/"8"/"°" in the
-        // screenshot on #1344. Setting it (as this did until #1357) shrinks
-        // nothing and reads as though the width problem were handled.
+        // not — so setting it shrinks nothing while reading as though the width
+        // problem were handled. `7f2c1b8b` added it in 2019, #1318's Configuration
+        // switch dropped it, and #1357 restored it; it has been inert since.
+        //
+        // It was never what fixed #1344 either: `18°` wrapped because `.plain()`
+        // insets ate the 42pt, which the block above corrects.
         //
         // Making it real needs `titleLabel?.numberOfLines = 1` alongside it, which
         // trades wrapping for truncation when the scale floor still doesn't fit.
         // That is a visible change to a 42pt toolbar button and wants a device.
-        // The zeroed horizontal insets above are what actually bought the room.
         button.addTarget(self, action: #selector(showWeather), for: .touchUpInside)
         button.accessibilityLabel = OBALoc("map_controller.show_weather_button", value: "Show Weather Forecast", comment: "Accessibility label for a button that provides the current forecast")
         return button


### PR DESCRIPTION
Follow-up from #1357:

> `adjustsFontSizeToFitWidth` may well be inert here. Autoshrink only applies to
> single-line labels, and this title is demonstrably multi-line. So `100°` may
> still wrap rather than scale.

Right, and #1344's own before-screenshot proves it: `18°` rendered as "1"/"8"/"°". A one-line label cannot wrap, so autoshrink was doing nothing.

Two checks: `numberOfLines` is set nowhere in this file, and the repo's one working autoshrink — `VehicleCalloutView.swift:176` — is a bare `UILabel()`, which defaults to one line. A `UIButton.Configuration` title doesn't.

Removed, with a comment saying why it isn't there. **The inset fix is untouched** — that's what actually bought the room, and what the #1357 screenshots show working.

Not doing the other half: `numberOfLines = 1` would switch autoshrink on and give `100°` scaling instead of wrapping, but it trades wrapping for truncation when 0.7 still doesn't fit — a visible change wanting a device and a before/after. This PR changes no rendering, only removes dead code. Happy to follow up.

The "inset fix is untouched" line is the one I'd keep no matter how short it gets — it's what stops a reviewer thinking you're reverting the thing they merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the weather toolbar button’s title layout to preserve corrected horizontal spacing and wrapping for narrow temperature displays.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->