### PR TITLE
Actually shorten the share escape's bar title in Arabic

### DIFF
--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "destination_stop_picker.share_without_destination_a11y_label" = "مشاركة الرحلة دون تحديد محطة وصول";
 
 /* Short navigation bar button that shares the trip without a destination stop, used where the full phrase will not fit. */
-"destination_stop_picker.share_without_destination_bar_button" = "مشاركة على أي حال";
+"destination_stop_picker.share_without_destination_bar_button" = "على أي حال";
 
 /* Button shown when a trip has no remaining stops, letting the user share the trip without picking a destination. */
 "destination_stop_picker.share_without_destination_button" = "مشاركة دون وجهة";


### PR DESCRIPTION
# Actually shorten the share escape's bar title in Arabic

## Description

Follow-up from #1362, which Aaron raised on merge:

> in `ar` the "short" title is actually slightly wider than the full phrase it
> replaces, so that locale gains a translation marginally worse than the one it
> had. It just makes the "used where the full phrase will not fit" comment untrue
> for that one locale.

`"مشاركة على أي حال"` is **17 characters** against the full phrase's **15**. So Arabic was the one locale where the short title was longer than the thing it exists to replace, and the key's own comment was false for it.

Now `"على أي حال"` — 10 characters. Same fix pt-BR and es got in #1362: drop the verb, keep the "anyway" sense. The bar sits beside Cancel and the accessibility label still carries the full phrase.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Arabic share button label for trips without a destination to use clearer, more concise wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->