### PR TITLE
  Track the one-time Always prompt for proximity alerts

### DIFF
--- a/OBAKit/ProximityAlerts/ProximityAlertAuthorization.swift
+++ b/OBAKit/ProximityAlerts/ProximityAlertAuthorization.swift
@@ -1,0 +1,107 @@
+//
+//  ProximityAlertAuthorization.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import UserNotifications
+import OBAKitCore
+
+/// The next thing that has to happen before a proximity alert can be armed.
+///
+/// A proximity alert needs two permissions that the rest of the app never asks
+/// for: `.authorizedAlways` location, because a geofence started under When In
+/// Use only delivers while the rider is looking at the screen, and notification
+/// permission, because the notification is the entire product. Each is
+/// separately grantable, separately refusable, and — once refused — reachable
+/// only through Settings.
+///
+/// Reducing all of that to a single next step keeps the decision in one place.
+/// The alternative is every caller re-deriving "can I still ask, or do I send
+/// them to Settings?" from a raw `CLAuthorizationStatus`, which is exactly the
+/// question the status alone cannot answer.
+public enum ProximityAlertAuthorizationStep: Equatable {
+
+    /// Nothing is missing.
+    case ready
+
+    /// The app can still raise the system location prompt. Whether that prompt
+    /// is the first one or the Always upgrade is iOS's business, not the
+    /// caller's — both are `requestAlwaysAuthorization()`.
+    case promptForLocation
+
+    /// Location is settled and the app can still raise the notification prompt.
+    case promptForNotifications
+
+    /// Location cannot be obtained by asking, so only Settings can fix it. The
+    /// status is carried because the rider's situation differs sharply between
+    /// them: `.denied` is a choice they can reverse, `.restricted` may be a
+    /// device policy they cannot, and `.authorizedWhenInUse` means they granted
+    /// something — just not the background access this feature needs.
+    case locationBlocked(CLAuthorizationStatus)
+
+    /// Notifications cannot be obtained by asking. Carries no status: every
+    /// route here wants the same thing from the rider, which is a trip to
+    /// Settings, and the resolver logs the distinction for anyone reading a
+    /// device log.
+    case notificationsBlocked
+}
+
+extension ProximityAlertAuthorizationStep {
+
+    /// Works out the next step from the two authorization states.
+    ///
+    /// Location is settled before notifications are asked about, and the order
+    /// matters rather than being arbitrary: a rider who will not grant
+    /// background location cannot use this feature at all, and iOS gives the
+    /// notification prompt one appearance per install. Asking for notifications
+    /// first would spend that one appearance on a feature already dead — and
+    /// spend it in a context the rider cannot make sense of, since nothing has
+    /// yet told them what the notification would be for.
+    ///
+    /// - Parameters:
+    ///   - locationStatus: `LocationService.authorizationStatus`.
+    ///   - canPromptForAlways: `LocationService.canPromptForAlwaysAuthorization`.
+    ///     Distinguishes "asking will raise a prompt" from "asking will silently
+    ///     do nothing", which the status alone cannot: `.authorizedWhenInUse`
+    ///     looks identical either side of the one-time upgrade prompt.
+    ///   - notificationStatus: the notification centre's authorization status.
+    public static func resolve(
+        locationStatus: CLAuthorizationStatus,
+        canPromptForAlways: Bool,
+        notificationStatus: UNAuthorizationStatus
+    ) -> ProximityAlertAuthorizationStep {
+        switch locationStatus {
+        case .authorizedAlways:
+            break
+        case .notDetermined, .authorizedWhenInUse:
+            // Both statuses can still be upgraded, but only while the one-time
+            // prompt is unspent. Once it is gone they are as blocked as a denial,
+            // and saying so is what stops the UI asking forever.
+            guard canPromptForAlways else { return .locationBlocked(locationStatus) }
+            return .promptForLocation
+        case .denied, .restricted:
+            return .locationBlocked(locationStatus)
+        @unknown default:
+            Logger.warn("Unrecognized location authorization status \(locationStatus.rawValue); treating proximity alerts as blocked.")
+            return .locationBlocked(locationStatus)
+        }
+
+        switch notificationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return .ready
+        case .notDetermined:
+            return .promptForNotifications
+        case .denied:
+            return .notificationsBlocked
+        @unknown default:
+            Logger.warn("Unrecognized notification authorization status \(notificationStatus.rawValue); treating proximity alerts as blocked.")
+            return .notificationsBlocked
+        }
+    }
+}

