### PR TITLE
fix: Live Activity countdown ticks on its own (#1187)

### DIFF
--- a/OBAKitCore/UI/TripLiveActivityCardView.swift
+++ b/OBAKitCore/UI/TripLiveActivityCardView.swift
@@ -113,11 +113,42 @@ public struct TripLiveActivityCardView: View {
 
     @ViewBuilder
     private func countdownBadge(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
-        CountdownView(
-            minutes: Int(arrival.departureDate.timeIntervalSince(now) / 60.0),
-            isRealTime: arrival.scheduleStatus != .unknown,
-            color: Color(uiColor: presenter.color(for: arrival))
-        )
+        let color = Color(uiColor: presenter.color(for: arrival))
+        let isRealTime = arrival.scheduleStatus != .unknown
+        VStack(spacing: 1) {
+            HStack(alignment: .top, spacing: 2) {
+                // Use SwiftUI's date-relative Text so the countdown ticks
+                // automatically on the lock screen without requiring a push
+                // to re-render the snapshot. (#1187)
+                //
+                // The `if` is evaluated once when the snapshot is rendered —
+                // Live Activity `body` is NOT re-invoked between pushes, so
+                // there is no risk of the surrounding condition flipping while
+                // Text(.relative) is ticking. `upcomingArrivals` dropping an
+                // arrival only happens on the next push, at which point a fresh
+                // snapshot replaces this one entirely. The `else` branch handles
+                // snapshots rendered at or after the departure time (e.g. a
+                // late-arriving push), showing "NOW" rather than a negative
+                // "X seconds ago" string.
+                if arrival.departureDate > now {
+                    Text(arrival.departureDate, style: .relative)
+                        .font(.system(.title2, design: .rounded, weight: .heavy))
+                        .monospacedDigit()
+                        .foregroundStyle(color)
+                        // Suppress the default "in X minutes" VoiceOver phrasing;
+                        // the parent row speaks its own combined a11y label.
+                        .accessibilityHidden(true)
+                } else {
+                    Text(OBALoc("stop_page.countdown.now", value: "NOW",
+                                comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
+                        .font(.system(.title2, design: .rounded, weight: .heavy))
+                        .foregroundStyle(color)
+                        .accessibilityHidden(true)
+                }
+                RealtimeGlyph(isRealTime: isRealTime, color: color, size: 11)
+                    .padding(.top, 1)
+            }
+        }
     }
 
     @ViewBuilder
@@ -141,16 +172,25 @@ public struct TripLiveActivityCardView: View {
     @ViewBuilder
     private func departurePill(for arrival: TripAttributes.ContentState.ArrivalInfo, now: Date) -> some View {
         let color = Color(uiColor: presenter.color(for: arrival))
-        let minutes = max(0, Int(arrival.departureDate.timeIntervalSince(now) / 60.0))
-        Text(minutes == 0
-             ? OBALoc("stop_page.countdown.now", value: "NOW", comment: "Shown in place of the minutes countdown when the vehicle is departing now")
-             : "\(minutes)m")
-            .font(.caption.weight(.heavy))
-            .monospacedDigit()
-            .foregroundStyle(color)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(color.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+        // Use date-relative Text so the chip ticks automatically on the lock
+        // screen without a keepalive push. (#1187)
+        // `body` is not re-invoked between pushes in a Live Activity — the
+        // `if` is evaluated once at snapshot render time. See countdownBadge
+        // for a full explanation of the rendering model.
+        Group {
+            if arrival.departureDate > now {
+                Text(arrival.departureDate, style: .relative)
+                    .monospacedDigit()
+            } else {
+                Text(OBALoc("stop_page.countdown.now", value: "NOW",
+                            comment: "Shown in place of the minutes countdown when the vehicle is departing now"))
+            }
+        }
+        .font(.caption.weight(.heavy))
+        .foregroundStyle(color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(color.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
     }
 
     private var resolvedRouteColor: Color {


### PR DESCRIPTION
Closes #1187

---

### Summary

The Live Activity lock-screen card was displaying a static countdown string (`"\(minutes)m"`) baked in at push time. Because there is no process running behind a Live Activity, nothing re-rendered the archived snapshot on its own — the displayed time only advanced when obacloud sent the next push. This forced obacloud to send a keepalive push every 55 seconds purely to advance the clock, even when no arrival data had changed.

This PR replaces the static minute strings with SwiftUI's built-in date-relative `Text(date, style: .relative)`, which the system renders and updates automatically on the lock screen without requiring any background process or a push to trigger a re-render.

---

### What changed

**File:** `OBAKitCore/UI/TripLiveActivityCardView.swift`

#### `countdownBadge(for:now:)`
- Replaced `CountdownView(minutes: Int(...))` with an inline `Text(arrival.departureDate, style: .relative)` +`RealtimeGlyph`, matching the visual layout of the original badge.
- Falls back to a static `"NOW"` string when `departureDate` is in the past (negative interval), since `.relative` would render "0 seconds ago" which is not the right UX.

#### `departurePill(for:now:)`
- Replaced the manual `Int(arrival.departureDate.timeIntervalSince(now) / 60.0)` calculation and `"\(minutes)m"` string with `Text(arrival.departureDate, style: .relative)`.
- Same `"NOW"` fallback for past dates.

---

### Why this approach

SwiftUI's `Text(_:style:)` with `.relative` is specifically designed for self-updating countdowns in Live Activities and Widgets. It is rendered by the system as a live timer with no app process involvement — exactly what this surface needs.

Both changed sites are internal `@ViewBuilder` methods, so no public API changed and no call sites outside the file are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live Activity countdowns now update automatically on the lock screen without requiring a refresh.
  - Departure times display a localized “NOW” label once the departure time has passed.
  - Countdown badges and departure chips use localized, date-aware formatting that stays synchronized with the current time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->