### PR TITLE
Bring the trip planner to the SwiftUI map panel

### DIFF
--- a/Apps/OneBusAway/Package.resolved
+++ b/Apps/OneBusAway/Package.resolved
@@ -178,7 +178,7 @@
       "location": "https://github.com/OneBusAway/otpkit.git",
       "state": {
         "branch": "main",
-        "revision": "5d2fb5a0e39b53a98050324b6a09b4d6eb240e0a"
+        "revision": "45438b555cb7071ab9ee47336425aaa1709fbdb4"
       }
     },
     {

--- a/OBAKit/Mapping/Layers/RentalDetailViewController.swift
+++ b/OBAKit/Mapping/Layers/RentalDetailViewController.swift
@@ -63,9 +63,8 @@ struct RentalDetailView: View {
     /// The layer's declared trust window; past it, the footer flags the data as stale.
     let staleAfter: Duration?
     let userLocation: CLLocation?
-    /// Nil on the SwiftUI map panel, which has no trip planner to route into —
-    /// `AppSheetRoute.tripPlanner` has no registered view. The button is hidden
-    /// rather than disabled: a dead primary action is worse than none.
+    /// Nil when the current region has no OTP server, on either surface. The button is
+    /// hidden rather than disabled: a dead primary action is worse than none.
     var onPlanTrip: ((VehicleRental) -> Void)?
     var onOpenURL: (URL, URL?, String?) -> Void
 
@@ -316,6 +315,18 @@ struct RentalClusterListView: View {
     let staleAfter: Duration?
     let userLocation: CLLocation?
     var onPlanTrip: ((VehicleRental) -> Void)?
+    /// Where tapping a row goes, when the host wants to own that.
+    ///
+    /// Nil on the UIKit surface, where this view is a modally-presented hosting
+    /// controller and the `selectedRental` sheet below is the only way to drill in.
+    ///
+    /// The map panel passes a closure instead, because that sheet is not the panel's to
+    /// present: `StackedSheetLayer` already attaches a `.sheet` to this same content for
+    /// the next stacked route, and SwiftUI allows one presentation per view — "Currently,
+    /// only presenting a single sheet is supported." A rental sheet opened here would hold
+    /// that slot, and the trip planner pushed from inside it would silently queue until the
+    /// rider dismissed the rental by hand.
+    var onSelectRental: ((VehicleRental) -> Void)?
     var onOpenURL: (URL, URL?, String?) -> Void
 
     @State private var selectedRental: VehicleRental?
@@ -324,7 +335,11 @@ struct RentalClusterListView: View {
         NavigationStack {
             List(rentals) { rental in
                 Button {
-                    selectedRental = rental
+                    if let onSelectRental {
+                        onSelectRental(rental)
+                    } else {
+                        selectedRental = rental
+                    }
                 } label: {
                     row(for: rental)
                 }

--- a/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
+++ b/OBAKit/Mapping/Layers/RentalLayerCoordinator.swift
@@ -101,6 +101,16 @@ import OTPKit
 
     var hasEnabledLayers: Bool { !enabledLayerFactors.isEmpty }
 
+    /// Whether the layer is currently in a position to say anything about vehicles.
+    ///
+    /// False when nothing is enabled, and false when the zoom gate is closed —
+    /// `MapRegionManager.forwardViewport(to:)` hands this coordinator a nil viewport
+    /// once the map is zoomed out past the layer's `zoomWindow`, which empties
+    /// `visibleRentals` wholesale. An empty list then means "not looking", not "none
+    /// there", and callers resolving a specific vehicle by id must not read the two the
+    /// same way.
+    var isReportingVehicles: Bool { hasEnabledLayers && lastMapRect != nil }
+
     private var combinedFormFactors: Set<VehicleFormFactor> {
         enabledLayerFactors.values.reduce(into: Set<VehicleFormFactor>()) { $0.formUnion($1) }
     }

--- a/OBAKit/Sheet/Content/Home/HomeSheetView.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetView.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import TipKit
 import OBAKitCore
 
 struct HomeSheetView: View {
@@ -86,6 +87,17 @@ struct HomeSheetView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 12)
+        // The map panel's home for `TripPlannerTip`, which on the UIKit surface
+        // points at `MapFloatingPanelController`'s search bar — this row is that
+        // bar's counterpart, and the tip's copy ("tap here to search for places")
+        // only reads correctly anchored to it. `popoverTip` rather than
+        // `TipPresenter`: the UIKit presenter exists to work around a broken
+        // system *controller*, and none of that applies here.
+        //
+        // Passing `nil` when the region has no OTP server withholds the tip
+        // instead of spending its one display announcing a feature the rider
+        // cannot reach.
+        .popoverTip(viewModel.offersTripPlanning ? TripPlannerTip() : nil)
     }
 
     // MARK: - Sections

--- a/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
+++ b/OBAKit/Sheet/Content/Home/HomeSheetViewModel.swift
@@ -32,6 +32,12 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
     /// something unrelated happened to invalidate the view.
     @Published private(set) var searchPlaceholder: String
 
+    /// Whether the trip planner is reachable from this region at all, which is
+    /// what decides if the discovery tip pointing at the search bar has anything
+    /// to introduce. Same gate the placeholder copy uses, published for the same
+    /// reason — a region change has to repaint it.
+    @Published private(set) var offersTripPlanning: Bool
+
     /// Sections that currently have something to show, in render order. Empty
     /// sections are dropped entirely — header included.
     @Published private(set) var visibleSections: [HomeSheetSection] = []
@@ -52,6 +58,7 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
     init(application: Application, stopsObserver: MapStopsObserver) {
         self.application = application
         self.searchPlaceholder = SearchPlaceholder.text(for: application)
+        self.offersTripPlanning = application.features.tripPlanning == .running
         self.nearby = HomeNearbyStopsSectionModel(observer: stopsObserver)
         self.recent = HomeRecentStopsSectionModel(application: application)
         self.bookmarks = HomeBookmarksSectionModel(application: application)
@@ -131,6 +138,7 @@ final class HomeSheetViewModel: NSObject, ObservableObject, RegionsServiceDelega
 
     func regionsService(_ service: RegionsService, updatedRegion region: Region) {
         searchPlaceholder = SearchPlaceholder.text(for: application)
+        offersTripPlanning = application.features.tripPlanning == .running
         // Which recents and bookmarks are "current" changed, and neither store
         // posts a notification for it.
         recent.reload()

--- a/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
+++ b/OBAKit/Sheet/Content/Search/MapItemSheetView.swift
@@ -55,6 +55,10 @@ struct MapItemSheetView: View {
         // drag frame.
         .onAppear {
             guard viewModel == nil else { return }
+            let planTripHandler: (() -> Void)? = application.regionsService.currentRegion?.supportsOTP == true ? {
+                coordinator.push(.tripPlanner(TripPlannerRequest(destination: mapItem)))
+            } : nil
+
             viewModel = MapItemViewModel(
                 mapItem: mapItem,
                 application: application,
@@ -64,10 +68,9 @@ struct MapItemSheetView: View {
                     dismiss: { dismiss() }
                 ),
                 removePinHandler: nil,
-                // No trip-planner route on this surface yet. `nil` hides the button
-                // rather than rendering one that does nothing; wire it up when the
-                // trip planner lands here.
-                planTripHandler: nil
+                // When the current region supports OTP, push the trip planner with this
+                // map item as the destination. Otherwise, `nil` hides the button entirely.
+                planTripHandler: planTripHandler
             )
         }
         .sheet(item: $website) { link in

--- a/OBAKit/Sheet/Content/TripPlanner/TripPlannerSheetView.swift
+++ b/OBAKit/Sheet/Content/TripPlanner/TripPlannerSheetView.swift
@@ -1,0 +1,244 @@
+//
+//  TripPlannerSheetView.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+import CoreLocation
+import OBAKitCore
+import OTPKit
+
+// MARK: - TripPlannerObservableWrapper
+
+/// Wraps `OTPKit.TripPlanner` for `@StateObject` use.
+///
+/// `TripPlanner` owns `TripPlannerViewModel` for its lifetime and is not itself
+/// an `ObservableObject`. The sheet holds it in `@StateObject` via this wrapper,
+/// so rebuilds of the view don't reconstruct `TripPlanner` mid-flow and reset the
+/// rider's trip state.
+@MainActor
+final class TripPlannerObservableWrapper: ObservableObject {
+    let tripPlanner: OTPKit.TripPlanner
+
+    init(tripPlanner: OTPKit.TripPlanner) {
+        self.tripPlanner = tripPlanner
+    }
+}
+
+// MARK: - TripPlannerSheetView
+
+/// The trip-planning sheet — `AppSheetRoute.tripPlanner`.
+///
+/// Renders OTPKit's `TripPlanner` with `.embedded` chrome (no close button or title)
+/// and provides the panel's own header, so a dismissal close button can clean up both
+/// the planner state and the map display model.
+///
+/// Split in two: this view owns the chrome and the "no OTP URL" case,
+/// while `TripPlannerSheetContent` owns the planner. A `@StateObject` can't
+/// be created conditionally, and there is no honest planner to build one
+/// with when OTP is not configured for the region.
+struct TripPlannerSheetView: View {
+    let application: Application
+    let request: TripPlannerRequest
+    let tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(OBALoc(
+                    "trip_planner.title",
+                    value: "Trip Planner",
+                    comment: "Title for the trip planner sheet"
+                )))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(Strings.close) { dismiss() }
+                    }
+                }
+        }
+        .searchSheetBackground()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if canBuildPlanner(application: application) {
+            TripPlannerSheetContent(
+                application: application,
+                request: request,
+                tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
+            )
+        } else {
+            unavailableStateView
+        }
+    }
+
+    /// When no OTP server is configured for this region, render an unavailable state
+    /// rather than crashing. Follows the pattern used by other sheets when content
+    /// cannot be loaded.
+    @ViewBuilder
+    private var unavailableStateView: some View {
+        EmptyStateView(
+            title: OBALoc(
+                "trip_planner.unavailable.title",
+                value: "Trip Planner Not Available",
+                comment: "Title shown when trip planning is not available for the current region"
+            ),
+            description: OBALoc(
+                "trip_planner.unavailable.body",
+                value: "This region does not support trip planning.",
+                comment: "Body text shown when trip planning is not available for the current region"
+            ),
+            systemImage: AppSymbol.search
+        )
+    }
+
+    /// Checks whether a planner can be built for the current region.
+    private func canBuildPlanner(application: Application) -> Bool {
+        guard let region = application.currentRegion,
+              region.supportsOTP,
+              application.userDataStore.isTripPlanningEnabled(for: region) else {
+            return false
+        }
+
+        return (region.openTripPlannerGraphQLURL != nil) || (region.openTripPlannerURL != nil)
+    }
+}
+
+// MARK: - TripPlannerSheetContent
+
+/// The planner UI. Owns `TripPlanner` via `@StateObject` so the parent can decline to
+/// build one when OTP is not configured.
+private struct TripPlannerSheetContent: View {
+    let application: Application
+    let request: TripPlannerRequest
+    let tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
+
+    @StateObject private var plannerWrapper: TripPlannerObservableWrapper
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        application: Application,
+        request: TripPlannerRequest,
+        tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
+    ) {
+        self.application = application
+        self.request = request
+        self.tripPlannerMapDisplayModel = tripPlannerMapDisplayModel
+
+        let planner = Self.buildTripPlanner(
+            application: application,
+            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
+        )!
+
+        _plannerWrapper = StateObject(wrappedValue: TripPlannerObservableWrapper(tripPlanner: planner))
+    }
+
+    var body: some View {
+        let tripPlannerView = plannerWrapper.tripPlanner.createTripPlannerView(
+            origin: nil,
+            destination: mapItemToLocation(request.destination),
+            viaPoint: request.viaPoint,
+            transportMode: request.transportMode,
+            chrome: .embedded,
+            onClose: nil
+        )
+
+        tripPlannerView
+            .onDisappear {
+                cleanupPlanner()
+            }
+    }
+
+    /// Converts an `MKMapItem` destination to OTPKit's `Location` type.
+    ///
+    /// Follows the same pattern as `MapViewController.showTripPlanner(_:)`.
+    private func mapItemToLocation(_ mapItem: MKMapItem?) -> Location? {
+        guard let mapItem else { return nil }
+        return Location(
+            title: mapItem.name ?? OBALoc(
+                "trip_planner.destination.default_title",
+                value: "Destination",
+                comment: "Default title for a trip planner destination"
+            ),
+            subTitle: mapItem.placemark.title ?? "",
+            latitude: mapItem.placemark.coordinate.latitude,
+            longitude: mapItem.placemark.coordinate.longitude
+        )
+    }
+
+    /// Builds an OTPKit `TripPlanner` for the current region.
+    ///
+    /// Follows the same pattern as `MapViewController.buildTripPlanner(region:)`,
+    /// selecting between GraphQL (OTP 2.x) and REST (OTP 1.x) based on region config.
+    ///
+    /// Must only be called when the region has been validated to support OTP.
+    private static func buildTripPlanner(
+        application: Application,
+        tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
+    ) -> OTPKit.TripPlanner? {
+        guard let region = application.currentRegion else {
+            return nil
+        }
+
+        // GraphQL (OTP 2.x) is preferred; REST (OTP 1.x) is the fallback.
+        let serverURL: URL
+        let apiService: OTPKit.APIService
+        if let graphQLURL = region.openTripPlannerGraphQLURL {
+            serverURL = graphQLURL
+            apiService = GraphQLAPIService(baseURL: graphQLURL)
+        } else if let restURL = region.openTripPlannerURL {
+            serverURL = restURL
+            apiService = RestAPIService(baseURL: restURL)
+        } else {
+            return nil
+        }
+
+        // Transport modes: always [.transit, .walk, .bike, .car];
+        // append rental modes if region supports bike rental.
+        var enabledModes: [TransportMode] = [.transit, .walk, .bike, .car]
+        if region.isBikeshareEnabled {
+            enabledModes.append(contentsOf: [.transitBikeRental, .bikeRental])
+        }
+
+        // Search region from the current region's service rect.
+        let searchRegion = MKCoordinateRegion(region.serviceRect)
+
+        let config = OTPConfiguration(
+            otpServerURL: serverURL,
+            enabledTransportModes: enabledModes,
+            themeConfiguration: .init(
+                primaryColor: Color(uiColor: ThemeColors().brand)
+            ),
+            searchRegion: searchRegion
+        )
+
+        let tripPlanner = TripPlanner(
+            otpConfig: config,
+            apiService: apiService,
+            mapProvider: tripPlannerMapDisplayModel,
+            notificationCenter: application.notificationCenter
+        )
+
+        return tripPlanner
+    }
+
+    /// Cleans up planner state when the view disappears.
+    private func cleanupPlanner() {
+        // Reset the planner: clears origin, destination, via point, plan response,
+        // selected itinerary, errors, and any routes/annotations drawn on the map.
+        plannerWrapper.tripPlanner.reset()
+
+        // Clear the display model: removes any remaining routes and annotations.
+        // Task 3 may already call this when the route leaves the stack; if it does,
+        // this call is redundant but harmless.
+        tripPlannerMapDisplayModel.clear()
+    }
+}

--- a/OBAKit/Sheet/Content/TripPlanner/TripPlannerSheetView.swift
+++ b/OBAKit/Sheet/Content/TripPlanner/TripPlannerSheetView.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import Combine
 import SwiftUI
 import MapKit
 import CoreLocation
@@ -25,8 +26,41 @@ import OTPKit
 final class TripPlannerObservableWrapper: ObservableObject {
     let tripPlanner: OTPKit.TripPlanner
 
+    private var didPrefill = false
+
     init(tripPlanner: OTPKit.TripPlanner) {
         self.tripPlanner = tripPlanner
+    }
+
+    /// Applies the route's prefill to the planner, exactly once.
+    ///
+    /// OTPKit prefills as a side effect of building the view: `createTripPlannerView`
+    /// writes `selectTransportMode` and `viaPoint`, and `TripPlannerView.init` writes
+    /// `selectedOrigin` / `selectedDestination`. Every one of those is `@Published` on
+    /// a view model SwiftUI is already observing, so doing it from `body` mutates
+    /// observed state in the middle of a view update — which is what SwiftUI reports as
+    /// "Publishing changes from within view updates is not allowed". Calling it from
+    /// `.task` instead runs the same writes one turn later, outside the update pass.
+    ///
+    /// The returned view is discarded: the prefill *is* the side effect, and the view
+    /// actually on screen is the unprefilled one `body` built, which renders from the
+    /// same view model and so picks these values up as published changes.
+    ///
+    /// Guarded because `.task` re-runs whenever the view's identity changes, and a
+    /// second application would stamp the route's original mode back over whatever the
+    /// rider has since chosen.
+    func applyPrefillIfNeeded(destination: Location?, viaPoint: CLLocationCoordinate2D?, transportMode: TransportMode?) {
+        guard !didPrefill else { return }
+        didPrefill = true
+
+        _ = tripPlanner.createTripPlannerView(
+            origin: nil,
+            destination: destination,
+            viaPoint: viaPoint,
+            transportMode: transportMode,
+            chrome: .embedded,
+            onClose: nil
+        )
     }
 }
 
@@ -122,6 +156,7 @@ private struct TripPlannerSheetContent: View {
     let tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
 
     @StateObject private var plannerWrapper: TripPlannerObservableWrapper
+    @EnvironmentObject private var coordinator: SheetCoordinator<AppSheetRoute>
     @Environment(\.dismiss) private var dismiss
 
     init(
@@ -133,25 +168,50 @@ private struct TripPlannerSheetContent: View {
         self.request = request
         self.tripPlannerMapDisplayModel = tripPlannerMapDisplayModel
 
-        let planner = Self.buildTripPlanner(
-            application: application,
-            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
-        )!
-
-        _plannerWrapper = StateObject(wrappedValue: TripPlannerObservableWrapper(tripPlanner: planner))
+        // Built inside the `@StateObject` autoclosure, which SwiftUI evaluates at most
+        // once per view lifetime. Hoisting it into a `let` first would construct a
+        // `TripPlanner` — and with it a `MapCoordinator` and a `TripPlannerViewModel` —
+        // on every re-init of this struct, which SwiftUI performs freely, only to throw
+        // all but the first away.
+        //
+        // Force-unwrapped because the parent renders this only when `canBuildPlanner`
+        // has already established the region has an OTP server.
+        _plannerWrapper = StateObject(wrappedValue: TripPlannerObservableWrapper(
+            tripPlanner: Self.buildTripPlanner(
+                application: application,
+                tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
+            )!
+        ))
     }
 
     var body: some View {
-        let tripPlannerView = plannerWrapper.tripPlanner.createTripPlannerView(
-            origin: nil,
-            destination: mapItemToLocation(request.destination),
-            viaPoint: request.viaPoint,
-            transportMode: request.transportMode,
-            chrome: .embedded,
-            onClose: nil
-        )
-
-        tripPlannerView
+        // Built with no prefill so this pass writes nothing to the planner's view
+        // model — see `applyPrefillIfNeeded`, which does the writing from `.task`.
+        // Every nil argument is a documented no-op inside OTPKit.
+        plannerWrapper.tripPlanner.createTripPlannerView(chrome: .embedded)
+            .task {
+                plannerWrapper.applyPrefillIfNeeded(
+                    destination: mapItemToLocation(request.destination),
+                    viaPoint: request.viaPoint,
+                    transportMode: request.transportMode
+                )
+            }
+            .onReceive(application.notificationCenter.publisher(for: Notifications.tripStarted)) { _ in
+                // The rider picked an itinerary, so OTPKit is presenting its directions
+                // sheet on top of this one. Drop to `.medium` to uncover the map the
+                // directions describe — a full-height planner underneath would leave the
+                // route invisible behind two stacked sheets.
+                //
+                // The UIKit surface does the same thing one rung lower, moving its panel
+                // to `.tip` (`MapViewController+TripPlanner.tripStarted`). The panel stops
+                // at `.medium` because its sheets are the app's own navigation, not a
+                // dedicated planner screen: collapsing to a sliver would strand the rider
+                // with no visible way back.
+                coordinator.setStackedDetent(.medium) { route in
+                    if case .tripPlanner = route { return true }
+                    return false
+                }
+            }
             .onDisappear {
                 cleanupPlanner()
             }

--- a/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
+++ b/OBAKit/Sheet/Coordinator/SheetCoordinator.swift
@@ -112,6 +112,28 @@ final class SheetCoordinator<Route: SheetRouteable>: ObservableObject {
         stackedEntries[depth].detent = detent
     }
 
+    /// Moves the topmost stacked sheet whose route matches `predicate` to `detent`.
+    ///
+    /// Depth-free on purpose: a sheet's own content knows *which route it is* but has
+    /// no way to learn its index in the pile, and that content is exactly what needs to
+    /// resize itself in response to something happening inside it.
+    ///
+    /// Refuses a detent the route doesn't declare — `presentationDetents(_:selection:)`
+    /// ignores a selection outside its set, so writing one would leave stored state
+    /// disagreeing with what is on screen. Returns whether the move was applied.
+    @discardableResult
+    func setStackedDetent(
+        _ detent: PresentationDetent,
+        forTopmostRouteMatching predicate: (Route) -> Bool
+    ) -> Bool {
+        guard let depth = stackedEntries.lastIndex(where: { predicate($0.route) }),
+              stackedEntries[depth].route.detentConfiguration.detents.contains(detent) else {
+            return false
+        }
+        stackedEntries[depth].detent = detent
+        return true
+    }
+
     /// Bounds-checked accessor for the stacked route at `depth`.
     /// Returns `nil` when `depth` is past the current pile.
     func stackedRoute(at depth: Int) -> Route? {

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -10,6 +10,95 @@
 import SwiftUI
 import MapKit
 import OBAKitCore
+import OTPKit
+
+// MARK: - TripPlannerRequest
+
+/// Parameters for initiating the OTPKit trip planner.
+///
+/// Both map-item and rental entry points carry payloads to prefill planner state:
+/// a map item prefills the destination and leaves the mode open; a rental (later)
+/// prefills a via point and locks the mode. All fields are optional so the planner
+/// can open empty (all three `nil`), with partial prefill, or fully configured.
+nonisolated struct TripPlannerRequest: Hashable, Equatable {
+    /// Destination pin on the map, if prefilled by the entry point (e.g., a
+    /// tapped map item). The planner uses this to seed the destination field.
+    let destination: MKMapItem?
+
+    /// Intermediate point (stopover) for multi-segment trips. Currently used by
+    /// rental (later) to seed a via point. `CLLocationCoordinate2D` is not
+    /// `Hashable` or `Equatable`, so we implement both over latitude/longitude.
+    let viaPoint: CLLocationCoordinate2D?
+
+    /// Transport mode to preselect or lock. Used by rental (later) to fix a mode
+    /// when the planner opens; map-item entry (this task) leaves it `nil` so the
+    /// user can pick freely.
+    let transportMode: TransportMode?
+
+    /// Initializer with all parameters optional, defaulting to `nil`.
+    init(
+        destination: MKMapItem? = nil,
+        viaPoint: CLLocationCoordinate2D? = nil,
+        transportMode: TransportMode? = nil
+    ) {
+        self.destination = destination
+        self.viaPoint = viaPoint
+        self.transportMode = transportMode
+    }
+
+    // MARK: - Hashable
+
+    func hash(into hasher: inout Hasher) {
+        // `MKMapItem` is a reference type; follow what `AppSheetRoute.mapItem`
+        // does — hash the coordinate.
+        if let destination {
+            let coordinate = destination.placemark.coordinate
+            hasher.combine(coordinate.latitude)
+            hasher.combine(coordinate.longitude)
+        } else {
+            hasher.combine(NSNull())
+        }
+
+        // `CLLocationCoordinate2D` is not `Hashable`; hash its components.
+        if let viaPoint {
+            hasher.combine(viaPoint.latitude)
+            hasher.combine(viaPoint.longitude)
+        } else {
+            hasher.combine(NSNull())
+        }
+
+        hasher.combine(transportMode)
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: TripPlannerRequest, rhs: TripPlannerRequest) -> Bool {
+        // For reference types like `MKMapItem`, compare by identity (===) or
+        // coordinate. The mapItem case uses coordinates, so we do the same.
+        let destinationEqual: Bool
+        if let lhsDest = lhs.destination, let rhsDest = rhs.destination {
+            let lhsCoord = lhsDest.placemark.coordinate
+            let rhsCoord = rhsDest.placemark.coordinate
+            destinationEqual = (lhsCoord.latitude == rhsCoord.latitude &&
+                               lhsCoord.longitude == rhsCoord.longitude)
+        } else {
+            destinationEqual = (lhs.destination == nil && rhs.destination == nil)
+        }
+
+        // For `CLLocationCoordinate2D`, compare latitude and longitude.
+        let viaPointEqual: Bool
+        if let lhsVia = lhs.viaPoint, let rhsVia = rhs.viaPoint {
+            viaPointEqual = (lhsVia.latitude == rhsVia.latitude &&
+                            lhsVia.longitude == rhsVia.longitude)
+        } else {
+            viaPointEqual = (lhs.viaPoint == nil && rhs.viaPoint == nil)
+        }
+
+        let transportModeEqual = lhs.transportMode == rhs.transportMode
+
+        return destinationEqual && viaPointEqual && transportModeEqual
+    }
+}
 
 // MARK: - SheetDetentConfiguration
 
@@ -79,7 +168,7 @@ nonisolated enum AppSheetRoute: SheetRouteable {
 
     // Stacked layer
     case stopDetails(stopID: Stop.ID)
-    case tripPlanner
+    case tripPlanner(TripPlannerRequest)
     case tripDetails(tripID: TripIdentifier)
     case routePicker
     case currentTrip(route: Route)
@@ -117,10 +206,27 @@ nonisolated extension AppSheetRoute {
     var id: String {
         switch self {
         case .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-             .tripPlanner, .routePicker, .more, .settings:
+             .routePicker, .more, .settings:
             return caseName
         case .stopDetails(let stopID):
             return "\(caseName)-\(stopID)"
+        case .tripPlanner(let request):
+            // Analytics key based on payload presence. Privacy guard: no
+            // coordinates in the key (rider location is sensitive). Instead, flag
+            // which fields are present so analytics can track entry points
+            // separately (map item, rental, etc.) without leaking location.
+            var parts: [String] = []
+            if request.destination != nil {
+                parts.append("destination")
+            }
+            if request.viaPoint != nil {
+                parts.append("viaPoint")
+            }
+            if request.transportMode != nil {
+                parts.append("transportMode")
+            }
+            let suffix = parts.isEmpty ? "blank" : parts.joined(separator: "_")
+            return "\(caseName)_\(suffix)"
         case .tripDetails(let tripID):
             return "\(caseName)-\(tripID)"
         case .currentTrip(let route):
@@ -185,6 +291,15 @@ nonisolated extension AppSheetRoute {
     /// occupies above it.
     static let homeCollapsedHeight: CGFloat = 75
 
+    /// Height of the trip planner's tip detent — a "peek" rung that leaves the
+    /// map dominant when the panel is minimized. OTPKit's
+    /// `DirectionsSheetView.tipDetent` collapses its own view when turn-by-turn
+    /// directions open, and the panel owns detents centrally, so the trip
+    /// planner needs a comparable rung for that handoff. Sized similarly to
+    /// `homeCollapsedHeight`: a single row (e.g., just a button bar) with
+    /// minimal padding.
+    static let tripPlannerTipHeight: CGFloat = 80
+
     var detentConfiguration: SheetDetentConfiguration {
         switch self {
         case .home:
@@ -236,7 +351,16 @@ nonisolated extension AppSheetRoute {
                 isDismissDisabled: false,
                 backgroundInteraction: .disabled
             )
-        case .tripPlanner, .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:
+        case .tripPlanner:
+            // OTPKit's trip planner collapses to its own custom tip detent when
+            // directions open. The panel owns detents, so it needs a comparable
+            // tip rung to stay in sync with OTPKit's collapsed state.
+            return SheetDetentConfiguration(
+                detents: [.height(AppSheetRoute.tripPlannerTipHeight), .medium, .large],
+                initialDetent: .large,
+                isDismissDisabled: false
+            )
+        case .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:
             return SheetDetentConfiguration(
                 detents: [.medium, .large],
                 initialDetent: .large,

--- a/OBAKit/Sheet/Coordinator/SheetRoute.swift
+++ b/OBAKit/Sheet/Coordinator/SheetRoute.swift
@@ -364,12 +364,16 @@ nonisolated extension AppSheetRoute {
                 backgroundInteraction: .disabled
             )
         case .tripPlanner:
-            // OTPKit's trip planner collapses to its own custom tip detent when
-            // directions open. The panel owns detents, so it needs a comparable
-            // tip rung to stay in sync with OTPKit's collapsed state.
+            // Opens at `.medium`: planning a trip is a map task, and the origin and
+            // destination fields are what the rider reads first — a full-height sheet
+            // hides the very map the trip is being drawn on.
+            //
+            // OTPKit's trip planner also collapses to its own custom tip detent when
+            // directions open. The panel owns detents, so it needs a comparable tip
+            // rung to stay in sync with OTPKit's collapsed state.
             return SheetDetentConfiguration(
                 detents: [.height(AppSheetRoute.tripPlannerTipHeight), .medium, .large],
-                initialDetent: .large,
+                initialDetent: .medium,
                 isDismissDisabled: false
             )
         case .tripDetails, .routePicker, .currentTrip, .transitAlert, .more, .settings:

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -106,7 +106,12 @@ final class AppSheetViewFactory {
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.
-        case .tripPlanner, .tripDetails, .transitAlert, .settings:
+        case .tripPlanner(let _request):
+            // TODO: Task 2 will build the actual trip planner view.
+            // For now, route to the placeholder while binding the request payload.
+            unimplementedView(for: route)
+
+        case .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
 
         case .searchResults(let response):

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -38,6 +38,7 @@ final class AppSheetViewFactory {
     let coordinator: SheetCoordinator<AppSheetRoute>
     let searchDisplayModel: MapSearchDisplayModel
     let stopsObserver: MapStopsObserver
+    let tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
 
     /// Nothing here is defaulted, on purpose, and for two separate reasons.
     ///
@@ -46,12 +47,13 @@ final class AppSheetViewFactory {
     /// it, so a call site that omitted it would build a factory whose sheet
     /// renders correctly and then silently ignores every button on it.
     ///
-    /// `coordinator`, `searchDisplayModel`, and `stopsObserver`: they must be the
-    /// same instances the hosting `MapPanelRootView` observes. A factory built with
-    /// its own private copies would push routes onto a coordinator nobody is
-    /// watching, draw into a display model nobody renders, or observe a different
-    /// stop set than the map is showing — silently, with the search sheet simply
-    /// appearing to do nothing.
+    /// `coordinator`, `searchDisplayModel`, `stopsObserver`, and
+    /// `tripPlannerMapDisplayModel`: they must be the same instances the hosting
+    /// `MapPanelRootView` observes. A factory built with its own private copies
+    /// would push routes onto a coordinator nobody is watching, draw into a
+    /// display model nobody renders, observe a different stop set than the map is
+    /// showing, or push trip state into a model nobody renders — silently, with
+    /// the sheets simply appearing to do nothing.
     init(
         application: Application,
         onPresentTrip: @escaping (ArrivalDeparture) -> Void,
@@ -59,7 +61,8 @@ final class AppSheetViewFactory {
         presentingController: @escaping () -> UIViewController?,
         coordinator: SheetCoordinator<AppSheetRoute>,
         searchDisplayModel: MapSearchDisplayModel,
-        stopsObserver: MapStopsObserver
+        stopsObserver: MapStopsObserver,
+        tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
     ) {
         self.application = application
         self.onPresentTrip = onPresentTrip
@@ -68,6 +71,7 @@ final class AppSheetViewFactory {
         self.coordinator = coordinator
         self.searchDisplayModel = searchDisplayModel
         self.stopsObserver = stopsObserver
+        self.tripPlannerMapDisplayModel = tripPlannerMapDisplayModel
     }
 
     /// Built once and shared: the search sheet and the results sheet must route a

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -110,10 +110,8 @@ final class AppSheetViewFactory {
         // Wiring a push for one of these routes before its view exists will
         // trip the debug assertion in `unimplementedView(for:)` — register the
         // view here before reaching for `SheetCoordinator.push(...)`.
-        case .tripPlanner(let _request):
-            // TODO: Task 2 will build the actual trip planner view.
-            // For now, route to the placeholder while binding the request payload.
-            unimplementedView(for: route)
+        case .tripPlanner(let request):
+            tripPlannerView(request: request)
 
         case .tripDetails, .transitAlert, .settings:
             unimplementedView(for: route)
@@ -246,6 +244,14 @@ final class AppSheetViewFactory {
                 router: self.searchResultRouter
             ),
             placeholder: SearchPlaceholder.text(for: self.application)
+        )
+    }
+
+    func tripPlannerView(request: TripPlannerRequest) -> TripPlannerSheetView {
+        TripPlannerSheetView(
+            application: application,
+            request: request,
+            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
         )
     }
 

--- a/OBAKit/Sheet/DI/AppSheetViewFactory.swift
+++ b/OBAKit/Sheet/DI/AppSheetViewFactory.swift
@@ -221,9 +221,6 @@ final class AppSheetViewFactory {
 
     /// Resolves the id to a live model, so a vehicle that leaves the feed while
     /// the sheet is open reads as gone rather than as a stale row.
-    ///
-    /// `onPlanTrip` is nil: the panel has no trip planner to route into. See
-    /// the doc comment on `RentalDetailView.onPlanTrip`.
     @ViewBuilder
     func rentalDetailView(rentalID: VehicleRental.ID) -> some View {
         if let rental = layersModel.rental(withID: rentalID) {
@@ -232,7 +229,7 @@ final class AppSheetViewFactory {
                 fetchedAt: layersModel.rentalFetchedAt,
                 staleAfter: layersModel.rentalStaleAfter,
                 userLocation: layersModel.rentalUserLocation,
-                onPlanTrip: nil,
+                onPlanTrip: planTripUsingRental,
                 onOpenURL: openRentalURL
             )
         } else {
@@ -251,9 +248,65 @@ final class AppSheetViewFactory {
                 fetchedAt: layersModel.rentalFetchedAt,
                 staleAfter: layersModel.rentalStaleAfter,
                 userLocation: layersModel.rentalUserLocation,
-                onPlanTrip: nil,
+                onPlanTrip: planTripUsingRental,
+                onSelectRental: selectRentalFromCluster,
                 onOpenURL: openRentalURL
             )
+        }
+    }
+
+    /// Drills from the cluster list into one vehicle's sheet, as a pushed route.
+    ///
+    /// The cluster list can present its own rental sheet, and does on the UIKit surface.
+    /// Here it must not: that sheet and the stacked layer's next route would be two
+    /// presentations from one view, which SwiftUI answers with "Currently, only presenting
+    /// a single sheet is supported" — leaving anything pushed from the rental sheet (the
+    /// trip planner, in particular) queued until the rider dismissed it by hand.
+    ///
+    /// Routing through the coordinator instead keeps one presentation owner, and lands on
+    /// the same `.rentalDetail` route a tap on a lone map pin opens.
+    var selectRentalFromCluster: (VehicleRental) -> Void {
+        { [coordinator, layersModel] rental in
+            layersModel.pinForOpenSheet([rental])
+            coordinator.push(.rentalDetail(rentalID: rental.id))
+        }
+    }
+
+    /// Whether the rental sheets should offer trip planning at all.
+    ///
+    /// Split out from `planTripUsingRental` so the gate is testable against an
+    /// arbitrary region. Driving it through `RegionsService` instead would mean
+    /// writing a custom region to the shared on-disk regions store, which every
+    /// `Application` in the test process reads — it takes down unrelated suites.
+    nonisolated static func offersTripPlanning(in region: Region?) -> Bool {
+        region?.supportsOTP == true
+    }
+
+    /// Plans a trip *through* this vehicle rather than *to* it.
+    ///
+    /// The vehicle is a via point, not a destination: a rider wants to walk to
+    /// the bike, ride it, and carry on. OTP will not route through a via point
+    /// in a rental-only mode, which is why the mode is pinned to
+    /// `.transitBikeRental`. Mirrors `MapViewController.rentalLayer(planTripUsing:)`
+    /// on the UIKit surface, analytics event included.
+    ///
+    /// `nil` when the region has no OTP server, which hides the button rather
+    /// than disabling it — a dead primary action is worse than none.
+    var planTripUsingRental: ((VehicleRental) -> Void)? {
+        guard AppSheetViewFactory.offersTripPlanning(in: application.regionsService.currentRegion) else {
+            return nil
+        }
+
+        return { [weak application, coordinator] rental in
+            application?.analytics?.reportEvent(
+                pageURL: "app://localhost/bikeshare",
+                label: AnalyticsLabels.rentalPlanTripTapped,
+                value: rental.rentalNetwork?.networkId
+            )
+            coordinator.push(.tripPlanner(TripPlannerRequest(
+                viaPoint: rental.coordinate,
+                transportMode: .transitBikeRental
+            )))
         }
     }
 

--- a/OBAKit/Sheet/Root/MapPanelLayersModel.swift
+++ b/OBAKit/Sheet/Root/MapPanelLayersModel.swift
@@ -128,8 +128,14 @@ import OTPKit
 
         rentalCancellables.removeAll()
 
+        // A rebind means a new region's coordinator, so anything held for the old
+        // region's sheets is now wrong rather than merely stale.
+        pinnedRentals.removeAll()
+        pinOrder.removeAll()
+
         guard let coordinator else {
             visibleRentals = []
+            lastReportedRentals = []
             rentalItems = []
             showsFuelLabels = false
             return
@@ -137,8 +143,12 @@ import OTPKit
 
         coordinator.$visibleRentals
             .sink { [weak self] rentals in
-                self?.visibleRentals = rentals
-                self?.recomputeClusters()
+                guard let self else { return }
+                self.visibleRentals = rentals
+                if !rentals.isEmpty {
+                    self.lastReportedRentals = rentals
+                }
+                self.recomputeClusters()
             }
             .store(in: &rentalCancellables)
 
@@ -198,16 +208,85 @@ import OTPKit
     /// The rider's location, for walk-time estimates in detail sheets.
     var rentalUserLocation: CLLocation? { registrar.rentalCoordinator?.userLocation }
 
-    /// Resolves a route's id back to a live model. Returns nil once the vehicle
-    /// has left the feed, so an open sheet reflects reality rather than a
-    /// snapshot taken at push time.
+    /// The last non-empty vehicle list the feed produced, retained for id resolution.
+    ///
+    /// Never drawn — `rentalItems` is computed from `visibleRentals` alone, so nothing
+    /// stale reaches the map. This exists only so an open sheet can still name the vehicle
+    /// it was opened for while the feed has nothing to say. See `resolutionSource`.
+    private var lastReportedRentals: [VehicleRental] = []
+
+    /// Vehicles an open sheet is about, held until the coordinator is rebuilt.
+    ///
+    /// `lastReportedRentals` covers the feed going silent *wholesale*. It cannot cover the
+    /// other half: the feed still reporting, from a viewport that no longer contains this
+    /// vehicle. Framing a planned trip re-fetches for the itinerary's bounding box, and
+    /// every bike outside it arrives back as a removal — indistinguishable, in the
+    /// snapshot, from one a rider just rode away. So a sheet two layers down watched its
+    /// own vehicle vanish and flipped to "Not available right now".
+    ///
+    /// Pinning happens where the sheet is opened — a map tap or a cluster row — which is
+    /// the one moment the vehicle is unambiguously live: the rider just touched it. From
+    /// then on the sheet keeps naming what it was opened for, and freshness is reported by
+    /// the sheet's own `fetchedAt` / `staleAfter` footer, which exists for exactly this.
+    private var pinnedRentals: [VehicleRental.ID: VehicleRental] = [:]
+
+    /// Insertion order for `pinnedRentals`, so the cap below evicts oldest-first.
+    private var pinOrder: [VehicleRental.ID] = []
+
+    /// Pins are only released wholesale, on a region change, so this bounds a long
+    /// session. A rider opening more than this many rental sheets without changing region
+    /// has long since stopped looking at the first one.
+    private static let pinnedRentalLimit = 64
+
+    /// Holds onto the vehicles a sheet is being opened for. Call from the push site.
+    func pinForOpenSheet(_ rentals: [VehicleRental]) {
+        for rental in rentals where pinnedRentals.updateValue(rental, forKey: rental.id) == nil {
+            pinOrder.append(rental.id)
+        }
+
+        while pinOrder.count > Self.pinnedRentalLimit {
+            pinnedRentals.removeValue(forKey: pinOrder.removeFirst())
+        }
+    }
+
+    /// What `rental(withID:)` and `rentals(withIDs:)` resolve against.
+    ///
+    /// `visibleRentals` is viewport-scoped and zoom-gated: pan away or zoom out past the
+    /// layer's window and `MapRegionManager.forwardViewport(to:)` hands the coordinator a
+    /// nil viewport, emptying it. That is the feed falling silent, not every vehicle
+    /// disappearing — but a sheet resolving against it reads the two identically and flips
+    /// to its "not available" state. Framing a planned trip zooms out far enough to do
+    /// this every time, which is how ending a trip left two dead rental sheets underneath
+    /// the planner; a rider pinching out with a rental sheet open hit the same thing.
+    ///
+    /// The fallback is deliberately narrow: only when the feed is *not* reporting and has
+    /// therefore emptied the list wholesale. While it is reporting, the live list is the
+    /// only truth — a vehicle missing from it really is gone, and saying so is the point of
+    /// resolving by id rather than carrying the model in the route. An area that genuinely
+    /// holds no vehicles still reads as empty.
+    private var resolutionSource: [VehicleRental] {
+        let isReporting = registrar.rentalCoordinator?.isReportingVehicles ?? false
+        guard !isReporting, visibleRentals.isEmpty else { return visibleRentals }
+        return lastReportedRentals
+    }
+
+    /// Resolves a route's id back to a model: the live list first, then anything pinned
+    /// for an open sheet, then the last report the feed made.
+    ///
+    /// Resolving live-first is what keeps an open sheet current — a vehicle's range and
+    /// position update under it as the feed refreshes. The fallbacks only answer when the
+    /// live list cannot, and each covers a different way of "cannot": see `pinnedRentals`
+    /// and `resolutionSource`. Nil still means nil for a vehicle the panel has never seen.
     func rental(withID id: VehicleRental.ID) -> VehicleRental? {
-        visibleRentals.first { $0.id == id }
+        resolutionSource.first { $0.id == id } ?? pinnedRentals[id]
     }
 
     func rentals(withIDs ids: [VehicleRental.ID]) -> [VehicleRental] {
-        let wanted = Set(ids)
-        return visibleRentals.filter { wanted.contains($0.id) }
+        let live = resolutionSource.filter { ids.contains($0.id) }
+        let liveIDs = Set(live.map(\.id))
+        // Order follows `ids` for the members the live list did not answer, so a cluster
+        // list does not reshuffle as vehicles drop in and out of the viewport.
+        return live + ids.compactMap { liveIDs.contains($0) ? nil : pinnedRentals[$0] }
     }
 
     /// Feeds the panel's camera into the layer pipeline. The `MKMapView` this

--- a/OBAKit/Sheet/Root/MapPanelRootController.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootController.swift
@@ -30,7 +30,10 @@ public final class MapPanelRootController: UIViewController {
         // Built here, not inside `MapPanelRootView`, because the factory is
         // constructed first and the home sheet's nearby section must observe
         // the same instance the map renders from. Same reasoning as
-        // `displayModel` above.
+        // `displayModel` below.
+        let tripPlannerMapDisplayModel = TripPlannerMapDisplayModel()
+        // Built here for the same reason: the factory must have the instance so the
+        // trip planner sheet can push the same model instance the map renders from.
         let stopsObserver = MapStopsObserver(application: application)
         let factory = AppSheetViewFactory(
             application: application,
@@ -39,14 +42,16 @@ public final class MapPanelRootController: UIViewController {
             presentingController: { [weak bridge] in bridge?.topmostController() },
             coordinator: coordinator,
             searchDisplayModel: displayModel,
-            stopsObserver: stopsObserver
+            stopsObserver: stopsObserver,
+            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
         )
         let rootView = MapPanelRootView(
             application: application,
             factory: factory,
             coordinator: coordinator,
             searchDisplayModel: displayModel,
-            stopsObserver: stopsObserver
+            stopsObserver: stopsObserver,
+            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel
         )
         self.host = UIHostingController(rootView: rootView)
         self.bridge = bridge

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -23,6 +23,7 @@ struct MapPanelRootView: View {
     @ObservedObject private var searchDisplay: MapSearchDisplayModel
     @StateObject private var mapViewModel: MapViewModel
     @ObservedObject private var stopsObserver: MapStopsObserver
+    @ObservedObject private var tripPlannerDisplay: TripPlannerMapDisplayModel
 
     /// Presentation state only. The popup reads its data from
     /// `mapViewModel.weatherDisplay` so a refresh that finishes while the card
@@ -91,11 +92,13 @@ struct MapPanelRootView: View {
         factory: AppSheetViewFactory,
         coordinator: SheetCoordinator<AppSheetRoute>,
         searchDisplayModel: MapSearchDisplayModel,
-        stopsObserver: MapStopsObserver
+        stopsObserver: MapStopsObserver,
+        tripPlannerMapDisplayModel: TripPlannerMapDisplayModel
     ) {
         _coordinator = StateObject(wrappedValue: coordinator)
         _searchDisplay = ObservedObject(wrappedValue: searchDisplayModel)
         _stopsObserver = ObservedObject(wrappedValue: stopsObserver)
+        _tripPlannerDisplay = ObservedObject(wrappedValue: tripPlannerMapDisplayModel)
         let initialMapType = MapBaseType(application.mapRegionManager.userSelectedMapType)
         _mapViewModel = StateObject(wrappedValue: MapViewModel(application: application, initialMapType: initialMapType))
         self.application = application
@@ -132,8 +135,9 @@ struct MapPanelRootView: View {
                 )
             }
             // Regular stops show only zoomed in; `renderStops` already excludes
-            // bookmarked stops and precomputes labels.
-            if isZoomedInForStops, !searchDisplay.suppressesAmbientStops {
+            // bookmarked stops and precomputes labels. Suppress them if a search
+            // result or trip is drawn, as those take over the map.
+            if isZoomedInForStops, !searchDisplay.suppressesAmbientStops, !tripPlannerDisplay.isShowingTrip {
                 ForEach(stopsObserver.renderStops) { renderStop in
                     stopAnnotation(
                         for: renderStop.stop,
@@ -150,11 +154,15 @@ struct MapPanelRootView: View {
                     traits: UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
                 )
             }
+            tripPlannerMapContent(for: tripPlannerDisplay)
         }
         .onMapCameraChange(frequency: .onEnd) { context in
             viewportRecorder.record(context.rect)
             visibleRegion = context.region
             visibleMapRectHeight = context.rect.height
+            // Feed the visible region to both the search and trip planner display
+            // models so they can frame results and answer region queries.
+            tripPlannerDisplay.updateVisibleRegion(context.region)
             // Keep the "Zoom in for stops" pill in sync with the stop-loading
             // threshold by updating it before the stop-loading early return, so it
             // also works when the map is zoomed out.
@@ -175,7 +183,7 @@ struct MapPanelRootView: View {
             }
             recomputeStopLabels()
             stopsObserver.updateViewport(context.region)
-            guard !searchDisplay.suppressesAmbientStops else { return }
+            guard !searchDisplay.suppressesAmbientStops, !tripPlannerDisplay.isShowingTrip else { return }
             application.mapRegionManager.scheduleStopsRequest(in: context.region)
         }
         // The map-type toggle changes the label gate (labels only show on the
@@ -191,14 +199,28 @@ struct MapPanelRootView: View {
             coordinator.push(.stopDetails(stopID: id))
             selectedStopID = nil
         }
-        // A searched result stays drawn for exactly as long as the sheet that owns it
-        // is on the stack. Watching the stack — rather than clearing from the owning
-        // sheet's `onDisappear` — keeps the drawing alive across the content
-        // teardowns the sheet system performs without dismissing anything, and still
-        // clears on a real exit, including the drag-down the OS routes through
-        // `truncateStacked`.
+        // A searched result and a trip plan stay drawn for exactly as long as the
+        // sheet that owns them is on the stack. Watching the stack — rather than
+        // clearing from the owning sheet's `onDisappear` — keeps the drawing alive
+        // across the content teardowns the sheet system performs without dismissing
+        // anything, and still clears on a real exit, including the drag-down the OS
+        // routes through `truncateStacked`.
         .onChange(of: coordinator.stackedRoutes) { _, _ in
             searchDisplay.clearIfOwnerAbsent(from: coordinator.routeStack + coordinator.stackedRoutes)
+            // Clear the trip planner when `.tripPlanner` is no longer on the stack.
+            // Unlike searchDisplay which uses `.clearIfOwnerAbsent`, the trip planner
+            // has no owner concept — it has a plain `clear()`. The check is simple: if
+            // the trip planner route isn't on the stack, clear the model.
+            let hasActiveTripPlanner = (coordinator.routeStack + coordinator.stackedRoutes)
+                .contains { route in
+                    if case .tripPlanner = route {
+                        return true
+                    }
+                    return false
+                }
+            if !hasActiveTripPlanner {
+                tripPlannerDisplay.clear()
+            }
         }
         .onChange(of: searchDisplay.cameraTarget) { _, target in
             guard let target else { return }
@@ -218,6 +240,11 @@ struct MapPanelRootView: View {
                 withAnimation { cameraPosition = .rect(rect) }
             }
             searchDisplay.consumeCameraTarget()
+        }
+        .onChange(of: tripPlannerDisplay.cameraTarget) { _, target in
+            guard let target else { return }
+            applyTripPlannerCameraTarget(target)
+            tripPlannerDisplay.consumeCameraTarget()
         }
         .mapStyle(mapViewModel.mapType == .standard ? .standard(emphasis: .muted) : .hybrid)
         .safeAreaPadding(.bottom, 180)
@@ -455,6 +482,34 @@ extension MapPanelRootView {
 extension MapPanelRootView {
 
     // MARK: - Actions
+
+    /// Applies the trip planner's requested camera movement to the map.
+    ///
+    /// Note: SwiftUI's MapCameraPosition API (iOS 18+) doesn't expose an insets
+    /// parameter; the rect is applied as-is. OTPKit's `edgePadding` is recorded
+    /// in the model for future use but not applied on the current platform.
+    private func applyTripPlannerCameraTarget(_ target: TripPlannerMapDisplayModel.CameraTarget) {
+        switch target {
+        case .region(let region, let animated):
+            if animated {
+                withAnimation { cameraPosition = .region(region) }
+            } else {
+                cameraPosition = .region(region)
+            }
+        case .rect(let rect, _, let animated):
+            if animated {
+                withAnimation { cameraPosition = .rect(rect) }
+            } else {
+                cameraPosition = .rect(rect)
+            }
+        case .userLocation(let animated):
+            if animated {
+                withAnimation { cameraPosition = .userLocation(fallback: .automatic) }
+            } else {
+                cameraPosition = .userLocation(fallback: .automatic)
+            }
+        }
+    }
 
     /// Performs the once-per-launch recenter on the user's first location fix,
     /// waiting out the `mapSize == .zero` window: called both when the fix

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -12,6 +12,47 @@ import SwiftUI
 import OBAKitCore
 import UIKit
 
+// MARK: - Map rect padding
+
+/// Applies `UIEdgeInsets` (view points) to an `MKMapRect` (map points) by
+/// converting through the map's current scale factor. UIEdgeInsets and MKMapRect
+/// use different units; the scale factor is derived from the map's rendered size.
+///
+/// When `mapSize` is zero (before first geometry report), falls back to expanding
+/// the rect by a fraction of its own dimensions — this is unit-safe because both
+/// sides are map-rect units — and avoids division by zero.
+func paddedMapRect(
+    _ rect: MKMapRect,
+    edgePadding: UIEdgeInsets,
+    mapSize: CGSize
+) -> MKMapRect {
+    // When the map has reported its size, calculate scale factors to convert from
+    // view points (UIEdgeInsets) to map points (MKMapRect). Scale factor =
+    // map-point dimension / view-point dimension.
+    guard mapSize.width > 0, mapSize.height > 0 else {
+        // Before first geometry report: fall back to size-proportional expansion
+        // in the shape of `MapSearchDisplayModel.show(stopsForRoute:)`.
+        return rect.insetBy(
+            dx: -rect.size.width * 0.15,
+            dy: -rect.size.height * 0.30
+        )
+    }
+
+    let scaleX = rect.size.width / mapSize.width
+    let scaleY = rect.size.height / mapSize.height
+
+    // Build the padded rect by adjusting origin and size. Unlike `insetBy`, this
+    // preserves asymmetric padding: OTPKit pads the bottom harder to clear the
+    // sheet, and that matters most.
+    var paddedRect = rect
+    paddedRect.origin.x -= edgePadding.left * scaleX
+    paddedRect.origin.y -= edgePadding.top * scaleY
+    paddedRect.size.width += (edgePadding.left + edgePadding.right) * scaleX
+    paddedRect.size.height += (edgePadding.top + edgePadding.bottom) * scaleY
+
+    return paddedRect
+}
+
 // MARK: - MapPanelRootView
 
 /// A pure-SwiftUI alternative to `MapViewController`: a full-screen SwiftUI
@@ -485,10 +526,11 @@ extension MapPanelRootView {
 
     /// Applies the trip planner's requested camera movement to the map.
     ///
-    /// For rect targets with edge padding: SwiftUI's MapCameraPosition doesn't expose an
-    /// insets parameter, so we approximate point-based insets by expanding the rect's frame
-    /// proportionally, following the precedent of `MapSearchDisplayModel.show(stopsForRoute:)`
-    /// which uses similar inset math to keep content off the screen edges and clear of the sheet.
+    /// For rect targets with edge padding: converts view-point insets to map-point
+    /// adjustments using the current map scale factor, because SwiftUI's
+    /// MapCameraPosition takes no insets parameter. Preserves asymmetric padding
+    /// (bottom padding is larger to clear the sheet). Falls back to fraction-based
+    /// expansion before the map's size is known.
     private func applyTripPlannerCameraTarget(_ target: TripPlannerMapDisplayModel.CameraTarget) {
         switch target {
         case .region(let region, let animated):
@@ -498,16 +540,11 @@ extension MapPanelRootView {
                 cameraPosition = .region(region)
             }
         case .rect(let rect, let edgePadding, let animated):
-            // Convert point-based UIEdgeInsets to map-rect deltas. Expand the rect outward
-            // (negative deltas) so content stays away from edges and clear of the sheet.
-            let insetRect = rect.insetBy(
-                dx: -(edgePadding.left + edgePadding.right) / 4,
-                dy: -(edgePadding.top + edgePadding.bottom) / 4
-            )
+            let paddedRect = paddedMapRect(rect, edgePadding: edgePadding, mapSize: mapSize)
             if animated {
-                withAnimation { cameraPosition = .rect(insetRect) }
+                withAnimation { cameraPosition = .rect(paddedRect) }
             } else {
-                cameraPosition = .rect(insetRect)
+                cameraPosition = .rect(paddedRect)
             }
         case .userLocation(let animated):
             if animated {

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -303,13 +303,25 @@ struct MapPanelRootView: View {
             case .stop(let stopID):
                 coordinator.push(.stopDetails(stopID: stopID))
             case .rental(let rentalID):
+                // Pin before pushing: the rider just tapped this pin, so it is live now,
+                // and the sheet must keep naming it even if the map later moves somewhere
+                // the feed no longer reports it from. See `pinForOpenSheet`.
+                if let rental = layersModel.rental(withID: rentalID) {
+                    layersModel.pinForOpenSheet([rental])
+                }
                 coordinator.push(.rentalDetail(rentalID: rentalID))
             case .rentalCluster(let clusterID):
                 let members = layersModel.rentalItems
                     .first { $0.id == clusterID }?
                     .members ?? []
                 guard !members.isEmpty else { break }
+                layersModel.pinForOpenSheet(members)
                 coordinator.push(.rentalCluster(memberIDs: members.map(\.id)))
+            case .tripPlannerAnnotation(let identifier):
+                // Hand the tap straight back to OTPKit, which owns what a pin on
+                // its own route means. No route is pushed: the planner sheet is
+                // already on the stack and reacts to this itself.
+                tripPlannerDisplay.handleAnnotationSelection(identifier: identifier)
             }
             mapSelection = nil
         }
@@ -791,4 +803,3 @@ private final class RegionMismatchCameraActions: ObservableObject {
     @Published var applyLaunch = false
     @Published var showSelectedServiceRect = false
 }
-

--- a/OBAKit/Sheet/Root/MapPanelRootView.swift
+++ b/OBAKit/Sheet/Root/MapPanelRootView.swift
@@ -485,9 +485,10 @@ extension MapPanelRootView {
 
     /// Applies the trip planner's requested camera movement to the map.
     ///
-    /// Note: SwiftUI's MapCameraPosition API (iOS 18+) doesn't expose an insets
-    /// parameter; the rect is applied as-is. OTPKit's `edgePadding` is recorded
-    /// in the model for future use but not applied on the current platform.
+    /// For rect targets with edge padding: SwiftUI's MapCameraPosition doesn't expose an
+    /// insets parameter, so we approximate point-based insets by expanding the rect's frame
+    /// proportionally, following the precedent of `MapSearchDisplayModel.show(stopsForRoute:)`
+    /// which uses similar inset math to keep content off the screen edges and clear of the sheet.
     private func applyTripPlannerCameraTarget(_ target: TripPlannerMapDisplayModel.CameraTarget) {
         switch target {
         case .region(let region, let animated):
@@ -496,11 +497,17 @@ extension MapPanelRootView {
             } else {
                 cameraPosition = .region(region)
             }
-        case .rect(let rect, _, let animated):
+        case .rect(let rect, let edgePadding, let animated):
+            // Convert point-based UIEdgeInsets to map-rect deltas. Expand the rect outward
+            // (negative deltas) so content stays away from edges and clear of the sheet.
+            let insetRect = rect.insetBy(
+                dx: -(edgePadding.left + edgePadding.right) / 4,
+                dy: -(edgePadding.top + edgePadding.bottom) / 4
+            )
             if animated {
-                withAnimation { cameraPosition = .rect(rect) }
+                withAnimation { cameraPosition = .rect(insetRect) }
             } else {
-                cameraPosition = .rect(rect)
+                cameraPosition = .rect(insetRect)
             }
         case .userLocation(let animated):
             if animated {

--- a/OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift
+++ b/OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift
@@ -1,0 +1,304 @@
+//
+//  TripPlannerMapDisplayModel.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Combine
+import CoreLocation
+import MapKit
+import OBAKitCore
+import OTPKit
+import SwiftUI
+
+/// What the SwiftUI map should draw for the current trip plan.
+///
+/// OTPKit drives a map through `OTPMapProvider`, and ships one implementation —
+/// `MKMapViewAdapter` — that mutates an `MKMapView` directly, taking its delegate and
+/// installing its own gesture recognizer. The UIKit map surface hands it a whole second
+/// map view for exactly that reason (`MapViewController.tripPlannerMapView`), swapping
+/// the two by alpha when a trip starts.
+///
+/// The panel has no `MKMapView` to hand over, so it implements the protocol a second way:
+/// calls land in published state and `MapPanelRootView` renders it declaratively. This is
+/// the same move `MapSearchDisplayModel` makes for search results, and it is why nothing
+/// here needs to fork OTPKit — the protocol is the seam, and `MKMapViewAdapter` is only
+/// one implementation of it.
+@MainActor
+final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
+
+    // MARK: - Drawn content
+
+    /// A polyline OTPKit asked for, carrying the styling it chose.
+    ///
+    /// `identifier` is OTPKit's own opaque key (`"leg_0"`, `"halo_leg_0"`). We never
+    /// interpret it — it exists so `removeRoute(identifier:)` can find this again.
+    struct Route: Identifiable, Equatable {
+        let identifier: String
+        let coordinates: [CLLocationCoordinate2D]
+        let color: Color
+        let lineWidth: CGFloat
+        let dashPattern: [NSNumber]?
+
+        var id: String { identifier }
+
+        static func == (lhs: Route, rhs: Route) -> Bool {
+            lhs.identifier == rhs.identifier
+                && lhs.lineWidth == rhs.lineWidth
+                && lhs.color == rhs.color
+                && lhs.coordinates.count == rhs.coordinates.count
+        }
+    }
+
+    /// An annotation OTPKit asked for.
+    struct Annotation: Identifiable, Equatable {
+        let identifier: String
+        let coordinate: CLLocationCoordinate2D
+        let title: String
+        let subtitle: String?
+        let type: OTPAnnotationType
+        let routeName: String?
+        let routeBackgroundColor: UIColor?
+        let routeTextColor: UIColor?
+
+        var id: String { identifier }
+
+        static func == (lhs: Annotation, rhs: Annotation) -> Bool {
+            lhs.identifier == rhs.identifier
+                && lhs.title == rhs.title
+                && lhs.subtitle == rhs.subtitle
+                && lhs.type == rhs.type
+                && lhs.routeName == rhs.routeName
+                && lhs.coordinate.latitude == rhs.coordinate.latitude
+                && lhs.coordinate.longitude == rhs.coordinate.longitude
+        }
+    }
+
+    /// Insertion-ordered on purpose: OTPKit draws a white halo under each leg and then
+    /// the coloured line on top, so the order it adds them in *is* the z-order. A
+    /// dictionary would lose that and the halos would paint over the routes.
+    @Published private(set) var routes: [Route] = []
+
+    /// Insertion-ordered for the same reason.
+    @Published private(set) var annotations: [Annotation] = []
+
+    /// Whether OTPKit currently wants the user's location shown. The panel already shows
+    /// it unconditionally, so this is recorded rather than acted on — see `setMapType`
+    /// below for the general rule.
+    @Published private(set) var wantsUserLocation = false
+
+    /// True once anything is drawn. Lets the view suppress the ambient stop layer while a
+    /// trip is on the map, the way `MapSearchDisplayModel.suppressesAmbientStops` does
+    /// for a searched route.
+    var isShowingTrip: Bool { !routes.isEmpty || !annotations.isEmpty }
+
+    // MARK: - Camera
+
+    /// Where OTPKit wants the camera next. One-shot: the view applies it and calls
+    /// `consumeCameraTarget()`.
+    ///
+    /// Modelled on `MapSearchDisplayModel.CameraTarget` for the reason documented there —
+    /// `body` re-runs on unrelated state changes, including every frame of a sheet drag,
+    /// and a target that stayed set would re-move the map out from under the rider.
+    enum CameraTarget: Equatable {
+        case region(MKCoordinateRegion, animated: Bool)
+        case rect(MKMapRect, edgePadding: UIEdgeInsets, animated: Bool)
+        case userLocation(animated: Bool)
+
+        static func == (lhs: CameraTarget, rhs: CameraTarget) -> Bool {
+            switch (lhs, rhs) {
+            case (.region(let l, let la), .region(let r, let ra)):
+                return l.center.latitude == r.center.latitude
+                    && l.center.longitude == r.center.longitude
+                    && l.span.latitudeDelta == r.span.latitudeDelta
+                    && l.span.longitudeDelta == r.span.longitudeDelta
+                    && la == ra
+            case (.rect(let l, let lp, let la), .rect(let r, let rp, let ra)):
+                return l.origin.x == r.origin.x && l.origin.y == r.origin.y
+                    && l.size.width == r.size.width && l.size.height == r.size.height
+                    && lp == rp && la == ra
+            case (.userLocation(let la), .userLocation(let ra)):
+                return la == ra
+            default:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var cameraTarget: CameraTarget?
+
+    /// The map's current visible region, pushed in by the view on every camera settle.
+    ///
+    /// `getCurrentRegion()` is a synchronous read in OTPKit's protocol, and a SwiftUI
+    /// `Map` has no equivalent to ask. Recording what the view last reported is the only
+    /// way to answer it honestly.
+    private var visibleRegion: MKCoordinateRegion?
+
+    // MARK: - Interaction
+
+    private var mapTapHandler: ((CLLocationCoordinate2D) -> Void)?
+    private var annotationSelectionHandler: ((String) -> Void)?
+
+    // MARK: - Host-facing API
+
+    /// Records the region the map is currently showing. Call on every camera settle.
+    func updateVisibleRegion(_ region: MKCoordinateRegion) {
+        visibleRegion = region
+    }
+
+    /// Applies-and-forgets the pending camera move.
+    func consumeCameraTarget() {
+        cameraTarget = nil
+    }
+
+    /// Forwards a map tap to OTPKit, if it asked for them.
+    func handleMapTap(at coordinate: CLLocationCoordinate2D) {
+        mapTapHandler?(coordinate)
+    }
+
+    /// Forwards an annotation selection to OTPKit, keyed by the identifier OTPKit gave us.
+    func handleAnnotationSelection(identifier: String) {
+        annotationSelectionHandler?(identifier)
+    }
+
+    /// Drops everything drawn for the trip. The host calls this alongside
+    /// `TripPlanner.reset()` when the planner leaves the sheet stack.
+    func clear() {
+        routes.removeAll()
+        annotations.removeAll()
+        cameraTarget = nil
+        wantsUserLocation = false
+    }
+
+    // MARK: - OTPMapProvider: routes
+
+    func addRoute(
+        coordinates: [CLLocationCoordinate2D],
+        color: Color,
+        lineWidth: CGFloat,
+        identifier: String,
+        lineDashPattern: [NSNumber]?
+    ) {
+        let route = Route(
+            identifier: identifier,
+            coordinates: coordinates,
+            color: color,
+            lineWidth: lineWidth,
+            dashPattern: lineDashPattern
+        )
+
+        // Replace in place rather than appending a duplicate: OTPKit reuses identifiers
+        // across re-renders of the same leg, and appending would both leak and reorder.
+        if let index = routes.firstIndex(where: { $0.identifier == identifier }) {
+            routes[index] = route
+        } else {
+            routes.append(route)
+        }
+    }
+
+    func removeRoute(identifier: String) {
+        routes.removeAll { $0.identifier == identifier }
+    }
+
+    func clearAllRoutes() {
+        routes.removeAll()
+    }
+
+    // MARK: - OTPMapProvider: annotations
+
+    func addAnnotation(
+        coordinate: CLLocationCoordinate2D,
+        title: String,
+        subtitle: String?,
+        identifier: String,
+        type: OTPAnnotationType,
+        routeName: String?,
+        routeBackgroundColor: UIColor?,
+        routeTextColor: UIColor?
+    ) {
+        let annotation = Annotation(
+            identifier: identifier,
+            coordinate: coordinate,
+            title: title,
+            subtitle: subtitle,
+            type: type,
+            routeName: routeName,
+            routeBackgroundColor: routeBackgroundColor,
+            routeTextColor: routeTextColor
+        )
+
+        if let index = annotations.firstIndex(where: { $0.identifier == identifier }) {
+            annotations[index] = annotation
+        } else {
+            annotations.append(annotation)
+        }
+    }
+
+    func removeAnnotation(identifier: String) {
+        annotations.removeAll { $0.identifier == identifier }
+    }
+
+    func clearAllAnnotations() {
+        annotations.removeAll()
+    }
+
+    // MARK: - OTPMapProvider: camera
+
+    func setRegion(_ region: MKCoordinateRegion, animated: Bool) {
+        cameraTarget = .region(region, animated: animated)
+    }
+
+    func setVisibleMapRect(
+        _ mapRect: MKMapRect,
+        edgePadding: UIEdgeInsets,
+        animated: Bool
+    ) {
+        cameraTarget = .rect(mapRect, edgePadding: edgePadding, animated: animated)
+    }
+
+    func getCurrentRegion() -> MKCoordinateRegion {
+        // Before the first camera settle there is nothing truthful to return. OTPKit uses
+        // this to frame results, and a zero-span region reads as "the whole world" rather
+        // than as a wrong place, which is the safer of the two lies available here.
+        visibleRegion ?? MKCoordinateRegion(.world)
+    }
+
+    // MARK: - OTPMapProvider: interaction
+
+    func onMapTap(_ handler: @escaping (CLLocationCoordinate2D) -> Void) {
+        mapTapHandler = handler
+    }
+
+    func onAnnotationSelected(_ handler: @escaping (String) -> Void) {
+        annotationSelectionHandler = handler
+    }
+
+    // MARK: - OTPMapProvider: user location
+
+    func showUserLocation(_ show: Bool) {
+        wantsUserLocation = show
+    }
+
+    func centerOnUserLocation(animated: Bool) {
+        cameraTarget = .userLocation(animated: animated)
+    }
+
+    // MARK: - OTPMapProvider: map configuration
+
+    // The three below are deliberately no-ops.
+    //
+    // On the UIKit surface OTPKit owns a private map view and may reconfigure it freely.
+    // Here it is a guest on the panel's one shared map, alongside stops, bookmarks and
+    // rentals — and basemap style is the rider's own choice, persisted through
+    // `MapViewModel` and the Map settings sheet. Letting a trip plan silently reset it
+    // would be a bug, not a feature.
+
+    func setMapType(_ mapType: MKMapType) {}
+
+    func setUserInteractionEnabled(_ enabled: Bool) {}
+
+    func setControlsVisible(_ visible: Bool) {}
+}

--- a/OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift
+++ b/OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift
@@ -80,15 +80,17 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
     /// Insertion-ordered on purpose: OTPKit draws a white halo under each leg and then
     /// the coloured line on top, so the order it adds them in *is* the z-order. A
     /// dictionary would lose that and the halos would paint over the routes.
-    @Published private(set) var routes: [Route] = []
+    ///
+    /// Deliberately not `@Published` — see `scheduleChangeNotification()`.
+    private(set) var routes: [Route] = []
 
-    /// Insertion-ordered for the same reason.
-    @Published private(set) var annotations: [Annotation] = []
+    /// Insertion-ordered for the same reason. Not `@Published`, same reason.
+    private(set) var annotations: [Annotation] = []
 
     /// Whether OTPKit currently wants the user's location shown. The panel already shows
     /// it unconditionally, so this is recorded rather than acted on — see `setMapType`
     /// below for the general rule.
-    @Published private(set) var wantsUserLocation = false
+    private(set) var wantsUserLocation = false
 
     /// True once anything is drawn. Lets the view suppress the ambient stop layer while a
     /// trip is on the map, the way `MapSearchDisplayModel.suppressesAmbientStops` does
@@ -128,7 +130,7 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
         }
     }
 
-    @Published private(set) var cameraTarget: CameraTarget?
+    private(set) var cameraTarget: CameraTarget?
 
     /// The map's current visible region, pushed in by the view on every camera settle.
     ///
@@ -142,6 +144,41 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
     private var mapTapHandler: ((CLLocationCoordinate2D) -> Void)?
     private var annotationSelectionHandler: ((String) -> Void)?
 
+    // MARK: - Change notification
+
+    /// True while a notification is already queued for this turn.
+    private var changeNotificationScheduled = false
+
+    /// Tells observers to re-read, one runloop turn later.
+    ///
+    /// OTPKit drives this model from inside SwiftUI's own update pass: `DirectionsSheetView`
+    /// calls `MapCoordinator.showItinerary` / `focusOnLeg` from `onAppear` and from
+    /// `onChange(of:)` on the detent, the focused leg and the trip phase, and every one of
+    /// those lands here as a mutation. Publishing synchronously from those call sites is
+    /// what SwiftUI reports as "Publishing changes from within view updates is not allowed"
+    /// — on *every* interaction with the directions sheet, because every interaction moves
+    /// the map.
+    ///
+    /// This is specific to a state-backed `OTPMapProvider`. `MKMapViewAdapter` writes to an
+    /// `MKMapView`, which no SwiftUI view observes, so the same calls are invisible there.
+    /// The seam is ours, so the deferral belongs here rather than in OTPKit.
+    ///
+    /// The properties stay plain stored values so reads remain synchronous and truthful in
+    /// the same turn as the write — `isShowingTrip` gates the ambient stop layer, and
+    /// `getCurrentRegion()` answers OTPKit synchronously. Only the *notification* moves.
+    /// Coalesced because OTPKit draws a halo and a line per leg plus an annotation per
+    /// stop: one itinerary is dozens of calls, and they deserve one re-render.
+    private func scheduleChangeNotification() {
+        guard !changeNotificationScheduled else { return }
+        changeNotificationScheduled = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.changeNotificationScheduled = false
+            self.objectWillChange.send()
+        }
+    }
+
     // MARK: - Host-facing API
 
     /// Records the region the map is currently showing. Call on every camera settle.
@@ -150,6 +187,10 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
     }
 
     /// Applies-and-forgets the pending camera move.
+    ///
+    /// No change notification: the view calls this from its own `onChange` handler, having
+    /// just applied the target, so nothing needs to re-read on account of the clear — and
+    /// notifying from there would be the very mid-update publish this model exists to avoid.
     func consumeCameraTarget() {
         cameraTarget = nil
     }
@@ -171,6 +212,7 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
         annotations.removeAll()
         cameraTarget = nil
         wantsUserLocation = false
+        scheduleChangeNotification()
     }
 
     // MARK: - OTPMapProvider: routes
@@ -197,14 +239,17 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
         } else {
             routes.append(route)
         }
+        scheduleChangeNotification()
     }
 
     func removeRoute(identifier: String) {
         routes.removeAll { $0.identifier == identifier }
+        scheduleChangeNotification()
     }
 
     func clearAllRoutes() {
         routes.removeAll()
+        scheduleChangeNotification()
     }
 
     // MARK: - OTPMapProvider: annotations
@@ -235,20 +280,24 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
         } else {
             annotations.append(annotation)
         }
+        scheduleChangeNotification()
     }
 
     func removeAnnotation(identifier: String) {
         annotations.removeAll { $0.identifier == identifier }
+        scheduleChangeNotification()
     }
 
     func clearAllAnnotations() {
         annotations.removeAll()
+        scheduleChangeNotification()
     }
 
     // MARK: - OTPMapProvider: camera
 
     func setRegion(_ region: MKCoordinateRegion, animated: Bool) {
         cameraTarget = .region(region, animated: animated)
+        scheduleChangeNotification()
     }
 
     func setVisibleMapRect(
@@ -257,6 +306,7 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
         animated: Bool
     ) {
         cameraTarget = .rect(mapRect, edgePadding: edgePadding, animated: animated)
+        scheduleChangeNotification()
     }
 
     func getCurrentRegion() -> MKCoordinateRegion {
@@ -280,10 +330,12 @@ final class TripPlannerMapDisplayModel: ObservableObject, OTPMapProvider {
 
     func showUserLocation(_ show: Bool) {
         wantsUserLocation = show
+        scheduleChangeNotification()
     }
 
     func centerOnUserLocation(animated: Bool) {
         cameraTarget = .userLocation(animated: animated)
+        scheduleChangeNotification()
     }
 
     // MARK: - OTPMapProvider: map configuration

--- a/OBAKit/Sheet/Root/TripPlannerMapOverlays.swift
+++ b/OBAKit/Sheet/Root/TripPlannerMapOverlays.swift
@@ -1,0 +1,93 @@
+//
+//  TripPlannerMapOverlays.swift
+//  OBAKit
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import SwiftUI
+import MapKit
+
+/// Trip planner map content: the planned route polylines and the trip's annotations
+/// (start, end, intermediate stops).
+///
+/// A free function rather than inline map content because `MapPanelRootView.body`
+/// has already exceeded Swift's type-check budget once.
+///
+/// The routes and annotations are insertion-ordered on purpose: OTPKit draws a white
+/// halo under each leg and then the coloured line on top, so the order it adds them
+/// in *is* the z-order. Annotations (drawn last) sit on top of all routes.
+@MapContentBuilder
+func tripPlannerMapContent(
+    for display: TripPlannerMapDisplayModel
+) -> some MapContent {
+    // Draw routes in insertion order to preserve z-order (halos first, then
+    // coloured lines on top).
+    ForEach(display.routes) { route in
+        MapPolyline(
+            MKPolyline(coordinates: route.coordinates, count: route.coordinates.count)
+        )
+        .stroke(
+            route.color,
+            style: StrokeStyle(
+                lineWidth: route.lineWidth,
+                lineCap: .round,
+                lineJoin: .round,
+                dash: (route.dashPattern ?? []).map { CGFloat($0.doubleValue) }
+            )
+        )
+    }
+
+    // Draw annotations untagged: the trip plan UI handles selection, and
+    // MapPinSelection (which would enable `@State var selectedAnnotation`) is
+    // on PR #1293. Tagging annotations here would duplicate that PR's work on
+    // a file it rewrites heavily.
+    ForEach(display.annotations) { annotation in
+        Annotation("", coordinate: annotation.coordinate) {
+            tripAnnotationContent(for: annotation)
+        }
+    }
+}
+
+/// Builds the visual representation of a trip annotation pin.
+@ViewBuilder
+private func tripAnnotationContent(
+    for annotation: TripPlannerMapDisplayModel.Annotation
+) -> some View {
+    VStack(spacing: 0) {
+        // Route badge (if this annotation has transit route info).
+        if let routeName = annotation.routeName,
+           let backgroundColor = annotation.routeBackgroundColor,
+           let textColor = annotation.routeTextColor {
+            Text(routeName)
+                .font(.system(size: 10, weight: .semibold))
+                .lineLimit(1)
+                .foregroundColor(Color(textColor))
+                .padding(.vertical, 2)
+                .padding(.horizontal, 4)
+                .background(Color(backgroundColor))
+                .cornerRadius(3)
+                .padding(.bottom, 4)
+        }
+
+        // Primary title.
+        Text(annotation.title)
+            .font(.system(size: 12, weight: .semibold))
+            .lineLimit(1)
+            .foregroundColor(Color(uiColor: .label))
+
+        // Optional subtitle.
+        if let subtitle = annotation.subtitle {
+            Text(subtitle)
+                .font(.system(size: 10))
+                .lineLimit(1)
+                .foregroundColor(Color(uiColor: .secondaryLabel))
+        }
+    }
+    .padding(6)
+    .background(Color(uiColor: .systemBackground))
+    .cornerRadius(6)
+    .shadow(radius: 2)
+}

--- a/OBAKit/Sheet/Root/TripPlannerMapOverlays.swift
+++ b/OBAKit/Sheet/Root/TripPlannerMapOverlays.swift
@@ -40,14 +40,14 @@ func tripPlannerMapContent(
         )
     }
 
-    // Draw annotations untagged: the trip plan UI handles selection, and
-    // MapPinSelection (which would enable `@State var selectedAnnotation`) is
-    // on PR #1293. Tagging annotations here would duplicate that PR's work on
-    // a file it rewrites heavily.
+    // Tagged with OTPKit's own opaque identifier so a tap routes back to OTPKit
+    // verbatim — the panel never interprets it. Same tagging shape the ambient
+    // stop and rental layers use, so all three share one `selection` binding.
     ForEach(display.annotations) { annotation in
         Annotation("", coordinate: annotation.coordinate) {
             tripAnnotationContent(for: annotation)
         }
+        .tag(MapPinSelection.tripPlannerAnnotation(annotation.identifier))
     }
 }
 

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -26,7 +26,6 @@ final class AppSheetRouteTests {
         #expect(AppSheetRoute.nearbyAll.id == "nearbyAll")
         #expect(AppSheetRoute.recentStopsAll.id == "recentStopsAll")
         #expect(AppSheetRoute.bookmarksAll.id == "bookmarksAll")
-        #expect(AppSheetRoute.tripPlanner.id == "tripPlanner")
         #expect(AppSheetRoute.routePicker.id == "routePicker")
         #expect(AppSheetRoute.more.id == "more")
         #expect(AppSheetRoute.settings.id == "settings")
@@ -56,7 +55,7 @@ final class AppSheetRouteTests {
 
     @Test func `Prefers stacking stacked layer routes`() throws {
         #expect(AppSheetRoute.stopDetails(stopID: "1").prefersStacking == true)
-        #expect(AppSheetRoute.tripPlanner.prefersStacking == true)
+        #expect(AppSheetRoute.tripPlanner(TripPlannerRequest()).prefersStacking == true)
         #expect(AppSheetRoute.tripDetails(tripID: "t").prefersStacking == true)
         let route = try Fixtures.createRoute(id: "r")
         #expect(AppSheetRoute.currentTrip(route: route).prefersStacking == true)
@@ -117,10 +116,17 @@ final class AppSheetRouteTests {
         #expect(config.fullScreenDetent == nil)
     }
 
+    @Test func `Trip planner detent includes tip rung`() {
+        let config = AppSheetRoute.tripPlanner(TripPlannerRequest()).detentConfiguration
+        #expect(config.detents == [.height(AppSheetRoute.tripPlannerTipHeight), .medium, .large])
+        #expect(config.initialDetent == .large)
+        #expect(config.isDismissDisabled == false)
+        #expect(config.fullScreenDetent == nil)
+    }
+
     @Test func `Stacked detail routes share large start and allow dismiss`() throws {
         let currentTripRoute = try Fixtures.createRoute(id: "r")
         let routes: [AppSheetRoute] = [
-            .tripPlanner,
             .tripDetails(tripID: "t"),
             .routePicker,
             .currentTrip(route: currentTripRoute),
@@ -144,7 +150,7 @@ final class AppSheetRouteTests {
         let currentTripRoute = try Fixtures.createRoute(id: "r")
         let routes: [AppSheetRoute] = [
             .home, .search, .nearbyAll, .recentStopsAll, .bookmarksAll,
-            .stopDetails(stopID: "1"), .tripPlanner, .tripDetails(tripID: "t"),
+            .stopDetails(stopID: "1"), .tripPlanner(TripPlannerRequest()), .tripDetails(tripID: "t"),
             .routePicker, .currentTrip(route: currentTripRoute), .transitAlert(alertID: "a"),
             .more, .settings
         ]
@@ -222,6 +228,55 @@ final class AppSheetRouteTests {
         let sheetRoute2 = AppSheetRoute.currentTrip(route: route2)
         // Two routes with the same ID should hash to the same value
         #expect(sheetRoute1.hashValue == sheetRoute2.hashValue)
+    }
+
+    // MARK: - TripPlannerRequest
+
+    @Test func `TripPlannerRequest with equal fields are equal and hash equally`() {
+        let req1 = TripPlannerRequest()
+        let req2 = TripPlannerRequest()
+        #expect(req1 == req2)
+        #expect(req1.hashValue == req2.hashValue)
+    }
+
+    @Test func `TripPlannerRequest with different coordinates are unequal`() {
+        let coord1 = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+        let coord2 = CLLocationCoordinate2D(latitude: 47.7, longitude: -122.4)
+        let req1 = TripPlannerRequest(viaPoint: coord1)
+        let req2 = TripPlannerRequest(viaPoint: coord2)
+        #expect(req1 != req2)
+    }
+
+    @Test func `Trip planner analytics key differs between destination, via-point, and empty requests`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)))
+        let coord = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+
+        let destinationRequest = AppSheetRoute.tripPlanner(TripPlannerRequest(destination: item))
+        let viaPointRequest = AppSheetRoute.tripPlanner(TripPlannerRequest(viaPoint: coord))
+        let emptyRequest = AppSheetRoute.tripPlanner(TripPlannerRequest())
+
+        #expect(destinationRequest.id == "tripPlanner_destination")
+        #expect(viaPointRequest.id == "tripPlanner_viaPoint")
+        #expect(emptyRequest.id == "tripPlanner_blank")
+
+        // Verify IDs differ
+        #expect(destinationRequest.id != viaPointRequest.id)
+        #expect(destinationRequest.id != emptyRequest.id)
+        #expect(viaPointRequest.id != emptyRequest.id)
+    }
+
+    @Test func `Trip planner analytics key contains no coordinate digits`() {
+        let item = MKMapItem(placemark: MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6123456, longitude: -122.3456789)))
+        let coord = CLLocationCoordinate2D(latitude: 47.6123456, longitude: -122.3456789)
+
+        let destinationRequest = AppSheetRoute.tripPlanner(TripPlannerRequest(destination: item))
+        let viaPointRequest = AppSheetRoute.tripPlanner(TripPlannerRequest(viaPoint: coord))
+
+        // Analytics keys should not contain coordinate numbers (privacy guard)
+        #expect(!destinationRequest.id.contains("47."))
+        #expect(!destinationRequest.id.contains("122."))
+        #expect(!viaPointRequest.id.contains("47."))
+        #expect(!viaPointRequest.id.contains("122."))
     }
 
     // MARK: - Search result routes

--- a/OBAKitTests/Sheet/AppSheetRouteTests.swift
+++ b/OBAKitTests/Sheet/AppSheetRouteTests.swift
@@ -116,10 +116,14 @@ final class AppSheetRouteTests {
         #expect(config.fullScreenDetent == nil)
     }
 
-    @Test func `Trip planner detent includes tip rung`() {
+    /// Opens at `.medium`, not `.large`: the planner draws its route on the map behind
+    /// it, and a full-height sheet would cover the answer. `.medium` is also the rung
+    /// the sheet returns to when OTPKit's directions sheet opens over it.
+    @Test func `Trip planner opens at medium and includes tip rung`() {
         let config = AppSheetRoute.tripPlanner(TripPlannerRequest()).detentConfiguration
         #expect(config.detents == [.height(AppSheetRoute.tripPlannerTipHeight), .medium, .large])
-        #expect(config.initialDetent == .large)
+        #expect(config.initialDetent == .medium)
+        #expect(config.detents.contains(config.initialDetent))
         #expect(config.isDismissDisabled == false)
         #expect(config.fullScreenDetent == nil)
     }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -282,4 +282,33 @@ final class AppSheetViewFactoryTests: OBATestCase {
 
         #expect(view.application === application)
     }
+
+    /// The trip planner sheet builds successfully when the region supports OTP
+    /// and trip planning is enabled. The view is no longer routed to `unimplementedView`.
+    @Test @MainActor
+    func `Trip planner view builds with a valid request`() throws {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let request = TripPlannerRequest()
+
+        let view = makeFactory(application: application).tripPlannerView(request: request)
+
+        #expect(view.application === application)
+        #expect(view.request == request)
+    }
+
+    /// The trip planner display model is shared with the map, so the sheet must
+    /// receive the same instance the factory was constructed with — not a private copy.
+    @Test @MainActor
+    func `Trip planner view forwards the shared trip planner display model`() {
+        let dataLoader = MockDataLoader(testName: name)
+        let application = buildApplication(queue: queue, dataLoader: dataLoader)
+        let displayModel = TripPlannerMapDisplayModel()
+        let request = TripPlannerRequest()
+
+        let factory = makeFactory(application: application, tripPlannerMapDisplayModel: displayModel)
+        let view = factory.tripPlannerView(request: request)
+
+        #expect(view.tripPlannerMapDisplayModel === displayModel)
+    }
 }

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -35,14 +35,15 @@ final class AppSheetViewFactoryTests: OBATestCase {
         queue.cancelAllOperations()
     }
 
-    /// The coordinator, display model, and stops observer are required dependencies, so every test
-    /// builds the factory the same way the app does.
+    /// The coordinator, display model, stops observer, and trip planner display model are required dependencies,
+    /// so every test builds the factory the same way the app does.
     @MainActor
     private func makeFactory(
         application: Application,
         coordinator: SheetCoordinator<AppSheetRoute> = SheetCoordinator(root: .home),
         displayModel: MapSearchDisplayModel = MapSearchDisplayModel(),
-        stopsObserver: MapStopsObserver? = nil
+        stopsObserver: MapStopsObserver? = nil,
+        tripPlannerMapDisplayModel: TripPlannerMapDisplayModel? = nil
     ) -> AppSheetViewFactory {
         AppSheetViewFactory(
             application: application,
@@ -51,7 +52,8 @@ final class AppSheetViewFactoryTests: OBATestCase {
             presentingController: { nil },
             coordinator: coordinator,
             searchDisplayModel: displayModel,
-            stopsObserver: stopsObserver ?? MapStopsObserver(application: application)
+            stopsObserver: stopsObserver ?? MapStopsObserver(application: application),
+            tripPlannerMapDisplayModel: tripPlannerMapDisplayModel ?? TripPlannerMapDisplayModel()
         )
     }
 

--- a/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
+++ b/OBAKitTests/Sheet/AppSheetViewFactoryTests.swift
@@ -12,6 +12,7 @@ import Foundation
 import Testing
 import CoreLocation
 import MapKit
+import OTPKit
 @testable import OBAKit
 @testable import OBAKitCore
 
@@ -312,5 +313,110 @@ final class AppSheetViewFactoryTests: OBATestCase {
         let view = factory.tripPlannerView(request: request)
 
         #expect(view.tripPlannerMapDisplayModel === displayModel)
+    }
+
+    // MARK: - Rental "plan a trip using this vehicle"
+
+    /// The rental sheets plan a trip *through* the vehicle: it becomes a via
+    /// point with the mode pinned to `.transitBikeRental`, matching
+    /// `MapViewController.rentalLayer(planTripUsing:)` on the UIKit surface.
+    /// Routing *to* the vehicle would be the wrong trip — a rider wants to ride
+    /// it onward, not arrive at it.
+    @Test @MainActor
+    func `Rental plan trip handler pushes the vehicle as a via point in bike rental mode`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        #expect(application.regionsService.currentRegion?.supportsOTP == true)
+
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let factory = makeFactory(application: application, coordinator: coordinator)
+        let rental = try RentalFixtures.pedalBike(id: "b7")
+
+        let handler = try #require(factory.planTripUsingRental)
+        handler(rental)
+
+        // `.tripPlanner` prefers stacking, so it lands on the stacked layer.
+        guard case .tripPlanner(let request) = coordinator.stackedRoutes.last else {
+            Issue.record("Expected .tripPlanner stacked, got \(String(describing: coordinator.stackedRoutes.last))")
+            return
+        }
+        #expect(request.transportMode == .transitBikeRental)
+        #expect(request.viaPoint?.latitude == rental.coordinate.latitude)
+        #expect(request.viaPoint?.longitude == rental.coordinate.longitude)
+        // The vehicle is not the destination — that field stays open for the rider.
+        #expect(request.destination == nil)
+    }
+
+    /// No OTP server means no trip planner to route into, so the handler is nil
+    /// and the sheets hide the button rather than showing a dead primary action.
+    ///
+    /// Exercises the gate directly rather than swapping the app's current region:
+    /// `RegionsService.add(customRegion:)` writes to the shared on-disk regions
+    /// store, and doing that mid-suite takes 17 unrelated suites down with it.
+    @Test @MainActor
+    func `Rental trip planning is offered only when the region has an OTP server`() {
+        let noOTPRegion = Region(
+            name: "No OTP Region",
+            OBABaseURL: URL(string: "http://example.com")!,
+            coordinateRegion: MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060),
+                latitudinalMeters: 1000.0,
+                longitudinalMeters: 1000.0
+            ),
+            contactEmail: "test@example.com"
+        )
+
+        #expect(AppSheetViewFactory.offersTripPlanning(in: noOTPRegion) == false)
+        #expect(AppSheetViewFactory.offersTripPlanning(in: nil) == false)
+        #expect(AppSheetViewFactory.offersTripPlanning(in: Fixtures.pugetSoundRegion))
+    }
+
+    // MARK: - Rental cluster drill-in
+
+    /// Tapping a row in the cluster list pushes the same `.rentalDetail` route a tap on a
+    /// lone map pin opens, rather than letting the list present its own sheet.
+    ///
+    /// The list *can* present one — it does on the UIKit surface — but on the panel that
+    /// sheet and `StackedSheetLayer`'s next route would be two presentations from one view.
+    /// SwiftUI permits one ("Currently, only presenting a single sheet is supported"), so
+    /// the trip planner pushed from inside the rental sheet stayed queued until the rider
+    /// dismissed the rental by hand.
+    @Test @MainActor
+    func `Selecting a rental from the cluster list pushes the rental detail route`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let factory = makeFactory(application: application, coordinator: coordinator)
+        let rental = try RentalFixtures.pedalBike(id: "b7")
+
+        coordinator.push(.rentalCluster(memberIDs: [rental.id, "b8"]))
+        factory.selectRentalFromCluster(rental)
+
+        #expect(coordinator.stackedRoutes == [
+            .rentalCluster(memberIDs: [rental.id, "b8"]),
+            .rentalDetail(rentalID: rental.id)
+        ])
+    }
+
+    /// The whole reported flow, as routes: cluster, then vehicle, then planner. Each is its
+    /// own stacked entry, which is what gives each one its own presenting host — the
+    /// property that was violated when the list presented the vehicle sheet itself.
+    @Test @MainActor
+    func `Cluster to vehicle to trip planner produces three distinct stacked sheets`() throws {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        let factory = makeFactory(application: application, coordinator: coordinator)
+        let rental = try RentalFixtures.pedalBike(id: "b7")
+
+        coordinator.push(.rentalCluster(memberIDs: [rental.id]))
+        factory.selectRentalFromCluster(rental)
+        let planTrip = try #require(factory.planTripUsingRental)
+        planTrip(rental)
+
+        #expect(coordinator.stackedRoutes.count == 3)
+        guard case .tripPlanner(let request) = coordinator.stackedRoutes.last else {
+            Issue.record("Expected .tripPlanner on top, got \(String(describing: coordinator.stackedRoutes.last))")
+            return
+        }
+        #expect(request.transportMode == .transitBikeRental)
+        #expect(request.viaPoint?.latitude == rental.coordinate.latitude)
     }
 }

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -40,7 +40,8 @@ final class MapItemSheetViewTests: OBATestCase {
             presentingController: { nil },
             coordinator: SheetCoordinator(root: .home),
             searchDisplayModel: MapSearchDisplayModel(),
-            stopsObserver: MapStopsObserver(application: application)
+            stopsObserver: MapStopsObserver(application: application),
+            tripPlannerMapDisplayModel: TripPlannerMapDisplayModel()
         )
     }
 

--- a/OBAKitTests/Sheet/MapItemSheetViewTests.swift
+++ b/OBAKitTests/Sheet/MapItemSheetViewTests.swift
@@ -149,4 +149,58 @@ final class MapItemSheetViewTests: OBATestCase {
         #expect(view.application === application)
         #expect(view.coordinate?.latitude == coordinate.latitude)
     }
+
+    @Test @MainActor
+    func `Region with OTP URL produces a plan trip handler that pushes trip planner`() {
+        let application = buildApplication(queue: queue, dataLoader: MockDataLoader(testName: name))
+
+        // Verify Puget Sound region supports OTP
+        #expect(application.regionsService.currentRegion?.supportsOTP == true)
+
+        let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3))
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = "Pike Place Market"
+
+        var pushed: AppSheetRoute?
+
+        // Create a handler like MapItemSheetView does
+        let planTripHandler: (() -> Void)? = application.regionsService.currentRegion?.supportsOTP == true ? {
+            pushed = .tripPlanner(TripPlannerRequest(destination: mapItem))
+        } : nil
+
+        #expect(planTripHandler != nil)
+        planTripHandler?()
+
+        #expect(pushed != nil)
+        if case .tripPlanner(let request) = pushed {
+            #expect(request.destination === mapItem)
+        } else {
+            Issue.record("Expected .tripPlanner route")
+        }
+    }
+
+    @Test @MainActor
+    func `Region without OTP URL produces nil plan trip handler`() {
+        let coordinateRegion = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060),
+            latitudinalMeters: 1000.0,
+            longitudinalMeters: 1000.0
+        )
+        let noOTPRegion = Region(
+            name: "No OTP Region",
+            OBABaseURL: URL(string: "http://example.com")!,
+            coordinateRegion: coordinateRegion,
+            contactEmail: "test@example.com"
+        )
+
+        // Verify this region doesn't support OTP
+        #expect(noOTPRegion.supportsOTP == false)
+
+        // Simulate what MapItemSheetView does with this region
+        let planTripHandler: (() -> Void)? = noOTPRegion.supportsOTP == true ? {
+            // This shouldn't execute
+        } : nil
+
+        #expect(planTripHandler == nil)
+    }
 }

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -172,6 +172,55 @@ final class SheetCoordinatorTests {
         #expect(coordinator.stackedDetents == original)
     }
 
+    // MARK: - setStackedDetent(_:forTopmostRouteMatching:)
+
+    /// The depth-free overload is what a sheet's own content can call: it knows which
+    /// route it is, never where it sits in the pile.
+    @Test func `Set stacked detent by predicate targets the topmost match`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
+        coordinator.push(.stopDetails(stopID: "1"))
+        coordinator.push(.tripPlanner(TripPlannerRequest(viaPoint: CLLocationCoordinate2D(latitude: 1, longitude: 2))))
+
+        let applied = coordinator.setStackedDetent(.large) { route in
+            if case .tripPlanner = route { return true }
+            return false
+        }
+
+        #expect(applied)
+        // Depth 2, not depth 0: the topmost planner is the one on screen.
+        #expect(coordinator.stackedDetents == [.medium, .large, .large])
+    }
+
+    @Test func `Set stacked detent by predicate is a no op when nothing matches`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.stopDetails(stopID: "1"))
+        let original = coordinator.stackedDetents
+
+        let applied = coordinator.setStackedDetent(.medium) { route in
+            if case .tripPlanner = route { return true }
+            return false
+        }
+
+        #expect(applied == false)
+        #expect(coordinator.stackedDetents == original)
+    }
+
+    /// `presentationDetents(_:selection:)` ignores a selection outside its set, so
+    /// storing one would leave the coordinator disagreeing with the screen.
+    @Test func `Set stacked detent by predicate refuses a detent the route does not declare`() {
+        let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
+        coordinator.push(.stopDetails(stopID: "1"))
+
+        let applied = coordinator.setStackedDetent(.medium) { route in
+            if case .stopDetails = route { return true }
+            return false
+        }
+
+        #expect(applied == false)
+        #expect(coordinator.stackedDetents == [.large])
+    }
+
     // MARK: - stackedRoute(at:) / stackedDetent(at:fallback:)
 
     @Test func `Stacked route at depth returns route when in range`() {

--- a/OBAKitTests/Sheet/SheetCoordinatorTests.swift
+++ b/OBAKitTests/Sheet/SheetCoordinatorTests.swift
@@ -54,12 +54,12 @@ final class SheetCoordinatorTests {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
 
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
 
         #expect(coordinator.routeStack.count == 2)
         #expect(coordinator.currentRoute == .search)
-        #expect(coordinator.stackedRoutes == [.tripPlanner])
-        #expect(coordinator.stackedDetents == [AppSheetRoute.tripPlanner.detentConfiguration.initialDetent])
+        #expect(coordinator.stackedRoutes == [.tripPlanner(TripPlannerRequest())])
+        #expect(coordinator.stackedDetents == [AppSheetRoute.tripPlanner(TripPlannerRequest()).detentConfiguration.initialDetent])
     }
 
     @Test func `Push stacking route stacks multiple sheets`() {
@@ -81,12 +81,12 @@ final class SheetCoordinatorTests {
     @Test func `Pop with stacked presented removes top stacked and preserves content stack`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         coordinator.push(.search)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         coordinator.push(.stopDetails(stopID: "1"))
 
         coordinator.pop()
 
-        #expect(coordinator.stackedRoutes == [.tripPlanner])
+        #expect(coordinator.stackedRoutes == [.tripPlanner(TripPlannerRequest())])
         #expect(coordinator.stackedDetents.count == 1)
         #expect(coordinator.routeStack.count == 2)
         #expect(coordinator.currentRoute == .search)
@@ -94,7 +94,7 @@ final class SheetCoordinatorTests {
 
     @Test func `Pop last stacked route empties stacked layer`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
 
         coordinator.pop()
 
@@ -142,18 +142,18 @@ final class SheetCoordinatorTests {
 
     @Test func `Truncate stacked ignores out of range depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
 
         coordinator.truncateStacked(toDepth: 5)
 
-        #expect(coordinator.stackedRoutes == [.tripPlanner])
+        #expect(coordinator.stackedRoutes == [.tripPlanner(TripPlannerRequest())])
     }
 
     // MARK: - setStackedDetent
 
     @Test func `Set stacked detent persists at given depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         coordinator.push(.stopDetails(stopID: "1"))
 
         coordinator.setStackedDetent(.medium, at: 0)
@@ -164,7 +164,7 @@ final class SheetCoordinatorTests {
 
     @Test func `Set stacked detent ignores out of range depth`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         let original = coordinator.stackedDetents
 
         coordinator.setStackedDetent(.medium, at: 5)
@@ -176,10 +176,10 @@ final class SheetCoordinatorTests {
 
     @Test func `Stacked route at depth returns route when in range`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         coordinator.push(.stopDetails(stopID: "1"))
 
-        #expect(coordinator.stackedRoute(at: 0) == .tripPlanner)
+        #expect(coordinator.stackedRoute(at: 0) == .tripPlanner(TripPlannerRequest()))
         #expect(coordinator.stackedRoute(at: 1) == .stopDetails(stopID: "1"))
     }
 
@@ -187,13 +187,13 @@ final class SheetCoordinatorTests {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.stackedRoute(at: 0) == nil)
 
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         #expect(coordinator.stackedRoute(at: 1) == nil)
     }
 
     @Test func `Stacked detent at depth returns stored detent`() {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         coordinator.setStackedDetent(.medium, at: 0)
 
         #expect(coordinator.stackedDetent(at: 0, fallback: .large) == .medium)
@@ -210,7 +210,7 @@ final class SheetCoordinatorTests {
         let coordinator = SheetCoordinator<AppSheetRoute>(root: .home)
         #expect(coordinator.canPop == false)
 
-        coordinator.push(.tripPlanner)
+        coordinator.push(.tripPlanner(TripPlannerRequest()))
         #expect(coordinator.canPop == true)
     }
 
@@ -237,7 +237,7 @@ final class SheetCoordinatorTests {
         coordinator.push(.search)
         #expect(coordinator.currentDetents == AppSheetRoute.search.detentConfiguration.detents)
 
-        coordinator.push(.tripPlanner) // stacked — must not alter currentDetents
+        coordinator.push(.tripPlanner(TripPlannerRequest())) // stacked — must not alter currentDetents
         #expect(coordinator.currentDetents == AppSheetRoute.search.detentConfiguration.detents)
     }
 

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -7,6 +7,7 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import Combine
 import CoreLocation
 import Foundation
 import MapKit
@@ -377,5 +378,133 @@ struct TripPlannerMapDisplayModelTests {
         #expect(heightFraction == 0.60) // Symmetric expansion: 0.30 each side
 
         // Does not trap on zero size
+    }
+
+    // MARK: - MapPinSelection round trip
+
+    /// The panel tags every trip pin with OTPKit's own opaque identifier and hands
+    /// it straight back on tap. This asserts the round trip end to end — the tag
+    /// the overlay builds is the identifier OTPKit gets back, unmodified.
+    @Test("Tapping a trip pin returns OTPKit's identifier verbatim")
+    func tripPinSelectionRoundTrip() {
+        let model = TripPlannerMapDisplayModel()
+        var selected: String?
+        model.onAnnotationSelected { selected = $0 }
+
+        model.addAnnotation(
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            title: "Westlake",
+            subtitle: nil,
+            identifier: "station_from_0",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+
+        guard let annotation = model.annotations.first else {
+            Issue.record("Expected the annotation to be recorded")
+            return
+        }
+        let tag = MapPinSelection.tripPlannerAnnotation(annotation.identifier)
+
+        guard case .tripPlannerAnnotation(let identifier) = tag else {
+            Issue.record("Expected .tripPlannerAnnotation")
+            return
+        }
+        model.handleAnnotationSelection(identifier: identifier)
+
+        #expect(selected == "station_from_0")
+    }
+
+    // MARK: - Deferred change notification
+
+    /// OTPKit drives this model from inside SwiftUI's update pass — `DirectionsSheetView`
+    /// calls into `MapCoordinator` from `onAppear` and from three `onChange` handlers — so
+    /// a synchronous publish here is "Publishing changes from within view updates is not
+    /// allowed" on every interaction with the directions sheet. The notification has to
+    /// land after the pass, and only the notification: reads stay synchronous.
+    @Test("Drawing does not notify observers synchronously")
+    func drawingDefersChangeNotification() {
+        let model = TripPlannerMapDisplayModel()
+        var notifications = 0
+        let cancellable = model.objectWillChange.sink { _ in notifications += 1 }
+        defer { cancellable.cancel() }
+
+        model.addRoute(
+            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
+            color: .blue,
+            lineWidth: 4,
+            identifier: "leg_0",
+            lineDashPattern: nil
+        )
+
+        #expect(notifications == 0)
+        // The write itself is not deferred — the ambient-stop gate reads this in the same
+        // turn OTPKit draws.
+        #expect(model.routes.count == 1)
+        #expect(model.isShowingTrip)
+    }
+
+    /// One itinerary is dozens of provider calls — a halo and a line per leg, an annotation
+    /// per stop. They deserve one re-render between them, not one each.
+    @Test("A burst of drawing calls coalesces into a single notification")
+    func drawingBurstCoalescesIntoOneNotification() async {
+        let model = TripPlannerMapDisplayModel()
+        var notifications = 0
+        let cancellable = model.objectWillChange.sink { _ in notifications += 1 }
+        defer { cancellable.cancel() }
+
+        for index in 0..<10 {
+            model.addRoute(
+                coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
+                color: .blue,
+                lineWidth: 4,
+                identifier: "leg_\(index)",
+                lineDashPattern: nil
+            )
+        }
+        model.setRegion(
+            MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+                               latitudinalMeters: 1000,
+                               longitudinalMeters: 1000),
+            animated: true
+        )
+
+        #expect(notifications == 0)
+
+        // Let the scheduled hop run.
+        await Task.yield()
+
+        #expect(notifications == 1)
+        #expect(model.routes.count == 10)
+    }
+
+    /// Clearing has to reach the map too, or a dismissed trip stays drawn.
+    @Test("Clearing notifies observers on the next turn")
+    func clearNotifiesAfterTheUpdatePass() async {
+        let model = TripPlannerMapDisplayModel()
+        model.addAnnotation(
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            title: "Westlake",
+            subtitle: nil,
+            identifier: "station_from_0",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+        await Task.yield()
+
+        var notifications = 0
+        let cancellable = model.objectWillChange.sink { _ in notifications += 1 }
+        defer { cancellable.cancel() }
+
+        model.clear()
+        #expect(notifications == 0)
+        #expect(model.isShowingTrip == false)
+
+        await Task.yield()
+        #expect(notifications == 1)
     }
 }

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -1,0 +1,322 @@
+//
+//  TripPlannerMapDisplayModelTests.swift
+//  OBAKitTests
+//
+//  Copyright © Open Transit Software Foundation
+//  This source code is licensed under the Apache 2.0 license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import SwiftUI
+import Testing
+import OTPKit
+@testable import OBAKit
+
+/// Tests for `TripPlannerMapDisplayModel`: the `OTPMapProvider` conformance that turns
+/// OTPKit's imperative map calls into state the SwiftUI panel can render.
+///
+/// Everything here drives the model through the protocol, the way `MapCoordinator` will,
+/// so the assertions describe the contract OTPKit actually depends on.
+@Suite(.serialized)
+@MainActor
+struct TripPlannerMapDisplayModelTests {
+
+    private let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
+    private let bellevue = CLLocationCoordinate2D(latitude: 47.6101, longitude: -122.2015)
+
+    private func makeModel() -> TripPlannerMapDisplayModel {
+        TripPlannerMapDisplayModel()
+    }
+
+    private func addRoute(
+        to model: TripPlannerMapDisplayModel,
+        identifier: String,
+        color: Color = .blue,
+        lineWidth: CGFloat = 4
+    ) {
+        model.addRoute(
+            coordinates: [seattle, bellevue],
+            color: color,
+            lineWidth: lineWidth,
+            identifier: identifier,
+            lineDashPattern: nil
+        )
+    }
+
+    private func addAnnotation(
+        to model: TripPlannerMapDisplayModel,
+        identifier: String,
+        type: OTPAnnotationType = .origin
+    ) {
+        model.addAnnotation(
+            coordinate: seattle,
+            title: identifier,
+            subtitle: nil,
+            identifier: identifier,
+            type: type,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+    }
+
+    // MARK: - Draw order
+
+    @Test("Routes keep insertion order, which is the z-order OTPKit relies on")
+    func routesKeepInsertionOrder() {
+        let model = makeModel()
+
+        // The order MapCoordinator uses: a white halo first, then the coloured leg on
+        // top. If this ever reordered, halos would paint over the routes.
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0")
+        addRoute(to: model, identifier: "halo_leg_1")
+        addRoute(to: model, identifier: "leg_1")
+
+        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0", "halo_leg_1", "leg_1"])
+    }
+
+    @Test("Annotations keep insertion order")
+    func annotationsKeepInsertionOrder() {
+        let model = makeModel()
+
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "station_from_0")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+
+        #expect(model.annotations.map(\.identifier) == ["origin", "station_from_0", "destination"])
+    }
+
+    // MARK: - Identifier reuse
+
+    @Test("Re-adding an identifier replaces in place rather than duplicating")
+    func reAddingRouteReplacesInPlace() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0", color: .blue)
+        addRoute(to: model, identifier: "leg_0", color: .red, lineWidth: 8)
+
+        // Still two routes, the updated one still second: OTPKit reuses identifiers
+        // across re-renders, so appending would both leak and disturb the z-order.
+        #expect(model.routes.count == 2)
+        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0"])
+        #expect(model.routes[1].lineWidth == 8)
+    }
+
+    @Test("Re-adding an annotation identifier replaces in place")
+    func reAddingAnnotationReplacesInPlace() {
+        let model = makeModel()
+
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+        model.addAnnotation(
+            coordinate: bellevue,
+            title: "moved",
+            subtitle: nil,
+            identifier: "origin",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+
+        #expect(model.annotations.count == 2)
+        #expect(model.annotations[0].title == "moved")
+        #expect(model.annotations[0].coordinate.latitude == bellevue.latitude)
+    }
+
+    // MARK: - Removal
+
+    @Test("Removing by identifier leaves the rest untouched")
+    func removalIsScopedToIdentifier() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+
+        model.removeRoute(identifier: "halo_leg_0")
+        model.removeAnnotation(identifier: "origin")
+
+        #expect(model.routes.map(\.identifier) == ["leg_0"])
+        #expect(model.annotations.map(\.identifier) == ["destination"])
+    }
+
+    @Test("clearAllRoutes leaves annotations alone, and vice versa")
+    func clearAllIsScopedToItsCollection() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+
+        model.clearAllRoutes()
+        #expect(model.routes.isEmpty)
+        #expect(model.annotations.count == 1)
+
+        addRoute(to: model, identifier: "leg_0")
+        model.clearAllAnnotations()
+        #expect(model.annotations.isEmpty)
+        #expect(model.routes.count == 1)
+    }
+
+    // MARK: - Trip presence
+
+    @Test("isShowingTrip tracks whether anything is drawn")
+    func isShowingTripTracksContent() {
+        let model = makeModel()
+        #expect(model.isShowingTrip == false)
+
+        addRoute(to: model, identifier: "leg_0")
+        #expect(model.isShowingTrip)
+
+        model.clearAllRoutes()
+        #expect(model.isShowingTrip == false)
+
+        // An annotation alone still counts — a planner that has set only an origin pin
+        // is showing something the ambient stop layer should not fight with.
+        addAnnotation(to: model, identifier: "origin")
+        #expect(model.isShowingTrip)
+    }
+
+    // MARK: - Camera
+
+    @Test("Camera targets are one-shot")
+    func cameraTargetIsOneShot() {
+        let model = makeModel()
+        #expect(model.cameraTarget == nil)
+
+        let rect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
+        model.setVisibleMapRect(rect, edgePadding: .zero, animated: true)
+        #expect(model.cameraTarget == .rect(rect, edgePadding: .zero, animated: true))
+
+        // Without consumption the view would re-apply this on every unrelated body pass,
+        // yanking the map back while the rider is panning.
+        model.consumeCameraTarget()
+        #expect(model.cameraTarget == nil)
+    }
+
+    @Test("centerOnUserLocation is expressed as a camera target, not a direct move")
+    func centerOnUserLocationBecomesTarget() {
+        let model = makeModel()
+
+        model.centerOnUserLocation(animated: false)
+
+        #expect(model.cameraTarget == .userLocation(animated: false))
+    }
+
+    @Test("getCurrentRegion reports what the view last recorded")
+    func currentRegionReflectsRecordedViewport() {
+        let model = makeModel()
+
+        let region = MKCoordinateRegion(
+            center: seattle,
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+        model.updateVisibleRegion(region)
+
+        let read = model.getCurrentRegion()
+        #expect(read.center.latitude == seattle.latitude)
+        #expect(read.span.latitudeDelta == 0.05)
+    }
+
+    @Test("getCurrentRegion falls back to the world before the first camera settle")
+    func currentRegionFallsBackToWorld() {
+        let model = makeModel()
+
+        // A zero-span region would read as a specific — and wrong — place. Reporting the
+        // world is the honest answer when the map has not said where it is looking.
+        #expect(model.getCurrentRegion().span.latitudeDelta > 100)
+    }
+
+    // MARK: - Interaction
+
+    @Test("Map taps reach the handler OTPKit registered")
+    func mapTapReachesHandler() {
+        let model = makeModel()
+
+        var tapped: CLLocationCoordinate2D?
+        model.onMapTap { tapped = $0 }
+        model.handleMapTap(at: bellevue)
+
+        #expect(tapped?.latitude == bellevue.latitude)
+    }
+
+    @Test("Annotation selection forwards OTPKit's own identifier verbatim")
+    func annotationSelectionForwardsIdentifier() {
+        let model = makeModel()
+
+        var selected: String?
+        model.onAnnotationSelected { selected = $0 }
+        model.handleAnnotationSelection(identifier: "station_from_0")
+
+        // The panel never interprets these — they are opaque keys OTPKit assigns and
+        // expects back unchanged.
+        #expect(selected == "station_from_0")
+    }
+
+    @Test("Interaction handlers are safe to invoke before OTPKit registers any")
+    func interactionIsSafeWithoutHandlers() {
+        let model = makeModel()
+
+        model.handleMapTap(at: seattle)
+        model.handleAnnotationSelection(identifier: "leg_0")
+
+        #expect(model.isShowingTrip == false)
+    }
+
+    // MARK: - Panel-owned settings
+
+    @Test("Map configuration calls do not disturb panel-wide state")
+    func mapConfigurationCallsAreIgnored() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "leg_0")
+
+        // Basemap style is the rider's own choice, persisted through MapViewModel. OTPKit
+        // may reconfigure its private map view on the UIKit surface, but here it is a
+        // guest on the panel's shared map.
+        model.setMapType(.satellite)
+        model.setUserInteractionEnabled(false)
+        model.setControlsVisible(false)
+
+        #expect(model.routes.count == 1)
+        #expect(model.cameraTarget == nil)
+    }
+
+    @Test("showUserLocation is recorded rather than acted on")
+    func userLocationPreferenceIsRecorded() {
+        let model = makeModel()
+        #expect(model.wantsUserLocation == false)
+
+        model.showUserLocation(true)
+        #expect(model.wantsUserLocation)
+    }
+
+    // MARK: - Teardown
+
+    @Test("clear drops everything the trip drew")
+    func clearDropsEverything() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+        model.showUserLocation(true)
+        model.setRegion(
+            MKCoordinateRegion(center: seattle, span: MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1)),
+            animated: true
+        )
+
+        model.clear()
+
+        #expect(model.routes.isEmpty)
+        #expect(model.annotations.isEmpty)
+        #expect(model.cameraTarget == nil)
+        #expect(model.wantsUserLocation == false)
+        #expect(model.isShowingTrip == false)
+    }
+}

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -354,8 +354,8 @@ struct TripPlannerMapDisplayModelTests {
         // Top: origin.y -= 20 * 10 = 200 map points upward
         // Bottom: size.height += (20 + 40) * 10 = 600 map points downward
         // Total height expansion: 800 map points (80% of viewport)
-        let heightFraction = (paddedRect.size.height - mapRect.size.height) / mapRect.size.height
-        #expect(heightFraction > 0.7) // Asymmetry visible in height alone
+        let heightExpansion = paddedRect.size.height - mapRect.size.height
+        #expect(heightExpansion == 600) // 20 + 40 = 60, times scale 10 = 600
 
         // Top inset pulls origin up: origin.y should decrease
         #expect(paddedRect.origin.y < mapRect.origin.y)
@@ -369,11 +369,12 @@ struct TripPlannerMapDisplayModelTests {
 
         let paddedRect = paddedMapRect(mapRect, edgePadding: padding, mapSize: mapSize)
 
-        // Falls back to fraction-based expansion: 15% horizontal, 30% vertical
+        // Falls back to insetBy with fractions: insetBy applies symmetrically
+        // so -0.15 * width on each side = 0.30 total, -0.30 * height on each side = 0.60 total
         let widthFraction = (paddedRect.size.width - mapRect.size.width) / mapRect.size.width
         let heightFraction = (paddedRect.size.height - mapRect.size.height) / mapRect.size.height
-        #expect(widthFraction == 0.15)
-        #expect(heightFraction == 0.30)
+        #expect(widthFraction == 0.30)  // Symmetric expansion: 0.15 each side
+        #expect(heightFraction == 0.60) // Symmetric expansion: 0.30 each side
 
         // Does not trap on zero size
     }

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -319,4 +319,62 @@ struct TripPlannerMapDisplayModelTests {
         #expect(model.wantsUserLocation == false)
         #expect(model.isShowingTrip == false)
     }
+
+    // MARK: - Map rect padding (view points to map points conversion)
+
+    @Test("Padded rect expands by scaled edge insets")
+    func paddedRectExpansion() {
+        // A realistic viewport: ~5km = ~33,492 map points wide
+        let mapRect = MKMapRect(x: 0, y: 0, width: 33492, height: 33492)
+        // Map display: 400x400 view points
+        let mapSize = CGSize(width: 400, height: 400)
+        // 50pt bottom padding (to clear the sheet) should expand height by a visible fraction
+        let padding = UIEdgeInsets(top: 0, left: 0, bottom: 50, right: 0)
+
+        let paddedRect = paddedMapRect(mapRect, edgePadding: padding, mapSize: mapSize)
+
+        // Scale factor: 33492 / 400 = 83.73 map points per view point
+        // 50pt padding * 83.73 = 4,186.5 map points expansion
+        // That is 12.5% of the 33,492 viewport height — clearly visible, not negligible
+        let heightExpansion = paddedRect.size.height - mapRect.size.height
+        let heightFraction = heightExpansion / mapRect.size.height
+        #expect(heightFraction > 0.1) // At least 10%, not the near-zero we'd get from dividing by a constant
+    }
+
+    @Test("Padded rect preserves asymmetric padding (bottom > top)")
+    func paddedRectAsymmetry() {
+        let mapRect = MKMapRect(x: 0, y: 0, width: 1000, height: 1000)
+        let mapSize = CGSize(width: 100, height: 100)
+        // 20pt top, 40pt bottom — bottom should move the origin up more
+        let padding = UIEdgeInsets(top: 20, left: 0, bottom: 40, right: 0)
+
+        let paddedRect = paddedMapRect(mapRect, edgePadding: padding, mapSize: mapSize)
+
+        // Scale: 1000 / 100 = 10 map points per view point
+        // Top: origin.y -= 20 * 10 = 200 map points upward
+        // Bottom: size.height += (20 + 40) * 10 = 600 map points downward
+        // Total height expansion: 800 map points (80% of viewport)
+        let heightFraction = (paddedRect.size.height - mapRect.size.height) / mapRect.size.height
+        #expect(heightFraction > 0.7) // Asymmetry visible in height alone
+
+        // Top inset pulls origin up: origin.y should decrease
+        #expect(paddedRect.origin.y < mapRect.origin.y)
+    }
+
+    @Test("Padded rect with zero map size uses fallback fraction")
+    func paddedRectZeroMapSize() {
+        let mapRect = MKMapRect(x: 100, y: 200, width: 1000, height: 1000)
+        let mapSize = CGSize.zero // Before first geometry report
+        let padding = UIEdgeInsets(top: 20, left: 20, bottom: 40, right: 40)
+
+        let paddedRect = paddedMapRect(mapRect, edgePadding: padding, mapSize: mapSize)
+
+        // Falls back to fraction-based expansion: 15% horizontal, 30% vertical
+        let widthFraction = (paddedRect.size.width - mapRect.size.width) / mapRect.size.width
+        let heightFraction = (paddedRect.size.height - mapRect.size.height) / mapRect.size.height
+        #expect(widthFraction == 0.15)
+        #expect(heightFraction == 0.30)
+
+        // Does not trap on zero size
+    }
 }

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -7,316 +7,238 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import CoreLocation
 import Foundation
 import MapKit
-import SwiftUI
 import Testing
-import OTPKit
+import CoreLocation
 @testable import OBAKit
+@testable import OBAKitCore
 
-/// Tests for `TripPlannerMapDisplayModel`: the `OTPMapProvider` conformance that turns
-/// OTPKit's imperative map calls into state the SwiftUI panel can render.
-///
-/// Everything here drives the model through the protocol, the way `MapCoordinator` will,
-/// so the assertions describe the contract OTPKit actually depends on.
-@Suite(.serialized)
+/// Trip planner map display model: rendered routes, annotations, camera
+/// targets, and ambient-stop suppression.
 @MainActor
-struct TripPlannerMapDisplayModelTests {
+@Suite(.serialized)
+final class TripPlannerMapDisplayModelTests {
 
-    private let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
-    private let bellevue = CLLocationCoordinate2D(latitude: 47.6101, longitude: -122.2015)
+    @Test
+    func `Starts with nothing displayed`() {
+        let model = TripPlannerMapDisplayModel()
 
-    private func makeModel() -> TripPlannerMapDisplayModel {
-        TripPlannerMapDisplayModel()
+        #expect(model.isShowingTrip == false)
+        #expect(model.routes.isEmpty == true)
+        #expect(model.annotations.isEmpty == true)
+        #expect(model.cameraTarget == nil)
+        #expect(model.wantsUserLocation == false)
     }
 
-    private func addRoute(
-        to model: TripPlannerMapDisplayModel,
-        identifier: String,
-        color: Color = .blue,
-        lineWidth: CGFloat = 4
-    ) {
+    // MARK: - Ambient stop suppression gate
+
+    /// The map layer that shows ambient stops checks `isShowingTrip` to suppress
+    /// them while a trip is drawn, matching how search results take over the map.
+    @Test
+    func `isShowingTrip is true once routes are added`() {
+        let model = TripPlannerMapDisplayModel()
+
         model.addRoute(
-            coordinates: [seattle, bellevue],
-            color: color,
-            lineWidth: lineWidth,
-            identifier: identifier,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+                CLLocationCoordinate2D(latitude: 47.61, longitude: -122.31)
+            ],
+            color: .blue,
+            lineWidth: 2,
+            identifier: "leg_0",
             lineDashPattern: nil
         )
+
+        #expect(model.isShowingTrip == true)
     }
 
-    private func addAnnotation(
-        to model: TripPlannerMapDisplayModel,
-        identifier: String,
-        type: OTPAnnotationType = .origin
-    ) {
+    @Test
+    func `isShowingTrip is true once annotations are added`() {
+        let model = TripPlannerMapDisplayModel()
+
         model.addAnnotation(
-            coordinate: seattle,
-            title: identifier,
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            title: "Start",
             subtitle: nil,
-            identifier: identifier,
-            type: type,
-            routeName: nil,
-            routeBackgroundColor: nil,
-            routeTextColor: nil
-        )
-    }
-
-    // MARK: - Draw order
-
-    @Test("Routes keep insertion order, which is the z-order OTPKit relies on")
-    func routesKeepInsertionOrder() {
-        let model = makeModel()
-
-        // The order MapCoordinator uses: a white halo first, then the coloured leg on
-        // top. If this ever reordered, halos would paint over the routes.
-        addRoute(to: model, identifier: "halo_leg_0")
-        addRoute(to: model, identifier: "leg_0")
-        addRoute(to: model, identifier: "halo_leg_1")
-        addRoute(to: model, identifier: "leg_1")
-
-        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0", "halo_leg_1", "leg_1"])
-    }
-
-    @Test("Annotations keep insertion order")
-    func annotationsKeepInsertionOrder() {
-        let model = makeModel()
-
-        addAnnotation(to: model, identifier: "origin")
-        addAnnotation(to: model, identifier: "station_from_0")
-        addAnnotation(to: model, identifier: "destination", type: .destination)
-
-        #expect(model.annotations.map(\.identifier) == ["origin", "station_from_0", "destination"])
-    }
-
-    // MARK: - Identifier reuse
-
-    @Test("Re-adding an identifier replaces in place rather than duplicating")
-    func reAddingRouteReplacesInPlace() {
-        let model = makeModel()
-
-        addRoute(to: model, identifier: "halo_leg_0")
-        addRoute(to: model, identifier: "leg_0", color: .blue)
-        addRoute(to: model, identifier: "leg_0", color: .red, lineWidth: 8)
-
-        // Still two routes, the updated one still second: OTPKit reuses identifiers
-        // across re-renders, so appending would both leak and disturb the z-order.
-        #expect(model.routes.count == 2)
-        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0"])
-        #expect(model.routes[1].lineWidth == 8)
-    }
-
-    @Test("Re-adding an annotation identifier replaces in place")
-    func reAddingAnnotationReplacesInPlace() {
-        let model = makeModel()
-
-        addAnnotation(to: model, identifier: "origin")
-        addAnnotation(to: model, identifier: "destination", type: .destination)
-        model.addAnnotation(
-            coordinate: bellevue,
-            title: "moved",
-            subtitle: nil,
-            identifier: "origin",
+            identifier: "start",
             type: .origin,
             routeName: nil,
             routeBackgroundColor: nil,
             routeTextColor: nil
         )
 
-        #expect(model.annotations.count == 2)
-        #expect(model.annotations[0].title == "moved")
-        #expect(model.annotations[0].coordinate.latitude == bellevue.latitude)
+        #expect(model.isShowingTrip == true)
     }
 
-    // MARK: - Removal
-
-    @Test("Removing by identifier leaves the rest untouched")
-    func removalIsScopedToIdentifier() {
-        let model = makeModel()
-
-        addRoute(to: model, identifier: "halo_leg_0")
-        addRoute(to: model, identifier: "leg_0")
-        addAnnotation(to: model, identifier: "origin")
-        addAnnotation(to: model, identifier: "destination", type: .destination)
-
-        model.removeRoute(identifier: "halo_leg_0")
-        model.removeAnnotation(identifier: "origin")
-
-        #expect(model.routes.map(\.identifier) == ["leg_0"])
-        #expect(model.annotations.map(\.identifier) == ["destination"])
-    }
-
-    @Test("clearAllRoutes leaves annotations alone, and vice versa")
-    func clearAllIsScopedToItsCollection() {
-        let model = makeModel()
-
-        addRoute(to: model, identifier: "leg_0")
-        addAnnotation(to: model, identifier: "origin")
-
-        model.clearAllRoutes()
-        #expect(model.routes.isEmpty)
-        #expect(model.annotations.count == 1)
-
-        addRoute(to: model, identifier: "leg_0")
-        model.clearAllAnnotations()
-        #expect(model.annotations.isEmpty)
-        #expect(model.routes.count == 1)
-    }
-
-    // MARK: - Trip presence
-
-    @Test("isShowingTrip tracks whether anything is drawn")
-    func isShowingTripTracksContent() {
-        let model = makeModel()
-        #expect(model.isShowingTrip == false)
-
-        addRoute(to: model, identifier: "leg_0")
-        #expect(model.isShowingTrip)
-
-        model.clearAllRoutes()
-        #expect(model.isShowingTrip == false)
-
-        // An annotation alone still counts — a planner that has set only an origin pin
-        // is showing something the ambient stop layer should not fight with.
-        addAnnotation(to: model, identifier: "origin")
-        #expect(model.isShowingTrip)
-    }
-
-    // MARK: - Camera
-
-    @Test("Camera targets are one-shot")
-    func cameraTargetIsOneShot() {
-        let model = makeModel()
-        #expect(model.cameraTarget == nil)
-
-        let rect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
-        model.setVisibleMapRect(rect, edgePadding: .zero, animated: true)
-        #expect(model.cameraTarget == .rect(rect, edgePadding: .zero, animated: true))
-
-        // Without consumption the view would re-apply this on every unrelated body pass,
-        // yanking the map back while the rider is panning.
-        model.consumeCameraTarget()
-        #expect(model.cameraTarget == nil)
-    }
-
-    @Test("centerOnUserLocation is expressed as a camera target, not a direct move")
-    func centerOnUserLocationBecomesTarget() {
-        let model = makeModel()
-
-        model.centerOnUserLocation(animated: false)
-
-        #expect(model.cameraTarget == .userLocation(animated: false))
-    }
-
-    @Test("getCurrentRegion reports what the view last recorded")
-    func currentRegionReflectsRecordedViewport() {
-        let model = makeModel()
-
-        let region = MKCoordinateRegion(
-            center: seattle,
-            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    @Test
+    func `isShowingTrip becomes false when all routes are removed`() {
+        let model = TripPlannerMapDisplayModel()
+        model.addRoute(
+            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
+            color: .blue,
+            lineWidth: 2,
+            identifier: "leg_0",
+            lineDashPattern: nil
         )
-        model.updateVisibleRegion(region)
 
-        let read = model.getCurrentRegion()
-        #expect(read.center.latitude == seattle.latitude)
-        #expect(read.span.latitudeDelta == 0.05)
-    }
+        #expect(model.isShowingTrip == true)
 
-    @Test("getCurrentRegion falls back to the world before the first camera settle")
-    func currentRegionFallsBackToWorld() {
-        let model = makeModel()
-
-        // A zero-span region would read as a specific — and wrong — place. Reporting the
-        // world is the honest answer when the map has not said where it is looking.
-        #expect(model.getCurrentRegion().span.latitudeDelta > 100)
-    }
-
-    // MARK: - Interaction
-
-    @Test("Map taps reach the handler OTPKit registered")
-    func mapTapReachesHandler() {
-        let model = makeModel()
-
-        var tapped: CLLocationCoordinate2D?
-        model.onMapTap { tapped = $0 }
-        model.handleMapTap(at: bellevue)
-
-        #expect(tapped?.latitude == bellevue.latitude)
-    }
-
-    @Test("Annotation selection forwards OTPKit's own identifier verbatim")
-    func annotationSelectionForwardsIdentifier() {
-        let model = makeModel()
-
-        var selected: String?
-        model.onAnnotationSelected { selected = $0 }
-        model.handleAnnotationSelection(identifier: "station_from_0")
-
-        // The panel never interprets these — they are opaque keys OTPKit assigns and
-        // expects back unchanged.
-        #expect(selected == "station_from_0")
-    }
-
-    @Test("Interaction handlers are safe to invoke before OTPKit registers any")
-    func interactionIsSafeWithoutHandlers() {
-        let model = makeModel()
-
-        model.handleMapTap(at: seattle)
-        model.handleAnnotationSelection(identifier: "leg_0")
+        model.removeRoute(identifier: "leg_0")
 
         #expect(model.isShowingTrip == false)
     }
 
-    // MARK: - Panel-owned settings
-
-    @Test("Map configuration calls do not disturb panel-wide state")
-    func mapConfigurationCallsAreIgnored() {
-        let model = makeModel()
-
-        addRoute(to: model, identifier: "leg_0")
-
-        // Basemap style is the rider's own choice, persisted through MapViewModel. OTPKit
-        // may reconfigure its private map view on the UIKit surface, but here it is a
-        // guest on the panel's shared map.
-        model.setMapType(.satellite)
-        model.setUserInteractionEnabled(false)
-        model.setControlsVisible(false)
-
-        #expect(model.routes.count == 1)
-        #expect(model.cameraTarget == nil)
-    }
-
-    @Test("showUserLocation is recorded rather than acted on")
-    func userLocationPreferenceIsRecorded() {
-        let model = makeModel()
-        #expect(model.wantsUserLocation == false)
-
-        model.showUserLocation(true)
-        #expect(model.wantsUserLocation)
-    }
-
-    // MARK: - Teardown
-
-    @Test("clear drops everything the trip drew")
-    func clearDropsEverything() {
-        let model = makeModel()
-
-        addRoute(to: model, identifier: "leg_0")
-        addAnnotation(to: model, identifier: "origin")
-        model.showUserLocation(true)
-        model.setRegion(
-            MKCoordinateRegion(center: seattle, span: MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1)),
-            animated: true
+    @Test
+    func `isShowingTrip becomes false when all annotations are removed`() {
+        let model = TripPlannerMapDisplayModel()
+        model.addAnnotation(
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            title: "Start",
+            subtitle: nil,
+            identifier: "start",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
         )
+
+        #expect(model.isShowingTrip == true)
+
+        model.removeAnnotation(identifier: "start")
+
+        #expect(model.isShowingTrip == false)
+    }
+
+    @Test
+    func `clear resets everything and makes isShowingTrip false`() {
+        let model = TripPlannerMapDisplayModel()
+        model.addRoute(
+            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
+            color: .blue,
+            lineWidth: 2,
+            identifier: "leg_0",
+            lineDashPattern: nil
+        )
+        model.addAnnotation(
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            title: "Start",
+            subtitle: nil,
+            identifier: "start",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+        model.setRegion(MKCoordinateRegion(), animated: true)
+
+        #expect(model.isShowingTrip == true)
+        #expect(model.cameraTarget != nil)
 
         model.clear()
 
-        #expect(model.routes.isEmpty)
-        #expect(model.annotations.isEmpty)
+        #expect(model.isShowingTrip == false)
+        #expect(model.routes.isEmpty == true)
+        #expect(model.annotations.isEmpty == true)
         #expect(model.cameraTarget == nil)
         #expect(model.wantsUserLocation == false)
-        #expect(model.isShowingTrip == false)
+    }
+
+    // MARK: - Annotation selection forwarding
+
+    /// OTPKit hands the model a handler for annotation selections. The model
+    /// records it and forwards calls from the view (which can't call OTPKit
+    /// directly because the planner is a guest on the shared map).
+    @Test
+    func `handleAnnotationSelection forwards to the registered handler`() {
+        let model = TripPlannerMapDisplayModel()
+        var received: String?
+
+        model.onAnnotationSelected { identifier in
+            received = identifier
+        }
+
+        model.handleAnnotationSelection(identifier: "stop_123")
+
+        #expect(received == "stop_123")
+    }
+
+    @Test
+    func `handleAnnotationSelection with no registered handler is a no-op`() {
+        let model = TripPlannerMapDisplayModel()
+
+        // Should not trap.
+        model.handleAnnotationSelection(identifier: "stop_123")
+    }
+
+    // MARK: - Camera targets
+
+    @Test
+    func `setRegion sets a region camera target`() {
+        let model = TripPlannerMapDisplayModel()
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
+
+        model.setRegion(region, animated: true)
+
+        guard case .region(let targetRegion, let animated) = model.cameraTarget else {
+            Issue.record("Expected a region camera target")
+            return
+        }
+        #expect(targetRegion.center.latitude == region.center.latitude)
+        #expect(animated == true)
+    }
+
+    @Test
+    func `setVisibleMapRect sets a rect camera target with edge padding`() {
+        let model = TripPlannerMapDisplayModel()
+        let mapRect = MKMapRect(x: 0, y: 0, width: 100, height: 100)
+        let edgePadding = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+
+        model.setVisibleMapRect(mapRect, edgePadding: edgePadding, animated: false)
+
+        guard case .rect(let targetRect, let targetPadding, let animated) = model.cameraTarget else {
+            Issue.record("Expected a rect camera target")
+            return
+        }
+        #expect(targetRect.origin.x == mapRect.origin.x)
+        #expect(targetPadding == edgePadding)
+        #expect(animated == false)
+    }
+
+    @Test
+    func `centerOnUserLocation sets a userLocation camera target`() {
+        let model = TripPlannerMapDisplayModel()
+
+        model.centerOnUserLocation(animated: true)
+
+        guard case .userLocation(let animated) = model.cameraTarget else {
+            Issue.record("Expected a userLocation camera target")
+            return
+        }
+        #expect(animated == true)
+    }
+
+    @Test
+    func `consumeCameraTarget clears the target without clearing routes or annotations`() {
+        let model = TripPlannerMapDisplayModel()
+        model.addRoute(
+            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
+            color: .blue,
+            lineWidth: 2,
+            identifier: "leg_0",
+            lineDashPattern: nil
+        )
+        model.setRegion(MKCoordinateRegion(), animated: false)
+
+        #expect(model.cameraTarget != nil)
+
+        model.consumeCameraTarget()
+
+        #expect(model.cameraTarget == nil)
+        #expect(model.routes.isEmpty == false)
+        #expect(model.isShowingTrip == true)
     }
 }

--- a/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
+++ b/OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift
@@ -7,238 +7,316 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
+import CoreLocation
 import Foundation
 import MapKit
+import SwiftUI
 import Testing
-import CoreLocation
+import OTPKit
 @testable import OBAKit
-@testable import OBAKitCore
 
-/// Trip planner map display model: rendered routes, annotations, camera
-/// targets, and ambient-stop suppression.
-@MainActor
+/// Tests for `TripPlannerMapDisplayModel`: the `OTPMapProvider` conformance that turns
+/// OTPKit's imperative map calls into state the SwiftUI panel can render.
+///
+/// Everything here drives the model through the protocol, the way `MapCoordinator` will,
+/// so the assertions describe the contract OTPKit actually depends on.
 @Suite(.serialized)
-final class TripPlannerMapDisplayModelTests {
+@MainActor
+struct TripPlannerMapDisplayModelTests {
 
-    @Test
-    func `Starts with nothing displayed`() {
-        let model = TripPlannerMapDisplayModel()
+    private let seattle = CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
+    private let bellevue = CLLocationCoordinate2D(latitude: 47.6101, longitude: -122.2015)
 
+    private func makeModel() -> TripPlannerMapDisplayModel {
+        TripPlannerMapDisplayModel()
+    }
+
+    private func addRoute(
+        to model: TripPlannerMapDisplayModel,
+        identifier: String,
+        color: Color = .blue,
+        lineWidth: CGFloat = 4
+    ) {
+        model.addRoute(
+            coordinates: [seattle, bellevue],
+            color: color,
+            lineWidth: lineWidth,
+            identifier: identifier,
+            lineDashPattern: nil
+        )
+    }
+
+    private func addAnnotation(
+        to model: TripPlannerMapDisplayModel,
+        identifier: String,
+        type: OTPAnnotationType = .origin
+    ) {
+        model.addAnnotation(
+            coordinate: seattle,
+            title: identifier,
+            subtitle: nil,
+            identifier: identifier,
+            type: type,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+    }
+
+    // MARK: - Draw order
+
+    @Test("Routes keep insertion order, which is the z-order OTPKit relies on")
+    func routesKeepInsertionOrder() {
+        let model = makeModel()
+
+        // The order MapCoordinator uses: a white halo first, then the coloured leg on
+        // top. If this ever reordered, halos would paint over the routes.
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0")
+        addRoute(to: model, identifier: "halo_leg_1")
+        addRoute(to: model, identifier: "leg_1")
+
+        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0", "halo_leg_1", "leg_1"])
+    }
+
+    @Test("Annotations keep insertion order")
+    func annotationsKeepInsertionOrder() {
+        let model = makeModel()
+
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "station_from_0")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+
+        #expect(model.annotations.map(\.identifier) == ["origin", "station_from_0", "destination"])
+    }
+
+    // MARK: - Identifier reuse
+
+    @Test("Re-adding an identifier replaces in place rather than duplicating")
+    func reAddingRouteReplacesInPlace() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0", color: .blue)
+        addRoute(to: model, identifier: "leg_0", color: .red, lineWidth: 8)
+
+        // Still two routes, the updated one still second: OTPKit reuses identifiers
+        // across re-renders, so appending would both leak and disturb the z-order.
+        #expect(model.routes.count == 2)
+        #expect(model.routes.map(\.identifier) == ["halo_leg_0", "leg_0"])
+        #expect(model.routes[1].lineWidth == 8)
+    }
+
+    @Test("Re-adding an annotation identifier replaces in place")
+    func reAddingAnnotationReplacesInPlace() {
+        let model = makeModel()
+
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+        model.addAnnotation(
+            coordinate: bellevue,
+            title: "moved",
+            subtitle: nil,
+            identifier: "origin",
+            type: .origin,
+            routeName: nil,
+            routeBackgroundColor: nil,
+            routeTextColor: nil
+        )
+
+        #expect(model.annotations.count == 2)
+        #expect(model.annotations[0].title == "moved")
+        #expect(model.annotations[0].coordinate.latitude == bellevue.latitude)
+    }
+
+    // MARK: - Removal
+
+    @Test("Removing by identifier leaves the rest untouched")
+    func removalIsScopedToIdentifier() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "halo_leg_0")
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+        addAnnotation(to: model, identifier: "destination", type: .destination)
+
+        model.removeRoute(identifier: "halo_leg_0")
+        model.removeAnnotation(identifier: "origin")
+
+        #expect(model.routes.map(\.identifier) == ["leg_0"])
+        #expect(model.annotations.map(\.identifier) == ["destination"])
+    }
+
+    @Test("clearAllRoutes leaves annotations alone, and vice versa")
+    func clearAllIsScopedToItsCollection() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+
+        model.clearAllRoutes()
+        #expect(model.routes.isEmpty)
+        #expect(model.annotations.count == 1)
+
+        addRoute(to: model, identifier: "leg_0")
+        model.clearAllAnnotations()
+        #expect(model.annotations.isEmpty)
+        #expect(model.routes.count == 1)
+    }
+
+    // MARK: - Trip presence
+
+    @Test("isShowingTrip tracks whether anything is drawn")
+    func isShowingTripTracksContent() {
+        let model = makeModel()
         #expect(model.isShowingTrip == false)
-        #expect(model.routes.isEmpty == true)
-        #expect(model.annotations.isEmpty == true)
+
+        addRoute(to: model, identifier: "leg_0")
+        #expect(model.isShowingTrip)
+
+        model.clearAllRoutes()
+        #expect(model.isShowingTrip == false)
+
+        // An annotation alone still counts — a planner that has set only an origin pin
+        // is showing something the ambient stop layer should not fight with.
+        addAnnotation(to: model, identifier: "origin")
+        #expect(model.isShowingTrip)
+    }
+
+    // MARK: - Camera
+
+    @Test("Camera targets are one-shot")
+    func cameraTargetIsOneShot() {
+        let model = makeModel()
         #expect(model.cameraTarget == nil)
+
+        let rect = MKMapRect(x: 100, y: 200, width: 300, height: 400)
+        model.setVisibleMapRect(rect, edgePadding: .zero, animated: true)
+        #expect(model.cameraTarget == .rect(rect, edgePadding: .zero, animated: true))
+
+        // Without consumption the view would re-apply this on every unrelated body pass,
+        // yanking the map back while the rider is panning.
+        model.consumeCameraTarget()
+        #expect(model.cameraTarget == nil)
+    }
+
+    @Test("centerOnUserLocation is expressed as a camera target, not a direct move")
+    func centerOnUserLocationBecomesTarget() {
+        let model = makeModel()
+
+        model.centerOnUserLocation(animated: false)
+
+        #expect(model.cameraTarget == .userLocation(animated: false))
+    }
+
+    @Test("getCurrentRegion reports what the view last recorded")
+    func currentRegionReflectsRecordedViewport() {
+        let model = makeModel()
+
+        let region = MKCoordinateRegion(
+            center: seattle,
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+        model.updateVisibleRegion(region)
+
+        let read = model.getCurrentRegion()
+        #expect(read.center.latitude == seattle.latitude)
+        #expect(read.span.latitudeDelta == 0.05)
+    }
+
+    @Test("getCurrentRegion falls back to the world before the first camera settle")
+    func currentRegionFallsBackToWorld() {
+        let model = makeModel()
+
+        // A zero-span region would read as a specific — and wrong — place. Reporting the
+        // world is the honest answer when the map has not said where it is looking.
+        #expect(model.getCurrentRegion().span.latitudeDelta > 100)
+    }
+
+    // MARK: - Interaction
+
+    @Test("Map taps reach the handler OTPKit registered")
+    func mapTapReachesHandler() {
+        let model = makeModel()
+
+        var tapped: CLLocationCoordinate2D?
+        model.onMapTap { tapped = $0 }
+        model.handleMapTap(at: bellevue)
+
+        #expect(tapped?.latitude == bellevue.latitude)
+    }
+
+    @Test("Annotation selection forwards OTPKit's own identifier verbatim")
+    func annotationSelectionForwardsIdentifier() {
+        let model = makeModel()
+
+        var selected: String?
+        model.onAnnotationSelected { selected = $0 }
+        model.handleAnnotationSelection(identifier: "station_from_0")
+
+        // The panel never interprets these — they are opaque keys OTPKit assigns and
+        // expects back unchanged.
+        #expect(selected == "station_from_0")
+    }
+
+    @Test("Interaction handlers are safe to invoke before OTPKit registers any")
+    func interactionIsSafeWithoutHandlers() {
+        let model = makeModel()
+
+        model.handleMapTap(at: seattle)
+        model.handleAnnotationSelection(identifier: "leg_0")
+
+        #expect(model.isShowingTrip == false)
+    }
+
+    // MARK: - Panel-owned settings
+
+    @Test("Map configuration calls do not disturb panel-wide state")
+    func mapConfigurationCallsAreIgnored() {
+        let model = makeModel()
+
+        addRoute(to: model, identifier: "leg_0")
+
+        // Basemap style is the rider's own choice, persisted through MapViewModel. OTPKit
+        // may reconfigure its private map view on the UIKit surface, but here it is a
+        // guest on the panel's shared map.
+        model.setMapType(.satellite)
+        model.setUserInteractionEnabled(false)
+        model.setControlsVisible(false)
+
+        #expect(model.routes.count == 1)
+        #expect(model.cameraTarget == nil)
+    }
+
+    @Test("showUserLocation is recorded rather than acted on")
+    func userLocationPreferenceIsRecorded() {
+        let model = makeModel()
         #expect(model.wantsUserLocation == false)
+
+        model.showUserLocation(true)
+        #expect(model.wantsUserLocation)
     }
 
-    // MARK: - Ambient stop suppression gate
+    // MARK: - Teardown
 
-    /// The map layer that shows ambient stops checks `isShowingTrip` to suppress
-    /// them while a trip is drawn, matching how search results take over the map.
-    @Test
-    func `isShowingTrip is true once routes are added`() {
-        let model = TripPlannerMapDisplayModel()
+    @Test("clear drops everything the trip drew")
+    func clearDropsEverything() {
+        let model = makeModel()
 
-        model.addRoute(
-            coordinates: [
-                CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
-                CLLocationCoordinate2D(latitude: 47.61, longitude: -122.31)
-            ],
-            color: .blue,
-            lineWidth: 2,
-            identifier: "leg_0",
-            lineDashPattern: nil
+        addRoute(to: model, identifier: "leg_0")
+        addAnnotation(to: model, identifier: "origin")
+        model.showUserLocation(true)
+        model.setRegion(
+            MKCoordinateRegion(center: seattle, span: MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1)),
+            animated: true
         )
-
-        #expect(model.isShowingTrip == true)
-    }
-
-    @Test
-    func `isShowingTrip is true once annotations are added`() {
-        let model = TripPlannerMapDisplayModel()
-
-        model.addAnnotation(
-            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
-            title: "Start",
-            subtitle: nil,
-            identifier: "start",
-            type: .origin,
-            routeName: nil,
-            routeBackgroundColor: nil,
-            routeTextColor: nil
-        )
-
-        #expect(model.isShowingTrip == true)
-    }
-
-    @Test
-    func `isShowingTrip becomes false when all routes are removed`() {
-        let model = TripPlannerMapDisplayModel()
-        model.addRoute(
-            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
-            color: .blue,
-            lineWidth: 2,
-            identifier: "leg_0",
-            lineDashPattern: nil
-        )
-
-        #expect(model.isShowingTrip == true)
-
-        model.removeRoute(identifier: "leg_0")
-
-        #expect(model.isShowingTrip == false)
-    }
-
-    @Test
-    func `isShowingTrip becomes false when all annotations are removed`() {
-        let model = TripPlannerMapDisplayModel()
-        model.addAnnotation(
-            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
-            title: "Start",
-            subtitle: nil,
-            identifier: "start",
-            type: .origin,
-            routeName: nil,
-            routeBackgroundColor: nil,
-            routeTextColor: nil
-        )
-
-        #expect(model.isShowingTrip == true)
-
-        model.removeAnnotation(identifier: "start")
-
-        #expect(model.isShowingTrip == false)
-    }
-
-    @Test
-    func `clear resets everything and makes isShowingTrip false`() {
-        let model = TripPlannerMapDisplayModel()
-        model.addRoute(
-            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
-            color: .blue,
-            lineWidth: 2,
-            identifier: "leg_0",
-            lineDashPattern: nil
-        )
-        model.addAnnotation(
-            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
-            title: "Start",
-            subtitle: nil,
-            identifier: "start",
-            type: .origin,
-            routeName: nil,
-            routeBackgroundColor: nil,
-            routeTextColor: nil
-        )
-        model.setRegion(MKCoordinateRegion(), animated: true)
-
-        #expect(model.isShowingTrip == true)
-        #expect(model.cameraTarget != nil)
 
         model.clear()
 
-        #expect(model.isShowingTrip == false)
-        #expect(model.routes.isEmpty == true)
-        #expect(model.annotations.isEmpty == true)
+        #expect(model.routes.isEmpty)
+        #expect(model.annotations.isEmpty)
         #expect(model.cameraTarget == nil)
         #expect(model.wantsUserLocation == false)
-    }
-
-    // MARK: - Annotation selection forwarding
-
-    /// OTPKit hands the model a handler for annotation selections. The model
-    /// records it and forwards calls from the view (which can't call OTPKit
-    /// directly because the planner is a guest on the shared map).
-    @Test
-    func `handleAnnotationSelection forwards to the registered handler`() {
-        let model = TripPlannerMapDisplayModel()
-        var received: String?
-
-        model.onAnnotationSelected { identifier in
-            received = identifier
-        }
-
-        model.handleAnnotationSelection(identifier: "stop_123")
-
-        #expect(received == "stop_123")
-    }
-
-    @Test
-    func `handleAnnotationSelection with no registered handler is a no-op`() {
-        let model = TripPlannerMapDisplayModel()
-
-        // Should not trap.
-        model.handleAnnotationSelection(identifier: "stop_123")
-    }
-
-    // MARK: - Camera targets
-
-    @Test
-    func `setRegion sets a region camera target`() {
-        let model = TripPlannerMapDisplayModel()
-        let region = MKCoordinateRegion(
-            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
-            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-        )
-
-        model.setRegion(region, animated: true)
-
-        guard case .region(let targetRegion, let animated) = model.cameraTarget else {
-            Issue.record("Expected a region camera target")
-            return
-        }
-        #expect(targetRegion.center.latitude == region.center.latitude)
-        #expect(animated == true)
-    }
-
-    @Test
-    func `setVisibleMapRect sets a rect camera target with edge padding`() {
-        let model = TripPlannerMapDisplayModel()
-        let mapRect = MKMapRect(x: 0, y: 0, width: 100, height: 100)
-        let edgePadding = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
-
-        model.setVisibleMapRect(mapRect, edgePadding: edgePadding, animated: false)
-
-        guard case .rect(let targetRect, let targetPadding, let animated) = model.cameraTarget else {
-            Issue.record("Expected a rect camera target")
-            return
-        }
-        #expect(targetRect.origin.x == mapRect.origin.x)
-        #expect(targetPadding == edgePadding)
-        #expect(animated == false)
-    }
-
-    @Test
-    func `centerOnUserLocation sets a userLocation camera target`() {
-        let model = TripPlannerMapDisplayModel()
-
-        model.centerOnUserLocation(animated: true)
-
-        guard case .userLocation(let animated) = model.cameraTarget else {
-            Issue.record("Expected a userLocation camera target")
-            return
-        }
-        #expect(animated == true)
-    }
-
-    @Test
-    func `consumeCameraTarget clears the target without clearing routes or annotations`() {
-        let model = TripPlannerMapDisplayModel()
-        model.addRoute(
-            coordinates: [CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)],
-            color: .blue,
-            lineWidth: 2,
-            identifier: "leg_0",
-            lineDashPattern: nil
-        )
-        model.setRegion(MKCoordinateRegion(), animated: false)
-
-        #expect(model.cameraTarget != nil)
-
-        model.consumeCameraTarget()
-
-        #expect(model.cameraTarget == nil)
-        #expect(model.routes.isEmpty == false)
-        #expect(model.isShowingTrip == true)
+        #expect(model.isShowingTrip == false)
     }
 }

--- a/OBAKitTests/ViewModels/MapPanelLayersModelTests.swift
+++ b/OBAKitTests/ViewModels/MapPanelLayersModelTests.swift
@@ -233,4 +233,171 @@ final class MapPanelLayersModelTests: OBATestCase {
         // depend on whether the two land in the same grid cell.
         #expect(model.rentalItems.flatMap(\.members).map(\.id).sorted() == ["a", "b"])
     }
+
+    // MARK: - Resolution while the feed is silent
+
+    /// Regression: framing a planned trip zooms the map out past the rental layer's
+    /// `zoomWindow`, so `MapRegionManager.forwardViewport(to:)` hands the coordinator a nil
+    /// viewport and `visibleRentals` empties wholesale. The rental sheets stacked under the
+    /// trip planner resolve their ids on every body pass, so they all flipped to their
+    /// "not available" state — the rider ended a trip, dismissed the planner, and found two
+    /// dead sheets underneath. A rider pinching out with a rental sheet open hit the same
+    /// thing without any trip involved.
+    @Test func `A closed zoom gate does not make an open sheet's vehicle unresolvable`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE")
+        ]))
+        #expect(model.rental(withID: "b7") != nil)
+
+        // The gate closing empties the feed: the next fetch reports nothing in view.
+        coordinator.viewportDidChange(nil)
+        coordinator.apply(RentalFixtures.snapshot(removed: ["b7"]))
+        #expect(coordinator.visibleRentals.isEmpty)
+
+        #expect(coordinator.isReportingVehicles == false)
+        #expect(model.rental(withID: "b7") != nil)
+        #expect(model.rentals(withIDs: ["b7"]).map(\.id) == ["b7"])
+    }
+
+    /// The fallback must not reach the map: a vehicle the feed is no longer reporting has
+    /// no business being drawn at a viewport it was never fetched for.
+    @Test func `The dormant-feed fallback never redraws vehicles on the map`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE")
+        ]))
+        #expect(model.rentalItems.isEmpty == false)
+
+        coordinator.viewportDidChange(nil)
+        coordinator.apply(RentalFixtures.snapshot(removed: ["b7"]))
+
+        #expect(model.rental(withID: "b7") != nil)
+        #expect(model.rentalItems.isEmpty)
+    }
+
+    /// The narrow half of the rule: while the feed *is* reporting, a vehicle missing from
+    /// it really is gone. Saying so is the whole point of resolving by id instead of
+    /// carrying the model in the route.
+    @Test func `A vehicle that leaves a live feed still resolves to nil`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE"),
+            try RentalFixtures.vehicle(id: "b8", formFactor: "BICYCLE")
+        ]))
+        #expect(model.rental(withID: "b7") != nil)
+
+        coordinator.apply(RentalFixtures.snapshot(removed: ["b7"]))
+
+        #expect(coordinator.isReportingVehicles)
+        #expect(model.rental(withID: "b7") == nil)
+        #expect(model.rental(withID: "b8") != nil)
+    }
+
+    // MARK: - Pinned vehicles
+
+    /// Regression, second half: the feed is still reporting, but from a viewport that no
+    /// longer holds this vehicle — which is what framing a planned trip does, since the
+    /// re-fetch for the itinerary's bounding box returns every bike outside it as a
+    /// removal. `lastReportedRentals` cannot help (the live list is non-empty, just
+    /// without this one), so the rental sheets stacked under the planner still died.
+    @Test func `A pinned vehicle survives the viewport moving off it`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE")
+        ]))
+
+        let opened = try #require(model.rental(withID: "b7"))
+        model.pinForOpenSheet([opened])
+
+        // The map moves; the re-fetch reports a different set entirely.
+        coordinator.apply(RentalFixtures.snapshot(
+            added: [try RentalFixtures.vehicle(id: "elsewhere", formFactor: "BICYCLE")],
+            removed: ["b7"]
+        ))
+
+        #expect(coordinator.isReportingVehicles)
+        #expect(coordinator.visibleRentals.map(\.id) == ["elsewhere"])
+        #expect(model.rental(withID: "b7")?.id == "b7")
+        #expect(model.rentals(withIDs: ["b7"]).map(\.id) == ["b7"])
+    }
+
+    /// Pinning must not freeze the sheet: the live list still answers first, so range and
+    /// position keep updating under an open sheet as the feed refreshes.
+    @Test func `A live report still wins over a pin`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE", batteryPercent: 0.2)
+        ]))
+        model.pinForOpenSheet([try #require(model.rental(withID: "b7"))])
+
+        coordinator.apply(RentalFixtures.snapshot(updated: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE", batteryPercent: 0.9)
+        ]))
+
+        #expect(model.rental(withID: "b7")?.batteryPercent == 0.9)
+    }
+
+    /// A pin is not a licence to draw: `rentalItems` still comes from the live list alone,
+    /// so a pinned vehicle is never painted at a viewport it was not fetched for.
+    @Test func `A pinned vehicle is never drawn on the map`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE")
+        ]))
+        model.pinForOpenSheet([try #require(model.rental(withID: "b7"))])
+
+        coordinator.apply(RentalFixtures.snapshot(removed: ["b7"]))
+
+        #expect(model.rental(withID: "b7") != nil)
+        #expect(model.rentalItems.flatMap(\.members).isEmpty)
+    }
+
+    /// A vehicle nobody opened a sheet for is still allowed to be gone — pinning widens
+    /// the answer only for the sheets that need it.
+    @Test func `An unpinned vehicle that leaves a live feed still resolves to nil`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "b7", formFactor: "BICYCLE"),
+            try RentalFixtures.vehicle(id: "b8", formFactor: "BICYCLE")
+        ]))
+        model.pinForOpenSheet([try #require(model.rental(withID: "b7"))])
+
+        coordinator.apply(RentalFixtures.snapshot(removed: ["b7", "b8"]))
+
+        #expect(model.rental(withID: "b7") != nil)
+        #expect(model.rental(withID: "b8") == nil)
+    }
+
+    /// The cluster list keeps its order as members drop out of the viewport, so rows do
+    /// not reshuffle under the rider's finger.
+    @Test func `A partially pinned cluster resolves every member in route order`() throws {
+        let coordinator = try #require(model.registrar.rentalCoordinator)
+        coordinator.setLayer(id: RentalMapLayer.bikesLayerID, enabled: true, formFactors: [.bicycle])
+        coordinator.viewportDidChange(TestData.seattleMapRect)
+        coordinator.apply(RentalFixtures.snapshot(added: [
+            try RentalFixtures.vehicle(id: "a", formFactor: "BICYCLE"),
+            try RentalFixtures.vehicle(id: "b", formFactor: "BICYCLE")
+        ]))
+        model.pinForOpenSheet(model.rentals(withIDs: ["a", "b"]))
+
+        coordinator.apply(RentalFixtures.snapshot(removed: ["a"]))
+
+        #expect(model.rentals(withIDs: ["a", "b"]).map(\.id) == ["b", "a"])
+        #expect(model.rentals(withIDs: ["a", "b"]).count == 2)
+    }
 }