--- a/OBAKit/ProximityAlerts/ProximityAlertManager.swift
+++ b/OBAKit/ProximityAlerts/ProximityAlertManager.swift
@@ -188,6 +188,24 @@ public final class ProximityAlertManager: NSObject, LocationServiceDelegate {
         userDataStore.proximityAlerts.first { $0.stopID == stopID && !$0.isExpired }
     }
 
+    // MARK: - Authorization
+
+    /// What has to happen before ``createProximityAlert(for:radiusMeters:)`` can
+    /// return `.activated`.
+    ///
+    /// Worth asking *before* offering the action, not only after a refusal.
+    /// `createProximityAlert` reports the same shortfall, but only once the rider
+    /// has committed to setting an alert — and it deliberately reports raw
+    /// statuses, which do not say whether asking again would raise a prompt or
+    /// silently do nothing. This does.
+    public func authorizationStep() async -> ProximityAlertAuthorizationStep {
+        ProximityAlertAuthorizationStep.resolve(
+            locationStatus: locationService.authorizationStatus,
+            canPromptForAlways: locationService.canPromptForAlwaysAuthorization,
+            notificationStatus: await authorizationStatusProvider()
+        )
+    }
+
     // MARK: - Creating and Cancelling
 
     /// Stores and arms an alert on `stop`, or explains why it couldn't.

--- a/OBAKitCore/Location/Location/LocationService.swift
+++ b/OBAKitCore/Location/Location/LocationService.swift
@@ -75,11 +75,15 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
 
     private struct UserDefaultsKeys {
         static let promptUserForLocationPermission = "LocationService.promptUserForLocationPermission"
+        static let promptUserForAlwaysAuthorization = "LocationService.promptUserForAlwaysAuthorization"
         static let locationServicesDenied = "LocationService.locationServicesDenied"
     }
 
     private func registerDefaults() {
-        userDefaults.register(defaults: [UserDefaultsKeys.promptUserForLocationPermission: true])
+        userDefaults.register(defaults: [
+            UserDefaultsKeys.promptUserForLocationPermission: true,
+            UserDefaultsKeys.promptUserForAlwaysAuthorization: true
+        ])
     }
 
     // MARK: - Location Properties
@@ -254,6 +258,30 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
         locationManager.requestWhenInUseAuthorization()
     }
 
+    /// Whether the one-time Always upgrade prompt is still available to spend.
+    ///
+    /// iOS surfaces that prompt once per install and silently does nothing on
+    /// every later call, so an app with no record of having spent it cannot tell
+    /// "asking will show a prompt" from "asking will do nothing" — and therefore
+    /// cannot know when to stop asking and send the rider to Settings instead.
+    ///
+    /// Read-only, and persisted rather than held in memory: the limit is per
+    /// install, not per launch. ``requestAlwaysAuthorization()`` is the only
+    /// thing that clears it, deliberately — the sibling
+    /// ``canPromptUserForPermission`` leaves that to its callers, and one of the
+    /// two call sites in this app already forgets to.
+    ///
+    /// - Note: This records what the app *asked*, which is not always what iOS
+    ///   *showed*. A rider who answered the first prompt with "Allow Once" leaves
+    ///   the status at `.authorizedWhenInUse` while Apple documents further
+    ///   upgrade requests as ignored, and `CLAuthorizationStatus` offers no way to
+    ///   tell that apart from an ordinary When In Use grant, so the flag is spent
+    ///   on a prompt nobody saw. That degrades to the Settings route rather than
+    ///   breaking anything, which is why it is documented rather than detected.
+    public var canPromptForAlwaysAuthorization: Bool {
+        userDefaults.bool(forKey: UserDefaultsKeys.promptUserForAlwaysAuthorization)
+    }
+
     /// Prompts the user to upgrade to Always authorization, which region
     /// monitoring requires to deliver geofence events in the background.
     ///
