### PR TITLE
Localize the 100 strings that were rendering in English everywhere

### DIFF
--- a/OBAKit/Bookmarks/BookmarksListView.swift
+++ b/OBAKit/Bookmarks/BookmarksListView.swift
@@ -151,8 +151,8 @@ struct BookmarksListView: View {
         .buttonStyle(.plain)
         .accessibilityLabel(section.title)
         .accessibilityValue(collapsed
-            ? OBALoc("stop_page.grouped.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of a collapsible section header when its contents are hidden.")
-            : OBALoc("stop_page.grouped.a11y_expanded", value: "expanded", comment: "VoiceOver value of a collapsible section header when its contents are visible."))
+            ? OBALoc("stop_page.grouped.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of a collapsible header or grouped route card whose contents are hidden.")
+            : OBALoc("stop_page.grouped.a11y_expanded", value: "expanded", comment: "VoiceOver value of a collapsible header or grouped route card whose contents are showing."))
     }
 
     // MARK: - Rows

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -83,7 +83,7 @@ struct RentalDetailView: View {
                     onPlanTrip(rental)
                 } label: {
                     Label(
-                        OBALoc("rental_detail.plan_trip", value: "Plan a trip using this bike", comment: "Primary action on the rental vehicle sheet"),
+                        OBALoc("rental_detail.plan_trip", value: "Plan a trip using this vehicle", comment: "Primary action on the rental vehicle sheet"),
                         systemImage: "arrow.triangle.turn.up.right.diamond.fill"
                     )
                     .font(.headline)
@@ -265,7 +265,7 @@ struct RentalDetailView: View {
         case "ELECTRIC", "ELECTRIC_ASSIST":
             return OBALoc("rental_detail.propulsion_electric", value: "Electric", comment: "Rental vehicle propulsion: electric")
         case "HUMAN":
-            return OBALoc("rental_detail.propulsion_human", value: "Pedal", comment: "Rental vehicle propulsion: human-powered")
+            return OBALoc("rental_detail.propulsion_human", value: "Human-powered", comment: "Rental vehicle propulsion: human-powered")
         case "COMBUSTION":
             return OBALoc("rental_detail.propulsion_combustion", value: "Gas", comment: "Rental vehicle propulsion: combustion")
         default:

--- a/OBAKit/Mapping/Layers/StopsMapLayer.swift
+++ b/OBAKit/Mapping/Layers/StopsMapLayer.swift
@@ -33,7 +33,7 @@ import OBAKitCore
     var id: String { Self.layerID }
 
     var title: String {
-        OBALoc("map_layers.bus_stops", value: "Bus stops", comment: "Map sheet row for the transit stops layer")
+        OBALoc("map_layers.bus_stops", value: "Transit stops", comment: "Map sheet row for the transit stops layer")
     }
 
     var iconName: String { "bus.fill" }

--- a/OBAKit/PushNotifications/AlarmBuilder.swift
+++ b/OBAKit/PushNotifications/AlarmBuilder.swift
@@ -320,7 +320,10 @@ class AlarmTimePickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSo
         }
         else {
             let fmt = OBALoc("alarm_builder_controller.minutes_fmt", value: "%d minutes", comment: "{X} minutes. always plural.")
-            return String(format: fmt, minutes)
+            // localizedStringWithFormat, not String(format:) — the latter resolves
+            // `%#@count@` against the root plural rule, so Polish `few`/`many` would
+            // be unreachable and 5 would read "5 minuty" instead of "5 minut".
+            return String.localizedStringWithFormat(fmt, minutes)
         }
     }
 }