--- a/docs/superpowers/plans/2026-08-22-map-panel-trip-planner.md
+++ b/docs/superpowers/plans/2026-08-22-map-panel-trip-planner.md
@@ -1,0 +1,296 @@
+# Trip Planner in the Map Panel — implementation plan
+
+## Context
+
+OTPKit's trip planner runs today only on the UIKit map surface
+(`MapViewController`), which hands OTPKit a whole second `MKMapView`
+(`tripPlannerMapView`) and alpha-swaps the two. The SwiftUI map panel
+(`MapPanelRoot`) has no `MKMapView`, so OTPKit's shipped `MKMapViewAdapter`
+cannot be used there.
+
+Already landed on this branch:
+
+- `OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift` — an `OTPMapProvider`
+  conformance backed by `@Published` state, so OTPKit's imperative map calls
+  become state the SwiftUI `Map` renders. Commit `d018e1ed`.
+- `OBAKitTests/Sheet/TripPlannerMapDisplayModelTests.swift` — 17 tests, passing.
+
+Already open upstream (both required for this branch to compile):
+
+- OneBusAway/otpkit#160 — `@MainActor` on `OTPMapProvider`.
+- OneBusAway/otpkit#161 — `chrome:` parameter on `TripPlannerView` /
+  `TripPlanner.createTripPlannerView`, plus `TripPlanner.reset()`.
+
+Out of scope for this plan: wiring the rental "Plan a trip using this bike"
+action. That depends on onebusaway-ios#1293, which is unmerged, and the shared
+`RentalDetailView` it introduces does not exist on this branch.
+
+## Spec
+
+The authority for this work is the integration study published at
+https://claude.ai/code/artifact/ec3932e7-93db-4966-b9dd-4ad6c9546db2 —
+in particular blockers B3 (route carries no destination), B4 (no `MKMapView`),
+B7 (detent vocabularies) and B11 (single map selection type). Where this plan
+and that study disagree, the study wins.
+
+## Global Constraints
+
+- **Build/test environment.** `Apps/Shared/app_shared.yml` temporarily points
+  the OTPKit dependency at the local checkout
+  `/Users/mohamedsliem/Desktop/Work/OBA/otpkit`, which sits on branch
+  `integration/trip-planner-embedding` (= #160 + #161 merged). Never commit a
+  change to `app_shared.yml`, and never commit `OBAKit.xcodeproj`.
+- **Regenerate before building.** `/usr/bin/ruby scripts/generate_project OneBusAway`
+  (the repo's rbenv ruby is not installed; system ruby works).
+- **Build:** `xcodebuild build-for-testing -scheme App -destination 'platform=iOS Simulator,name=iPhone 16'`
+- **Test:** `xcodebuild test-without-building -only-testing:OBAKitTests -project OBAKit.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 16'`
+- **Always iPhone 16 (iOS 26).** Never iPhone 17 Pro.
+- **Two pre-existing test failures** are expected and are NOT yours to fix:
+  `RentalFormatTests.rangeFallbackUsesAbbreviatedUnits` (locale artifact) and
+  `BackgroundAnnotationDeemphasisTests` "Opening a sheet refreshes every
+  participating annotation but the selected stop" (cross-suite interference;
+  passes in isolation). Baseline is 2294 tests with exactly these 2 failures.
+- **Swift 6 language mode**, main-actor default isolation, five concurrency
+  diagnostic groups escalated to errors. A data race warning fails the build.
+- **Tests use Swift Testing** (`@Suite(.serialized)` / `@Test` / `#expect`),
+  never XCTest.
+- **SwiftLint:** `scripts/swiftlint.sh` must report no new violations. Five
+  violations are pre-existing in files this plan does not touch.
+- **No Claude/AI attribution** in commit messages.
+- Follow the surrounding code's comment density and idiom. This codebase
+  documents *why*, at length, on non-obvious decisions.
+
+---
+
+## Task 1: Give `.tripPlanner` a destination payload and a tip detent
+
+**Files:** `OBAKit/Sheet/Coordinator/SheetRoute.swift`,
+`OBAKitTests/Sheet/AppSheetRouteTests.swift`
+
+`AppSheetRoute.tripPlanner` currently takes no associated value, so pushing it
+cannot say where the rider is going. Both entry points need a payload, and they
+need different shapes: a map item prefills a destination and leaves the mode
+open; a rental (later) prefills a via point and locks the mode.
+
+**Requirements:**
+
+1. Add a `TripPlannerRequest` type in `SheetRoute.swift`, `nonisolated`,
+   `Hashable` and `Equatable`, with exactly these stored properties, all
+   optional, all defaulting to `nil`:
+   - `destination: MKMapItem?`
+   - `viaPoint: CLLocationCoordinate2D?`
+   - `transportMode: TransportMode?` (from `import OTPKit`)
+
+   `CLLocationCoordinate2D` is not `Hashable` or `Equatable` — implement both
+   by hand over `latitude`/`longitude`. `MKMapItem` is a reference type that
+   is already used as an associated value by `case mapItem(MKMapItem)`; follow
+   whatever that case does.
+
+2. Change the case to `case tripPlanner(TripPlannerRequest)`.
+
+3. Add an arm for the payload in the analytics-key `switch` (the one deriving
+   a key per case, around line 123). Key format must follow the existing
+   mechanical convention in that switch. Do not include the payload's
+   coordinates in the key — an analytics key with a rider's location in it is
+   a privacy leak. Use the presence/absence of each field instead, e.g.
+   `tripPlanner_destination` / `tripPlanner_viaPoint` / `tripPlanner_blank`.
+
+4. Give `.tripPlanner` its own detent configuration, split out of the group it
+   currently shares with `.tripDetails`, `.routePicker`, `.currentTrip`,
+   `.transitAlert`, `.more`, `.settings`:
+   - detents: a tip-sized `.height(_)` detent, `.medium`, and `.large`
+   - initial detent: `.large`
+   - `isDismissDisabled: false`
+
+   Define the tip height as a named static constant on `AppSheetRoute`
+   alongside `homeCollapsedHeight`, and document why it exists: OTPKit
+   collapses to its own custom tip detent when turn-by-turn directions open
+   (`DirectionsSheetView.tipDetent`), and the panel owns detents centrally, so
+   the panel needs a comparable rung. Pick a value consistent with the
+   existing `homeCollapsedHeight`.
+
+   Note the `precondition` in `SheetDetentConfiguration.init`: the initial
+   detent must be a member of the detents set.
+
+5. Leave `.tripPlanner`'s existing stacking preference (`prefersStacking == true`)
+   as it is.
+
+**Tests** in `OBAKitTests/Sheet/AppSheetRouteTests.swift` (existing file —
+match its conventions):
+
+- Two `TripPlannerRequest` values with equal fields are equal and hash equally;
+  differing coordinates compare unequal.
+- The analytics key differs between a destination request, a via-point request
+  and an empty one, and contains no coordinate digits.
+- `.tripPlanner`'s detent configuration contains three detents, opens `.large`,
+  and its initial detent is a member of its detent set.
+
+**Verification:** build, then run the full `OBAKitTests`. Expect the 2
+pre-existing failures and no others. Note that changing the case's shape will
+break `AppSheetViewFactory`'s existing `.tripPlanner` arm — update that arm
+minimally to keep compiling (it currently routes to `unimplementedView(for:)`;
+it must keep doing so until Task 2 replaces it).
+
+---
+
+## Task 2: Build `TripPlannerSheetView` and register it in the factory
+
+**Files:** new `OBAKit/Sheet/Content/TripPlanner/TripPlannerSheetView.swift`,
+`OBAKit/Sheet/DI/AppSheetViewFactory.swift`,
+`OBAKitTests/Sheet/AppSheetViewFactoryTests.swift`
+
+**Requirements:**
+
+1. `TripPlannerSheetView` owns one `OTPKit.TripPlanner` for the lifetime of the
+   sheet. Construct it **once in `init`** and hold it in `@StateObject` (wrap it
+   in a small `ObservableObject` box if `TripPlanner` is not one). This is
+   load-bearing: `AppSheetViewFactory` rebuilds view bodies freely, `TripPlanner`
+   owns exactly one `TripPlannerViewModel` for its lifetime, and rebuilding it
+   mid-flow would reset the rider's trip.
+
+2. Build the planner the way `MapViewController.buildTripPlanner(region:)`
+   (around line 528) does, and keep parity with it:
+   - `GraphQLAPIService(baseURL:)` when `region.openTripPlannerGraphQLURL` exists,
+     else `RestAPIService(baseURL:)` when `region.openTripPlannerURL` exists,
+     else the sheet renders an unavailable state rather than crashing.
+   - enabled modes `[.transit, .walk, .bike, .car]`, plus
+     `[.transitBikeRental, .bikeRental]` when `region.isBikeshareEnabled`.
+   - `OTPConfiguration` with `themeConfiguration` primary colour
+     `Color(uiColor: ThemeColors().brand)` and `searchRegion` from
+     `application.currentRegion?.serviceRect`.
+   - Pass `application.notificationCenter`.
+
+3. The map provider is the **already-built** `TripPlannerMapDisplayModel`
+   (`OBAKit/Sheet/Root/TripPlannerMapDisplayModel.swift`), injected from the
+   factory — not constructed here. It is owned by the panel, because the panel's
+   `Map` renders it.
+
+   Task 3 runs before this task and constructs that instance in
+   `MapPanelRootController`, handing it to `MapPanelRootView`. **This task adds
+   the `AppSheetViewFactory` parameter** for the same instance and updates the
+   controller's factory call site. Splitting it this way keeps each task's diff
+   self-consistent: Task 3 never adds a parameter it does not use.
+
+4. Render OTPKit's view with `chrome: .embedded` via
+   `tripPlanner.createTripPlannerView(destination:viaPoint:transportMode:chrome:onClose:)`,
+   supplying the panel's own header in the style of the other detail sheets.
+   Translate `TripPlannerRequest.destination` (`MKMapItem`) into OTPKit's
+   `Location` the way `MapViewController.showTripPlanner` does.
+
+5. On dismissal, call `TripPlanner.reset()` **and** the display model's
+   `clear()`. OTPKit's `.embedded` chrome renders no close button, so this
+   cleanup is the host's responsibility; without it the next presentation
+   reopens on the previous trip.
+
+6. In `AppSheetViewFactory`, replace `.tripPlanner` in the `unimplementedView`
+   group with a real arm calling a new `tripPlannerView(request:)`. The factory
+   already holds `application`; add whatever it needs for the display model,
+   following how `layersModel`/`mapViewModel` are injected in that file.
+
+**Tests:** extend `AppSheetViewFactoryTests.swift` — building `.tripPlanner`
+no longer hits the unimplemented path, and a factory built for a region with no
+OTP URL still produces a view rather than trapping.
+
+**Verification:** build, full `OBAKitTests`, `scripts/swiftlint.sh`.
+
+---
+
+## Task 3: Render the trip on the panel's map
+
+**Execution order: this task runs BEFORE Task 2.** Task 2 consumes the display
+model instance this task creates.
+
+**Files:** `OBAKit/Sheet/Root/MapPanelRootView.swift`, new
+`OBAKit/Sheet/Root/TripPlannerMapOverlays.swift`,
+`OBAKit/Sheet/Root/MapPanelRootController.swift`,
+`OBAKitTests/Sheet/` (new or existing suite)
+
+Construct the model in `MapPanelRootController` and pass it to
+`MapPanelRootView` only. Task 2 threads the same instance into
+`AppSheetViewFactory`.
+
+**Requirements:**
+
+1. Own one `TripPlannerMapDisplayModel` at the panel level: construct it in
+   `MapPanelRootController` beside `MapPanelLayersModel`, hand it to both
+   `MapPanelRootView` and `AppSheetViewFactory`.
+
+2. Add a free `@MapContentBuilder` function in a new
+   `TripPlannerMapOverlays.swift` that renders the model's `routes` as
+   `MapPolyline` and its `annotations` as `Annotation`. Put it in its own file
+   for the reason `MapSearchOverlays.swift` states in its own doc comment:
+   `MapPanelRootView.body` has already exceeded Swift's type-check budget once.
+   Follow `MapSearchOverlays.swift` closely — it is the precedent.
+
+   Route styling: honour each `Route`'s `color`, `lineWidth` and `dashPattern`.
+   Draw in array order; that order is OTPKit's z-order (white halo first, then
+   the coloured leg on top).
+
+3. **Do not make trip annotations selectable in this pass.** Render them
+   untagged.
+
+   The study's B11 assumed `MapPinSelection`, a closed selection enum — but
+   that type arrives with onebusaway-ios#1293 and does not exist on this
+   branch, where the `Map`'s selection is still
+   `@State private var selectedStopID: Stop.ID?`. Introducing an equivalent
+   enum here would duplicate #1293's work inside `MapPanelRootView.swift`,
+   the file that PR rewrites most heavily.
+
+   `TripPlannerMapDisplayModel` already stores OTPKit's handler and exposes
+   `handleAnnotationSelection(identifier:)`, so the seam is built; wiring it
+   is a one-line change once #1293 lands. Leave `selectedStopID` and its
+   `onChange` exactly as they are.
+
+4. Feed the model the map's viewport: call `updateVisibleRegion(_:)` from the
+   existing `.onMapCameraChange` handler. `getCurrentRegion()` is a synchronous
+   read in OTPKit's protocol and a SwiftUI `Map` has nothing to ask.
+
+5. Apply `cameraTarget` when it appears and call `consumeCameraTarget()`, exactly
+   as the view already does for `MapSearchDisplayModel.CameraTarget`. Handle all
+   three cases: `.region`, `.rect` (respect `edgePadding`), `.userLocation`.
+
+6. Suppress the ambient stop layer while a trip is drawn — extend the existing
+   `searchDisplay.suppressesAmbientStops` gate to also consider
+   `displayModel.isShowingTrip`, matching how a drawn search route already
+   takes over the map.
+
+7. Clear the model when `.tripPlanner` leaves the sheet stack, in the existing
+   `.onChange(of: coordinator.stackedRoutes)` handler that
+   `MapSearchDisplayModel.clearIfOwnerAbsent(from:)` already uses. Route-stack
+   lifetime, not `onDisappear` — read that method's doc comment for why.
+
+**Tests:** the ambient-stop suppression gate and the selection-forwarding
+behaviour are the testable parts; assert them directly on the model plus
+whatever seam the view exposes. Do not write tests that assert on SwiftUI view
+internals.
+
+**Verification:** build, full `OBAKitTests`, `scripts/swiftlint.sh`.
+
+---
+
+## Task 4: Wire the map item "Directions" action
+
+**Files:** `OBAKit/Sheet/Content/Search/MapItemSheetView.swift`,
+`OBAKitTests/Sheet/MapItemSheetViewTests.swift`
+
+`MapItemSheetView` builds its `MapItemViewModel` with `planTripHandler: nil`
+(around line 70), which hides the button. The comment there names this exact
+task.
+
+**Requirements:**
+
+1. Replace `planTripHandler: nil` with a handler that pushes
+   `.tripPlanner(TripPlannerRequest(destination: mapItem))`.
+
+2. Gate it on the region actually supporting OTP — `Region.supportsOTP`. When
+   the current region has no OTP server, keep passing `nil` so the button stays
+   hidden. A visible button that opens an unavailable planner is worse than no
+   button; the existing comment makes the same argument for the `nil` case.
+
+3. Replace the stale comment explaining why the handler is `nil`.
+
+**Tests:** extend `MapItemSheetViewTests.swift` — a region with an OTP URL
+produces a handler that pushes `.tripPlanner` carrying the map item; a region
+without one leaves the handler `nil`.
+
+**Verification:** build, full `OBAKitTests`, `scripts/swiftlint.sh`.


