### PR TITLE
Scope the simulator-UDID note to the commands that actually need one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ scripts/generate_project                # Defaults to OneBusAway if no app speci
 
 ### Picking a Simulator
 
-Every command below needs a simulator UDID. Resolve one with:
+The `xcodebuild` and `xcodebuildmcp` blocks below need a simulator UDID —
+`scripts/swiftlint.sh`, `scripts/docs` (which builds for `generic/platform=iOS`),
+`scripts/version` and the `--help` blocks need nothing. Resolve one with:
 
 ```bash
 SIMULATOR_UDID=$(scripts/resolve_simulator_udid)


### PR DESCRIPTION
## Description

Follow-up from #1307, which Aaron raised on merge:

> line 22's "Every command below needs a simulator UDID" still isn't true —
> `scripts/swiftlint.sh`, `scripts/docs`, `scripts/version` and the `--help`
> blocks need nothing. "Every command that touches a simulator" would fix it.
> Worth a one-line follow-up.

Checked each: `scripts/swiftlint.sh` and `scripts/version` have no simulator reference at all, and `scripts/docs` builds for `-destination 'generic/platform=iOS'` — a generic destination, not a device.

Phrased as a list rather than a rule with exceptions. The failure this line invites is an agent resolving a UDID before running `swiftlint`; "every command that touches a simulator" still leaves it to guess which those are, so the line now names both sides.

Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which development commands require a simulator UDID.
  - Documented that build-related commands require a UDID, while linting, documentation, versioning, and help commands do not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->