--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -332,8 +332,8 @@ public class MoreViewController: UIViewController,
             contents.append(OBAListRowView.DefaultViewModel(
                 title: OBALoc(
                     "more_controller.text_agency",
-                    value: "Text Agency",
-                    comment: "Opens an sms: (or web) link for the agency's text information service."),
+                    value: "Message Agency",
+                    comment: "Opens the agency's text information service, which may be an sms: link or a web page — so the label names neither."),
                 onSelectAction: { [weak self] _ in
                     self?.application.open(textURL, options: [:], completionHandler: nil)
                 }

--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -35,7 +35,7 @@ public class MoreViewController: UIViewController,
         self.application = application
         super.init(nibName: nil, bundle: nil)
 
-        title = OBALoc("more_controller.title", value: "More", comment: "Title of the More tab")
+        title = OBALoc("more_controller.title", value: "More", comment: "Title of the More tab / accessibility label for the map-panel more button.")
         tabBarItem.image = Icons.moreTabIcon
         tabBarItem.selectedImage = Icons.moreSelectedTabIcon
 

--- a/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
+++ b/OBAKit/Stops/StopPage/Departures/DepartureRowView.swift
@@ -212,7 +212,9 @@ struct DepartureRowView: View {
         switch style {
         case .past:
             let fmt = OBALoc("stop_page.row.a11y_past_fmt", value: "Route %@ to %@, departed %d minutes ago, %@", comment: "VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status.")
-            return String(format: fmt, departure.routeShortName, departure.tripHeadsign ?? "", abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
+            // localizedStringWithFormat so the stringsdict plural categories resolve
+            // against the rider's locale rather than the root rule.
+            return String.localizedStringWithFormat(fmt, departure.routeShortName, departure.tripHeadsign ?? "", abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
         case .normal, .missed:
             return StopPageAccessibilityCopy.upcomingIdentity(
                 routeShortName: departure.routeShortName,

--- a/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
+++ b/OBAKit/Stops/StopPage/Departures/GroupedListView.swift
@@ -116,8 +116,8 @@ struct GroupedListView: View {
         // Disclosure state: the card header's activation toggles the list of
         // departures beneath it, so announce which way it will go.
         .accessibilityValue(expandedRouteID == group.routeID
-            ? OBALoc("stop_page.grouped.a11y_expanded", value: "expanded", comment: "VoiceOver value of a grouped route card whose departure list is showing.")
-            : OBALoc("stop_page.grouped.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of a grouped route card whose departure list is hidden."))
+            ? OBALoc("stop_page.grouped.a11y_expanded", value: "expanded", comment: "VoiceOver value of a collapsible header or grouped route card whose contents are showing.")
+            : OBALoc("stop_page.grouped.a11y_collapsed", value: "collapsed", comment: "VoiceOver value of a collapsible header or grouped route card whose contents are hidden."))
         // The combined element above (`children: .ignore`) swallows the alarm
         // pill Button inside `headerChipsRow`, so VoiceOver can never reach it.
         // `.accessibilityActions` is applied unconditionally (keeping this a

--- a/OBAKit/Stops/StopPage/Shared/StopPageAccessibilityCopy.swift
+++ b/OBAKit/Stops/StopPage/Shared/StopPageAccessibilityCopy.swift
@@ -13,13 +13,21 @@ import OBAKitCore
 /// Spoken identity for an upcoming stop-page row. The minutes badge is
 /// "5m" either way; first/layover stops are `.departing` and every other
 /// stop is `.arriving`. VoiceOver used to say "departs" for both (#447).
+///
+/// These formats carry a minute count and resolve through `Localizable.stringsdict`.
+/// The locale has to be passed to `String(format:locale:)` explicitly: the no-locale
+/// overload resolves `%#@count@` against the *root* plural rule, so only `one` and
+/// `other` are ever reachable and a Polish rider hears "5 minuty" instead of
+/// "5 minut". `locale` is injectable so tests can exercise a locale whose categories
+/// differ from the root's.
 enum StopPageAccessibilityCopy {
     static func upcomingIdentity(
         routeShortName: String,
         headsign: String,
         minutes: Int,
         arrivalDepartureStatus: ArrivalDepartureStatus,
-        adherence: String
+        adherence: String,
+        locale: Locale = .current
     ) -> String {
         let fmt: String
         switch arrivalDepartureStatus {
@@ -36,7 +44,7 @@ enum StopPageAccessibilityCopy {
                 comment: "VoiceOver for a stop-page row whose vehicle is departing this stop (first stop or layover). Route, headsign, minutes, adherence."
             )
         }
-        return String(format: fmt, routeShortName, headsign, minutes, adherence)
+        return String(format: fmt, locale: locale, routeShortName, headsign, minutes, adherence)
     }
 
     /// VoiceOver for a grouped route card. The next trip is arriving or
@@ -47,7 +55,8 @@ enum StopPageAccessibilityCopy {
         minutes: Int,
         arrivalDepartureStatus: ArrivalDepartureStatus,
         adherence: String,
-        moreCount: Int
+        moreCount: Int,
+        locale: Locale = .current
     ) -> String {
         let fmt: String
         switch arrivalDepartureStatus {
@@ -64,6 +73,6 @@ enum StopPageAccessibilityCopy {
                 comment: "VoiceOver for a grouped route card whose next vehicle is departing this stop (first stop or layover)."
             )
         }
-        return String(format: fmt, routeShortName, headsign, minutes, adherence, moreCount)
+        return String(format: fmt, locale: locale, routeShortName, headsign, minutes, adherence, moreCount)
     }
 }

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1068,10 +1068,10 @@
 "settings_controller.arrival_display_section.title" = "عرض الوصول والمغادرة";
 
 /* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
-"settings_controller.arrival_display_section.transfer_banner" = "إظهار شريط وصول التحويلة";
+"settings_controller.arrival_display_section.transfer_banner" = "إظهار شريط وصول التبديل";
 
 /* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
-"settings_controller.arrival_display_section.transfer_banner.footer" = "إظهار شريط وصول التحويلة: عند التشغيل تُعرض الأوقات نسبة إلى وصولك عند فتح محطة من رحلة. أوقف هذا المفتاح لرؤية الساعة وكل المغادرات.";
+"settings_controller.arrival_display_section.transfer_banner.footer" = "إظهار شريط وصول التبديل: عند التشغيل تُعرض الأوقات نسبة إلى وصولك عند فتح محطة من رحلة. أوقف هذا المفتاح لرؤية الساعة وكل المغادرات.";
 
 /* Title for the departure filter selection alert */
 "settings_controller.arrival_filter.selector_title" = "إظهار المغادرات";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "يُرجى السماح للتطبيق بالوصول إلى موقعك لتسهيل العثور على مواقف النقل القريبة منك.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "ليس الآن";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "مرحبًا!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "استخدام موقعي";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "التفعيل من الإعدادات";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "ضبط تذكير";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "الخط %1$@ إلى %2$@، تغادر خلال %3$d دقائق، %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "المغادرات التالية";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "الخط";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "عرض الرحلة كاملة";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "مباشر · المركبة %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "لا توجد إشارة مباشرة من هذه الحافلة بعد — هذا هو الوقت المفترض لوصولها. قد تصل مبكرة أو متأخرة أو لا تصل إطلاقًا.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "الوقت المجدول فقط";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "السابقة · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "بيانات الجدول";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d مواقف";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "المركبة هنا · على بُعد %d د";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· موقفك";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d د مشيًا";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "سرعة الرياح";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "اختياري. عنوان خادم تحليلات Umami ومعرّف الموقع الإلكتروني لهذه المنطقة. كلا الحقلين مطلوبان لتفعيل التحليلات؛ اتركهما فارغين لتعطيلها.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "التحليلات";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "معرّف الموقع الإلكتروني";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "اختياري. عنوان خادم Obaco (OneBusAway.co) المساعد الذي يشغّل ميزات مثل التذكيرات والاستطلاعات. من المفترض استخدام \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "الخادم المساعد";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "هل هناك شيء آخر ينبغي أن نعرفه؟ (اختياري)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "تفاصيل البلاغ";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "الخط";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "الوقت المجدول";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "الموقف";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "المركبة";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "يبدو أنه تم الإبلاغ عن هذه الرحلة بالفعل من هذا الجهاز.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "تعذّر الإرسال";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "بلاغك مجهول الهوية ويُرسل إلى هيئة النقل المشغّلة لهذه الخدمة.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "مشاركة موقعي";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "إرسال البلاغ";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "الإبلاغ عن حافلة لم تأتِ";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "بعد الوقت المجدول";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "كم من الوقت انتظرت؟";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d د";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "أكثر من 30 د";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "تفعيل خدمات الموقع";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "الدراجات";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "مواقف النقل";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "غير متاحة حاليًا";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "السكوترات";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "مسارات الخطوط والمركبات";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "الرحلة المتابَعة";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "مختلطة";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "الأقمار الصناعية";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "قياسية";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "عرض الخريطة";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "الحد الأدنى للمدى";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "أي مدى";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "وسائل تنقّل أخرى";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "إعادة تعيين";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "نقاط الاهتمام";
+/* Title of the Map sheet */
+"map_sheet.title" = "الخريطة";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "النقل العام";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "التواصل والمساعدة";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "الاتصال بالهيئة";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "مراسلة الهيئة";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "الشروحات";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d متاحة";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "البطارية";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "الدراجات";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "المرابط";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "الإعادة";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "لا";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "خارج الخدمة";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "فتح في %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "الاستلام";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "تخطيط رحلة باستخدام هذه الدراجة";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "النوع";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "بنزين";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "كهربائية";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "هوائية";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "المدى";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "قد تكون هذه البيانات غير حديثة.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "آخر تحديث %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d د مشيًا";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "اسم جهاز الاختبار";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "مثال: iPhone الخاص بأحمد";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "نقاط الاهتمام";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "لم يتم العثور على الموقف";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "تم تغيير فلتر المغادرات";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "تم إخفاء المغادرات السابقة";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "يتم عرض %d مغادرات سابقة";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "تم تحديث المغادرات";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "يتم عرض جميع الخطوط";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "يتم عرض الخطوط المصفّاة";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "المغادرات";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "لم يعد هذا الموقف موجودًا في بيانات هيئة النقل. ربما تم نقله أو إزالته.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "رحلة التبديل الخاصة بك";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "إشارة مرجعية";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "الاتجاهات من هنا";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "الاتجاهات إلى هنا";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "جميع المواقف الـ%d";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "الخط %1$@ إلى %2$@، تصل خلال %3$d دقائق، %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "الخط %1$@ إلى %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "تعذّر إرسال هذا البلاغ لأن خدمة الإبلاغ غير متاحة حاليًا. يُرجى المحاولة مرة أخرى لاحقًا.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "النشاط المباشر — التتبّع على شاشة القفل";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "التتبّع على شاشة القفل";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "تم تحديث الموقع %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "إزالة التذكير";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "الإبلاغ عن حافلة لم تأتِ";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "تم تجاوزه بالفعل";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "الموقف الأخير";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "المركبة هنا";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "موقفك";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "المواقف";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "جارٍ تحميل مواقف هذه الرحلة…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "قائمة مواقف هذه الرحلة غير متاحة حاليًا.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "المركبة %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "عرض جدول المواعيد";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "تصل الآن";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d د حتى موقفك";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "تجاوزت موقفك";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "الموقف %1$d من %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "موقف تم تجاوزه";

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "الاستلام";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "تخطيط رحلة باستخدام هذه الدراجة";
+"rental_detail.plan_trip" = "تخطيط رحلة باستخدام هذه المركبة";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "النوع";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "كهربائية";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "هوائية";
+"rental_detail.propulsion_human" = "بشرية";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "المدى";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/ar.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ar.lproj/Localizable.stringsdict
@@ -2,6 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d دقائق</string>
+			<key>many</key>
+			<string>%d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتان</string>
+			<key>zero</key>
+			<string>صفر دقيقة</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -12,18 +36,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد حالات فشل</string>
-			<key>one</key>
-			<string>حالة فشل واحدة</string>
-			<key>two</key>
-			<string>حالتا فشل</string>
 			<key>few</key>
 			<string>%d حالات فشل</string>
 			<key>many</key>
 			<string>%d حالة فشل</string>
+			<key>one</key>
+			<string>حالة فشل واحدة</string>
 			<key>other</key>
 			<string>%d حالة فشل</string>
+			<key>two</key>
+			<string>حالتا فشل</string>
+			<key>zero</key>
+			<string>لا توجد حالات فشل</string>
 		</dict>
 	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_successes</key>
@@ -36,18 +60,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد حالات ناجحة</string>
-			<key>one</key>
-			<string>حالة ناجحة واحدة</string>
-			<key>two</key>
-			<string>حالتان ناجحتان</string>
 			<key>few</key>
 			<string>%d حالات ناجحة</string>
 			<key>many</key>
 			<string>%d حالة ناجحة</string>
+			<key>one</key>
+			<string>حالة ناجحة واحدة</string>
 			<key>other</key>
 			<string>%d حالة ناجحة</string>
+			<key>two</key>
+			<string>حالتان ناجحتان</string>
+			<key>zero</key>
+			<string>لا توجد حالات ناجحة</string>
 		</dict>
 	</dict>
 	<key>map_controller.map_type.accessibility_value_with_layers_fmt</key>
@@ -60,18 +84,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد طبقات مفعّلة</string>
-			<key>one</key>
-			<string>طبقة واحدة مفعّلة</string>
-			<key>two</key>
-			<string>طبقتان مفعّلتان</string>
 			<key>few</key>
 			<string>%2$d طبقات مفعّلة</string>
 			<key>many</key>
 			<string>%2$d طبقة مفعّلة</string>
+			<key>one</key>
+			<string>طبقة واحدة مفعّلة</string>
 			<key>other</key>
 			<string>%2$d طبقة مفعّلة</string>
+			<key>two</key>
+			<string>طبقتان مفعّلتان</string>
+			<key>zero</key>
+			<string>لا توجد طبقات مفعّلة</string>
 		</dict>
 	</dict>
 	<key>rental_cluster.title_fmt</key>
@@ -84,18 +108,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد مركبات هنا</string>
-			<key>one</key>
-			<string>مركبة واحدة هنا</string>
-			<key>two</key>
-			<string>مركبتان هنا</string>
 			<key>few</key>
 			<string>%d مركبات هنا</string>
 			<key>many</key>
 			<string>%d مركبة هنا</string>
+			<key>one</key>
+			<string>مركبة واحدة هنا</string>
 			<key>other</key>
 			<string>%d مركبة هنا</string>
+			<key>two</key>
+			<string>مركبتان هنا</string>
+			<key>zero</key>
+			<string>لا توجد مركبات هنا</string>
 		</dict>
 	</dict>
 	<key>search_results_sheet.result_count_fmt</key>
@@ -108,18 +132,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد نتائج</string>
-			<key>one</key>
-			<string>نتيجة واحدة</string>
-			<key>two</key>
-			<string>نتيجتان</string>
 			<key>few</key>
 			<string>%d نتائج</string>
 			<key>many</key>
 			<string>%d نتيجة</string>
+			<key>one</key>
+			<string>نتيجة واحدة</string>
 			<key>other</key>
 			<string>%d نتيجة</string>
+			<key>two</key>
+			<string>نتيجتان</string>
+			<key>zero</key>
+			<string>لا توجد نتائج</string>
 		</dict>
 	</dict>
 	<key>stop_controller.transfer_show_earlier_departures_fmt</key>
@@ -132,18 +156,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد مغادرات أبكر</string>
-			<key>one</key>
-			<string>إظهار مغادرة واحدة أبكر</string>
-			<key>two</key>
-			<string>إظهار مغادرتين أبكر</string>
 			<key>few</key>
 			<string>إظهار %d مغادرات أبكر</string>
 			<key>many</key>
 			<string>إظهار %d مغادرة أبكر</string>
+			<key>one</key>
+			<string>إظهار مغادرة واحدة أبكر</string>
 			<key>other</key>
 			<string>إظهار %d مغادرة أبكر</string>
+			<key>two</key>
+			<string>إظهار مغادرتين أبكر</string>
+			<key>zero</key>
+			<string>لا توجد مغادرات أبكر</string>
 		</dict>
 	</dict>
 	<key>stop_page.empty.no_departures_fmt</key>
@@ -156,18 +180,61 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد مغادرات قادمة</string>
-			<key>one</key>
-			<string>لا توجد مغادرات خلال الدقيقة القادمة</string>
-			<key>two</key>
-			<string>لا توجد مغادرات خلال الدقيقتين القادمتين</string>
 			<key>few</key>
 			<string>لا توجد مغادرات خلال الـ%d دقائق القادمة</string>
 			<key>many</key>
 			<string>لا توجد مغادرات خلال الـ%d دقيقة القادمة</string>
+			<key>one</key>
+			<string>لا توجد مغادرات خلال الدقيقة القادمة</string>
 			<key>other</key>
 			<string>لا توجد مغادرات خلال الـ%d دقيقة القادمة</string>
+			<key>two</key>
+			<string>لا توجد مغادرات خلال الدقيقتين القادمتين</string>
+			<key>zero</key>
+			<string>لا توجد مغادرات قادمة</string>
+		</dict>
+	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، المغادرة التالية خلال %3$#@count@، %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>تم تحميل %5$d مغادرات إضافية</string>
+			<key>many</key>
+			<string>تم تحميل %5$d مغادرة إضافية</string>
+			<key>one</key>
+			<string>تم تحميل مغادرة إضافية واحدة</string>
+			<key>other</key>
+			<string>تم تحميل %5$d مغادرة إضافية</string>
+			<key>two</key>
+			<string>تم تحميل مغادرتين إضافيتين</string>
+			<key>zero</key>
+			<string>لم يتم تحميل مغادرات إضافية</string>
 		</dict>
 	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
@@ -180,18 +247,66 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد مغادرات سابقة</string>
-			<key>one</key>
-			<string>إظهار مغادرة سابقة واحدة</string>
-			<key>two</key>
-			<string>إظهار مغادرتين سابقتين</string>
 			<key>few</key>
 			<string>إظهار %d مغادرات سابقة</string>
 			<key>many</key>
 			<string>إظهار %d مغادرة سابقة</string>
+			<key>one</key>
+			<string>إظهار مغادرة سابقة واحدة</string>
 			<key>other</key>
 			<string>إظهار %d مغادرة سابقة</string>
+			<key>two</key>
+			<string>إظهار مغادرتين سابقتين</string>
+			<key>zero</key>
+			<string>لا توجد مغادرات سابقة</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، تصل خلال %3$#@count@، %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، غادرت قبل %3$#@count@، %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -204,18 +319,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد تنبيهات لإظهارها</string>
-			<key>one</key>
-			<string>إظهار تنبيه واحد</string>
-			<key>two</key>
-			<string>إظهار تنبيهين</string>
 			<key>few</key>
 			<string>إظهار %d تنبيهات</string>
 			<key>many</key>
 			<string>إظهار %d تنبيهًا</string>
+			<key>one</key>
+			<string>إظهار تنبيه واحد</string>
 			<key>other</key>
 			<string>إظهار %d تنبيه</string>
+			<key>two</key>
+			<string>إظهار تنبيهين</string>
+			<key>zero</key>
+			<string>لا توجد تنبيهات لإظهارها</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.summary_fmt</key>
@@ -228,18 +343,18 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد تنبيهات خدمة</string>
-			<key>one</key>
-			<string>تنبيه خدمة واحد</string>
-			<key>two</key>
-			<string>تنبيها خدمة</string>
 			<key>few</key>
 			<string>%d تنبيهات خدمة</string>
 			<key>many</key>
 			<string>%d تنبيهًا للخدمة</string>
+			<key>one</key>
+			<string>تنبيه خدمة واحد</string>
 			<key>other</key>
 			<string>%d تنبيه خدمة</string>
+			<key>two</key>
+			<string>تنبيها خدمة</string>
+			<key>zero</key>
+			<string>لا توجد تنبيهات خدمة</string>
 		</dict>
 	</dict>
 	<key>stop_page.timeline.skipped_stops_fmt</key>
@@ -252,18 +367,42 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>zero</key>
-			<string>لا توجد مواقف</string>
-			<key>one</key>
-			<string>موقف واحد</string>
-			<key>two</key>
-			<string>موقفان</string>
 			<key>few</key>
 			<string>%d مواقف</string>
 			<key>many</key>
 			<string>%d موقفًا</string>
+			<key>one</key>
+			<string>موقف واحد</string>
 			<key>other</key>
 			<string>%d موقف</string>
+			<key>two</key>
+			<string>موقفان</string>
+			<key>zero</key>
+			<string>لا توجد مواقف</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، تصل خلال %3$#@count@، %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/ar.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ar.lproj/Localizable.stringsdict
@@ -194,6 +194,49 @@
 			<string>لا توجد مغادرات قادمة</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، الوصول التالي خلال %3$#@count@، %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>تم تحميل %5$d مغادرات إضافية</string>
+			<key>many</key>
+			<string>تم تحميل %5$d مغادرة إضافية</string>
+			<key>one</key>
+			<string>تم تحميل مغادرة إضافية واحدة</string>
+			<key>other</key>
+			<string>تم تحميل %5$d مغادرة إضافية</string>
+			<key>two</key>
+			<string>تم تحميل مغادرتين إضافيتين</string>
+			<key>zero</key>
+			<string>لم يتم تحميل مغادرات إضافية</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -265,6 +308,30 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>الخط %1$@ إلى %2$@، تصل خلال %3$#@count@، %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d دقائق</string>
+			<key>many</key>
+			<string>%3$d دقيقة</string>
+			<key>one</key>
+			<string>دقيقة واحدة</string>
+			<key>other</key>
+			<string>%3$d دقيقة</string>
+			<key>two</key>
+			<string>دقيقتين</string>
+			<key>zero</key>
+			<string>أقل من دقيقة</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>الخط %1$@ إلى %2$@، تغادر خلال %3$#@count@، %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -732,8 +732,8 @@
 /* A row that opens the App Store review form. %@ is the app name. */
 "more_controller.rate_app" = "Rate %@";
 
-/* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "Text Agency";
+/* Opens the agency's text information service, which may be an sms: link or a web page — so the label names neither. */
+"more_controller.text_agency" = "Message Agency";
 
 /* Title of the More tab
    Title of the More tab / accessibility label for the map-panel more button. */

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -145,6 +145,15 @@
 /* Button to retry finding the user's vehicle. */
 "current_trip_controller.retry" = "Try Again";
 
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Optional. The address of an Umami analytics server and this region's website ID. Both fields are required to enable analytics; leave them blank to disable it.";
+
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Analytics";
+
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "Website ID";
+
 /* An explanation of what the Base URL field of a custom region requires. */
 "custom_region_builder_controller.base_url_section.explanation" = "The root address of the region's API server, without the \"/api/where\" part—that gets added automatically. \"https://\" is assumed.";
 
@@ -174,6 +183,12 @@
 
 /* Title of the Service Area header. */
 "custom_region_builder_controller.service_area_section.header_title" = "Service Area";
+
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Optional. The address of an Obaco (OneBusAway.co) sidecar server, which powers features like alarms and surveys. \"https://\" is assumed.";
+
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Sidecar Server";
 
 /* Action button title for the DataMigrationBulletinPage. */
 "data_migration_bulletin.action_button" = "Continue";
@@ -358,6 +373,54 @@
 /* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
 "floating_panel.controller.position.minimized" = "Minimized";
 
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Anything else we should know? (optional)";
+
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Reporting";
+
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Route";
+
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Scheduled";
+
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Stop";
+
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Vehicle";
+
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "It looks like this trip has already been reported from this device.";
+
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Unable to Submit";
+
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Your report is anonymous and goes to the agency that runs this service.";
+
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Share my location";
+
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Submit Report";
+
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Report Ghost Bus";
+
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Past the scheduled time";
+
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "How long did you wait?";
+
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+
 /* Body for the home sheet's empty state, shown when there are no nearby stops, no recent stops, and no bookmarks. */
 "home_sheet.empty_set.body" = "Nearby stops, stops you've viewed, and your bookmarks will show up here.";
 
@@ -382,16 +445,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Please allow the app to access your location to make it easier to find your transit stops.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Not Now";
-
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Welcome!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Use My Location";
-
-/* No comment provided by engineer. */
+/* Button that opens iOS Settings so the user can enable location services for the app. */
 "locationservices_alert_gotosettings.button" = "Turn On in Settings";
 
 /* Body of the alert prompting the user to grant precise location. */
@@ -400,11 +457,14 @@
 /* Title of the alert prompting the user to upgrade from approximate to precise location. %@ is the app name. */
 "locationservices_alert_imprecise.title" = "%@ works best with your precise location";
 
-/* No comment provided by engineer. */
+/* Cancel button in the precise-location alert; dismisses without raising accuracy from reduced to full. */
 "locationservices_alert_keep_precise_location_off.button" = "Keep Precise Location Off";
 
-/* No comment provided by engineer. */
+/* Cancel button in the location-permission alert; dismisses without granting authorization or opening Settings. */
 "locationservices_alert_keepoff.button" = "Keep Location Off";
+
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Enable Location Services";
 
 /* Body of the alert prompting the user to turn on location services. */
 "locationservices_alert_off.message" = "You'll get to see where you are on the map and see nearby stops, making it easier to get where you need to go.";
@@ -412,7 +472,7 @@
 /* Title of the alert prompting the user to turn on location services. %@ is the app name. */
 "locationservices_alert_off.title" = "%@ works best with your location.";
 
-/* No comment provided by engineer. */
+/* Button that grants one-time full-accuracy location for the current map session while keeping the default reduced-accuracy setting. */
 "locationservices_alert_request_precise_location_once.button" = "Allow Once";
 
 /* Message shown when there are no logs to display */
@@ -460,7 +520,8 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Change Region?";
 
-/* Voiceover text indicating that this button toggles the base map type. */
+/* Voiceover text for the button that opens the Map settings sheet.
+   Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Map type";
 
 /* Voiceover value combining the base map type with the number of enabled map layers. %1$@ is the base map type, %2$d is the layer count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
@@ -533,6 +594,63 @@
 /* Accessibility label for website button */
 "map_item_controller.website_accessibility" = "Open website";
 
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Bikes";
+
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Transit stops";
+
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Not available right now";
+
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Scooters";
+
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Route lines & vehicles";
+
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Followed trip";
+
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Hybrid";
+
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satellite";
+
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Standard";
+
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Map display";
+
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Minimum range";
+
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Any";
+
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Other ways to get around";
+
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Reset";
+
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Points of Interest";
+
+/* Title of the Map sheet */
+"map_sheet.title" = "Map";
+
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transit";
+
+/* Title of the alert shown when location services are disabled for the app. */
+"map_status_alert.location_services_off.title" = "Location Services Off";
+
+/* Title of the alert shown when the user has restricted the app to reduced-accuracy location. */
+"map_status_alert.precise_location_off.title" = "Precise Location Off";
+
 /* Displayed in the map status view at the top of the map when the user has declined to give the app access to their location */
 "map_status_view.location_services_unavailable" = "Location services unavailable";
 
@@ -542,17 +660,17 @@
 /* Displayed in the map status view at the top of the map when the user must zoom in to see stops on the map */
 "map_status_view.zoom_in_for_stops" = "Zoom in for stops";
 
-/* Title of the alert shown when location services are disabled for the app. */
-"map_status_alert.location_services_off.title" = "Location Services Off";
-
-/* Title of the alert shown when the user has restricted the app to reduced-accuracy location. */
-"map_status_alert.precise_location_off.title" = "Precise Location Off";
-
 /* Header for a section that shows the user information about this app. */
 "more_controller.about_app" = "About this App";
 
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contact & Help";
+
 /* Alerts for region row in the More controller */
 "more_controller.alerts_for_region" = "Alerts";
+
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Call Agency";
 
 /* Title of the action sheet option for contacting the developers of the app. */
 "more_controller.contact_developers" = "Feature Request/Bug Report";
@@ -614,12 +732,18 @@
 /* A row that opens the App Store review form. %@ is the app name. */
 "more_controller.rate_app" = "Rate %@";
 
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Text Agency";
+
 /* Title of the More tab
    Title of the More tab / accessibility label for the map-panel more button. */
 "more_controller.title" = "More";
 
 /* Request to help localize the app */
 "more_controller.translate_the_app" = "Help Translate the App";
+
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Tutorials";
 
 /* Updates and Alerts header text */
 "more_controller.updates_and_alerts.header" = "Updates and Alerts";
@@ -900,11 +1024,65 @@
 /* Error message of Custom Region URL if it's invalid or does not point to a functional OBA server */
 "region_url.error_messsage" = "The provided region URL is invalid or does not point to a functional OBA server.";
 
-/* Title of the Report Problem view controller. */
-"report_problem.title" = "Report a Problem";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d available";
 
 /* Title of the sheet listing the members of a rental cluster. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
 "rental_cluster.title_fmt" = "%d vehicles here";
+
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Battery";
+
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Bikes";
+
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Docks";
+
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Drop-off";
+
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "No";
+
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Not in service";
+
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Open in %@";
+
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Pickup";
+
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Plan a trip using this bike";
+
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Type";
+
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Gas";
+
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Electric";
+
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Pedal";
+
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Range";
+
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "This data may be out of date.";
+
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Updated %@";
+
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min walk";
+
+/* Title of the Report Problem view controller. */
+"report_problem.title" = "Report a Problem";
 
 /* Report a problem with the stop at {Stop Name} */
 "report_problem_controller.report_stop_problem_fmt" = "Report a problem with the stop at %@";
@@ -912,7 +1090,7 @@
 /* Section header for reporting incorrect stop names, numbers, locations, or missing routes or trips, not app bugs. */
 "report_problem_controller.stop_problem.header" = "Problem with the Stop";
 
-/* Section header for reporting a problem with a specific trip service, not app bugs. */
+/* Section header for reporting a problem with a specific trip or vehicle service. Feedback helps improve transit data. */
 "report_problem_controller.trip_problem.header" = "Problem with a Trip";
 
 /* Error when location is unavailable in the route picker. */
@@ -1071,10 +1249,10 @@
 /* Settings section title for controlling which arrivals/departures are shown */
 "settings_controller.arrival_display_section.title" = "Arrival & Departure Display";
 
-/* Settings > Arrival Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
+/* Settings > Arrival & Departure Display > Toggle that shows the Arriving at XX:XX via route banner when opening a stop from a trip */
 "settings_controller.arrival_display_section.transfer_banner" = "Show transfer arrival banner";
 
-/* Settings > Arrival Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
+/* Settings > Arrival & Departure Display > Footer for the Show transfer arrival banner switch only, not the Show Departures filter */
 "settings_controller.arrival_display_section.transfer_banner.footer" = "Show transfer arrival banner: when on, opening a stop from a trip shows times relative to when you arrive. Turn that switch off for ordinary clock times and every departure.";
 
 /* Title for the departure filter selection alert */
@@ -1088,6 +1266,12 @@
 
 /* Settings > Debug section > Debug mode */
 "settings_controller.debug_section.debug_mode" = "Debug Mode";
+
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Test Device Name";
+
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "e.g. Aaron's iPhone";
 
 /* Settings > Debug section title */
 "settings_controller.debug_section.title" = "Debug";
@@ -1118,6 +1302,9 @@
 
 /* Settings > Map section > Show my current heading */
 "settings_controller.map_section.shows_heading" = "Show my current heading";
+
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Points of Interest";
 
 /* Settings > Map section > Shows scale */
 "settings_controller.map_section.shows_scale" = "Shows scale";
@@ -1194,6 +1381,9 @@
 /* Header for past departures of a specific route */
 "stop_controller.past_departures_route_header" = "Past Departures - %@";
 
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Stop Not Found";
+
 /* This is an instruction given to the user the first time they look at a stop view instructing them on how to access more options, including the ability to add alarms. */
 "stop_controller.swipe_spotlight_text.with_alarm" = "Swipe on a row to view more options, including adding alarms.";
 
@@ -1209,6 +1399,24 @@
 /* Spoken suffix on a route chip whose route has a vehicle on the map. */
 "stop_header.chip.live_tracking" = "live tracking";
 
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Departure filter changed";
+
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Past departures hidden";
+
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Showing %d past departures";
+
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Departures updated";
+
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Showing all routes";
+
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Showing filtered routes";
+
 /* Error shown when a departure alarm can't be cancelled because the region's alarm service is unreachable. */
 "stop_page.alarm_cancel_unavailable" = "This alarm couldn't be cancelled because the alarm service isn't available right now. Please try again later.";
 
@@ -1223,6 +1431,9 @@
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NOW";
+
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Departures";
 
 /* Empty state shown when every route at the stop is hidden by the user's filter. */
 "stop_page.empty.all_filtered" = "All routes at this stop are filtered";
@@ -1242,11 +1453,17 @@
 /* Button that clears the route filter so all routes are shown. */
 "stop_page.empty.show_all_routes" = "Show all routes";
 
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "This stop isn't in the transit agency's data anymore. It may have been moved or removed.";
+
 /* VoiceOver value of the route-filter bar button when the filter is inactive. */
 "stop_page.filter.a11y_off" = "off";
 
 /* VoiceOver value of the route-filter bar button when the filter is active. */
 "stop_page.filter.a11y_on" = "on";
+
+/* VoiceOver for a grouped route card whose next vehicle is arriving at this stop. */
+"stop_page.grouped.a11y_arrives_fmt" = "Route %1$@ to %2$@, next arrival in %3$d minutes, %4$@. %5$d more departures loaded.";
 
 /* VoiceOver value of a collapsible section header when its contents are hidden.
    VoiceOver value of a grouped route card whose departure list is hidden. */
@@ -1256,18 +1473,14 @@
    VoiceOver value of a grouped route card whose departure list is showing. */
 "stop_page.grouped.a11y_expanded" = "expanded";
 
-/* VoiceOver label for a grouped route card */
+/* VoiceOver for a grouped route card whose next vehicle is departing this stop (first stop or layover). */
 "stop_page.grouped.a11y_fmt" = "Route %1$@ to %2$@, next departure in %3$d minutes, %4$@. %5$d more departures loaded.";
-"stop_page.grouped.a11y_arrives_fmt" = "Route %1$@ to %2$@, next arrival in %3$d minutes, %4$@. %5$d more departures loaded.";
 
 /* VoiceOver custom action on a grouped route card's header that cancels the alarm already set for the next departure. */
 "stop_page.grouped.a11y_remove_alarm" = "Remove alarm";
 
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Set alarm";
-
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Next departures";
@@ -1284,23 +1497,11 @@
 /* Caption under the spinner shown while the stop page's departure list loads. */
 "stop_page.loading_departures" = "Loading departures…";
 
-/* Stop page mode toggle: flat time-sorted list */
-"stop_page.mode.time" = "Time";
-
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Route";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "View full trip";
-
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "Live · vehicle %@";
-
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "No live signal from this bus yet — this is when it's supposed to arrive. It may run early, late, or not at all.";
-
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Scheduled time only";
+/* Stop page mode toggle: flat time-sorted list */
+"stop_page.mode.time" = "Time";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Past · %d";
@@ -1317,15 +1518,20 @@
 /* VoiceOver suffix indicating a departure alarm is active */
 "stop_page.row.a11y_alarm_set" = "alarm set";
 
-/* VoiceOver label for a departure row: route, headsign, minutes, status. */
-"stop_page.row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
+/* VoiceOver for a stop-page row whose vehicle is arriving at this stop. Route, headsign, minutes, adherence. */
 "stop_page.row.a11y_arrives_fmt" = "Route %1$@ to %2$@, arrives in %3$d minutes, %4$@";
+
+/* VoiceOver for a stop-page row whose vehicle is departing this stop (first stop or layover). Route, headsign, minutes, adherence. */
+"stop_page.row.a11y_fmt" = "Route %1$@ to %2$@, departs in %3$d minutes, %4$@";
 
 /* VoiceOver clause appended to a departure row that's upcoming but not reachable on foot before it leaves. */
 "stop_page.row.a11y_missed" = "likely missed — departs sooner than your walk to the stop";
 
 /* VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status. */
 "stop_page.row.a11y_past_fmt" = "Route %1$@ to %2$@, departed %3$d minutes ago, %4$@";
+
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "your transfer trip";
 
 /* Swipe/context menu action that cancels an existing arrival alarm. */
 "stop_page.row.remove_alarm" = "Remove Alarm";
@@ -1369,14 +1575,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "schedule data";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d stops";
-
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "vehicle here · %dm away";
-
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· your stop";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Bookmark";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min walk";
@@ -1452,6 +1652,12 @@
 
 /* Message displayed when a new bookmark is created. */
 "stops_controller.created_new_bookmark" = "Added Bookmark";
+
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Directions from Here";
+
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Directions to Here";
 
 /* A menu item on a Stop page that toggles the visible list of transit vehicles from a filtered list to all of the list items. e.g. a stop serves routes 1, 2, and 3. The user has filtered the stop to only show route 3. Chooosing this item will show 1, 2, and 3 again. */
 "stops_controller.filter.all_routes" = "All Routes";
@@ -1561,6 +1767,72 @@
 /* Describes the previous trip of this vehicle. e.g. Starts as 10 - Downtown Seattle */
 "trip_details_controller.starts_as_fmt" = "Starts as %@";
 
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "All %d stops";
+
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Route %1$@ to %2$@, arrives in %3$d minutes, %4$@";
+
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Route %1$@ to %2$@";
+
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "This report couldn't be submitted because the reporting service isn't available right now. Please try again later.";
+
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Live Activity — track on Lock Screen";
+
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Tracking on Lock Screen";
+
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "position updated %@";
+
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Remove alarm";
+
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Report Ghost Bus";
+
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "already passed";
+
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "last stop";
+
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "vehicle is here";
+
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "your stop";
+
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Stops";
+
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Loading this trip's stops…";
+
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "This trip's stop list isn't available right now.";
+
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Vehicle %@";
+
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "View schedule";
+
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Arriving now";
+
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min to your stop";
+
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Passed your stop";
+
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Stop %1$d of %2$d";
+
 /* Alert message when trip sharing fails. */
 "trip_sharing.share_error.message" = "Something went wrong while preparing the trip link. Please try again.";
 
@@ -1573,6 +1845,9 @@
 /* Shown on the map when the user taps on a vehicle to indicate we don't know the vehicle's ID. */
 "trip_status_annotation.vehicle_id_unavailable" = "Vehicle ID Unavailable";
 
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Passed stop";
+
 /* Voiceover text explaining that this stop is the user's destination */
 "trip_stop.user_destination.accessibility_label" = "Your destination";
 
@@ -1582,14 +1857,14 @@
 /* Suggested invocation phrase for Siri Shortcut */
 "user_activity_builder.show_me_my_bus" = "Show me my bus";
 
-/* Qualifies the countdown in the live-vehicle map callout, as in '1m to this stop'. */
-"vehicle_callout.to_this_stop" = "to this stop";
+/* Button in the live-vehicle map callout that opens the trip screen. */
+"vehicle_callout.follow_this_trip" = "Follow this trip";
 
 /* Freshness line in the live-vehicle map callout. %@ is a relative time, e.g. '12s ago'. */
 "vehicle_callout.position_updated_fmt" = "Position updated %@";
 
-/* Button in the live-vehicle map callout that opens the trip screen. */
-"vehicle_callout.follow_this_trip" = "Follow this trip";
+/* Qualifies the countdown in the live-vehicle map callout, as in '1m to this stop'. */
+"vehicle_callout.to_this_stop" = "to this stop";
 
 /* Label identifying a vehicle by its ID in the map's vehicle callout, e.g. 'Vehicle 1234'. */
 "vehicle_callout.vehicle_label_fmt" = "Vehicle %@";

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -566,8 +566,7 @@
 /* Accessibility label for Look Around preview */
 "map_item_controller.look_around" = "Look Around preview. Tap to open full screen viewer";
 
-/* Button to view nearby stops
-   Nearby stops button */
+/* Button that shows the stops near this map item. */
 "map_item_controller.nearby_stops" = "Nearby Stops";
 
 /* Accessibility label for nearby stops button */
@@ -735,8 +734,7 @@
 /* Opens the agency's text information service, which may be an sms: link or a web page — so the label names neither. */
 "more_controller.text_agency" = "Message Agency";
 
-/* Title of the More tab
-   Title of the More tab / accessibility label for the map-panel more button. */
+/* Title of the More tab / accessibility label for the map-panel more button. */
 "more_controller.title" = "More";
 
 /* Request to help localize the app */
@@ -1465,12 +1463,10 @@
 /* VoiceOver for a grouped route card whose next vehicle is arriving at this stop. */
 "stop_page.grouped.a11y_arrives_fmt" = "Route %1$@ to %2$@, next arrival in %3$d minutes, %4$@. %5$d more departures loaded.";
 
-/* VoiceOver value of a collapsible section header when its contents are hidden.
-   VoiceOver value of a grouped route card whose departure list is hidden. */
+/* VoiceOver value of a collapsible header or grouped route card whose contents are hidden. */
 "stop_page.grouped.a11y_collapsed" = "collapsed";
 
-/* VoiceOver value of a collapsible section header when its contents are visible.
-   VoiceOver value of a grouped route card whose departure list is showing. */
+/* VoiceOver value of a collapsible header or grouped route card whose contents are showing. */
 "stop_page.grouped.a11y_expanded" = "expanded";
 
 /* VoiceOver for a grouped route card whose next vehicle is departing this stop (first stop or layover). */

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -1055,7 +1055,7 @@
 "rental_detail.pickup" = "Pickup";
 
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Plan a trip using this bike";
+"rental_detail.plan_trip" = "Plan a trip using this vehicle";
 
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Type";
@@ -1067,7 +1067,7 @@
 "rental_detail.propulsion_electric" = "Electric";
 
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "Pedal";
+"rental_detail.propulsion_human" = "Human-powered";
 
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Range";

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minute</string>
+			<key>other</key>
+			<string>%d minutes</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -98,22 +114,6 @@
 			<string>Show %d earlier departures</string>
 		</dict>
 	</dict>
-	<key>stop_page.empty.no_departures_fmt</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@count@</string>
-		<key>count</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>No departures in the next minute</string>
-			<key>other</key>
-			<string>No departures in the next %d minutes</string>
-		</dict>
-	</dict>
 	<key>stop_page.a11y.past_shown_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -130,6 +130,49 @@
 			<string>Showing %d past departures</string>
 		</dict>
 	</dict>
+	<key>stop_page.empty.no_departures_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>No departures in the next minute</string>
+			<key>other</key>
+			<string>No departures in the next %d minutes</string>
+		</dict>
+	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, next departure in %3$#@count@, %4$@. %5$#@departures@ loaded.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d more departure</string>
+			<key>other</key>
+			<string>%5$d more departures</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -144,6 +187,38 @@
 			<string>Show 1 past departure</string>
 			<key>other</key>
 			<string>Show %d past departures</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, arrives in %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, departed %3$#@count@ ago, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -192,6 +267,22 @@
 			<string>1 stop</string>
 			<key>other</key>
 			<string>%d stops</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, arrives in %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/en.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/en.lproj/Localizable.stringsdict
@@ -146,6 +146,33 @@
 			<string>No departures in the next %d minutes</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, next arrival in %3$#@count@, %4$@. %5$#@departures@ loaded.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d more departure</string>
+			<key>other</key>
+			<string>%5$d more departures</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -193,6 +220,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Route %1$@ to %2$@, arrives in %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Route %1$@ to %2$@, departs in %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Recogida";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Planificar un viaje con esta bicicleta";
+"rental_detail.plan_trip" = "Planificar un viaje con este vehículo";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Tipo";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "Eléctrico";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "A pedales";
+"rental_detail.propulsion_human" = "Sin motor";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Autonomía";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Por favor permitir a la aplicación acceder a su ubicación para hacer más fácil encontrar su parada.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Ahora no";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "¡Bien venido!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Usar mi ubicación";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Seleccionar en Opciones";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Poner alarma";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Ruta %1$@ hacia %2$@, sale en %3$d minutos, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Próximas salidas";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Ruta";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Ver viaje completo";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "En tiempo real · vehículo %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Todavía no hay señal en tiempo real de este bus: esta es la hora a la que debería llegar. Puede adelantarse, retrasarse o no pasar.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Solo hora programada";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Anteriores · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "datos de horario";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "vehículo aquí · a %d min";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· su parada";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min a pie";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Velocidad del viento";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Opcional. La dirección de un servidor de analíticas Umami y el ID del sitio web de esta región. Ambos campos son obligatorios para activar las analíticas; déjelos en blanco para desactivarlas.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Analíticas";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID del sitio web";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Opcional. La dirección de un servidor sidecar de Obaco (OneBusAway.co), que habilita funciones como alarmas y encuestas. Se asume \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Servidor Sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "¿Algo más que debamos saber? (opcional)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Informando sobre";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Ruta";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Hora programada";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Parada";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Vehículo";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Parece que este viaje ya se informó desde este dispositivo.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "No se pudo enviar";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Su informe es anónimo y se envía a la agencia que opera este servicio.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Compartir mi ubicación";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Enviar informe";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Informar de un autobús fantasma";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Después de la hora programada";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "¿Cuánto tiempo esperó?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Activar los servicios de ubicación";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Bicicletas";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Paradas";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "No disponible en este momento";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Scooters";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Líneas de ruta y vehículos";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Viaje en seguimiento";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Híbrido";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satélite";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Estándar";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Visualización del mapa";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Autonomía mínima";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Cualquiera";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Otras formas de moverse";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Restablecer";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Puntos de interés";
+/* Title of the Map sheet */
+"map_sheet.title" = "Mapa";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transporte público";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contacto y ayuda";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Llamar a la agencia";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Enviar mensaje a la agencia";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Tutoriales";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d disponibles";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Batería";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Bicicletas";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Anclajes";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Devolución";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "No";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Fuera de servicio";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Abrir en %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Recogida";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Planificar un viaje con esta bicicleta";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Tipo";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Gasolina";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Eléctrico";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "A pedales";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Autonomía";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Estos datos podrían estar desactualizados.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Actualizado %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min a pie";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Nombre del dispositivo de prueba";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "p. ej. el iPhone de Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Puntos de interés";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Parada no encontrada";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Filtro de salidas cambiado";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Salidas anteriores ocultas";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Mostrando %d salidas anteriores";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Salidas actualizadas";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Mostrando todas las rutas";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Mostrando rutas filtradas";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Salidas";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Esta parada ya no aparece en los datos de la agencia de tránsito. Es posible que se haya movido o eliminado.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "su viaje de transbordo";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Marcar";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Indicaciones desde aquí";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Indicaciones hasta aquí";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Todas las %d paradas";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Ruta %1$@ hacia %2$@, llega en %3$d minutos, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Ruta %1$@ hacia %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "No se pudo enviar este informe porque el servicio de informes no está disponible en este momento. Inténtelo de nuevo más tarde.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Actividad en Vivo: seguir en la pantalla bloqueada";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Siguiendo en la pantalla bloqueada";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "posición actualizada %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Eliminar alarma";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Informar de un autobús fantasma";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "ya pasó";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "última parada";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "el vehículo está aquí";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "su parada";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Paradas";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Cargando las paradas de este viaje…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "La lista de paradas de este viaje no está disponible en este momento.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Vehículo %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Ver horario";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Llegando ahora";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min a su parada";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Ya pasó su parada";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Parada %1$d de %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "El vehículo ya pasó esta parada";

--- a/OBAKit/Strings/es.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/es.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -114,6 +130,33 @@
 			<string>No hay salidas en los próximos %d minutos</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, próxima salida en %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d salida más cargada</string>
+			<key>other</key>
+			<string>%5$d salidas más cargadas</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -128,6 +171,38 @@
 			<string>Mostrar 1 salida anterior</string>
 			<key>other</key>
 			<string>Mostrar %d salidas anteriores</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, llega en %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, salió hace %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -176,6 +251,22 @@
 			<string>1 parada</string>
 			<key>other</key>
 			<string>%d paradas</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, llega en %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/es.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/es.lproj/Localizable.stringsdict
@@ -130,6 +130,33 @@
 			<string>No hay salidas en los próximos %d minutos</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, próxima llegada en %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d salida más cargada</string>
+			<key>other</key>
+			<string>%5$d salidas más cargadas</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -177,6 +204,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Ruta %1$@ hacia %2$@, llega en %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ hacia %2$@, sale en %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Pickup";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Magplano ng biyahe gamit ang bisikletang ito";
+"rental_detail.plan_trip" = "Magplano ng biyahe gamit ang sasakyang ito";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Uri";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "De-kuryente";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "Pedal";
+"rental_detail.propulsion_human" = "Lakas-tao";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Range";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "Tawagan ang Ahensya";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "I-text ang Ahensya";
+"more_controller.text_agency" = "Magmensahe sa Ahensya";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "Mga Tutorial";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Pakipayagan ang app na ma-access ang iyong lokasyon para mas madaling mahanap ang mga hintuan ng transit.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Hindi Ngayon";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Maligayang Pagdating!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Gamitin ang Aking Lokasyon";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "I-on sa Mga Setting";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Magtakda ng paalala";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Ruta %1$@ papuntang %2$@, aalis sa loob ng %3$d minuto, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Mga susunod na pag-alis";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Ruta";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Tingnan ang buong biyahe";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "Live · sasakyan %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Wala pang live na signal mula sa bus na ito — ito ang oras kung kailan ito nakatakdang dumating. Maaaring maaga, huli, o hindi na ito dumating.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Nakaiskedyul na oras lang";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Nakaraan · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "data ng iskedyul";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d hintuan";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "nandito ang sasakyan · %d min ang layo";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· ang hintuan mo";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min lakad";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Bilis ng hangin";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Opsyonal. Ang address ng isang Umami analytics server at ang website ID ng rehiyong ito. Kailangan ang parehong field para ma-enable ang analytics; iwanang blangko ang mga ito para i-disable ito.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Analytics";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "Website ID";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Opsyonal. Ang address ng isang Obaco (OneBusAway.co) sidecar server, na nagpapagana sa mga feature tulad ng mga paalala at survey. Ipinapalagay na \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Sidecar Server";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "May iba pa ba kaming dapat malaman? (opsyonal)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Iniuulat";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Ruta";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Nakaiskedyul na oras";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Hintuan";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Sasakyan";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Mukhang naiulat na ang biyaheng ito mula sa device na ito.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Hindi Maisumite";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Anonymous ang iyong ulat at ipapadala ito sa ahensyang nagpapatakbo ng serbisyong ito.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Ibahagi ang aking lokasyon";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Isumite ang Ulat";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Mag-ulat ng Ghost Bus";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Lampas sa nakaiskedyul na oras";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Gaano ka katagal naghintay?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "I-on ang Mga Serbisyo ng Lokasyon";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Mga bisikleta";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Mga hintuan";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Hindi available ngayon";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Mga scooter";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Mga linya ng ruta at sasakyan";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Sinusundang biyahe";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Hybrid";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satellite";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Standard";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Display ng mapa";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Pinakamababang range";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Kahit ano";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Iba pang paraan ng pagbiyahe";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "I-reset";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Mga Points of Interest";
+/* Title of the Map sheet */
+"map_sheet.title" = "Mapa";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transit";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contact at Tulong";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Tawagan ang Ahensya";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "I-text ang Ahensya";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Mga Tutorial";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d ang available";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Baterya";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Mga bisikleta";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Mga dock";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Drop-off";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Hindi";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Wala sa serbisyo";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Buksan sa %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Pickup";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Magplano ng biyahe gamit ang bisikletang ito";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Uri";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Gasolina";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "De-kuryente";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Pedal";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Range";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Maaaring luma na ang data na ito.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Na-update %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min lakad";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Pangalan ng Test Device";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "hal. iPhone ni Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Mga Points of Interest";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Hindi Nahanap ang Hintuan";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Nabago ang filter ng pag-alis";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Nakatago ang mga nakaraang pag-alis";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Ipinapakita ang %d nakaraang pag-alis";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Na-update ang mga pag-alis";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Ipinapakita ang lahat ng ruta";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Ipinapakita ang mga na-filter na ruta";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Mga Pag-alis";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Wala na ang hintuang ito sa data ng ahensya ng transit. Maaaring inilipat o inalis ito.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "ang iyong transfer na biyahe";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "I-bookmark";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Direksyon Mula Rito";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Direksyon Papunta Rito";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Lahat ng %d hintuan";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Ruta %1$@ papuntang %2$@, darating sa loob ng %3$d minuto, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Ruta %1$@ papuntang %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Hindi maisumite ang ulat na ito dahil hindi available ngayon ang serbisyo ng pag-uulat. Pakisubukang muli mamaya.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Live Activity — i-track sa Lock Screen";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Sinusubaybayan sa Lock Screen";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "na-update ang posisyon %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Alisin ang paalala";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Mag-ulat ng Ghost Bus";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "nadaanan na";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "huling hintuan";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "nandito ang sasakyan";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "ang hintuan mo";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Mga Hintuan";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Nilo-load ang mga hintuan ng biyaheng ito…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "Hindi available ngayon ang listahan ng mga hintuan ng biyaheng ito.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Sasakyan %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Tingnan ang iskedyul";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Darating na";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min papunta sa hintuan mo";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Nadaanan na ang hintuan mo";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Hintuan %1$d sa %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Nadaanang hintuan";

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>other</key>
+			<string>%d na minuto</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -114,6 +130,33 @@
 			<string>Walang pag-alis sa susunod na %d na minuto</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, susunod na pag-alis sa loob ng %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d na minuto</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d pang pag-alis ang na-load</string>
+			<key>other</key>
+			<string>%5$d na pang pag-alis ang na-load</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -128,6 +171,38 @@
 			<string>Ipakita ang %d nakaraang pag-alis</string>
 			<key>other</key>
 			<string>Ipakita ang %d na nakaraang pag-alis</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, darating sa loob ng %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d na minuto</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, umalis %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto ang nakalipas</string>
+			<key>other</key>
+			<string>%3$d na minuto ang nakalipas</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -176,6 +251,22 @@
 			<string>%d hintuan</string>
 			<key>other</key>
 			<string>%d na hintuan</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, darating sa loob ng %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d na minuto</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/fil.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fil.lproj/Localizable.stringsdict
@@ -130,6 +130,33 @@
 			<string>Walang pag-alis sa susunod na %d na minuto</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, susunod na pagdating sa loob ng %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d na minuto</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d pang pag-alis ang na-load</string>
+			<key>other</key>
+			<string>%5$d na pang pag-alis ang na-load</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -177,6 +204,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Ruta %1$@ papuntang %2$@, darating sa loob ng %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d na minuto</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ruta %1$@ papuntang %2$@, aalis sa loob ng %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Emprunt";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Planifier un trajet avec ce vélo";
+"rental_detail.plan_trip" = "Planifier un trajet avec ce véhicule";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Type";
 /* Rental vehicle propulsion: combustion */

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "Appeler l'agence";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "Envoyer un SMS à l'agence";
+"more_controller.text_agency" = "Envoyer un message à l'agence";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "Tutoriels";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Veuillez autoriser l'app à accéder à votre position pour faciliter la recherche de vos arrêts de transport.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Plus tard";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Bienvenue !";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Utiliser ma position";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Activer dans Réglages";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Ajouter un rappel";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Ligne %1$@ vers %2$@, part dans %3$d minutes, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Prochains départs";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Ligne";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Voir le trajet complet";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "En direct · véhicule %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Aucun signal en temps réel de ce bus pour le moment — voici l'heure prévue. Il peut passer en avance, en retard, ou ne pas passer du tout.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Horaire théorique uniquement";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Passés · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horaire théorique";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d arrêts";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "véhicule ici · à %d min";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· votre arrêt";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min à pied";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Vitesse du vent";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Facultatif. L'adresse d'un serveur de statistiques Umami et l'ID du site web de cette région. Les deux champs sont obligatoires pour activer les statistiques ; laissez-les vides pour les désactiver.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Statistiques";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID du site web";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Facultatif. L'adresse d'un serveur sidecar Obaco (OneBusAway.co), qui alimente des fonctionnalités comme les rappels et les enquêtes. « https:// » est supposé.";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Serveur sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Autre chose à nous signaler ? (facultatif)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Signalement";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Ligne";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Heure prévue";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Arrêt";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Véhicule";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Il semble que ce trajet ait déjà été signalé depuis cet appareil.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Envoi impossible";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Votre signalement est anonyme et est transmis à l'agence qui exploite ce service.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Partager ma position";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Envoyer le signalement";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Signaler un bus fantôme";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Après l'heure prévue";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Combien de temps avez-vous attendu ?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Activer les services de localisation";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Vélos";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Arrêts";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Indisponible pour le moment";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Trottinettes";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Tracés de lignes et véhicules";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Trajet suivi";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Hybride";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satellite";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Standard";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Affichage de la carte";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Autonomie minimale";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Peu importe";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Autres moyens de se déplacer";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Réinitialiser";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Points d'intérêt";
+/* Title of the Map sheet */
+"map_sheet.title" = "Carte";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transports en commun";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contact et aide";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Appeler l'agence";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Envoyer un SMS à l'agence";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Tutoriels";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d disponibles";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Batterie";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Vélos";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Bornes";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Restitution";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Non";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Hors service";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Ouvrir dans %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Emprunt";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Planifier un trajet avec ce vélo";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Type";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Essence";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Électrique";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Mécanique";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Autonomie";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Ces données peuvent être obsolètes.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Mis à jour %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min à pied";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Nom de l'appareil de test";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "ex. : iPhone d'Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Points d'intérêt";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Arrêt introuvable";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Filtre de départ modifié";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Départs passés masqués";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Affichage de %d départs passés";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Départs mis à jour";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Affichage de toutes les lignes";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Affichage des lignes filtrées";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Départs";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Cet arrêt ne figure plus dans les données de l'agence de transport. Il a peut-être été déplacé ou supprimé.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "votre trajet de correspondance";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Ajouter aux favoris";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Itinéraire depuis cet arrêt";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Itinéraire vers cet arrêt";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Tous les %d arrêts";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Ligne %1$@ vers %2$@, arrive dans %3$d minutes, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Ligne %1$@ vers %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Ce signalement n'a pas pu être envoyé, car le service de signalement n'est pas disponible pour le moment. Veuillez réessayer plus tard.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Activité en direct — suivre sur l'écran verrouillé";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Suivi sur l'écran verrouillé";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "position mise à jour %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Supprimer le rappel";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Signaler un bus fantôme";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "déjà passé";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "dernier arrêt";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "le véhicule est ici";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "votre arrêt";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Arrêts";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Chargement des arrêts de ce trajet…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "La liste des arrêts de ce trajet n'est pas disponible pour le moment.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Véhicule %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Voir les horaires";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Arrive maintenant";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min jusqu'à votre arrêt";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Votre arrêt est dépassé";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Arrêt %1$d sur %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Arrêt déjà passé";

--- a/OBAKit/Strings/fr.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fr.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minute</string>
+			<key>other</key>
+			<string>%d minutes</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -114,6 +130,33 @@
 			<string>Aucun départ dans les %d prochaines minutes</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, prochain départ dans %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d autre départ chargé</string>
+			<key>other</key>
+			<string>%5$d autres départs chargés</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -128,6 +171,38 @@
 			<string>Afficher %d départ passé</string>
 			<key>other</key>
 			<string>Afficher %d départs passés</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, arrive dans %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, parti il y a %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -176,6 +251,22 @@
 			<string>%d arrêt</string>
 			<key>other</key>
 			<string>%d arrêts</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, arrive dans %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/fr.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/fr.lproj/Localizable.stringsdict
@@ -130,6 +130,33 @@
 			<string>Aucun départ dans les %d prochaines minutes</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, prochaine arrivée dans %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%5$d autre départ chargé</string>
+			<key>other</key>
+			<string>%5$d autres départs chargés</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -177,6 +204,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Ligne %1$@ vers %2$@, arrive dans %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minute</string>
+			<key>other</key>
+			<string>%3$d minutes</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ligne %1$@ vers %2$@, part dans %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Consenti all'applicazione di accedere alla tua posizione per facilitare l'individuazione di fermate nei tuoi dintorni. ";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Non adesso";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Ti diamo il benvenuto!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Usa la mia posizione";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Attiva nelle impostazioni";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Imposta sveglia";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Linea %1$@ per %2$@, parte tra %3$d minuti, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Prossime partenze";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Linea";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Vedi itinerario completo";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "In tempo reale · veicolo %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Nessun segnale in tempo reale da questo autobus: questo è l'orario previsto di arrivo. Potrebbe arrivare in anticipo, in ritardo o non arrivare affatto.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Solo orario previsto";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Passate · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dati di orario";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d fermate";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "veicolo qui · a %d min";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· la tua fermata";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min a piedi";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Velocità del vento";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Facoltativo. L'indirizzo di un server di analisi Umami e l'ID del sito web di questa regione. Entrambi i campi sono obbligatori per attivare le analisi; lasciali vuoti per disattivarle.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Analisi";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID sito web";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Facoltativo. L'indirizzo di un server sidecar Obaco (OneBusAway.co), che abilita funzioni come le sveglie e i sondaggi. Si presume \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Server sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Altro che dovremmo sapere? (facoltativo)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Segnalazione";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Linea";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Orario previsto";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Fermata";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Veicolo";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Sembra che questa corsa sia già stata segnalata da questo dispositivo.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Impossibile inviare";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "La tua segnalazione è anonima e viene inviata all'ente che gestisce questo servizio.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Condividi la mia posizione";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Invia segnalazione";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Segnala corsa fantasma";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Oltre l'orario previsto";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Quanto hai aspettato?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Attiva i servizi di localizzazione";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Bici";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Fermate";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Non disponibile al momento";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Monopattini";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Linee e veicoli";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Corsa seguita";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Ibrida";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satellite";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Standard";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Visualizzazione mappa";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Autonomia minima";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Qualsiasi";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Altri modi per spostarti";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Reimposta";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Punti di interesse";
+/* Title of the Map sheet */
+"map_sheet.title" = "Mappa";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Trasporto pubblico";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contatti e assistenza";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Chiama l'ente";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Invia SMS all'ente";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Tutorial";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d disponibili";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Batteria";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Bici";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Stalli";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Riconsegna";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "No";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Fuori servizio";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Apri in %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Ritiro";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Pianifica un viaggio con questa bici";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Tipo";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Benzina";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Elettrico";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "A pedali";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Autonomia";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Questi dati potrebbero non essere aggiornati.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Aggiornato %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min a piedi";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Nome dispositivo di test";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "es. iPhone di Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Punti di interesse";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Fermata non trovata";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Filtro delle partenze modificato";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Partenze passate nascoste";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Vengono mostrate %d partenze passate";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Partenze aggiornate";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Vengono mostrate tutte le linee";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Vengono mostrate le linee filtrate";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Partenze";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Questa fermata non è più presente nei dati dell'ente di trasporto. Potrebbe essere stata spostata o rimossa.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "la tua corsa in coincidenza";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Segnalibro";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Indicazioni da qui";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Indicazioni fin qui";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Tutte le %d fermate";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Linea %1$@ per %2$@, arriva tra %3$d minuti, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Linea %1$@ per %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Non è stato possibile inviare questa segnalazione perché il servizio di segnalazione non è disponibile al momento. Riprova più tardi.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Attività in tempo reale — traccia sulla schermata di blocco";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Tracciamento sulla schermata di blocco";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "posizione aggiornata %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Rimuovi sveglia";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Segnala corsa fantasma";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "già superata";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "ultima fermata";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "il veicolo è qui";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "la tua fermata";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Fermate";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Caricamento delle fermate di questa corsa…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "L'elenco delle fermate di questa corsa non è disponibile al momento.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Veicolo %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Vedi orario";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "In arrivo adesso";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min alla tua fermata";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Ha superato la tua fermata";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Fermata %1$d di %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Fermata superata";

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "Chiama l'ente";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "Invia SMS all'ente";
+"more_controller.text_agency" = "Scrivi all'ente";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "Tutorial";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Ritiro";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Pianifica un viaggio con questa bici";
+"rental_detail.plan_trip" = "Pianifica un viaggio con questo veicolo";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Tipo";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "Elettrico";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "A pedali";
+"rental_detail.propulsion_human" = "Muscolare";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Autonomia";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/it.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/it.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>other</key>
+			<string>%d minuti</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -114,6 +130,33 @@
 			<string>Nessuna partenza nei prossimi %d minuti</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, prossima partenza tra %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minuti</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Altra %5$d partenza caricata</string>
+			<key>other</key>
+			<string>Altre %5$d partenze caricate</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -128,6 +171,38 @@
 			<string>Mostra 1 partenza passata</string>
 			<key>other</key>
 			<string>Mostra %d partenze passate</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, arriva tra %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minuti</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, partita %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto fa</string>
+			<key>other</key>
+			<string>%3$d minuti fa</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -176,6 +251,22 @@
 			<string>1 fermata</string>
 			<key>other</key>
 			<string>%d fermate</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, arriva tra %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minuti</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/it.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/it.lproj/Localizable.stringsdict
@@ -130,6 +130,33 @@
 			<string>Nessuna partenza nei prossimi %d minuti</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, prossimo arrivo tra %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minuti</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Altra %5$d partenza caricata</string>
+			<key>other</key>
+			<string>Altre %5$d partenze caricate</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -177,6 +204,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Linea %1$@ per %2$@, arriva tra %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minuti</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linea %1$@ per %2$@, parte tra %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "대여";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "이 자전거로 경로 계획하기";
+"rental_detail.plan_trip" = "이 차량으로 경로 계획하기";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "동력";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "전기";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "페달";
+"rental_detail.propulsion_human" = "인력";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "주행 거리";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "운영 기관에 전화";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "운영 기관에 문자";
+"more_controller.text_agency" = "운영 기관에 메시지 보내기";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "이용 안내";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "대중교통 정류장을 더 쉽게 찾을 수 있도록 앱이 사용자의 위치에 접근하도록 허용해 주세요.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "나중에";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "환영합니다!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "내 위치 사용";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "설정에서 켜기";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "미리 알림 설정";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "노선 %1$@, %2$@ 방면, %3$d분 후 출발, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "다음 출발";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "노선";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "전체 운행 보기";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "실시간 · 차량 %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "아직 이 버스의 실시간 신호가 없습니다. 표시된 시각은 예정 도착 시각이며, 실제로는 더 일찍 오거나 늦게 오거나 오지 않을 수도 있습니다.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "시간표 기준 시각만 표시";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "지난 출발 · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "시간표 기준";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "정류장 %d개";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "차량 위치 · %d분 거리";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· 내 정류장";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "도보 %d분";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "풍속";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "선택 사항입니다. Umami 분석 서버의 주소와 이 지역의 웹 사이트 ID입니다. 분석을 사용하려면 두 항목을 모두 입력해야 하며, 비워 두면 분석이 비활성화됩니다.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "분석";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "웹 사이트 ID";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "선택 사항입니다. 미리 알림과 설문조사 같은 기능을 지원하는 Obaco(OneBusAway.co) 사이드카 서버의 주소입니다. \"https://\"가 기본으로 적용됩니다.";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "사이드카 서버";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "더 알려주실 내용이 있나요? (선택 사항)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "신고 대상";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "노선";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "예정 시각";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "정류장";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "차량";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "이 기기에서 이 운행을 이미 신고한 것으로 보입니다.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "제출할 수 없음";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "신고는 익명으로 처리되며 이 서비스를 운영하는 기관에 전달됩니다.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "내 위치 공유";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "신고 제출";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "유령 버스 신고";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "예정 시각 이후";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "얼마나 기다리셨나요?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d분";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30분 이상";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "위치 서비스 켜기";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "자전거";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "정류장";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "지금은 사용할 수 없음";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "킥보드";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "노선 경로 및 차량";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "추적 중인 운행";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "하이브리드";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "위성";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "표준";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "지도 표시";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "최소 주행 거리";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "제한 없음";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "다른 이동 수단";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "초기화";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "관심 지점";
+/* Title of the Map sheet */
+"map_sheet.title" = "지도";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "대중교통";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "문의 및 도움말";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "운영 기관에 전화";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "운영 기관에 문자";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "이용 안내";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d대 이용 가능";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "배터리";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "자전거";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "거치대";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "반납";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "불가";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "운영 중지";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "%@에서 열기";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "대여";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "이 자전거로 경로 계획하기";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "동력";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "가솔린";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "전기";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "페달";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "주행 거리";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "이 데이터가 오래되었을 수 있습니다.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "업데이트 %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "도보 %d분";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "테스트 기기 이름";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "예: Aaron의 iPhone";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "관심 지점";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "정류장을 찾을 수 없음";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "출발 유형 필터 변경됨";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "지난 출발 숨김";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "지난 출발 %d건 표시";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "출발 정보 업데이트됨";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "모든 노선 표시 중";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "필터링된 노선 표시 중";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "출발";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "이 정류장은 더 이상 운영 기관 데이터에 없습니다. 이전되었거나 폐지되었을 수 있습니다.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "내 환승 운행";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "즐겨찾기";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "여기에서 출발하는 경로";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "여기로 가는 경로";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "전체 정류장 %d개";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "노선 %1$@, %2$@ 방면, %3$d분 후 도착, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "노선 %1$@, %2$@ 방면";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "신고 서비스를 사용할 수 없어 이 신고를 제출하지 못했습니다. 나중에 다시 시도해 주세요.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "실시간 액티비티 — 잠금 화면에서 추적";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "잠금 화면에서 추적 중";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "위치 업데이트 %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "미리 알림 제거";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "유령 버스 신고";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "이미 지나감";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "마지막 정류장";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "차량이 여기에 있습니다";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "내 정류장";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "정류장";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "이 운행의 정류장을 불러오는 중…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "지금은 이 운행의 정류장 목록을 사용할 수 없습니다.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "차량 %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "시간표 보기";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "지금 도착";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "내 정류장까지 약 %d분";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "내 정류장 지나감";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "%2$d개 중 %1$d번째 정류장";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "지나간 정류장";

--- a/OBAKit/Strings/ko.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ko.lproj/Localizable.stringsdict
@@ -114,6 +114,29 @@
 			<string>앞으로 %d분 내에 예정된 출발이 없습니다</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, 다음 도착 %3$#@count@ 후, %4$@. 출발 %5$#@departures@을 추가로 불러왔습니다.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d건</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -155,6 +178,20 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>노선 %1$@, %2$@ 방면, %3$#@count@ 후 도착, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, %3$#@count@ 후 출발, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/ko.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ko.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d분</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -100,6 +114,29 @@
 			<string>앞으로 %d분 내에 예정된 출발이 없습니다</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, 다음 출발 %3$#@count@ 후, %4$@. 출발 %5$#@departures@을 추가로 불러왔습니다.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d건</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -112,6 +149,34 @@
 			<string>d</string>
 			<key>other</key>
 			<string>지난 출발 %d건 표시</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, %3$#@count@ 후 도착, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, %3$#@count@ 전 출발, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -154,6 +219,20 @@
 			<string>d</string>
 			<key>other</key>
 			<string>정류장 %d개</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>노선 %1$@, %2$@ 방면, %3$#@count@ 후 도착, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d분</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Zezwól aplikacji na dostęp do Twojej lokalizacji, aby ułatwić wyszukiwanie Twoich najbliższych przystanków.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Nie teraz";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Witaj!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Użyj mojej lokalizacji";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Włącz w ustawieniach";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Ustaw alarm";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Linia %1$@ do %2$@, odjazd za %3$d minut, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Najbliższe odjazdy";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Linia";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Zobacz cały kurs";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "Na żywo · pojazd %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Brak sygnału na żywo z tego autobusu — to tylko rozkładowa godzina przyjazdu. Pojazd może przyjechać wcześniej, później lub wcale.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Tylko godzina rozkładowa";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Minione · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dane rozkładowe";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d przyst.";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "pojazd tutaj · %d min stąd";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· Twój przystanek";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min pieszo";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Prędkość wiatru";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Opcjonalnie. Adres serwera analitycznego Umami oraz identyfikator witryny tego regionu. Oba pola są wymagane, aby włączyć analitykę; pozostaw je puste, aby ją wyłączyć.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Analityka";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID witryny";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Opcjonalnie. Adres serwera sidecar Obaco (OneBusAway.co), który odpowiada za funkcje takie jak alarmy i ankiety. Zakłada się \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Serwer sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Coś jeszcze, o czym powinniśmy wiedzieć? (opcjonalnie)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Zgłaszasz";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Linia";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Godzina rozkładowa";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Przystanek";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Pojazd";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Wygląda na to, że ten kurs został już zgłoszony z tego urządzenia.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Nie można wysłać";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Twoje zgłoszenie jest anonimowe i trafia do przewoźnika obsługującego ten kurs.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Udostępnij moją lokalizację";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Wyślij zgłoszenie";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Zgłoś autobus widmo";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Po godzinie rozkładowej";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Czas oczekiwania";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Włącz usługi lokalizacji";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Rowery";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Przystanki";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Chwilowo niedostępne";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Hulajnogi";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Trasy linii i pojazdy";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Śledzony kurs";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Hybrydowa";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satelitarna";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Standardowa";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Wyświetlanie mapy";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Minimalny zasięg";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Dowolny";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Inne środki transportu";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Resetuj";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Ciekawe miejsca";
+/* Title of the Map sheet */
+"map_sheet.title" = "Mapa";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transport publiczny";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Kontakt i pomoc";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Zadzwoń do przewoźnika";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Wyślij SMS do przewoźnika";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Poradniki";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "Dostępne: %d";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Bateria";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Rowery";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Wolne stojaki";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Zwrot";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Nie";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Nieczynne";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Otwórz w %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Wypożyczenie";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Zaplanuj podróż tym rowerem";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Napęd";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Spalinowy";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Elektryczny";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Mięśniowy";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Zasięg";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Te dane mogą być nieaktualne.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Zaktualizowano %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min pieszo";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Nazwa urządzenia testowego";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "np. iPhone Aarona";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Ciekawe miejsca";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Nie znaleziono przystanku";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Zmieniono filtr odjazdów";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Ukryto minione odjazdy";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Pokazano minione odjazdy (%d)";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Zaktualizowano odjazdy";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Pokazano wszystkie linie";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Pokazano filtrowane linie";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Odjazdy";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Tego przystanku nie ma już w danych przewoźnika. Mógł zostać przeniesiony lub usunięty.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "Twoja przesiadka";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Dodaj zakładkę";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Trasa z tego miejsca";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Trasa do tego miejsca";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Wszystkie przystanki (%d)";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Linia %1$@ do %2$@, przyjazd za %3$d minut, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Linia %1$@ do %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Nie udało się wysłać zgłoszenia, ponieważ usługa zgłoszeń jest teraz niedostępna. Spróbuj ponownie później.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Aktywność na żywo — śledź na ekranie blokady";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Śledzenie na ekranie blokady";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "pozycja zaktualizowana %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Usuń alarm";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Zgłoś autobus widmo";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "już minięty";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "przystanek końcowy";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "pojazd jest tutaj";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "Twój przystanek";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Przystanki";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Wczytywanie przystanków tego kursu…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "Lista przystanków tego kursu jest teraz niedostępna.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Pojazd %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Zobacz rozkład";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Przyjeżdża teraz";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min do Twojego przystanku";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Minął Twój przystanek";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Przystanek %1$d z %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Minięty przystanek";

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Wypożyczenie";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Zaplanuj podróż tym rowerem";
+"rental_detail.plan_trip" = "Zaplanuj podróż tym pojazdem";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Napęd";
 /* Rental vehicle propulsion: combustion */

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "Zadzwoń do przewoźnika";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "Wyślij SMS do przewoźnika";
+"more_controller.text_agency" = "Napisz do przewoźnika";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "Poradniki";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/pl.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pl.lproj/Localizable.stringsdict
@@ -2,6 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d minuty</string>
+			<key>many</key>
+			<string>%d minut</string>
+			<key>one</key>
+			<string>%d minuta</string>
+			<key>other</key>
+			<string>%d minuty</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -12,12 +32,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 nieudane zadanie</string>
 			<key>few</key>
 			<string>%d nieudane zadania</string>
 			<key>many</key>
 			<string>%d nieudanych zadań</string>
+			<key>one</key>
+			<string>1 nieudane zadanie</string>
 			<key>other</key>
 			<string>%d nieudanego zadania</string>
 		</dict>
@@ -32,12 +52,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 udane zadanie</string>
 			<key>few</key>
 			<string>%d udane zadania</string>
 			<key>many</key>
 			<string>%d udanych zadań</string>
+			<key>one</key>
+			<string>1 udane zadanie</string>
 			<key>other</key>
 			<string>%d udanego zadania</string>
 		</dict>
@@ -52,12 +72,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%2$d warstwa włączona</string>
 			<key>few</key>
 			<string>%2$d warstwy włączone</string>
 			<key>many</key>
 			<string>%2$d warstw włączonych</string>
+			<key>one</key>
+			<string>%2$d warstwa włączona</string>
 			<key>other</key>
 			<string>%2$d warstwy włączonej</string>
 		</dict>
@@ -72,12 +92,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 pojazd tutaj</string>
 			<key>few</key>
 			<string>%d pojazdy tutaj</string>
 			<key>many</key>
 			<string>%d pojazdów tutaj</string>
+			<key>one</key>
+			<string>1 pojazd tutaj</string>
 			<key>other</key>
 			<string>%d pojazdu tutaj</string>
 		</dict>
@@ -92,12 +112,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 wynik</string>
 			<key>few</key>
 			<string>%d wyniki</string>
 			<key>many</key>
 			<string>%d wyników</string>
+			<key>one</key>
+			<string>1 wynik</string>
 			<key>other</key>
 			<string>%d wyniku</string>
 		</dict>
@@ -112,12 +132,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Pokaż 1 wcześniejszy odjazd</string>
 			<key>few</key>
 			<string>Pokaż %d wcześniejsze odjazdy</string>
 			<key>many</key>
 			<string>Pokaż %d wcześniejszych odjazdów</string>
+			<key>one</key>
+			<string>Pokaż 1 wcześniejszy odjazd</string>
 			<key>other</key>
 			<string>Pokaż %d wcześniejszego odjazdu</string>
 		</dict>
@@ -132,14 +152,49 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Brak odjazdów w ciągu najbliższej minuty</string>
 			<key>few</key>
 			<string>Brak odjazdów w ciągu najbliższych %d minut</string>
 			<key>many</key>
 			<string>Brak odjazdów w ciągu najbliższych %d minut</string>
+			<key>one</key>
+			<string>Brak odjazdów w ciągu najbliższej minuty</string>
 			<key>other</key>
 			<string>Brak odjazdów w ciągu najbliższych %d minuty</string>
+		</dict>
+	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, najbliższy odjazd za %3$#@count@, %4$@. Wczytano jeszcze %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%5$d odjazdy</string>
+			<key>many</key>
+			<string>%5$d odjazdów</string>
+			<key>one</key>
+			<string>%5$d odjazd</string>
+			<key>other</key>
+			<string>%5$d odjazdu</string>
 		</dict>
 	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
@@ -152,14 +207,54 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Pokaż 1 miniony odjazd</string>
 			<key>few</key>
 			<string>Pokaż %d minione odjazdy</string>
 			<key>many</key>
 			<string>Pokaż %d minionych odjazdów</string>
+			<key>one</key>
+			<string>Pokaż 1 miniony odjazd</string>
 			<key>other</key>
 			<string>Pokaż %d minionego odjazdu</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, przyjazd za %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, odjechał %3$#@count@ temu, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -172,12 +267,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Pokaż 1 alert</string>
 			<key>few</key>
 			<string>Pokaż wszystkie %d alerty</string>
 			<key>many</key>
 			<string>Pokaż wszystkie %d alertów</string>
+			<key>one</key>
+			<string>Pokaż 1 alert</string>
 			<key>other</key>
 			<string>Pokaż wszystkie %d alertu</string>
 		</dict>
@@ -192,12 +287,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 alert funkcjonowania komunikacji</string>
 			<key>few</key>
 			<string>%d alerty funkcjonowania komunikacji</string>
 			<key>many</key>
 			<string>%d alertów funkcjonowania komunikacji</string>
+			<key>one</key>
+			<string>1 alert funkcjonowania komunikacji</string>
 			<key>other</key>
 			<string>%d alertu funkcjonowania komunikacji</string>
 		</dict>
@@ -212,14 +307,34 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>1 przystanek</string>
 			<key>few</key>
 			<string>%d przystanki</string>
 			<key>many</key>
 			<string>%d przystanków</string>
+			<key>one</key>
+			<string>1 przystanek</string>
 			<key>other</key>
 			<string>%d przystanku</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, przyjazd za %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/pl.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pl.lproj/Localizable.stringsdict
@@ -162,6 +162,41 @@
 			<string>Brak odjazdów w ciągu najbliższych %d minuty</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, najbliższy przyjazd za %3$#@count@, %4$@. Wczytano jeszcze %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%5$d odjazdy</string>
+			<key>many</key>
+			<string>%5$d odjazdów</string>
+			<key>one</key>
+			<string>%5$d odjazd</string>
+			<key>other</key>
+			<string>%5$d odjazdu</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -221,6 +256,26 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Linia %1$@ do %2$@, przyjazd za %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d minuty</string>
+			<key>many</key>
+			<string>%3$d minut</string>
+			<key>one</key>
+			<string>%3$d minutę</string>
+			<key>other</key>
+			<string>%3$d minuty</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linia %1$@ do %2$@, odjazd za %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Retirada";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Planejar uma viagem com esta bicicleta";
+"rental_detail.plan_trip" = "Planejar uma viagem com este veículo";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Tipo";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "Elétrico";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "A pedal";
+"rental_detail.propulsion_human" = "Sem motor";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Autonomia";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Permita que o app acesse sua localização para facilitar encontrar suas paradas de transporte público.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Agora não";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Boas-vindas!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Usar minha localização";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Ativar nos Ajustes";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Adicionar lembrete";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Linha %1$@ para %2$@, parte em %3$d minutos, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Próximas partidas";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Linha";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Ver viagem completa";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "Tempo real · veículo %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Ainda não há sinal em tempo real deste ônibus — este é o horário programado de chegada. Ele pode chegar adiantado, atrasado ou não passar.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Apenas horário programado";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Anteriores · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "horário programado";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d paradas";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "veículo aqui · a %d min";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· sua parada";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d min a pé";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Velocidade do vento";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Opcional. O endereço de um servidor de análise Umami e o ID do site desta região. Os dois campos são obrigatórios para ativar a análise de dados; deixe-os em branco para desativá-la.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Análise de Dados";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID do site";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Opcional. O endereço de um servidor sidecar Obaco (OneBusAway.co), que fornece recursos como lembretes e pesquisas. Assume-se \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Servidor Sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Mais alguma coisa que devemos saber? (opcional)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Você está relatando";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Linha";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Horário programado";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Parada";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Veículo";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Parece que esta viagem já foi relatada a partir deste dispositivo.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Não Foi Possível Enviar";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Seu relato é anônimo e vai para a agência que opera este serviço.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Compartilhar minha localização";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Enviar Relato";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Relatar Ônibus Fantasma";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Após o horário programado";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Quanto tempo você esperou?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d min";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ min";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Ativar Serviços de Localização";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Bicicletas";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Paradas";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Indisponível no momento";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Patinetes";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Traçados das linhas e veículos";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Viagem acompanhada";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Híbrido";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Satélite";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Padrão";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Exibição do mapa";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Autonomia mínima";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Qualquer";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Outras formas de se locomover";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Redefinir";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Pontos de Interesse";
+/* Title of the Map sheet */
+"map_sheet.title" = "Mapa";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Transporte público";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Contato e Ajuda";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Ligar para a Agência";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Enviar SMS para a Agência";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Tutoriais";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d disponíveis";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Bateria";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Bicicletas";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Vagas";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Devolução";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Não";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Fora de serviço";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Abrir em %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Retirada";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Planejar uma viagem com esta bicicleta";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Tipo";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Gasolina";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Elétrico";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "A pedal";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Autonomia";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Estes dados podem estar desatualizados.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Atualizado %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d min a pé";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Nome do Dispositivo de Teste";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "ex.: iPhone de Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Pontos de Interesse";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Parada Não Encontrada";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Filtro de partidas alterado";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Partidas anteriores ocultas";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Mostrando %d partidas anteriores";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Partidas atualizadas";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Mostrando todas as linhas";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Mostrando linhas filtradas";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Partidas";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Esta parada não está mais nos dados da agência de transporte. Ela pode ter sido movida ou removida.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "sua viagem de conexão";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Favoritar";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Itinerário a Partir Daqui";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Itinerário Até Aqui";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Todas as %d paradas";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Linha %1$@ para %2$@, chega em %3$d minutos, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Linha %1$@ para %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Não foi possível enviar este relato porque o serviço de relatos está indisponível no momento. Tente novamente mais tarde.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Atividade ao Vivo — acompanhar na Tela Bloqueada";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Acompanhando na Tela Bloqueada";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "posição atualizada %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Remover lembrete";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Relatar Ônibus Fantasma";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "já passou";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "última parada";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "o veículo está aqui";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "sua parada";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Paradas";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Carregando as paradas desta viagem…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "A lista de paradas desta viagem está indisponível no momento.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Veículo %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Ver horários";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Chegando agora";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d min até sua parada";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Passou da sua parada";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Parada %1$d de %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "O veículo já passou por esta parada";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -158,7 +158,7 @@
 "custom_region_builder_controller.example_data.region_name" = "Minha Região Personalizada";
 
 /* An explanation of the optional custom region name field. */
-"custom_region_builder_controller.name_section.explanation" = "Opcional. Se você deixar em branco, a região será nomeada de acordo com sua primeira agência de trânsito.";
+"custom_region_builder_controller.name_section.explanation" = "Opcional. Se você deixar em branco, a região será nomeada de acordo com sua primeira agência de transporte.";
 
 /* Title of the Name header. */
 "custom_region_builder_controller.name_section.header_title" = "Nome";
@@ -167,7 +167,7 @@
 "custom_region_builder_controller.new_title" = "Nova região personalizada";
 
 /* An error message displayed when a custom region's server cannot be validated. First parameter is the server URL, second is the underlying error message. */
-"custom_region_builder_controller.server_validation_error_fmt" = "Não foi possível acessar um servidor de API de trânsito compatível em %1$@. Verifique a URL base e tente novamente.\n\n%2$@";
+"custom_region_builder_controller.server_validation_error_fmt" = "Não foi possível acessar um servidor de API de transporte compatível em %1$@. Verifique a URL base e tente novamente.\n\n%2$@";
 
 /* An explanation of dragging the map to highlight the service area of a custom region. */
 "custom_region_builder_controller.service_area_section.explanation" = "Arraste o mapa até a área de serviço aproximada desta região.";
@@ -783,10 +783,10 @@
 "onboarding.progress.accessibility_label" = "Progresso da integração";
 
 /* Body of the region onboarding screen when the region was detected from the rider's location */
-"onboarding.region.body" = "Encontramos a rede de trânsito mais próxima de você.";
+"onboarding.region.body" = "Encontramos a rede de transporte público mais próxima de você.";
 
 /* Body of the region onboarding screen prompting the rider to choose a transit network */
-"onboarding.region.body_choose" = "Escolha a rede de trânsito que você usa.";
+"onboarding.region.body_choose" = "Escolha a rede de transporte público que você usa.";
 
 /* Label on the region card when the region was already selected by app configuration or an earlier launch rather than detected from the rider's location */
 "onboarding.region.current_label" = "Região atual";
@@ -810,7 +810,7 @@
 "onboarding.welcome.body" = "Chegadas em tempo real para os ônibus, trens e balsas que você usa — criado por usuários de transporte público, grátis e de código aberto.";
 
 /* Footnote of the first onboarding screen */
-"onboarding.welcome.footnote" = "Disponível em dezenas de regiões de trânsito ao redor do mundo";
+"onboarding.welcome.footnote" = "Disponível em dezenas de regiões de transporte público ao redor do mundo";
 
 /* Primary button on the first onboarding screen */
 "onboarding.welcome.primary_button" = "Começar";

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "Ligar para a Agência";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "Enviar SMS para a Agência";
+"more_controller.text_agency" = "Enviar Mensagem para a Agência";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "Tutoriais";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -130,6 +130,33 @@
 			<string>Nenhuma partida nos próximos %d minutos</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, próxima chegada em %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Mais %5$d partida carregada</string>
+			<key>other</key>
+			<string>Mais %5$d partidas carregadas</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -177,6 +204,22 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Linha %1$@ para %2$@, chega em %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, parte em %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -114,6 +130,33 @@
 			<string>Nenhuma partida nos próximos %d minutos</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, próxima partida em %3$#@count@, %4$@. %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Mais %5$d partida carregada</string>
+			<key>other</key>
+			<string>Mais %5$d partidas carregadas</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -128,6 +171,38 @@
 			<string>Mostrar 1 partida anterior</string>
 			<key>other</key>
 			<string>Mostrar %d partidas anteriores</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, chega em %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, partiu há %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -176,6 +251,22 @@
 			<string>1 parada</string>
 			<key>other</key>
 			<string>%d paradas</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Linha %1$@ para %2$@, chega em %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%3$d minuto</string>
+			<key>other</key>
+			<string>%3$d minutos</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Разрешите приложению доступ к вашей геопозиции, чтобы было проще находить остановки рядом с вами.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Не сейчас";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Добро пожаловать!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Использовать мою геопозицию";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Включить в Настройках";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Добавить напоминание";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Маршрут %1$@ до %2$@, отправление через %3$d мин., %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Следующие отправления";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Маршрут";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Показать весь рейс";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "В реальном времени · транспорт %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "От этого автобуса пока нет сигнала в реальном времени — это лишь время по расписанию. Он может прийти раньше, позже или не прийти вовсе.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Только время по расписанию";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Прошедшие · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "по расписанию";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d ост.";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "транспорт здесь · %d мин.";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· ваша остановка";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "%d мин. пешком";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Скорость ветра";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Необязательно. Адрес сервера аналитики Umami и ID сайта этого региона. Аналитика включается, только если заполнены оба поля; оставьте их пустыми, чтобы отключить её.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Аналитика";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "ID сайта";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Необязательно. Адрес sidecar-сервера Obaco (OneBusAway.co), который обеспечивает работу таких функций, как напоминания и опросы. Предполагается \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Сервер Sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Хотите сообщить что-то ещё? (необязательно)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "О чём сообщение";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Маршрут";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "По расписанию";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Остановка";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Транспорт";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Похоже, об этом рейсе уже сообщали с этого устройства.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Не удалось отправить";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Ваше сообщение анонимно и направляется транспортному агентству, которое обслуживает этот рейс.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Поделиться моей геопозицией";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Отправить сообщение";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Сообщить об автобусе-призраке";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "После времени по расписанию";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Сколько вы ждали?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d мин.";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ мин.";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Включить службы геолокации";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Велосипеды";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Остановки";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Сейчас недоступно";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Самокаты";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Линии маршрутов и транспорт";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Отслеживаемый рейс";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Гибрид";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Спутник";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Стандартная";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Отображение карты";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Минимальный запас хода";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Любой";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Другие способы передвижения";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Сбросить";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Объекты на карте";
+/* Title of the Map sheet */
+"map_sheet.title" = "Карта";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Общественный транспорт";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Контакты и помощь";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Позвонить в агентство";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Написать агентству";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Инструкции";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "Доступно: %d";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Заряд";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Велосипеды";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Свободные места";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Возврат";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Нет";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Не работает";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Открыть в %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Аренда";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Спланировать поездку на этом велосипеде";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Тип";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Бензиновый";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Электрический";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Механический";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Запас хода";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Эти данные могут быть устаревшими.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Обновлено %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "%d мин. пешком";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Имя тестового устройства";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "напр., iPhone Аарона";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Объекты на карте";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Остановка не найдена";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Фильтр отправлений изменён";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Прошедшие отправления скрыты";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Показано прошедших отправлений: %d";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Отправления обновлены";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Показаны все маршруты";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Показаны отфильтрованные маршруты";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Отправления";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Этой остановки больше нет в данных транспортного агентства. Возможно, её перенесли или удалили.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "ваш пересадочный рейс";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "В закладки";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Маршрут отсюда";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Маршрут сюда";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Все остановки (%d)";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Маршрут %1$@ до %2$@, прибытие через %3$d мин., %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Маршрут %1$@ до %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Не удалось отправить сообщение: сервис приёма сообщений сейчас недоступен. Повторите попытку позже.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Live-активность — отслеживание на экране блокировки";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Отслеживание на экране блокировки";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "местоположение обновлено %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Удалить напоминание";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Сообщить об автобусе-призраке";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "уже пройдена";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "конечная остановка";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "транспорт здесь";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "ваша остановка";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Остановки";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Загрузка остановок этого рейса…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "Список остановок этого рейса сейчас недоступен.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Транспорт %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Показать расписание";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Прибывает сейчас";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d мин. до вашей остановки";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Ваша остановка пройдена";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Остановка %1$d из %2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Пройденная остановка";

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Аренда";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Спланировать поездку на этом велосипеде";
+"rental_detail.plan_trip" = "Спланировать поездку на этом транспорте";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Тип";
 /* Rental vehicle propulsion: combustion */

--- a/OBAKit/Strings/ru.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ru.lproj/Localizable.stringsdict
@@ -2,6 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d минуты</string>
+			<key>many</key>
+			<string>%d минут</string>
+			<key>one</key>
+			<string>%d минута</string>
+			<key>other</key>
+			<string>%d минуты</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -12,12 +32,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%d сбой</string>
 			<key>few</key>
 			<string>%d сбоя</string>
 			<key>many</key>
 			<string>%d сбоев</string>
+			<key>one</key>
+			<string>%d сбой</string>
 			<key>other</key>
 			<string>%d сбоя</string>
 		</dict>
@@ -32,12 +52,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%d успешный перенос</string>
 			<key>few</key>
 			<string>%d успешных переноса</string>
 			<key>many</key>
 			<string>%d успешных переносов</string>
+			<key>one</key>
+			<string>%d успешный перенос</string>
 			<key>other</key>
 			<string>%d успешного переноса</string>
 		</dict>
@@ -52,12 +72,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>включён %2$d слой</string>
 			<key>few</key>
 			<string>включено %2$d слоя</string>
 			<key>many</key>
 			<string>включено %2$d слоёв</string>
+			<key>one</key>
+			<string>включён %2$d слой</string>
 			<key>other</key>
 			<string>включено %2$d слоя</string>
 		</dict>
@@ -72,12 +92,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Здесь %d транспортное средство</string>
 			<key>few</key>
 			<string>Здесь %d транспортных средства</string>
 			<key>many</key>
 			<string>Здесь %d транспортных средств</string>
+			<key>one</key>
+			<string>Здесь %d транспортное средство</string>
 			<key>other</key>
 			<string>Здесь %d транспортного средства</string>
 		</dict>
@@ -92,12 +112,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%d результат</string>
 			<key>few</key>
 			<string>%d результата</string>
 			<key>many</key>
 			<string>%d результатов</string>
+			<key>one</key>
+			<string>%d результат</string>
 			<key>other</key>
 			<string>%d результата</string>
 		</dict>
@@ -112,12 +132,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Показать %d более раннее отправление</string>
 			<key>few</key>
 			<string>Показать %d более ранних отправления</string>
 			<key>many</key>
 			<string>Показать %d более ранних отправлений</string>
+			<key>one</key>
+			<string>Показать %d более раннее отправление</string>
 			<key>other</key>
 			<string>Показать %d более раннего отправления</string>
 		</dict>
@@ -132,14 +152,49 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Нет отправлений в ближайшую %d минуту</string>
 			<key>few</key>
 			<string>Нет отправлений в ближайшие %d минуты</string>
 			<key>many</key>
 			<string>Нет отправлений в ближайшие %d минут</string>
+			<key>one</key>
+			<string>Нет отправлений в ближайшую %d минуту</string>
 			<key>other</key>
 			<string>Нет отправлений в ближайшие %d минуты</string>
+		</dict>
+	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, следующее отправление через %3$#@count@, %4$@. Загружено ещё %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%5$d отправления</string>
+			<key>many</key>
+			<string>%5$d отправлений</string>
+			<key>one</key>
+			<string>%5$d отправление</string>
+			<key>other</key>
+			<string>%5$d отправления</string>
 		</dict>
 	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
@@ -152,14 +207,54 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Показать %d прошедшее отправление</string>
 			<key>few</key>
 			<string>Показать %d прошедших отправления</string>
 			<key>many</key>
 			<string>Показать %d прошедших отправлений</string>
+			<key>one</key>
+			<string>Показать %d прошедшее отправление</string>
 			<key>other</key>
 			<string>Показать %d прошедшего отправления</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, прибытие через %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, отправился %3$#@count@ назад, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -172,12 +267,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Показать %d оповещение</string>
 			<key>few</key>
 			<string>Показать все %d оповещения</string>
 			<key>many</key>
 			<string>Показать все %d оповещений</string>
+			<key>one</key>
+			<string>Показать %d оповещение</string>
 			<key>other</key>
 			<string>Показать все %d оповещения</string>
 		</dict>
@@ -192,12 +287,12 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%d сервисное оповещение</string>
 			<key>few</key>
 			<string>%d сервисных оповещения</string>
 			<key>many</key>
 			<string>%d сервисных оповещений</string>
+			<key>one</key>
+			<string>%d сервисное оповещение</string>
 			<key>other</key>
 			<string>%d сервисного оповещения</string>
 		</dict>
@@ -212,14 +307,34 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>%d остановка</string>
 			<key>few</key>
 			<string>%d остановки</string>
 			<key>many</key>
 			<string>%d остановок</string>
+			<key>one</key>
+			<string>%d остановка</string>
 			<key>other</key>
 			<string>%d остановки</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, прибытие через %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/ru.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/ru.lproj/Localizable.stringsdict
@@ -162,6 +162,41 @@
 			<string>Нет отправлений в ближайшие %d минуты</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, следующее прибытие через %3$#@count@, %4$@. Загружено ещё %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%5$d отправления</string>
+			<key>many</key>
+			<string>%5$d отправлений</string>
+			<key>one</key>
+			<string>%5$d отправление</string>
+			<key>other</key>
+			<string>%5$d отправления</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -221,6 +256,26 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Маршрут %1$@ до %2$@, прибытие через %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%3$d минуты</string>
+			<key>many</key>
+			<string>%3$d минут</string>
+			<key>one</key>
+			<string>%3$d минуту</string>
+			<key>other</key>
+			<string>%3$d минуты</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Маршрут %1$@ до %2$@, отправление через %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "Lấy xe";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "Lên kế hoạch chuyến đi bằng xe đạp này";
+"rental_detail.plan_trip" = "Lên kế hoạch chuyến đi bằng phương tiện này";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "Loại";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "Điện";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "Đạp chân";
+"rental_detail.propulsion_human" = "Sức người";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "Quãng đường";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "Vui lòng cho phép ứng dụng truy cập vị trí của bạn để việc tìm các điểm dừng phương tiện công cộng dễ dàng hơn.";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "Để sau";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "Chào mừng!";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "Dùng vị trí của tôi";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "Bật trong Cài đặt";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "Đặt lời nhắc";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "Tuyến %1$@ đi %2$@, khởi hành sau %3$d phút, %4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "Chuyến khởi hành tiếp theo";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "Tuyến";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "Xem toàn bộ chuyến đi";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "Trực tiếp · phương tiện %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "Chưa có tín hiệu trực tiếp từ xe buýt này — đây là giờ đến theo lịch trình. Xe có thể đến sớm, đến trễ hoặc không đến.";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "Chỉ có giờ theo lịch trình";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "Đã qua · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "dữ liệu lịch trình";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d điểm dừng";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "phương tiện ở đây · còn %d phút";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· điểm dừng của bạn";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "Đi bộ %d phút";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "Tốc độ gió";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "Tùy chọn. Địa chỉ của máy chủ phân tích Umami và mã trang web của khu vực này. Cần điền cả hai trường để bật phân tích; để trống cả hai để tắt.";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "Phân tích";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "Mã trang web";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "Tùy chọn. Địa chỉ của máy chủ sidecar Obaco (OneBusAway.co), nơi cung cấp các tính năng như lời nhắc và khảo sát. Mặc định là \"https://\".";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Máy chủ Sidecar";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "Bạn có muốn cho chúng tôi biết thêm điều gì không? (không bắt buộc)";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "Nội dung báo cáo";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "Tuyến";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "Giờ theo lịch trình";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "Điểm dừng";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "Phương tiện";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "Có vẻ chuyến đi này đã được báo cáo từ thiết bị này.";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "Không thể gửi";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "Báo cáo của bạn là ẩn danh và được gửi đến đơn vị vận tải điều hành dịch vụ này.";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "Chia sẻ vị trí của tôi";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "Gửi báo cáo";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "Báo cáo xe buýt không đến";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "Sau giờ theo lịch trình";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "Bạn đã chờ bao lâu?";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d phút";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30+ phút";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "Bật dịch vụ định vị";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "Xe đạp";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "Điểm dừng";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "Hiện không khả dụng";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "Xe scooter";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "Đường tuyến & phương tiện";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "Chuyến đi đang theo dõi";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "Kết hợp";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "Vệ tinh";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "Tiêu chuẩn";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "Hiển thị bản đồ";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "Quãng đường tối thiểu";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "Bất kỳ";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "Cách di chuyển khác";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "Đặt lại";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "Địa điểm quan tâm";
+/* Title of the Map sheet */
+"map_sheet.title" = "Bản đồ";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "Phương tiện công cộng";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "Liên hệ & trợ giúp";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "Gọi đơn vị vận tải";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "Nhắn tin cho đơn vị vận tải";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "Hướng dẫn";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "Còn %d xe";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "Pin";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "Xe đạp";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "Chỗ trả xe";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "Trả xe";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "Không";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "Không hoạt động";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "Mở trong %@";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "Lấy xe";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "Lên kế hoạch chuyến đi bằng xe đạp này";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "Loại";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "Xăng";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "Điện";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "Đạp chân";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "Quãng đường";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "Dữ liệu này có thể đã cũ.";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "Đã cập nhật %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "Đi bộ %d phút";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "Tên thiết bị thử nghiệm";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "ví dụ: iPhone của Aaron";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "Địa điểm quan tâm";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "Không tìm thấy điểm dừng";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "Đã thay đổi bộ lọc khởi hành";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "Đã ẩn các chuyến đã khởi hành";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "Đang hiện %d chuyến đã khởi hành";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "Đã cập nhật các chuyến khởi hành";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "Đang hiện tất cả tuyến";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "Đang hiện các tuyến đã lọc";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "Chuyến khởi hành";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "Điểm dừng này không còn trong dữ liệu của đơn vị vận tải. Có thể điểm dừng đã được dời đi hoặc gỡ bỏ.";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "chuyến chuyển tuyến của bạn";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "Đánh dấu";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "Chỉ đường từ đây";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "Chỉ đường đến đây";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "Tất cả %d điểm dừng";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "Tuyến %1$@ đi %2$@, đến sau %3$d phút, %4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "Tuyến %1$@ đi %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "Không thể gửi báo cáo này vì dịch vụ báo cáo hiện không khả dụng. Vui lòng thử lại sau.";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "Hoạt động Trực tiếp — theo dõi trên Màn hình khóa";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "Đang theo dõi trên Màn hình khóa";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "vị trí đã cập nhật %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "Xóa lời nhắc";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "Báo cáo xe buýt không đến";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "đã đi qua";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "điểm dừng cuối";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "phương tiện đang ở đây";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "điểm dừng của bạn";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "Điểm dừng";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "Đang tải điểm dừng của chuyến đi này…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "Danh sách điểm dừng của chuyến đi này hiện không khả dụng.";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "Xe %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "Xem lịch trình";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "Đang đến";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "~%d phút đến điểm dừng của bạn";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "Đã đi qua điểm dừng của bạn";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "Điểm dừng %1$d/%2$d";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "Điểm dừng đã đi qua";

--- a/OBAKit/Strings/vi.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/vi.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d phút</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -100,6 +114,29 @@
 			<string>Không có chuyến khởi hành trong %d phút tới</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, chuyến khởi hành tiếp theo sau %3$#@count@, %4$@. Đã tải thêm %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d chuyến khởi hành</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -112,6 +149,34 @@
 			<string>d</string>
 			<key>other</key>
 			<string>Hiện %d chuyến đã khởi hành</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, đến sau %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, đã khởi hành %3$#@count@ trước, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -154,6 +219,20 @@
 			<string>d</string>
 			<key>other</key>
 			<string>%d điểm dừng</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, đến sau %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/vi.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/vi.lproj/Localizable.stringsdict
@@ -114,6 +114,29 @@
 			<string>Không có chuyến khởi hành trong %d phút tới</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, chuyến đến tiếp theo sau %3$#@count@, %4$@. Đã tải thêm %5$#@departures@.</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d chuyến khởi hành</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -155,6 +178,20 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Tuyến %1$@ đi %2$@, đến sau %3$#@count@, %4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d phút</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Tuyến %1$@ đi %2$@, khởi hành sau %3$#@count@, %4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "致电交通局";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "短信联系交通局";
+"more_controller.text_agency" = "发送消息给交通局";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "使用教程";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "取车";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "使用这辆单车规划行程";
+"rental_detail.plan_trip" = "使用这辆车规划行程";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "动力类型";
 /* Rental vehicle propulsion: combustion */
@@ -1784,7 +1784,7 @@
 /* Rental vehicle propulsion: electric */
 "rental_detail.propulsion_electric" = "电动";
 /* Rental vehicle propulsion: human-powered */
-"rental_detail.propulsion_human" = "脚踏";
+"rental_detail.propulsion_human" = "人力";
 /* Label for a rental vehicle's estimated remaining range */
 "rental_detail.range" = "续航里程";
 /* Warning shown when rental data is older than the layer's freshness window */

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "请允许本App使用您的定位信息，以便更好地帮您找到附近的公交车站。";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "暂不";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "您好！";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "使用我的位置";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "前往“设置”页面打开定位分享";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "设置闹钟";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "%1$@号公交线路，开往%2$@，将在%3$d分钟后离站，%4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "后续班次";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "线路";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "查看完整车程";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "实时 · 车辆%@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "尚未收到这辆车的实时信号——以下是它的计划到站时间。实际可能提前、延迟，甚至不来。";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "仅为计划时间";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "已离站 · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "时刻表数据";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d个车站";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "车辆在此 · 还有%d分钟";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· 您的车站";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "步行%d分钟";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "风速";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "可选。Umami 分析服务器的地址以及该地区的网站 ID。两个字段都填写后才会启用分析；留空则停用。";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "数据分析";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "网站 ID";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "可选。Obaco（OneBusAway.co）辅助服务器的地址，它为闹钟、问卷等功能提供支持。默认为\"https://\"。";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "辅助服务器";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "还有其他需要告诉我们的吗？（非必填）";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "报告内容";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "线路";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "计划时间";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "车站";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "车辆";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "本次车程似乎已从本设备报告过。";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "无法提交";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "您的报告将匿名提交给运营此服务的交通局。";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "分享我的定位";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "提交报告";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "报告未到站车辆";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "超过计划时间";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "您等了多久？";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d分钟";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30分钟以上";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "开启定位服务";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "共享单车";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "站点";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "当前不可用";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "共享滑板车";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "线路与车辆";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "追踪的车程";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "混合";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "卫星";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "标准";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "地图显示";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "最低续航里程";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "不限";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "其他出行方式";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "重置";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "兴趣点";
+/* Title of the Map sheet */
+"map_sheet.title" = "地图";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "公共交通";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "联系与帮助";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "致电交通局";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "短信联系交通局";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "使用教程";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d辆可用";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "电量";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "可借单车";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "空余车位";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "还车";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "否";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "暂停服务";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "在%@中打开";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "取车";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "使用这辆单车规划行程";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "动力类型";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "燃油";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "电动";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "脚踏";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "续航里程";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "此数据可能已过时。";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "更新于 %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "步行%d分钟";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "测试设备名称";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "例如：Aaron 的 iPhone";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "兴趣点";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "未找到车站";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "班次筛选条件已更改";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "已离站的班次已隐藏";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "正在显示%d个已离站的班次";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "班次信息已更新";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "正在显示所有线路";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "正在显示已筛选的线路";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "班次";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "此车站已不在交通局的数据中，可能已被移动或删除。";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "您的换乘车程";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "加入书签";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "从这里出发";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "到这里去";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "全部%d个车站";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "%1$@号公交线路，开往%2$@，将在%3$d分钟后到站，%4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "%1$@号公交线路，开往%2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "由于报告服务当前不可用，此报告无法提交。请稍后重试。";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "实时活动 — 在锁定屏幕上追踪";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "正在锁定屏幕上追踪";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "位置更新于 %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "移除闹钟";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "报告未到站车辆";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "已过站";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "终点站";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "车辆已到站";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "您的车站";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "车站";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "正在加载本次车程的车站……";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "本次车程的车站列表当前不可用。";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "车辆 %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "查看时刻表";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "即将到站";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "距您的车站约%d分钟";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "已过您的车站";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "第%1$d站，共%2$d站";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "已过的车站";

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d分钟</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -100,6 +114,29 @@
 			<string>未来%d分钟内没有离站班次</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，下一班将在%3$#@count@后离站，%4$@。另外加载了%5$#@departures@。</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d个班次</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -112,6 +149,34 @@
 			<string>d</string>
 			<key>other</key>
 			<string>显示%d个已离站的班次</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，将在%3$#@count@后到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，已在%3$#@count@前离站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -154,6 +219,20 @@
 			<string>d</string>
 			<key>other</key>
 			<string>%d个车站</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，将在%3$#@count@后到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.stringsdict
@@ -114,6 +114,29 @@
 			<string>未来%d分钟内没有离站班次</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，下一班将在%3$#@count@后到站，%4$@。另外加载了%5$#@departures@。</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d个班次</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -155,6 +178,20 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%1$@号公交线路，开往%2$@，将在%3$#@count@后到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d分钟</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@号公交线路，开往%2$@，将在%3$#@count@后离站，%4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1776,7 +1776,7 @@
 /* Label for whether picking up a vehicle is currently allowed */
 "rental_detail.pickup" = "借車";
 /* Primary action on the rental vehicle sheet */
-"rental_detail.plan_trip" = "使用這輛單車規劃行程";
+"rental_detail.plan_trip" = "使用這輛車規劃行程";
 /* Label for a rental vehicle's propulsion type */
 "rental_detail.propulsion" = "類型";
 /* Rental vehicle propulsion: combustion */

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -382,14 +382,10 @@
 /* Description of why we need location services */
 "location_permission_bulletin.description_text" = "請允許 App 取用您的位置，以便更輕鬆地找到附近的大眾運輸站牌。";
 
-/* Button the user can tap on to decline access to their location. */
-"location_permission_bulletin.do_not_use_location_button_text" = "暫時不要";
 
 /* Title of the alert that appears to request your location. */
 "location_permission_bulletin.title" = "歡迎！";
 
-/* Button the user taps to grant access to their location. */
-"location_permission_bulletin.use_location_button_text" = "使用我的位置";
 
 /* No comment provided by engineer. */
 "locationservices_alert_gotosettings.button" = "前往「設定」開啟";
@@ -1264,8 +1260,6 @@
 /* VoiceOver custom action on a grouped route card's header that creates an alarm for the next departure. */
 "stop_page.grouped.a11y_set_alarm" = "設定提醒";
 
-/* VoiceOver label for one expanded departure row inside a grouped route card: route, headsign, minutes, status. */
-"stop_page.grouped.expanded_row.a11y_fmt" = "路線 %1$@ 往 %2$@，將於 %3$d 分鐘後離站，%4$@";
 
 /* Caption above the upcoming-departure minute chips on a grouped route card at accessibility text sizes. */
 "stop_page.grouped.next_departures" = "接下來的離站班次";
@@ -1288,17 +1282,9 @@
 /* Stop page mode toggle: grouped by route */
 "stop_page.mode.route" = "路線";
 
-/* Opens the full trip screen */
-"stop_page.panel.full_trip" = "檢視完整班次";
 
-/* Trip panel live strip. %@ is the vehicle id. */
-"stop_page.panel.live_vehicle_fmt" = "即時 · 車輛 %@";
 
-/* Body of the schedule-only notice; must communicate uncertainty (§4.1/§4.4) */
-"stop_page.panel.scheduled_body" = "這班車尚未傳回即時訊號——以下是時刻表上的預定到站時間，實際可能提早、誤點，甚至未行駛。";
 
-/* Title of the schedule-only notice */
-"stop_page.panel.scheduled_title" = "僅為時刻表時間";
 
 /* Button revealing recently departed trips. %d is the count. */
 "stop_page.past_toggle_fmt" = "已離站 · %d";
@@ -1367,14 +1353,8 @@
 /* Adherence label for a departure with no real-time signal; deliberately avoids claiming the bus is on time. */
 "stop_page.status.schedule_data" = "時刻表資料";
 
-/* Gap marker in the approach timeline. %d is the number of elided stops between the vehicle and the stops shown. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
-"stop_page.timeline.skipped_stops_fmt" = "%d 站";
 
-/* Vehicle-position marker. %d is minutes to the user's stop. */
-"stop_page.timeline.vehicle_here_fmt" = "車輛在此 · %d 分鐘後到站";
 
-/* Marker on the user's stop in the approach timeline */
-"stop_page.timeline.your_stop" = "· 您的站牌";
 
 /* Walk chip on the header card. %d is the walk time in minutes. */
 "stop_page.walk_chip_minutes_fmt" = "步行 %d 分鐘";
@@ -1690,3 +1670,204 @@
 
 /* VoiceOver label for the wind speed stat on the weather card. */
 "weather.stat.wind" = "風速";
+
+/* An explanation of the optional Umami analytics fields of a custom region. */
+"custom_region_builder_controller.analytics_section.explanation" = "選填。Umami 分析伺服器的位址，以及此地區的網站 ID。兩個欄位都必須填寫才會啟用分析；留空則停用。";
+/* Title of the Analytics header. */
+"custom_region_builder_controller.analytics_section.header_title" = "分析";
+/* Placeholder for the Umami analytics website ID field. */
+"custom_region_builder_controller.analytics_section.website_id_placeholder" = "網站 ID";
+/* An explanation of the optional Obaco sidecar server URL field of a custom region. */
+"custom_region_builder_controller.sidecar_section.explanation" = "選填。Obaco（OneBusAway.co）Sidecar 伺服器的位址，提供提醒與問卷等功能。預設為「https://」。";
+/* Title of the Sidecar Server header. */
+"custom_region_builder_controller.sidecar_section.header_title" = "Sidecar 伺服器";
+/* Placeholder for the optional comment field on the ghost bus form. */
+"ghost_bus_report.comment.placeholder" = "還有其他需要我們知道的嗎？（選填）";
+/* Header over the trip summary on the ghost bus form. */
+"ghost_bus_report.context.header" = "回報內容";
+/* Label for the route being reported on the ghost bus form. */
+"ghost_bus_report.context.route" = "路線";
+/* Label for the scheduled time on the ghost bus form. */
+"ghost_bus_report.context.scheduled" = "表定時間";
+/* Label for the stop being reported on the ghost bus form. */
+"ghost_bus_report.context.stop" = "站牌";
+/* Label for the vehicle ID on the ghost bus form. */
+"ghost_bus_report.context.vehicle" = "車輛";
+/* Error message when the server rejects a duplicate ghost bus report. */
+"ghost_bus_report.error.already_reported" = "這趟班次似乎已從此裝置回報過了。";
+/* Title of the ghost bus submission error alert. */
+"ghost_bus_report.error.title" = "無法送出";
+/* Footer text under the submit button on the ghost bus form. */
+"ghost_bus_report.footer" = "您的回報為匿名，並會送交提供此服務的營運機構。";
+/* Toggle on the ghost bus form for including the rider's location with the report. */
+"ghost_bus_report.share_location" = "分享我的位置";
+/* Submit button on the ghost bus form. */
+"ghost_bus_report.submit" = "送出回報";
+/* Title of the ghost bus report sheet. */
+"ghost_bus_report.title" = "回報幽靈公車";
+/* Header over the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.header" = "超過表定時間";
+/* Label for the wait-duration picker on the ghost bus form. */
+"ghost_bus_report.wait.label" = "您等了多久？";
+/* Wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.minutes_fmt" = "%d 分鐘";
+/* Longest wait-duration choice on the ghost bus form. */
+"ghost_bus_report.wait.thirty_plus" = "30 分鐘以上";
+/* Title of the alert asking the user to enable location services. */
+"locationservices_alert_notdetermined.title" = "開啟定位服務";
+/* Map sheet row for the rental bikes layer */
+"map_layers.bikes" = "共享單車";
+/* Map sheet row for the transit stops layer */
+"map_layers.bus_stops" = "站點";
+/* Reason shown on a dimmed rental layer row when its server is unreachable */
+"map_layers.rental_unavailable" = "目前無法使用";
+/* Map sheet row for the rental scooters layer */
+"map_layers.scooters" = "滑板車";
+/* Map sheet row for the layer drawing a selected stop's routes and live vehicles. */
+"map_layers.stop_routes" = "路線與車輛";
+/* Map sheet row for the layer drawing the trip the rider is following. */
+"map_layers.trip_focus" = "追蹤中的行程";
+/* Basemap style: satellite imagery with labels */
+"map_sheet.basemap_hybrid" = "混合";
+/* Basemap style: satellite imagery */
+"map_sheet.basemap_satellite" = "衛星";
+/* Basemap style: standard street map */
+"map_sheet.basemap_standard" = "標準";
+/* Map sheet section for display options like Points of Interest */
+"map_sheet.display_group" = "地圖顯示";
+/* Map sheet row label for the rental minimum-range filter */
+"map_sheet.minimum_range" = "最低續航里程";
+/* Range filter menu option imposing no minimum range */
+"map_sheet.minimum_range_any" = "不限";
+/* Map sheet group header for non-transit mobility layers */
+"map_sheet.other_modes_group" = "其他交通方式";
+/* Button restoring the default map layer configuration */
+"map_sheet.reset" = "重設";
+/* Map sheet toggle for Apple MapKit Points of Interest (restaurants, shops, etc.) */
+"map_sheet.shows_points_of_interest" = "興趣點";
+/* Title of the Map sheet */
+"map_sheet.title" = "地圖";
+/* Map sheet group header for transit layers */
+"map_sheet.transit_group" = "大眾運輸";
+/* Header for More-tab rows that open tutorial, phone, or text links configured by the agency. */
+"more_controller.agency_contact.header" = "聯絡與協助";
+/* Opens a tel: link to call the transit agency from the More tab. */
+"more_controller.call_agency" = "致電營運機構";
+/* Opens an sms: (or web) link for the agency's text information service. */
+"more_controller.text_agency" = "傳簡訊給營運機構";
+/* Opens the agency's tutorial or user-manual page from the More tab. */
+"more_controller.tutorials" = "使用教學";
+/* Number of rental vehicles available at a station */
+"rental_annotation.vehicles_available_fmt" = "%d 輛可租借";
+/* Label for a rental vehicle's battery charge */
+"rental_detail.battery" = "電量";
+/* Label for the number of bikes available at a station */
+"rental_detail.bikes_available" = "單車";
+/* Label for the number of open docks at a station */
+"rental_detail.docks_available" = "空位";
+/* Label for whether dropping off a vehicle is currently allowed */
+"rental_detail.dropoff" = "還車";
+/* Value shown when pickup or dropoff is not currently allowed */
+"rental_detail.no" = "否";
+/* Shown for a rental vehicle or station that is not operative */
+"rental_detail.not_in_service" = "暫停服務";
+/* Button opening the rental operator's app or website */
+"rental_detail.open_in_fmt" = "在 %@ 中開啟";
+/* Label for whether picking up a vehicle is currently allowed */
+"rental_detail.pickup" = "借車";
+/* Primary action on the rental vehicle sheet */
+"rental_detail.plan_trip" = "使用這輛單車規劃行程";
+/* Label for a rental vehicle's propulsion type */
+"rental_detail.propulsion" = "類型";
+/* Rental vehicle propulsion: combustion */
+"rental_detail.propulsion_combustion" = "汽油";
+/* Rental vehicle propulsion: electric */
+"rental_detail.propulsion_electric" = "電動";
+/* Rental vehicle propulsion: human-powered */
+"rental_detail.propulsion_human" = "人力";
+/* Label for a rental vehicle's estimated remaining range */
+"rental_detail.range" = "續航里程";
+/* Warning shown when rental data is older than the layer's freshness window */
+"rental_detail.stale_warning" = "此資料可能已過時。";
+/* Feed freshness line; the argument is a relative time like '12 seconds ago' */
+"rental_detail.updated_fmt" = "更新於 %@";
+/* Estimated walking time to a rental vehicle */
+"rental_detail.walk_time_fmt" = "步行 %d 分鐘";
+/* Settings > Debug section > Name identifying this device for test push notifications */
+"settings_controller.debug_section.test_device_description" = "測試裝置名稱";
+/* Placeholder example for the test device name field */
+"settings_controller.debug_section.test_device_description.placeholder" = "例如：Aaron 的 iPhone";
+/* Settings > Map section > Show Apple MapKit Points of Interest */
+"settings_controller.map_section.shows_points_of_interest" = "興趣點";
+/* Title of the message shown when the server has no stop at the requested ID. */
+"stop_controller.stop_not_found_title" = "找不到站牌";
+/* VoiceOver announcement posted when the Departure Type filter changes which departures are visible. */
+"stop_page.a11y.filter_changed" = "離站班次篩選條件已變更";
+/* VoiceOver announcement when the Past disclosure is closed. */
+"stop_page.a11y.past_hidden" = "已隱藏已離站的班次";
+/* VoiceOver announcement when the Past disclosure is opened. %d is the count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */
+"stop_page.a11y.past_shown_fmt" = "顯示 %d 班已離站的班次";
+/* VoiceOver announcement posted when a rider-initiated refresh finishes and the departure times have been updated. */
+"stop_page.a11y.refreshed" = "離站班次已更新";
+/* VoiceOver announcement posted when the route filter is turned off. */
+"stop_page.a11y.routes_all" = "顯示所有路線";
+/* VoiceOver announcement posted when the route filter is turned on. */
+"stop_page.a11y.routes_filtered" = "顯示已篩選的路線";
+/* VoiceOver-only heading that anchors the departures list in the Headings rotor, and the title of the rotor itself; not shown on screen. */
+"stop_page.departures_heading" = "離站班次";
+/* Empty state shown when the server has no stop at the requested ID and there is no bookmark to repair — the rider arrived from a deep link, a search result or a map pin. */
+"stop_page.empty.stop_not_found" = "此站牌已不在營運機構的資料中，可能已遷移或移除。";
+/* VoiceOver clause appended to a departure row that matches the rider's inbound transfer trip. */
+"stop_page.row.a11y_transfer_trip" = "您的轉乘班次";
+/* Bottom-toolbar item on the Stop page that opens the Add Bookmark screen. */
+"stop_page.toolbar.bookmark" = "加入書籤";
+/* Stop Location menu action that opens the trip planner with this stop as the origin. */
+"stops_controller.directions_from_here" = "從這裡出發的路線";
+/* Stop Location menu action that opens the trip planner with this stop as the destination. */
+"stops_controller.directions_to_here" = "到這裡的路線";
+/* Header above the trip's full stop list. %d is the number of stops. Plural forms live in Localizable.stringsdict; this value is only the not-found fallback. */
+"trip_page.all_stops_fmt" = "全部 %d 站";
+/* VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status. */
+"trip_page.card.a11y_fmt" = "路線 %1$@ 往 %2$@，將於 %3$d 分鐘後到站，%4$@";
+/* VoiceOver label for the trip page's header card when the trip was reached without a stop, so there is no arrival time. */
+"trip_page.card.a11y_no_arrival_fmt" = "路線 %1$@ 往 %2$@";
+/* Error shown when a ghost bus report can't be submitted because the region's Obaco service is unreachable. */
+"trip_page.ghost_bus_report_unavailable" = "無法送出此回報，因為回報服務目前無法使用。請稍後再試。";
+/* Trip page button that starts a Live Activity for this trip. */
+"trip_page.live_activity_start" = "即時動態 — 在鎖定畫面上追蹤";
+/* Trip page button state once a Live Activity is running for this trip. */
+"trip_page.live_activity_tracking" = "正在鎖定畫面上追蹤";
+/* How stale the vehicle's reported position is. %@ is a relative time like '12s ago'. */
+"trip_page.position_updated_fmt" = "位置更新於 %@";
+/* Trip page button cancelling this trip's arrival alarm. */
+"trip_page.remove_alarm" = "移除提醒";
+/* Trip page menu item for reporting a scheduled vehicle that never arrived. */
+"trip_page.report_ghost_bus" = "回報幽靈公車";
+/* VoiceOver clause on a stop the vehicle has already served. */
+"trip_page.stop_list.a11y_passed" = "已通過";
+/* VoiceOver clause on the final stop of the trip. */
+"trip_page.stop_list.a11y_terminal" = "最後一站";
+/* VoiceOver clause on the stop the vehicle is currently at. */
+"trip_page.stop_list.a11y_vehicle_here" = "車輛在此";
+/* VoiceOver clause on the rider's own stop. */
+"trip_page.stop_list.a11y_your_stop" = "您的站牌";
+/* Header above the trip's stop list before the stops are known. */
+"trip_page.stops_header" = "站牌";
+/* Shown while the trip's stop list is being fetched. */
+"trip_page.stops_loading" = "正在載入此班次的站牌…";
+/* Shown when the trip's stop list could not be loaded. */
+"trip_page.stops_unavailable" = "目前無法取得此班次的站牌列表。";
+/* Identifies a vehicle by its ID on the trip page, e.g. 'Vehicle 6821'. */
+"trip_page.vehicle_label_fmt" = "車輛 %@";
+/* Trip page button opening the route's schedule. */
+"trip_page.view_schedule" = "檢視時刻表";
+/* Shown when the vehicle is arriving at the user's stop */
+"trip_progress.arriving_now" = "即將到站";
+/* Estimated time of arrival to the user's stop. e.g. ~8 min to your stop */
+"trip_progress.eta_to_stop_fmt" = "約 %d 分鐘後抵達您的站牌";
+/* Shown when the vehicle has already passed the user's destination stop */
+"trip_progress.passed_your_stop" = "已駛過您的站牌";
+/* Shows the current stop position. e.g. Stop 5 of 18 */
+"trip_progress.stop_count_fmt" = "第 %1$d 站，共 %2$d 站";
+/* Voiceover text explaining that the vehicle has already passed this stop */
+"trip_stop.passed_stop.accessibility_label" = "已通過的站牌";

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -1754,7 +1754,7 @@
 /* Opens a tel: link to call the transit agency from the More tab. */
 "more_controller.call_agency" = "致電營運機構";
 /* Opens an sms: (or web) link for the agency's text information service. */
-"more_controller.text_agency" = "傳簡訊給營運機構";
+"more_controller.text_agency" = "傳送訊息給營運機構";
 /* Opens the agency's tutorial or user-manual page from the More tab. */
 "more_controller.tutorials" = "使用教學";
 /* Number of rental vehicles available at a station */

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>alarm_builder_controller.minutes_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 分鐘</string>
+		</dict>
+	</dict>
 	<key>data_migration_bulletin.report_summary_number_of_failures</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -100,6 +114,29 @@
 			<string>接下來 %d 分鐘內沒有離站班次</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，下一班將於 %3$#@count@後離站，%4$@。另外已載入 %5$#@departures@。</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d 班離站班次</string>
+		</dict>
+	</dict>
 	<key>stop_page.past_toggle_show_a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -112,6 +149,34 @@
 			<string>d</string>
 			<key>other</key>
 			<string>顯示 %d 班已離站的班次</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，將於 %3$#@count@後到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_past_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，已於 %3$#@count@前離站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
 		</dict>
 	</dict>
 	<key>stop_page.service_alerts.show_all_fmt</key>
@@ -154,6 +219,20 @@
 			<string>d</string>
 			<key>other</key>
 			<string>%d 站</string>
+		</dict>
+	</dict>
+	<key>trip_page.card.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，將於 %3$#@count@後到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
 		</dict>
 	</dict>
 </dict>

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.stringsdict
@@ -114,6 +114,29 @@
 			<string>接下來 %d 分鐘內沒有離站班次</string>
 		</dict>
 	</dict>
+	<key>stop_page.grouped.a11y_arrives_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，下一班將於 %3$#@count@後到站，%4$@。另外已載入 %5$#@departures@。</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
+		</dict>
+		<key>departures</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%5$d 班離站班次</string>
+		</dict>
+	</dict>
 	<key>stop_page.grouped.a11y_fmt</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -155,6 +178,20 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>路線 %1$@ 往 %2$@，將於 %3$#@count@後到站，%4$@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%3$d 分鐘</string>
+		</dict>
+	</dict>
+	<key>stop_page.row.a11y_fmt</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>路線 %1$@ 往 %2$@，將於 %3$#@count@後離站，%4$@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/OBAKit/Trip/TripPage/TripCardView.swift
+++ b/OBAKit/Trip/TripPage/TripCardView.swift
@@ -117,14 +117,16 @@ struct TripCardView: View {
         let identity: String
         if departure.arrivalDepartureMinutes < 0 {
             let fmt = OBALoc("stop_page.row.a11y_past_fmt", value: "Route %@ to %@, departed %d minutes ago, %@", comment: "VoiceOver label for a departure row that has already departed: route, headsign, minutes ago, status.")
-            identity = String(format: fmt, routeShortName, headsign, abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
+            // localizedStringWithFormat: see StopPageAccessibilityCopy — the no-locale
+            // overload makes Slavic `few`/`many` unreachable.
+            identity = String.localizedStringWithFormat(fmt, routeShortName, headsign, abs(departure.arrivalDepartureMinutes), status.accessibilityStatusDescription)
         } else {
             let fmt = OBALoc(
                 "trip_page.card.a11y_fmt",
                 value: "Route %@ to %@, arrives in %d minutes, %@",
                 comment: "VoiceOver label for the trip page's header card: route, headsign, minutes until arrival, status."
             )
-            identity = String(format: fmt, routeShortName, headsign, departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
+            identity = String.localizedStringWithFormat(fmt, routeShortName, headsign, departure.arrivalDepartureMinutes, status.accessibilityStatusDescription)
         }
 
         return DepartureAccessibility.label(

--- a/OBAKit/TripPlanning/MapItemView.swift
+++ b/OBAKit/TripPlanning/MapItemView.swift
@@ -60,7 +60,7 @@ public struct MapItemView: View {
                                 },
                                 label: {
                                     HStack {
-                                        Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button to view nearby stops"))
+                                        Text(OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button that shows the stops near this map item."))
                                             .bold()
                                         Spacer()
                                         Image(systemName: "chevron.right")
@@ -212,7 +212,7 @@ public struct MapItemView: View {
             // Nearby Stops - show next to Plan Trip when call/website buttons are absent
             if viewModel.phoneNumber == nil && viewModel.url == nil {
                 actionButton(
-                    title: OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Nearby stops button"),
+                    title: OBALoc("map_item_controller.nearby_stops", value: "Nearby Stops", comment: "Button that shows the stops near this map item."),
                     icon: "mappin.and.ellipse",
                     backgroundColor: Color(uiColor: .secondarySystemBackground),
                     foregroundColor: Color(uiColor: ThemeColors.shared.brand),

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -4,12 +4,13 @@
 /* An error that tells the user that cellular data access is disabled for this app in iOS Settings. Both substituted values are the app name. */
 "api_error.cellular_data_restricted_fmt" = "%1$@ is not currently allowed to access cellular data. To fix this, go to Settings > Cellular and enable cellular data for %2$@, or connect to a WiFi network.";
 
-/* An error shown when the server returns data the app can't understand, indicating a likely server-side issue. */
+/* An error shown when the server returns a body the app cannot decode and no region name is available to specialize the copy. */
 "api_error.decoding_failure" = "The server returned data this app can't read. That's usually a problem with the stop or agency feed. Please try again shortly.";
 
 /* An error message that informs the user that the wrong kind of content was received from the server. */
 "api_error.invalid_content_type_fmt" = "Expected to receive %1$@ data from the server, but we received %2$@ instead.";
 
+/* An error shown when the regional server returned a body the app cannot decode. Distinct from a down server. The first substituted value is the region name, the second is the app name. */
 "api_error.invalid_response_data_fmt" = "The server for %1$@ returned data this app can't read. That's usually a problem with the stop or agency feed, not with %2$@. Try again shortly.";
 
 /* An error that tells the user that the network connection isn't working. */
@@ -30,7 +31,7 @@
 /* An error shown when the server returns a 500 Internal Server Error. The substituted value is the region name, e.g. 'Puget Sound'. */
 "api_error.server_error_fmt" = "The server for %@ encountered an error while handling your request. Please try again.";
 
-/* An error shown when the regional transit server is unavailable. The first substituted value is the region name, the second is the app name. */
+/* An error shown when the regional transit server cannot be reached. Mentions VPN because riders often hit this with a working phone on a filtered network. The first substituted value is the region name, the second is the app name. */
 "api_error.server_unavailable_fmt" = "Unable to reach the server for %1$@. %2$@ can't show transit information for this region right now. The server may be down, or a VPN or firewall may be blocking it.";
 
 /* An error message that tells the user that surveys are not available. */
@@ -218,13 +219,21 @@
 
 /* Use for vehicles arriving in X minutes. */
 "formatters.arrives_in_x_min_fmt" = "Arrives in %d min";
-"formatters.caption.arrives" = "Arrives";
-"formatters.caption.departs" = "Departs";
-"formatters.caption.arrived" = "Arrived";
-"formatters.caption.departed" = "Departed";
 
 /* Use for vehicles arriving now. */
 "formatters.arriving_now" = "Arriving now";
+
+/* Short caption under a past stop-page countdown for a vehicle that already arrived. */
+"formatters.caption.arrived" = "Arrived";
+
+/* Short caption under a stop-page countdown for a vehicle arriving at this stop. */
+"formatters.caption.arrives" = "Arrives";
+
+/* Short caption under a past stop-page countdown for a vehicle that already left. */
+"formatters.caption.departed" = "Departed";
+
+/* Short caption under a stop-page countdown for a vehicle departing this stop (first stop or layover). */
+"formatters.caption.departs" = "Departs";
 
 /* Headed in an eastern direction */
 "formatters.cardinal_adjective.east" = "Eastbound";
@@ -388,6 +397,9 @@
 /* Short text shown when a departure occurs at the same time as the rider's transfer arrival. */
 "formatters.transfer.on_arrival" = "NOW";
 
+/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
+"live_activity.stale_warning" = "This data may be out of date.";
+
 /* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
 "map_layers_tip.message" = "Tap here to show bikes and scooters on the map.";
 
@@ -429,9 +441,6 @@
 
 /* Title for the schedule/timetable feature tip */
 "schedule_tip.title" = "View Your Route's Schedule";
-
-/* Shown on a Live Activity when ActivityKit marks it stale (no recent update). */
-"live_activity.stale_warning" = "This data may be out of date.";
 
 /* Shown in place of the minutes countdown when the vehicle is departing now */
 "stop_page.countdown.now" = "NOW";

--- a/OBAKitCore/Strings/es.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/es.lproj/Localizable.strings
@@ -389,10 +389,10 @@
 "formatters.transfer.on_arrival" = "AHORA";
 
 /* The body of the tip pointing at the map toolbar's basemap button, which opens the Map sheet where the rental layers are turned on and off */
-"map_layers_tip.message" = "Toque aquí para mostrar bicicletas y patinetes en el mapa.";
+"map_layers_tip.message" = "Toque aquí para mostrar bicicletas y scooters en el mapa.";
 
 /* Title for the tip pointing at the map toolbar's basemap button when a region gains bike and scooter rental map layers */
-"map_layers_tip.title" = "Nuevo: Bicicletas y Patinetes";
+"map_layers_tip.title" = "Nuevo: Bicicletas y Scooters";
 
 /* Error when a route has no real-time vehicle tracking data. */
 "nearby_trip_matcher.error.no_realtime" = "No hay datos de seguimiento en tiempo real disponibles para esta ruta.";

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -149,6 +149,24 @@ final class LocalizationTests {
         }
     }
 
+    /// One sheet serves both rental layers: `RentalDetailViewController` branches on
+    /// `vehicle.vehicleType?.formFactor?.isScooter` and `RentalMapLayer` declares both a
+    /// bikes and a scooters layer. So the sheet's own copy must not name a vehicle type —
+    /// a scooter rider reading "Plan a trip using this bike" is being told about a vehicle
+    /// they are not looking at. Likewise GBFS `propulsion_type: HUMAN` means human-powered,
+    /// which for a kick scooter is not pedalling.
+    @Test func `Rental sheet copy does not assume a bike`() throws {
+        let english = try #require(strings(in: Bundle(for: DonationCell.self), localization: "en"))
+
+        let planTrip = try #require(english["rental_detail.plan_trip"])
+        #expect(!planTrip.localizedCaseInsensitiveContains("bike"),
+                "rental_detail.plan_trip names a bike but the sheet also shows scooters: \(planTrip)")
+
+        let human = try #require(english["rental_detail.propulsion_human"])
+        #expect(!human.localizedCaseInsensitiveContains("pedal"),
+                "rental_detail.propulsion_human says pedal, but GBFS HUMAN covers kick scooters too: \(human)")
+    }
+
     /// The footer names the switch. A locale that leaves the English phrase in
     /// the footer while translating the title makes the two unrecognizable as
     /// the same control.

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -228,6 +228,37 @@ final class LocalizationTests {
         }
     }
 
+    /// OBAKitCore's `map_layers_tip` is the onboarding tip that introduces the rental layers,
+    /// and OBAKit's `map_layers.scooters` is the row it points at. If the two modules pick
+    /// different words, the tip names something the sheet does not offer.
+    ///
+    /// Compared by shared substring rather than equality: several locales qualify the row
+    /// ("Mga scooter", "共享滑板车") while the tip carries the bare noun, and that is fine —
+    /// what matters is that the same word for the vehicle appears in both.
+    @Test func `Both modules use the same word for a scooter`() throws {
+        let kit = Bundle(for: DonationCell.self)
+        let core = Bundle(for: Strings.self)
+
+        func sharesRun(_ a: String, _ b: String, minimum: Int) -> Bool {
+            let x = Array(a.lowercased()), y = b.lowercased()
+            guard x.count >= minimum else { return false }
+            for start in 0...(x.count - minimum) {
+                for length in stride(from: x.count - start, through: minimum, by: -1) {
+                    if y.contains(String(x[start..<(start + length)])) { return true }
+                }
+            }
+            return false
+        }
+
+        for localization in kit.localizations where localization != "Base" {
+            guard let row = strings(in: kit, localization: localization)?["map_layers.scooters"],
+                  let tip = strings(in: core, localization: localization)?["map_layers_tip.title"]
+            else { continue }
+            #expect(sharesRun(row, tip, minimum: 3),
+                    "\(localization): OBAKit says \"\(row)\" but OBAKitCore's tip says \"\(tip)\"")
+        }
+    }
+
     /// The footer names the switch. A locale that leaves the English phrase in
     /// the footer while translating the title makes the two unrecognizable as
     /// the same control.

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -189,6 +189,23 @@ final class LocalizationTests {
         }
     }
 
+    /// Portuguese "trânsito" is road traffic, not public transport — a false friend for
+    /// English "transit". The distinction is load-bearing in this catalog, which legitimately
+    /// uses "Mostrar trânsito" for `settings_controller.map_section.shows_traffic`. So the
+    /// rule keys off the English: where the source says "transit", pt-BR must not answer
+    /// "trânsito".
+    @Test func `Brazilian Portuguese does not render transit as trânsito`() throws {
+        let bundle = Bundle(for: DonationCell.self)
+        let english = try #require(strings(in: bundle, localization: "en"))
+        let ptBR = try #require(strings(in: bundle, localization: "pt-BR"))
+
+        for (key, source) in english where source.localizedCaseInsensitiveContains("transit") {
+            guard let translated = ptBR[key] else { continue }
+            #expect(!translated.localizedCaseInsensitiveContains("trânsito"),
+                    "pt-BR/\(key): \"transit\" became \"trânsito\" (road traffic): \(translated)")
+        }
+    }
+
     /// The footer names the switch. A locale that leaves the English phrase in
     /// the footer while translating the title makes the two unrecognizable as
     /// the same control.

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -40,7 +40,17 @@ final class LocalizationTests {
         "data_migration_bulletin.report_summary_number_of_successes",
         "map_controller.map_type.accessibility_value_with_layers_fmt",
         "search_results_sheet.result_count_fmt",
-        "rental_cluster.title_fmt"
+        "rental_cluster.title_fmt",
+        // VoiceOver strings that interpolate a minute count. Slavic locales need
+        // one/few/many agreement, so a single plain form is wrong at some counts —
+        // Polish "minut" is right for 5+ and wrong for 1 and 2-4.
+        "stop_page.row.a11y_arrives_fmt",
+        "stop_page.row.a11y_past_fmt",
+        "trip_page.card.a11y_fmt",
+        "alarm_builder_controller.minutes_fmt",
+        // Two counts: the minute countdown (bound to "count", which the well-formedness
+        // check below inspects) and the number of extra departures loaded.
+        "stop_page.grouped.a11y_fmt"
     ]
 
     /// `%@`, `%d`, `%1$@`, `%2$d`, … and the escaped `%%`.
@@ -333,6 +343,46 @@ final class LocalizationTests {
     /// Regression: `MapTypeButton.accessibilityValueText` shipped calling `String(format:)`,
     /// which rendered a Polish count of 5 as `other` ("5 warstwy włączonej") rather than
     /// `many` ("5 warstw włączonych").
+    /// Structure checks only prove the categories exist. This proves the countdown actually
+    /// resolves them: Polish needs "minutę" at 1, "minuty" at 2-4 and "minut" at 5+, and the
+    /// plain string these keys used to carry was stuck on the 5+ form at every count.
+    ///
+    /// Note this must use `String.localizedStringWithFormat`, not `String(format:)` — the
+    /// latter resolves against the root plural rule, so `few`/`many` would be unreachable and
+    /// the test would pass against a broken catalog.
+    @Test func `Polish arrival countdown reaches its few and many forms`() throws {
+        let format = try #require(localizedFormat(forKey: "stop_page.row.a11y_arrives_fmt", localization: "pl"))
+        // The locale MUST be passed explicitly. `String.localizedStringWithFormat` selects the
+        // category using `Locale.current`, which on this test host is English — so 5 would pick
+        // `other`, quietly rendering "5 minuty" and passing a `contains("5 minut")` check
+        // without ever reaching Polish's `many`.
+        let polish = Locale(identifier: "pl")
+        func rendered(_ minutes: Int) -> String {
+            String(format: format, locale: polish, "10", "Centrum", minutes, "o czasie")
+        }
+
+        #expect(rendered(1).contains("1 minutę"), "pl one: \(rendered(1))")
+        #expect(rendered(3).contains("3 minuty"), "pl few: \(rendered(3))")
+        #expect(rendered(5).contains("5 minut"), "pl many: \(rendered(5))")
+        #expect(rendered(22).contains("22 minuty"), "pl few at 22: \(rendered(22))")
+    }
+
+    /// The simplest of the countdown keys, and the one a rider hears most: a bare minute count.
+    @Test func `Alarm minute count agrees in Polish and Russian`() throws {
+        let plFormat = try #require(localizedFormat(forKey: "alarm_builder_controller.minutes_fmt", localization: "pl"))
+        let pl = Locale(identifier: "pl")
+        #expect(String(format: plFormat, locale: pl, 1) == "1 minuta", "pl one: \(String(format: plFormat, locale: pl, 1))")
+        #expect(String(format: plFormat, locale: pl, 3) == "3 minuty", "pl few: \(String(format: plFormat, locale: pl, 3))")
+        #expect(String(format: plFormat, locale: pl, 5) == "5 minut", "pl many: \(String(format: plFormat, locale: pl, 5))")
+
+        let ruFormat = try #require(localizedFormat(forKey: "alarm_builder_controller.minutes_fmt", localization: "ru"))
+        let ru = Locale(identifier: "ru")
+        let one = String(format: ruFormat, locale: ru, 1)
+        let few = String(format: ruFormat, locale: ru, 3)
+        let many = String(format: ruFormat, locale: ru, 5)
+        #expect(one != few && few != many, "ru forms must differ across 1/3/5: \(one) / \(few) / \(many)")
+    }
+
     @Test func `Polish layer count reaches its few and many forms`() throws {
         let format = try #require(localizedFormat(
             forKey: "map_controller.map_type.accessibility_value_with_layers_fmt",

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -167,6 +167,28 @@ final class LocalizationTests {
                 "rental_detail.propulsion_human says pedal, but GBFS HUMAN covers kick scooters too: \(human)")
     }
 
+    /// `MoreViewController` opens `MoreTabConfiguration.textURL` with no scheme check, and
+    /// the key's own comment says that URL may be `sms:` **or** web. A label promising SMS
+    /// therefore mislabels every region that configures a web contact form. English "Text
+    /// Agency" uses "text" as a verb, which is SMS in en-US, so the narrowing starts at the
+    /// source rather than in translation.
+    @Test func `Agency contact action does not promise SMS`() throws {
+        let bundle = Bundle(for: DonationCell.self)
+        // Words that name SMS specifically, per locale. Deliberately not a blanket "sms"
+        // substring check: several locales use a generic "message"/"write to" verb that is
+        // correct for both destinations.
+        let smsWords = ["sms", "短信", "簡訊", "문자", "i-text"]
+
+        for localization in bundle.localizations where localization != "Base" {
+            guard let value = strings(in: bundle, localization: localization)?["more_controller.text_agency"]
+            else { continue }
+            let lowered = value.lowercased()
+            let offender = smsWords.first { lowered.contains($0) }
+            #expect(offender == nil,
+                    "\(localization): more_controller.text_agency promises SMS (\"\(value)\") but textURL may be a web link")
+        }
+    }
+
     /// The footer names the switch. A locale that leaves the English phrase in
     /// the footer while translating the title makes the two unrecognizable as
     /// the same control.

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -206,6 +206,28 @@ final class LocalizationTests {
         }
     }
 
+    /// Four keys name the same rider-facing concept — changing from one vehicle to another —
+    /// and Arabic had drifted into two words for it: التبديل on the two accessibility labels,
+    /// التحويلة in Settings. التحويلة is a detour or a railway switch, i.e. the *vehicle* being
+    /// rerouted, not the rider changing services. One term, all four keys.
+    @Test func `Arabic uses one word for a transfer`() throws {
+        let arabic = try #require(strings(in: Bundle(for: DonationCell.self), localization: "ar"))
+        let transferKeys = [
+            "settings_controller.arrival_display_section.transfer_banner",
+            "settings_controller.arrival_display_section.transfer_banner.footer",
+            "walk_time_view.transfer_accessibility_label",
+            "stop_page.row.a11y_transfer_trip"
+        ]
+
+        for key in transferKeys {
+            let value = try #require(arabic[key], "ar/\(key) is missing")
+            #expect(!value.contains("التحويلة"),
+                    "ar/\(key) says التحويلة (a detour/junction) where the app means a rider transfer: \(value)")
+            #expect(value.contains("التبديل"),
+                    "ar/\(key) does not use the app's transfer term التبديل: \(value)")
+        }
+    }
+
     /// The footer names the switch. A locale that leaves the English phrase in
     /// the footer while translating the title makes the two unrecognizable as
     /// the same control.

--- a/OBAKitTests/Strings/LocalizationTests.swift
+++ b/OBAKitTests/Strings/LocalizationTests.swift
@@ -50,7 +50,11 @@ final class LocalizationTests {
         "alarm_builder_controller.minutes_fmt",
         // Two counts: the minute countdown (bound to "count", which the well-formedness
         // check below inspects) and the number of extra departures loaded.
-        "stop_page.grouped.a11y_fmt"
+        "stop_page.grouped.a11y_fmt",
+        // The arriving/departing counterparts. Leaving these out would have made
+        // VoiceOver correct for arriving vehicles and wrong for departing ones.
+        "stop_page.row.a11y_fmt",
+        "stop_page.grouped.a11y_arrives_fmt"
     ]
 
     /// `%@`, `%d`, `%1$@`, `%2$d`, … and the escaped `%%`.
@@ -267,6 +271,36 @@ final class LocalizationTests {
             #expect(sharesRun(row, tip, minimum: 3),
                     "\(localization): OBAKit says \"\(row)\" but OBAKitCore's tip says \"\(tip)\"")
         }
+    }
+
+    /// Proves the production formatter goes through `Localizable.stringsdict` at all.
+    ///
+    /// `OBALoc` loads the format from the *test host's* localization, which is English, so this
+    /// cannot assert Polish words — passing a locale to `String(format:locale:)` selects the
+    /// plural category, it does not switch language. What it can prove is that the singular is
+    /// reached: before these keys had stringsdict entries the call site rendered the one plain
+    /// form at every count and said "arrives in 1 minutes". Polish `few`/`many` reachability is
+    /// a property of the catalog, pinned separately in the tests above.
+    @Test @MainActor func `Stop page VoiceOver copy resolves its plural forms`() {
+        func spoken(_ minutes: Int, _ status: ArrivalDepartureStatus) -> String {
+            StopPageAccessibilityCopy.upcomingIdentity(
+                routeShortName: "10", headsign: "Downtown", minutes: minutes,
+                arrivalDepartureStatus: status, adherence: "on time"
+            )
+        }
+
+        for status in [ArrivalDepartureStatus.arriving, .departing] {
+            #expect(spoken(1, status).contains("1 minute,"), "\(status) singular: \(spoken(1, status))")
+            #expect(!spoken(1, status).contains("1 minutes"), "\(status) said \"1 minutes\": \(spoken(1, status))")
+            #expect(spoken(5, status).contains("5 minutes"), "\(status) plural: \(spoken(5, status))")
+        }
+
+        let groupedOne = StopPageAccessibilityCopy.groupedCardIdentity(
+            routeShortName: "10", headsign: "Downtown", minutes: 1,
+            arrivalDepartureStatus: .departing, adherence: "on time", moreCount: 1
+        )
+        #expect(groupedOne.contains("1 minute,"), "grouped singular: \(groupedOne)")
+        #expect(groupedOne.contains("1 more departure loaded"), "grouped departures singular: \(groupedOne)")
     }
 
     /// The footer names the switch. A locale that leaves the English phrase in


### PR DESCRIPTION
Fills a gap that had been widening quietly: 100 keys were reachable from `OBALoc` call sites but missing from `en.lproj`, and therefore from all twelve translated catalogs. Those strings rendered their inline English fallback in every language — the Ghost Bus report sheet, the map layers sheet, the rental detail sheet, the custom region builder's sidecar and analytics sections, and a batch of VoiceOver labels.

All twelve locales now sit at 655 keys, matching `en` exactly.

## Commits

**1. Say "Transit stops" on the map layer that shows transit stops** — `StopsMapLayer` is the general stops layer and the app models subway, rail and ferry route types, but the label said "Bus stops". The key's own comment has always read "Map sheet row for the transit stops layer", so the string was narrower than both the behavior and the documented intent. Also regenerates the English catalogs with `scripts/extract_strings`, which drops ten keys it can no longer find — all ten verified unreferenced in Swift, xib, storyboard and plist first.

**2. Translate the 100 unlocalized strings into all twelve locales** — every string translated twice independently and adjudicated against the shipped catalog, so new wording reuses what the app already says rather than forking it.

## Choices that aren't obvious from the diff

**Spanish uses `usted`.** The catalog is genuinely mixed, but unambiguous imperatives run nine `usted` to three `tú`. Normalizing the other 555 keys is its own job.

**Russian and Polish avoid agreement after a numeral** rather than guessing a plural form. These are plain strings with no `.stringsdict`, and Slavic one/few/many agreement makes `%d остановок` wrong at 1 and 2. The catalog's own evasions — `Все остановки (%d)`, `Доступно: %d`, the invariable `%d мин.` — are grammatical at every count.

**Traditional Chinese keeps 單車, not the Taiwan-standard 自行車**, because OBAKitCore's `map_layers_tip` strings introduce this very feature as 共享單車. A layer row reading 自行車 would contradict the tip beside it. Worth switching, but as one coordinated pass.

**Quote marks follow each locale, not the source.** French and Traditional Chinese convert `\"https://\"` to `« »` and `「」`, matching each catalog's sibling base-URL string; Spanish, Russian, Simplified Chinese and Vietnamese keep the escaped straight quotes theirs already use.

## Verification

- 655-key parity with `en` across all twelve locales
- `plutil -lint` clean on all thirteen catalogs
- UTF-8 throughout
- Per-key format specifiers matched against English — no mismatches
- Paired keys byte-identical within each locale
- **2563 tests in 274 suites passing**, `LocalizationTests` included

## Follow-ups found along the way, not fixed here

Each verified against the code; none are regressions from this branch.

- **Five Polish strings interpolate `%d` with no `.stringsdict`**, so they read wrong at counts 2–4 — the commonest case for "minutes": `stop_page.row.a11y_arrives_fmt`, `stop_page.grouped.a11y_fmt`, `stop_page.row.a11y_past_fmt`, `alarm_builder_controller.minutes_fmt`, and `trip_page.card.a11y_fmt`. The new key is deliberately kept byte-identical to its broken sibling rather than diverging one member of the family. Russian has the same exposure. Wants one sweep.
- **pt-BR renders "transit agency" as "agência de trânsito"** in `custom_region_builder_controller.name_section.explanation` — *trânsito* is road traffic. New strings here use "agência de transporte"; the existing key is untouched.
- **Italian ships `"ibrido"` where the basemap label wants `"Ibrida"`** to agree with *mappa*.
- **Arabic is split on "transfer"**: `التبديل` in `walk_time_view` vs `التحويلة` in `settings_controller.arrival_display_section`.
- **OBAKitCore ships Peninsular `Patinetes` for scooters** while this branch chose the neutral `Scooters` for OBAKit. The two modules should agree.
- **`genstrings` reports five keys used with conflicting developer comments** and silently keeps one, so translators can receive context for the wrong call site: `more_controller.title`, `map_controller.map_type.accessibility_label`, `map_item_controller.nearby_stops`, `stop_page.grouped.a11y_collapsed`, `stop_page.grouped.a11y_expanded`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized text for ghost-bus reporting, map layers, rental vehicles, agency contacts, custom-region settings, trip controls, and accessibility announcements.
  - Added localized plural forms for alarm durations, stop departures, arrival times, and trip cards.

- **Localization**
  - Updated translations across supported languages with clearer vehicle-neutral rental and message-based agency contact wording.
  - Renamed the map layer label from “Bus stops” to “Transit stops.”

- **Bug Fixes**
  - Improved locale-aware pluralization for accessibility labels and alarm minute counts.

- **Cleanup**
  - Removed obsolete permission, trip-panel, timeline, and accessibility strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->