### PR DESCRIPTION
Brings OTPKit's trip planner to the SwiftUI map panel. `AppSheetRoute.tripPlanner` existed but had no registered view, so both entry points into trip planning — a map item's "Directions" and a rental's "Plan a trip using this bike" — passed `nil` handlers and hid their buttons. Both work on the panel now.

OTPKit's only shipped `OTPMapProvider` mutates an `MKMapView` outright, taking its delegate and installing its own gesture recognizer; the UIKit surface obliges by handing over a whole second, hidden map view and swapping the two by alpha. The panel has no view to hand over. Rather than fork OTPKit, this implements the protocol a second way — `TripPlannerMapDisplayModel` records OTPKit's calls into published state the panel renders declaratively as `MapPolyline` and `Annotation`. Two upstream OTPKit changes made that possible and are already merged there: `@MainActor` on the protocol (OneBusAway/otpkit#160), without which a conforming type in OBAKit's Swift 6 main-actor-isolated module cannot satisfy it, and `TripPlannerChrome.embedded`, so the planner renders inside the panel's navigation instead of bringing a second header and close button.

## Summary

- **`TripPlannerMapDisplayModel`** — an `OTPMapProvider` backed by state instead of a map view. Camera moves route through the one-shot `CameraTarget` mechanism `MapSearchDisplayModel` already uses, so `setVisibleMapRect` can't yank the map out from under the rider on an unrelated body pass. `setMapType` and friends are deliberate no-ops: OTPKit is a guest on the panel's one shared map, and basemap style is the rider's persisted choice.
- **`AppSheetRoute.tripPlanner` carries a `TripPlannerRequest`** — optional destination, via point and transport mode, covering both entry points from one payload. Analytics keys derive from which fields are *present*, never from coordinates.
- **`TripPlannerSheetView`** holds `TripPlanner` in a `@StateObject` wrapper, so the factory rebuilding a view body can't reset the rider's trip mid-flow. It opens at `.medium` and returns there when OTPKit's directions sheet opens over it — a full-height planner hides the very map the route is drawn on.
- **Both entry points push the route**, gated on `Region.supportsOTP`. The rental case plans *through* the vehicle — a via point paired with `.transitBikeRental`, matching `MapViewController.rentalLayer(planTripUsing:)` — because OTP won't route through a via point in a rental-only mode.
- **`TripPlannerTip` gets a map-panel home** on the home sheet's search row, the counterpart of the UIKit panel's search bar its copy names.
- Trip pins are tagged with OTPKit's own opaque identifier and handed back verbatim on tap, through the `MapPinSelection` binding stops and rentals already share.

## Fixes for defects this flow exposed

- **Publishing from within view updates, twice over.** OTPKit prefills as a side effect of *building* its view, so doing that from `body` mutated observed state mid-update; it now happens once, from `.task`. Separately, the display model published synchronously while OTPKit drove it from inside SwiftUI's update pass (`DirectionsSheetView` calls the map coordinator from `onAppear` and three `onChange` handlers), so every interaction with the directions sheet warned. Its notification is now deferred and coalesced — one itinerary is dozens of provider calls and deserves one re-render. Reads stay synchronous, because `isShowingTrip` gates the ambient stop layer during `body`.
- **Two sheets from one view.** The rental cluster list presents its own detail sheet, which is right on the UIKit surface but collides here: `StackedSheetLayer` attaches the next stacked route's `.sheet` to that same content, and SwiftUI allows one — *"Currently, only presenting a single sheet is supported."* The trip planner pushed from inside the rental sheet stayed queued until the rider dismissed the rental by hand. The list now delegates the drill-in to the host, which pushes `.rentalDetail` through the coordinator.
- **An open rental sheet dying when the map moves.** The sheets resolve their vehicle by id every body pass, against a list that is viewport-scoped *and* zoom-gated. Framing a planned trip re-fetches for the itinerary's bounding box, and every vehicle outside it returns as a removal — indistinguishable, in the snapshot, from one a rider just rode away. Resolution now falls back to vehicles pinned when the sheet was opened, then to the last report the feed made. Pinned vehicles never reach the map, and a vehicle nobody opened a sheet for can still be genuinely gone. Pre-existing and reproducible without any trip: pan the map with a rental sheet open.

## Verification

- **2619 tests in 275 suites**, one pre-existing failure (`RentalFormatTests.rangeFallbackUsesAbbreviatedUnits`, a locale artifact on code this branch does not touch)
- SwiftLint clean on every touched file
- Each of the three fixes above landed against a reproduction in the simulator, iPhone 16 / iOS 26, and carries regression tests

## Follow-up, not fixed here

**Stop details → Directions is hidden on the panel.** `StopTripPlannerAction` already ships "Directions to Here" / "Directions from Here" in the stop page's More menu, but `canPresent` requires `viewRouter.rootController`, which is nil in map-panel mode, so `StopPageActionPresenter` passes `nil` for both and the items disappear. `StopPageActionRow` already renders them when non-nil — only the panel's push is missing. Follow-up, since it also needs an `origin` on `TripPlannerRequest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trip planning to the SwiftUI map panel, including route previews, map annotations, and destination, via-point, and transport-mode options.
  * Added a trip-planning tip to the home search bar when available.
  * Added “Plan Trip” actions for map items and rental vehicles.
  * Added rental cluster drill-in navigation.

* **Bug Fixes**
  * Rental details remain available when vehicles move outside the current map viewport.
  * Trip-planning actions are hidden in regions without trip-planning support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
