### PR TITLE
Extract MapViewController context menus to clear SwiftLint type_body_length (#1303)

### DIFF
--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -1451,8 +1451,11 @@ class MapViewController: UIViewController,
         applyLaunchCamera(userLocation: location)
     }
 
-    // MARK: - Context Menus
+}
 
+// MARK: - Context Menus
+
+extension MapViewController {
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         guard
             let annotationView = interaction.view as? MKAnnotationView,
@@ -1491,7 +1494,6 @@ class MapViewController: UIViewController,
             didTapMapStatus(interaction)
         }
     }
-
 }
 
 // MARK: - ViewModel Binding


### PR DESCRIPTION
## Summary
- Moves context-menu / large-content viewer methods into an `extension MapViewController` so the primary type body drops under SwiftLint’s error threshold.
- `swiftlint lint OBAKit/Mapping/MapViewController.swift` → 0 violations (was error at 1004 / warning at ~912).
- CLAUDE.md simulator destination / UDID guidance was already fixed via earlier docs PRs.

## Test plan
- [x] `swiftlint lint OBAKit/Mapping/MapViewController.swift` — clean
- [x] `xcodebuild build-for-testing -scheme App` — succeeded

Closes #1303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified location-change handling for clearer camera updates.
  * Reorganized context menu implementation without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->