@@ -262,12 +290,31 @@ public protocol LocationServiceDelegate: NSObjectProtocol {
     /// nothing at all. Callers should therefore treat it as a one-shot upgrade
     /// path and fall back to deep-linking Settings when it no-ops.
     ///
+    /// Refuses, and logs, from any *status* Core Location would reject the
+    /// request from, so nothing is spent where nothing could have been raised. It
+    /// also refuses once ``canPromptForAlwaysAuthorization`` is gone, which is
+    /// what stops a caller asking forever into silence.
+    ///
     /// - Important: This also requires `NSLocationAlwaysAndWhenInUseUsageDescription`
     ///   in the host app's Info.plist; without it iOS ignores the call entirely.
     ///   `Apps/Shared/app_shared.yml` declares it for every white-label app, and
     ///   KiedyBus overrides the body with its own. A new app that skips both will
-    ///   never reach `.authorizedAlways`, and this method will silently do nothing.
+    ///   never reach `.authorizedAlways`, and this method will silently do nothing
+    ///   — while still spending ``canPromptForAlwaysAuthorization``, because the
+    ///   status looks promptable and nothing reports back that no prompt appeared.
+    ///   The status guard above cannot cover this; only the Info.plist can.
     @objc public func requestAlwaysAuthorization() {
+        guard authorizationStatus == .notDetermined || authorizationStatus == .authorizedWhenInUse else {
+            Logger.warn("Not requesting Always authorization from \(authorizationStatus): iOS only raises that prompt from notDetermined or authorizedWhenInUse.")
+            return
+        }
+
+        guard canPromptForAlwaysAuthorization else {
+            Logger.warn("Not requesting Always authorization: this install already spent its one-time prompt. Settings is the only route left.")
+            return
+        }
+
+        userDefaults.set(false, forKey: UserDefaultsKeys.promptUserForAlwaysAuthorization)
         locationManager.requestAlwaysAuthorization()
     }
 

--- a/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
+++ b/OBAKitTests/Location/LocationServiceRegionMonitoringTests.swift
@@ -146,6 +146,51 @@ final class LocationServiceRegionMonitoringTests: OBATestCase {
         #expect(self.service.isProximityMonitoringAuthorized)
     }
 
+    @Test func `Always prompt is unspent on a fresh install`() {
+        #expect(self.service.canPromptForAlwaysAuthorization)
+    }
+
+    @Test func `Requesting Always spends the one time prompt`() {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+
+        service.requestAlwaysAuthorization()
+
+        #expect(self.service.isProximityMonitoringAuthorized)
+        #expect(!self.service.canPromptForAlwaysAuthorization)
+    }
+
+    @Test func `A second Always request is never forwarded`() {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        service.requestAlwaysAuthorization()
+        // Back where a rider who dismissed the prompt would be.
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+
+        service.requestAlwaysAuthorization()
+
+        // The mock upgrades whenever it is asked, so a status that did not move
+        // is proof the request stopped here instead of reaching Core Location —
+        // which is what the real one-shot does, silently.
+        #expect(self.service.authorizationStatus == .authorizedWhenInUse)
+    }
+
+    @Test func `A denied status does not spend the Always prompt`() {
+        locationManagerMock._authorizationStatus = .denied
+
+        service.requestAlwaysAuthorization()
+
+        // iOS raises nothing from `.denied`, so nothing was spent: a rider who
+        // turns location back on in Settings still has their upgrade path.
+        #expect(self.service.canPromptForAlwaysAuthorization)
+    }
+
+    @Test func `Already having Always does not spend the prompt`() {
+        locationManagerMock._authorizationStatus = .authorizedAlways
+
+        service.requestAlwaysAuthorization()
+
+        #expect(self.service.canPromptForAlwaysAuthorization)
+    }
+
     @Test func `Request always authorization does nothing when denied`() {
         locationManagerMock._authorizationStatus = .denied
 

--- a/OBAKitTests/ProximityAlerts/ProximityAlertAuthorizationTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertAuthorizationTests.swift
@@ -1,0 +1,116 @@
+//
+//  ProximityAlertAuthorizationTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+import UserNotifications
+@testable import OBAKit
+@testable import OBAKitCore
+
+@Suite(.serialized)
+final class ProximityAlertAuthorizationTests: OBATestCase {
+
+    private func step(
+        location: CLAuthorizationStatus,
+        canPromptForAlways: Bool = true,
+        notifications: UNAuthorizationStatus = .authorized
+    ) -> ProximityAlertAuthorizationStep {
+        ProximityAlertAuthorizationStep.resolve(
+            locationStatus: location,
+            canPromptForAlways: canPromptForAlways,
+            notificationStatus: notifications
+        )
+    }
+
+    // MARK: - Nothing missing
+
+    @Test func `Always plus authorized notifications is ready`() {
+        #expect(step(location: .authorizedAlways, notifications: .authorized) == .ready)
+    }
+
+    @Test func `Provisional notifications are enough`() {
+        // Quiet delivery is a poor fit for an alert meant to interrupt someone
+        // watching the road, but it is still delivery — and `createProximityAlert`
+        // accepts it, so refusing here would disagree with the code that acts.
+        #expect(step(location: .authorizedAlways, notifications: .provisional) == .ready)
+    }
+
+    @Test func `Ephemeral notifications are enough`() {
+        #expect(step(location: .authorizedAlways, notifications: .ephemeral) == .ready)
+    }
+
+    @Test func `A spent Always prompt is irrelevant once Always is granted`() {
+        // The one-shot only gates *asking*. Having spent it says nothing about a
+        // rider who has already granted what was asked for.
+        #expect(step(location: .authorizedAlways, canPromptForAlways: false) == .ready)
+    }
+
+    // MARK: - Location can still be asked for
+
+    @Test func `Undetermined location can be prompted for`() {
+        #expect(step(location: .notDetermined) == .promptForLocation)
+    }
+
+    @Test func `When In Use can be upgraded while the prompt is unspent`() {
+        #expect(step(location: .authorizedWhenInUse) == .promptForLocation)
+    }
+
+    // MARK: - Location cannot be asked for
+
+    @Test func `When In Use is blocked once the prompt is spent`() {
+        // The status is identical either side of the one-time upgrade prompt, so
+        // without the flag this case is indistinguishable from the one above —
+        // and the UI would ask forever, raising nothing.
+        #expect(step(location: .authorizedWhenInUse, canPromptForAlways: false) == .locationBlocked(.authorizedWhenInUse))
+    }
+
+    @Test func `Undetermined location is blocked once the prompt is spent`() {
+        #expect(step(location: .notDetermined, canPromptForAlways: false) == .locationBlocked(.notDetermined))
+    }
+
+    @Test func `Denied location is blocked even with the prompt unspent`() {
+        // iOS raises nothing from `.denied`, however much prompt budget is left.
+        #expect(step(location: .denied) == .locationBlocked(.denied))
+    }
+
+    @Test func `Restricted location is blocked`() {
+        // Carried through rather than folded into `.denied`: a restriction may be
+        // device policy the rider cannot lift, so the copy differs.
+        #expect(step(location: .restricted) == .locationBlocked(.restricted))
+    }
+
+    // MARK: - Notifications
+
+    @Test func `Undetermined notifications are prompted for after location is settled`() {
+        #expect(step(location: .authorizedAlways, notifications: .notDetermined) == .promptForNotifications)
+    }
+
+    @Test func `Denied notifications are blocked`() {
+        #expect(step(location: .authorizedAlways, notifications: .denied) == .notificationsBlocked)
+    }
+
+    // MARK: - Ordering
+
+    @Test func `Location is resolved before notifications`() {
+        // Both are missing. Location has to win: a rider who will not grant
+        // background location cannot use this feature at all, and iOS gives the
+        // notification prompt one appearance per install — spending it here would
+        // burn it on a feature already dead, in a context that explains nothing.
+        #expect(step(location: .notDetermined, notifications: .notDetermined) == .promptForLocation)
+    }
+
+    @Test func `Blocked location outranks blocked notifications`() {
+        #expect(step(location: .denied, notifications: .denied) == .locationBlocked(.denied))
+    }
+
+    @Test func `Blocked location outranks perfectly good notifications`() {
+        #expect(step(location: .denied, notifications: .authorized) == .locationBlocked(.denied))
+    }
+}

--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -107,6 +107,47 @@ final class ProximityAlertManagerTests: OBATestCase {
         }
     }
 
+    // MARK: - Authorization Step
+
+    @Test func `Authorization step is ready when both permissions are held`() async {
+        let manager = makeManager(notificationStatus: .authorized)
+
+        #expect(await manager.authorizationStep() == .ready)
+    }
+
+    @Test func `Authorization step asks for location before notifications`() async {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let manager = makeManager(notificationStatus: .notDetermined)
+
+        // Both are missing; location is what gets asked about first.
+        #expect(await manager.authorizationStep() == .promptForLocation)
+    }
+
+    @Test func `Authorization step asks for notifications once location is granted`() async {
+        let manager = makeManager(notificationStatus: .notDetermined)
+
+        #expect(await manager.authorizationStep() == .promptForNotifications)
+    }
+
+    @Test func `Authorization step reports location blocked once the prompt is spent`() async {
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        locationService.requestAlwaysAuthorization()
+        // The rider dismissed the prompt, so the status is back where it started
+        // while the one-shot is now gone.
+        locationManagerMock._authorizationStatus = .authorizedWhenInUse
+        let manager = makeManager(notificationStatus: .authorized)
+
+        // End to end: the flag `LocationService` persisted is what turns an
+        // otherwise promptable status into a trip to Settings.
+        #expect(await manager.authorizationStep() == .locationBlocked(.authorizedWhenInUse))
+    }
+
+    @Test func `Authorization step reports notifications blocked`() async {
+        let manager = makeManager(notificationStatus: .denied)
+
+        #expect(await manager.authorizationStep() == .notificationsBlocked)
+    }
+
     // MARK: - Creating Alerts
 
     @Test func `Create stores the alert and arms its geofence`() async {


### PR DESCRIPTION

## Track the one-time Always prompt for proximity alerts

Makes background location obtainable for proximity alerts, and works out what a rider still has to grant before one can arm.

Part of [#455](https://github.com/OneBusAway/onebusaway-ios/issues/455). No UI — the stop-page entry point is the next PR.

Today nothing calls `requestAlwaysAuthorization()`, so `createProximityAlert` always returns `.needsLocationAuthorization`. Calling it isn't enough on its own: iOS raises that prompt once per install and silently does nothing afterwards, and `.authorizedWhenInUse` looks identical either side of it. Without a record, the UI would ask forever and never learn to send the rider to Settings.

### What changed

**`LocationService` (`OBAKitCore`)**

`canPromptForAlwaysAuthorization`, persisted, mirroring the existing `canPromptUserForPermission`. `requestAlwaysAuthorization()` spends it itself rather than trusting callers — the sibling flag leaves that to its callers and one of the two call sites already forgets. It refuses, and logs, from statuses iOS would ignore, so a rider who re-enables location in Settings keeps their upgrade path.

**New file — `ProximityAlertAuthorization.swift` (`OBAKit`)**

`ProximityAlertAuthorizationStep.resolve(locationStatus:canPromptForAlways:notificationStatus:)`, a pure function returning one next step: `ready`, `promptForLocation`, `promptForNotifications`, `locationBlocked(status)`, `notificationsBlocked`. Location resolves before notifications deliberately — iOS gives the notification prompt one appearance per install, and spending it on a feature that cannot work, before anything has explained what the notification is for, wastes it.

**`ProximityAlertManager`**

`authorizationStep()` wires the live statuses to the resolver, so the UI asks one question instead of re-deriving it from a raw `CLAuthorizationStatus` — which cannot answer it.



---

> **PR Roadmap for [#455](https://github.com/OneBusAway/onebusaway-ios/issues/455)**
>
> | # | PR | Status |
> |---|-----|--------|
> | 1 | `ProximityAlert` model + `UserDataStore` persistence | `Merged` |
> | 2 | `LocationService` geofencing + hardening | `Merged` |
> | 3 | `ProximityAlertManager` + local notifications | `Merged` |
> | 4a | **Always-authorization tracking + what's-still-needed** | `Current` |
> | 4b | Stop page UI to create and cancel alerts | `Next` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified authorization status for proximity alerts, showing whether location and notification access is ready, requires action, or is blocked.
  - Added an authorization check that identifies the next permission step, prioritizing location before notifications.
  - Added safeguards to ensure the one-time “Always Allow” location prompt is requested only when available.

- **Tests**
  - Added coverage for authorization states, permission ordering, blocked access, and one-time location prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->