### PR TITLE
Say Map settings for the button that opens the Map sheet

### DIFF
--- a/OBAKit/Sheet/Root/Controls/MapTypeButton.swift
+++ b/OBAKit/Sheet/Root/Controls/MapTypeButton.swift
@@ -41,10 +41,15 @@ struct MapTypeButton: View {
                     .accessibilityHidden(true)
             }
         }
+        // Distinct from the UIKit hover bar's `map_controller.map_type.*` label,
+        // which really does toggle the basemap. This opens `MapSheetView`, whose
+        // basemap picker is one of four sections — the others cover POI display,
+        // transit layers and rental modes — so "Map type" described a quarter of
+        // where it leads (#1412).
         .accessibilityLabel(Text(OBALoc(
-            "map_controller.map_type.accessibility_label",
-            value: "Map type",
-            comment: "Voiceover text for the button that opens the Map settings sheet."
+            "map_controller.map_settings.accessibility_label",
+            value: "Map settings",
+            comment: "Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes."
         )))
         .accessibilityValue(Text(accessibilityValueText))
     }

--- a/OBAKit/Strings/ar.lproj/Localizable.strings
+++ b/OBAKit/Strings/ar.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "هل تريد تغيير المنطقة؟";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "إعدادات الخريطة";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "نوع الخريطة";
 

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -520,8 +520,10 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Change Region?";
 
-/* Voiceover text for the button that opens the Map settings sheet.
-   Voiceover text indicating that this button toggles the base map type. */
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Map settings";
+
+/* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Map type";
 
 /* Voiceover value combining the base map type with the number of enabled map layers. %1$@ is the base map type, %2$d is the layer count. Plural forms live in Localizable.stringsdict; the value above is only the not-found fallback. */

--- a/OBAKit/Strings/es.lproj/Localizable.strings
+++ b/OBAKit/Strings/es.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "¿Cambiar Región?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Ajustes del mapa";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Tipo de mapa";
 

--- a/OBAKit/Strings/fil.lproj/Localizable.strings
+++ b/OBAKit/Strings/fil.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Palitan ang Rehiyon?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Mga setting ng mapa";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Uri ng mapa";
 

--- a/OBAKit/Strings/fr.lproj/Localizable.strings
+++ b/OBAKit/Strings/fr.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Changer de région ?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Réglages de la carte";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Type de carte";
 

--- a/OBAKit/Strings/it.lproj/Localizable.strings
+++ b/OBAKit/Strings/it.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Desideri modificare la tua area?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Impostazioni mappa";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Tipo di mappa";
 

--- a/OBAKit/Strings/ko.lproj/Localizable.strings
+++ b/OBAKit/Strings/ko.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "지역을 변경하시겠습니까?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "지도 설정";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "지도 유형";
 

--- a/OBAKit/Strings/pl.lproj/Localizable.strings
+++ b/OBAKit/Strings/pl.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Zmienić region?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Ustawienia mapy";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Typ mapy";
 

--- a/OBAKit/Strings/pt-BR.lproj/Localizable.strings
+++ b/OBAKit/Strings/pt-BR.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Mudar Região?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Configurações do mapa";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Tipo de mapa";
 

--- a/OBAKit/Strings/ru.lproj/Localizable.strings
+++ b/OBAKit/Strings/ru.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Сменить регион?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Настройки карты";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Тип карты";
 

--- a/OBAKit/Strings/vi.lproj/Localizable.strings
+++ b/OBAKit/Strings/vi.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "Đổi khu vực?";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "Cài đặt bản đồ";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "Loại bản đồ";
 

--- a/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hans.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "确定要更改地区？";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "地图设置";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "地图类型";
 

--- a/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
+++ b/OBAKit/Strings/zh-Hant.lproj/Localizable.strings
@@ -456,6 +456,9 @@
 /* Title of the alert that appears when the user is updating their current region manually. */
 "map_controller.change_region_alert.title" = "更改區域？";
 
+/* Voiceover text for the button that opens the Map settings sheet, which covers the base map, points of interest, transit layers and other travel modes. */
+"map_controller.map_settings.accessibility_label" = "地圖設定";
+
 /* Voiceover text indicating that this button toggles the base map type. */
 "map_controller.map_type.accessibility_label" = "地圖類型";
 


### PR DESCRIPTION
Closes #1412.
`map_controller.map_type.accessibility_label` labelled two controls that do different things. The UIKit hover-bar button really does toggle the basemap, so "Map type" is right there. The SwiftUI control opens `MapSheetView`, whose basemap picker is one of four sections — the others cover points of interest, transit layers and other travel modes — so the label described a quarter of where it leads.
New key `map_controller.map_settings.accessibility_label` = **"Map settings"**, on the sheet-opening button only. The UIKit button keeps the old key, which now has one call site and one comment, so the `genstrings` duplicate-comment warning is resolved rather than suppressed.
All 13 catalogs, `plutil -lint` clean, every locale at 566 keys.
**On the copy:** you listed "Map settings", "Map options" and "Map". Went with "Map settings" — it matches the sheet's scope, and "Map" alone reads thin on a button. Happy to switch; it's your call.
**On the value:** left it leading with the basemap name. VoiceOver now says "Map settings, hybrid, 3 layers on" — the label names the destination, the value summarises state.
VoiceOver-only; nothing changes for sighted users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Updated the map controls VoiceOver label to clearly identify Map settings.
  * Clarified that Map settings includes base maps, points of interest, transit layers, and travel modes.

* **Localization**
  * Added translated Map settings accessibility labels across supported languages.
  * Added translations for map layers, rental details, reporting, stop and trip screens, and accessibility announcements.
  * Removed obsolete translations for unused location-permission, stop, trip-panel, and timeline labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->