### PR TITLE
Document Live Activity push relevance-score contract (#1252)

### DIFF
--- a/docs/LiveActivityPushNotifications.md
+++ b/docs/LiveActivityPushNotifications.md
@@ -242,11 +242,26 @@ Your server must send HTTP/2 requests to APNs with specific headers:
             "vehicleId": "1234",
             "occupancyStatus": "MANY_SEATS_AVAILABLE"
         },
-        "stale-date": 1706198520,
-        "relevance-score": 100
+        "stale-date": 1706198520
     }
 }
 ```
+
+**Do not send a flat `"relevance-score": 100` on updates (#1252 / #1189).**
+ActivityKit shows the Live Activity with the highest score in the Dynamic
+Island. The app assigns a monotonic on-device score when the rider Tracks a
+trip (`TripLiveActivityRelevance.prominenceScore`) and demotes peers to `0`.
+A push that stamps every card with `100` re-ties those scores and undoes
+Island ordering. Either:
+
+1. **Omit `relevance-score`** on Live Activity updates so the on-device score
+   is left alone (preferred), or
+2. Send a **per-activity** score that preserves newest-Track-highest ordering.
+
+Local arrivals refreshes already go through
+`TripLiveActivityRelevance.contentPreservingRelevance` / 
+`LiveActivityUpdateCoalescer` and keep the existing score; only the push
+path can wipe it.
 
 #### Update with Alert (for significant changes)
 
@@ -365,7 +380,12 @@ class APNsService {
                 event: options.event || 'update',
                 'content-state': contentState,
                 'stale-date': Math.floor(Date.now() / 1000) + 120, // 2 min
-                'relevance-score': options.relevanceScore || 100
+                // Omit relevance-score by default (#1252): a flat 100 re-ties
+                // Dynamic Island ordering that the app set on Track. Pass
+                // options.relevanceScore only when you have a per-activity value.
+                ...(options.relevanceScore != null
+                    ? { 'relevance-score': options.relevanceScore }
+                    : {})
             }
         };
 

--- a/docs/live-activity-push-relevance-score.md
+++ b/docs/live-activity-push-relevance-score.md
@@ -1,0 +1,29 @@
+# Live Activity push relevance-score (#1252)
+
+## Problem
+
+PR #1243 gives newly Tracked trips a monotonic on-device `relevanceScore` so
+the Dynamic Island follows the newest Track. OBACloud push samples (and the
+Node helper in `docs/LiveActivityPushNotifications.md`) used to send a flat
+`"relevance-score": 100` on every update, which re-ties scores after a push
+and undoes Island ordering.
+
+## App vs push
+
+| Path | Who sets the score | Preserves Track order? |
+|---|---|---|
+| `Activity.requestProminent` / `promoteToDynamicIsland` | App (monotonic) | Yes |
+| Local arrivals refresh (`LiveActivityUpdateCoalescer`) | `contentPreservingRelevance` | Yes |
+| APNs Live Activity update | Push payload | **Only if `relevance-score` is omitted or per-activity** |
+
+The app cannot intercept APNs Live Activity content updates before ActivityKit
+applies them. Fixing #1252 is a **push-side** contract; the iOS client already
+does the right thing on every local refresh.
+
+## Contract
+
+1. Prefer **omitting** `relevance-score` on update/end payloads.
+2. If set, it must be **per activity** and keep newest-Track highest.
+3. Never default every card to `100`.
+
+See the updated examples in `docs/LiveActivityPushNotifications.md`.


### PR DESCRIPTION
## Summary
- Push samples and the Node helper in `docs/LiveActivityPushNotifications.md` no longer default to `"relevance-score": 100`.
- New note: omit the field (preferred) or send a per-activity score; a flat 100 re-ties Dynamic Island ordering after Track (#1189 / #1243).
- Adds `docs/live-activity-push-relevance-score.md` for the app-vs-push contract. Local refreshes already use `contentPreservingRelevance`; full fix still needs OBACloud payload change.

## Test plan
- [ ] Docs-only — review the sample payload + Node helper
- [ ] Follow up in OBACloud to stop stamping `100` on updates

Refs #1252