### PR TITLE
Prove proximity expiry-guard test hits the guard (#1347)

### DIFF
--- a/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
+++ b/OBAKitTests/ProximityAlerts/ProximityAlertManagerTests.swift
@@ -603,9 +603,13 @@ final class ProximityAlertManagerTests: OBATestCase {
         // this manager observes with the selector form — `NotificationCenter`
         // invokes that inline, so reconciliation reaps the alert before the
         // crossing arrives and the test passes through the no-longer-stored
-        // branch instead of the expiry guard it names.
+        // branch instead of the expiry guard it names (#1347).
         store.proximityAlerts = [expired]
         #expect(locationService.startMonitoringProximity(for: expired) == .started)
+        // Still stored when we cross — otherwise we'd be covering the "gone"
+        // branch, not `guard !alert.isExpired`.
+        #expect(store.proximityAlerts.contains { $0.id == expired.id })
+        #expect(expired.isExpired)
 
         enterRegion(for: expired)
 


### PR DESCRIPTION
## Summary
- Strengthens `Entering the geofence of an expired alert delivers nothing` so it asserts the expired alert is still stored (and `isExpired`) before the crossing — otherwise the test can pass via the gone-alert branch.
- Items 2–4 from #1347 (`regionID`, non-tautological `ApplicationTests`, duplicate-per-stop guard) are already on `main`.

## Test plan
- [x] `ProximityAlertManagerTests` (39 tests) — passed, including the strengthened expiry case

Closes #1347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded proximity alert coverage to confirm expired alerts remain stored while producing no notification when their geofence is entered.
  * Added assertions verifying the alert’s expired state and clarifying test comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->